### PR TITLE
Filter out fellows with placeholder profile images

### DIFF
--- a/build/filter_demo_data.py
+++ b/build/filter_demo_data.py
@@ -5,6 +5,7 @@ Reads:  final_fellows_set/ehf_fellow_profiles_deduped.json
 Writes: final_fellows_set/ehf_fellow_profiles_demo_data.json
 """
 
+import hashlib
 import json
 import re
 import unicodedata
@@ -18,60 +19,75 @@ IMAGES_DIRS = [
     REPO_ROOT / "final_fellows_set" / "fellow_profile_images_by_name",
 ]
 
+# MD5 hashes of known placeholder images (grey background with white diamond logo)
+PLACEHOLDER_HASHES = {
+    "5aa43d100ed38aabebbd8393338e961d",
+    "d01a4e3bd727674a2e698c18b61a63bb",
+}
+
 
 def slugify(text: str) -> str:
     text = unicodedata.normalize("NFKD", str(text)).encode("ascii", "ignore").decode("ascii")
     return re.sub(r"[^a-z0-9]+", "_", text.lower().strip()).strip("_")
 
 
-def build_image_index() -> set[str]:
-    """Build a set of normalized image stems from available image directories."""
-    stems = set()
+def find_image_path(slug: str) -> Path | None:
+    """Return the image file path for a slug, or None if not found."""
     for d in IMAGES_DIRS:
         if not d.is_dir():
             continue
+        for ext in (".jpg", ".jpeg", ".png"):
+            p = d / f"{slug}{ext}"
+            if p.is_file():
+                return p
+        # Fuzzy match: strip non-alnum like the server does
+        slug_norm = re.sub(r"[^a-z0-9]", "", slug)
         for p in d.iterdir():
-            if p.is_file() and p.suffix.lower() in (".jpg", ".jpeg", ".png"):
-                stems.add(p.stem.lower())
-    return stems
+            if not p.is_file() or p.suffix.lower() not in (".jpg", ".jpeg", ".png"):
+                continue
+            if re.sub(r"[^a-z0-9]", "", p.stem.lower()) == slug_norm:
+                return p
+    return None
 
 
-def has_local_image(slug: str, image_stems: set[str]) -> bool:
-    """Check if an image file exists for the given slug (exact or normalized match)."""
-    if slug in image_stems:
-        return True
-    # Normalize both sides to strip all non-alnum to match server fallback logic
-    slug_norm = re.sub(r"[^a-z0-9]", "", slug)
-    return any(re.sub(r"[^a-z0-9]", "", s) == slug_norm for s in image_stems)
+def is_placeholder(image_path: Path) -> bool:
+    """Return True if the image file matches a known placeholder hash."""
+    md5 = hashlib.md5(image_path.read_bytes()).hexdigest()
+    return md5 in PLACEHOLDER_HASHES
 
 
 def main():
     with open(INPUT, "r", encoding="utf-8") as f:
         records = json.load(f)
 
-    image_stems = build_image_index()
-    if not image_stems:
-        print("WARNING: No image files found in image directories")
-
     filtered = []
-    skipped = []
+    skipped_no_image = []
+    skipped_placeholder = []
     for r in records:
         name = (r.get("name") or "").strip()
         if not name:
             continue
         slug = slugify(name)
-        if has_local_image(slug, image_stems):
-            filtered.append(r)
+        img = find_image_path(slug)
+        if not img:
+            skipped_no_image.append(name)
+        elif is_placeholder(img):
+            skipped_placeholder.append(name)
         else:
-            skipped.append(name)
+            filtered.append(r)
 
     with open(OUTPUT, "w", encoding="utf-8") as f:
         json.dump(filtered, f, indent=2, ensure_ascii=False)
 
-    print(f"Filtered {len(records)} -> {len(filtered)} records (removed {len(records) - len(filtered)})")
-    if skipped:
-        print(f"Skipped {len(skipped)} named fellows with no local image:")
-        for name in skipped:
+    total_skipped = len(skipped_no_image) + len(skipped_placeholder)
+    print(f"Filtered {len(records)} -> {len(filtered)} records (removed {total_skipped})")
+    if skipped_no_image:
+        print(f"Skipped {len(skipped_no_image)} fellows with no local image:")
+        for name in skipped_no_image:
+            print(f"  {name}")
+    if skipped_placeholder:
+        print(f"Skipped {len(skipped_placeholder)} fellows with placeholder image:")
+        for name in skipped_placeholder:
             print(f"  {name}")
     print(f"Written to {OUTPUT}")
 

--- a/docs/Architecture.md
+++ b/docs/Architecture.md
@@ -16,6 +16,16 @@ ehf_fellow_profiles_deduped.json  →  import_json_to_sqlite.py  →  fellows.db
 Browser (vanilla JS SPA)  ←  HTTP API (server.py)  ←  SQL queries
 ```
 
+### Demo Data Filtering
+
+`build/filter_demo_data.py` filters the full JSON source down to fellows suitable for demo:
+
+1. **Name required** — records without a name are dropped
+2. **Image required** — records without a matching local image file are dropped
+3. **Placeholder detection** — images are checked against known placeholder hashes (MD5). The EHF wiki used a grey diamond logo as a default avatar; fellows with this placeholder are excluded so the demo only shows real profile photos.
+
+The filtered output is written to `ehf_fellow_profiles_demo_data.json`, which can be passed to the import script.
+
 ### Build Phase
 
 `build/import_json_to_sqlite.py` reads the JSON, deduplicates slugs, and writes two tables:

--- a/final_fellows_set/ehf_fellow_profiles_demo_data.json
+++ b/final_fellows_set/ehf_fellow_profiles_demo_data.json
@@ -648,33 +648,6 @@
     "table_name": "Alexandra Johnes"
   },
   {
-    "name": "Alexey Rostapshov",
-    "gender_pronouns": "Man",
-    "ethnicity": "Caucasian/European",
-    "bio_tagline": "Search Tags",
-    "image_url": "https://s3.ap-southeast-2.amazonaws.com/ap-southeast-2-assets.knack.com/assets/63306ddbdfad5247a024eac3/60c66e6a33ee78071b3cc4bc/original/tempfellowdetailpic.png",
-    "fellow_status": "Alumni",
-    "fellow_type": "International Investor",
-    "contact_email": "alexey.rostapshov@gmail.com",
-    "contact_email_urls": [
-      "mailto:alexey.rostapshov@gmail.com"
-    ],
-    "cohort": "Iti Rearea",
-    "primary_citizenship": "United States of America",
-    "all_citizenships": "United States of America",
-    "primary_global_region_of_citizenship": "North America",
-    "global_networks": "United States of America",
-    "currently_based_in": "29 Halifax StNelson, Nelson 7010New Zealand",
-    "global_regions_currently_based_in": "NZ",
-    "search_tags": "",
-    "this_profile_last_updated": "14/06/2021 8:38am",
-    "industries": "",
-    "what_is_your_main_mode_of_working": "",
-    "career_highlights": "",
-    "record_id": "60c66cc933ee78071b3cabca",
-    "table_name": "Alexey Rostapshov"
-  },
-  {
     "name": "Aliesha Staples",
     "gender_pronouns": "Aliesha | Woman",
     "ethnicity": "Pākeha New Zealander",
@@ -1210,33 +1183,6 @@
     "career_highlights": "",
     "record_id": "60c66cd933ee78071b3cad60",
     "table_name": "Anita Baldauf"
-  },
-  {
-    "name": "Ankur Nandwani",
-    "gender_pronouns": "Man",
-    "ethnicity": "South Asian",
-    "bio_tagline": "Investing in digital currency and financial technology companies",
-    "image_url": "https://s3.ap-southeast-2.amazonaws.com/ap-southeast-2-assets.knack.com/assets/63306ddbdfad5247a024eac3/60c66e1a33ee78071b3cc2ca/original/tempfellowdetailpic.png",
-    "fellow_status": "Alumni",
-    "fellow_type": "International Investor",
-    "contact_email": "ankur.nandwani@gmail.com",
-    "contact_email_urls": [
-      "mailto:ankur.nandwani@gmail.com"
-    ],
-    "cohort": "C8",
-    "primary_citizenship": "India",
-    "all_citizenships": "India",
-    "primary_global_region_of_citizenship": "Southern Asia (includes India)",
-    "global_networks": "India, United States of America",
-    "currently_based_in": "St Andrew's RdSingapore, Singapore100 N BroadwayLos Angeles, California 90012United States",
-    "global_regions_currently_based_in": "North AmericaSouth East Asia",
-    "this_profile_last_updated": "16/10/2020 11:57am",
-    "industries": "",
-    "industries_other": "",
-    "what_is_your_main_mode_of_working": "",
-    "career_highlights": "",
-    "record_id": "60c66cd533ee78071b3cad0e",
-    "table_name": "Ankur Nandwani"
   },
   {
     "name": "Ann Smith",
@@ -1904,37 +1850,6 @@
     "key_networks": "",
     "record_id": "60c66cd533ee78071b3cad06",
     "table_name": "Benedict Perez"
-  },
-  {
-    "name": "Benjamin Ha",
-    "gender_pronouns": "Ben | Man",
-    "ethnicity": "East Asian",
-    "bio_tagline": "A global technology entrepreneur and investor bridging resources from different parts of the world.",
-    "image_url": "https://s3.ap-southeast-2.amazonaws.com/ap-southeast-2-assets.knack.com/assets/63306ddbdfad5247a024eac3/60c66ec033ee78071b3cc64e/original/tempfellowdetailpic.png",
-    "fellow_status": "Alumni",
-    "fellow_type": "International Investor",
-    "contact_email": "benjamin.ha@gmail.com",
-    "contact_email_urls": [
-      "mailto:benjamin.ha@gmail.com"
-    ],
-    "cohort": "Manu Tukutuku",
-    "primary_citizenship": "China",
-    "all_citizenships": "Hong Kong",
-    "primary_global_region_of_citizenship": "East & Central Asia (includes China)",
-    "global_networks": "Hong Kong",
-    "currently_based_in": "St Andrew's RdSingapore, Singapore71 橋樂坊元朗, 香港 香港-中國",
-    "global_regions_currently_based_in": "East & Central Asia (includes China)South East Asia",
-    "this_profile_last_updated": "12/10/2020 2:49am",
-    "ventures": "",
-    "industries": "",
-    "un_sdgs_you_are_working_on": "",
-    "what_is_your_main_mode_of_working": "",
-    "career_highlights": "",
-    "what_5_things_do_you_want_fellows_to_know_about_you": "",
-    "impact_goals_for_new_zealand": "",
-    "how_im_looking_to_support_the_nz_ecosystem": "",
-    "record_id": "60c66cbc33ee78071b3caa54",
-    "table_name": "Benjamin Ha"
   },
   {
     "name": "Bernadette Casey",
@@ -6849,38 +6764,6 @@
     "key_networks": "",
     "record_id": "60c66cb633ee78071b3ca9d6",
     "table_name": "Jason Saw"
-  },
-  {
-    "name": "Jason Saw",
-    "gender_pronouns": "Jason | Man",
-    "ethnicity": "East Asian",
-    "bio_tagline": "Co Founder, CEO/President of Invantest Inc (IVT).",
-    "image_url": "https://s3.ap-southeast-2.amazonaws.com/ap-southeast-2-assets.knack.com/assets/63306ddbdfad5247a024eac3/60c66ed833ee78071b3cc6c4/original/tempfellowdetailpic.png",
-    "fellow_status": "Alumni",
-    "fellow_type": "International Entrepreneur",
-    "key_links": "LinkedIn",
-    "key_links_urls": [
-      "https://www.linkedin.com/in/jason-saw-65a5a5/"
-    ],
-    "contact_email": "jason.saw@invantest.com",
-    "contact_email_urls": [
-      "mailto:jason.saw@invantest.com"
-    ],
-    "cohort": "C8",
-    "primary_citizenship": "Malaysia",
-    "all_citizenships": "Malaysia",
-    "primary_global_region_of_citizenship": "South East Asia",
-    "global_networks": "Singapore",
-    "currently_based_in": "Jalan Sultan Ahmad ShahGeorge Town, Pulau Pinang 10050Malaysia1 N 6th StSan Jose, California 95112United StatesSt Andrew's RdSingapore, Singapore",
-    "global_regions_currently_based_in": "North AmericaSouth East Asia",
-    "this_profile_last_updated": "01/11/2020 6:47pm",
-    "ventures": "",
-    "industries": "",
-    "career_highlights": "",
-    "what_5_things_do_you_want_fellows_to_know_about_you": "",
-    "impact_goals_for_new_zealand": "",
-    "record_id": "60c66cc333ee78071b3cab1a",
-    "table_name": "Janine Edge"
   },
   {
     "name": "Jeffrey Paine",


### PR DESCRIPTION
## Summary
- Detects placeholder profile images (grey diamond logo from EHF wiki) by MD5 hash in `build/filter_demo_data.py`
- Excludes 4 fellows with placeholders from demo dataset: Alexey Rostapshov, Ankur Nandwani, Benjamin Ha, Jason Saw
- Documents the filtering pipeline in `docs/Architecture.md`

## Test plan
- [x] `python build/filter_demo_data.py` reports 4 placeholder-image fellows skipped
- [x] `python build/import_json_to_sqlite.py final_fellows_set/ehf_fellow_profiles_demo_data.json` imports 261 records
- [x] `pytest tests/test_database.py tests/test_api.py -v` — 15/15 pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)