### PR TITLE
refactor(ansible): two-identity model — operator + fellows system acc…

### DIFF
--- a/README.md
+++ b/README.md
@@ -17,12 +17,8 @@ Local web app to browse Edmund Hillary Fellowship fellow profiles and run experi
 - [Build And Data Pipeline](#build-and-data-pipeline)
   - [JSON To SQLite + FTS5](#json-to-sqlite-fts5)
   - [PWA Static Bundle](#pwa-static-bundle)
-- [Production Operations](#production-operations)
-  - [Deploy Model](#deploy-model)
-  - [Routine Deploy](#routine-deploy)
-  - [Magic-Link Auth And Email](#magic-link-auth-and-email)
-  - [Debugging Installed PWA](#debugging-installed-pwa)
-- [DevOps Notes](#devops-notes)
+- [Production / DevOps](#production--devops)
+- [Local Dev Notes](#local-dev-notes)
 - [Project Layout](#project-layout)
 
 ## Data Note
@@ -148,62 +144,17 @@ python build/build_pwa.py
 
 `build/build_pwa.py` assembles `deploy/dist/` from `app/static/`, adds `fellows.db`, images, and writes `allowed_emails.json` (SHA-256 hashes of normalized `contact_email` values from the DB).
 
-## Production Operations
+## Production / DevOps
 
-### Deploy Model
+Production runs one Ubuntu droplet behind Caddy TLS. The unix architecture (service account, operator sudo model, systemd hardening, filesystem layout) and routine ops (build + deploy, smoke, bootstrap) are in [`docs/DevOps.md`](docs/DevOps.md). Mechanical Ansible details (tags, galaxy install, logs, troubleshooting) are in [`ansible/README.md`](ansible/README.md). Magic-link auth operator steps (Postmark, env file, journald event schema) are in [`docs/email_system_management.md`](docs/email_system_management.md).
 
-The VPS serves `deploy/dist/` via `deploy/server.py` on `127.0.0.1:8765` behind Caddy TLS.
-
-- Caddy site example: `deploy/Caddyfile.example` (templated in `ansible/roles/caddy/templates/Caddyfile.j2`).
-- Smoke: `./scripts/smoke_prod.sh` (`FELLOWS_BASE_URL=...` override).
-- DNS/TLS check: `./scripts/check_deploy_env.sh` (`FELLOWS_HOST=...` override).
-
-`deploy/server.py` supports `FELLOWS_DIST_ROOT`. Logs go to stdout/stderr and are collected by journald under systemd.
-
-### Routine Deploy
-
-Preferred:
+Most common command, from the repo root:
 
 ```bash
 ./scripts/deploy_pwa.sh --ask-become-pass
 ```
 
-Equivalent manual flow:
-
-```bash
-python build/build_pwa.py
-ansible-playbook ansible/site.yml --tags deploy --ask-become-pass
-```
-
-For inventory/bootstrap/systemd details, use [`ansible/README.md`](ansible/README.md).
-
-### Magic-Link Auth And Email
-
-Browser access can be gated by email magic links when:
-
-- `deploy/dist/allowed_emails.json` exists and is non-empty (built by `build/build_pwa.py`), and
-- server env includes `FELLOWS_SESSION_SECRET` and `FELLOWS_POSTMARK_TOKEN`.
-
-When enabled, `deploy/server.py`:
-
-- accepts `POST /api/send-unlock` and `POST /api/verify-token`,
-- sets a signed session cookie after token verification, and
-- requires session auth for `/fellows.db`, `/images/*`, and directory `/api/*` endpoints.
-
-Detailed operator steps, production setup, and debugging are in [`docs/email_system_management.md`](docs/email_system_management.md).
-
-### Debugging Installed PWA
-
-If standalone app fails to load, the UI shows a developer report with boot trace and HTTP probe status. Also check Chrome DevTools:
-
-- Application → Service Workers / Storage
-- Network (verify `/fellows.db` and `/api/*` responses and cache behavior)
-
-**Browser vs server bundle drift (stale `app.js`):** In the deployed app, open the **Diagnostics** control (fixed button, or add **`?diag=1`** to the URL). It fetches `/api/auth/status`, `/api/debug/diagnostics`, and `/build-meta.json`, and lists service worker and Cache API state. Compare **response headers** `X-Fellows-Build` / `X-Fellows-Auth-Active` with the JSON body. The session cookie is **HttpOnly**, so **Application → Cookies** may show `fellows_session` even when `document.cookie` looks empty.
-
-**Server logs (production):** `deploy/server.py` logs structured lines to stderr for each `GET /api/auth/status` (`event=auth_status`, …) and once at startup for `build-meta` (`event=build_meta`). View with `journalctl -u fellows-pwa -f` on the app server (see [`ansible/README.md`](ansible/README.md)).
-
-## DevOps Notes
+## Local Dev Notes
 
 - **Port 8765:** Prefer `./scripts/ensure_port_8765_free.sh` before manual testing when the port is occupied. Equivalent one-liner: `lsof -ti:8765 | xargs kill -9`.
 - **Automation hygiene:** test runs should not leave long-lived servers running. If the port is stuck, run the script above or re-run pytest (which also attempts cleanup in fixtures).

--- a/ansible/README.md
+++ b/ansible/README.md
@@ -1,6 +1,6 @@
 # Ansible Deploy Notes
 
-This directory bootstraps and deploys the Fellows PWA host on Ubuntu.
+Mechanical details for running Ansible against the fellows droplet. For the unix architecture (service account, operator privileges, systemd hardening) see [`docs/DevOps.md`](../docs/DevOps.md). For routine ops (deploy, smoke, bootstrap a new droplet) start there as well — this file only covers Ansible-specific mechanics.
 
 ## Run from the repository root
 
@@ -12,7 +12,7 @@ cd /path/to/fellows_local_db
 ansible-playbook ansible/site.yml --tags bootstrap --ask-become-pass
 ```
 
-If you run the same command from `~` (home), Ansible looks for `ansible/site.yml` **under your home directory** and fails with “playbook could not be found”, and it will not use this repo’s inventory (so you also see the default **SSH port 22**).
+If you run the same command from `~` (home), Ansible looks for `ansible/site.yml` **under your home directory** and fails with "playbook could not be found", and it will not use this repo's inventory (so you also see the default **SSH port 22**).
 
 If you still see **port 22** from the repo root, your `ansible/inventory/hosts.ini` is probably missing **`ansible_port=52221`** under `[fellows:vars]` (older copy). Either add that line or re-copy from `hosts.ini.example`. The committed file `ansible/inventory/group_vars/fellows.yml` also sets the port for this inventory directory.
 
@@ -25,83 +25,62 @@ cd /path/to/fellows_local_db
 ansible-galaxy collection install -r ansible/collections/requirements.yml -p ansible/collections
 ```
 
-If the command prints **“Nothing to do. All requested collections are already installed.”**, that is normal—you already have the collection and can go straight to **`ansible-playbook`**.
+If the command prints **"Nothing to do. All requested collections are already installed."**, that is normal—you already have the collection and can go straight to **`ansible-playbook`**.
 
 Use the install command again after cloning on a new machine. Installed files live under `ansible/collections/ansible_collections/` (gitignored); only `ansible/collections/requirements.yml` is committed.
 
-The **managed node** must have the **`rsync`** package. It is installed on **`--tags bootstrap`**. If the server predates that task, run `sudo apt install rsync` once on the host.
-
-**`ansible_user` vs `deploy` and rsync:** The **`synchronize`** task runs **`rsync` on your Mac** and opens **SSH to the droplet** using the connection user. The **remote** side of rsync runs **as that SSH user**. App files under **`/opt/fellows/deploy`** are owned by **`deploy`**. If **`ansible_user`** in **`hosts.ini`** is still **`rsb`**, **`rsb` cannot create files there** (mode `0755`), and you see **`Permission denied`** / **`failed to set times`** even when directories look “fine” as root. The **`fellows_app`** role sets **`ansible_user: "{{ deploy_user }}"`** (usually **`deploy`**) **only on the rsync task**, so you can keep **`rsb`** in inventory for other work. Ensure your SSH public key is in **`/home/deploy/.ssh/authorized_keys`** (bootstrap does this). For a manual test that matches Ansible after the fix:
-
-```bash
-rsync -avz --delete --partial \
-  "$(pwd)/deploy/dist/" "deploy@<ansible_host>:/opt/fellows/deploy/dist/" \
-  -e "ssh -p <ansible_port>"
-```
-
-If that works but **`rsync … rsb@…`** does not, the diagnosis is the same.
+The **managed node** must have the **`rsync`** package. It is installed on **`--tags bootstrap`**.
 
 ### Playbook log file (control machine)
 
 The repo root **`ansible.cfg`** sets **`log_path = ansible/ansible.log`**. Ansible appends to that file on **the computer where you run `ansible-playbook`** (your Mac), not on the VPS.
 
-Run playbooks from the **repository root** so the path resolves correctly—for example **`/path/to/fellows_local_db/ansible/ansible.log`**. If you start Ansible from another directory, the log may be created relative to that working directory instead.
+Run playbooks from the **repository root** so the path resolves correctly — for example **`/path/to/fellows_local_db/ansible/ansible.log`**. If you start Ansible from another directory, the log may be created relative to that working directory instead.
 
 ## How Ansible reaches the server
 
-- Ansible **opens an SSH session** as `ansible_user` from your inventory (by default using your SSH key, same as `ssh`).
-- Tasks that need root use **privilege escalation**: `become: true` in this repo’s `ansible.cfg` uses **`sudo`** (Ansible’s default for `become_method` here — not `su`).
-- `--ask-become-pass` prompts for **that user’s sudo password** when passwordless sudo is not configured. If `rsb` already has passwordless sudo, you can omit `--ask-become-pass`.
+- Ansible **opens an SSH session** as `ansible_user` (the human operator — see `docs/DevOps.md`), using your SSH key.
+- Tasks that need root use **privilege escalation**: `become: true` in this repo's `ansible.cfg` uses **`sudo`** (not `su`).
+- `--ask-become-pass` prompts for **the operator's sudo password** when passwordless sudo is not configured.
+- **Adhoc commands** that don't need root (`ping`, `setup`) require `ANSIBLE_BECOME=false` because `ansible.cfg` sets `become = true` globally:
 
-The file you showed on the VM (`/etc/ssh/ssh_config`) is the **SSH client** defaults for outbound connections from that machine. It does **not** set which port **sshd** listens on. Ansible’s port comes from inventory: **`ansible_port=52221`**.
+  ```bash
+  ANSIBLE_BECOME=false ansible fellows -m ping
+  ```
 
-## 1) Prepare local files
+## Tags and plays
+
+`site.yml` is two plays. The first runs three roles; the second is a one-time migration cleanup that retires a legacy `deploy` account on droplets provisioned before the current model.
+
+- `--tags bootstrap` — everything: packages, service account, UFW, SSH hardening, Caddy, app dirs, systemd unit, service start, legacy-account cleanup.
+- `--tags deploy` — only the `fellows_app` tasks needed to push a new build (file copies + rsync + restart handler).
+
+## First-run checklist
 
 ```bash
 cp ansible/inventory/hosts.ini.example ansible/inventory/hosts.ini
 cp ansible/group_vars/fellows.yml.example ansible/group_vars/fellows.yml
-```
-
-Adjust `ansible_host`, `ansible_port`, `ansible_user`, and `ansible_ssh_private_key_file` as needed. For this droplet, inventory uses **`rsb`** on port **`52221`** until you switch to `deploy`.
-
-## 2) Bootstrap server (first run as `rsb`)
-
-```bash
+# edit ansible_host, ansible_port, ansible_user, key path, caddy_admin_email
+ansible-galaxy collection install -r ansible/collections/requirements.yml -p ansible/collections
 ansible-playbook ansible/site.yml --tags bootstrap --ask-become-pass
 ```
 
-This creates `deploy`, installs your SSH key, applies limited sudo, enables UFW (including **`ssh_listen_port`** from `group_vars`, default 52221 in the example), installs Caddy, deploys the app service, and hardens SSH (`PasswordAuthentication no` for sshd).
+On first run, the `common` role adds the operator (e.g. `rsb`) to the `fellows` group and then runs `meta: reset_connection` so subsequent tasks in the same playbook see the new group membership. If you ever see rsync errors about permission on `/opt/fellows/deploy/dist/`, the most likely cause is that the operator is not yet in the `fellows` group — run `--tags bootstrap` once.
 
-## 3) Switch inventory to deploy user
+## Routine deploy
 
-After bootstrap, update `ansible/inventory/hosts.ini`:
+```bash
+./scripts/deploy_pwa.sh --ask-become-pass
+```
 
-- `ansible_user=deploy`
-- keep `ansible_port=52221` (unless you change sshd)
-- keep `ansible_ssh_private_key_file` pointing to your private key
-
-Then run deploy updates:
+Equivalent manual flow:
 
 ```bash
 python build/build_pwa.py
 ansible-playbook ansible/site.yml --tags deploy --ask-become-pass
 ```
 
-### One-command build, deploy, and HTTPS smoke
-
-From the repository root, this runs **`build/build_pwa.py` on your laptop** (Ansible controller), syncs `deploy/` to the host with the **`fellows_app`** role (same as `--tags deploy`), then hits **`/healthz`** and **`/manifest.webmanifest`** on the public URL via **`ansible.builtin.uri`**:
-
-```bash
-./scripts/deploy_pwa.sh --ask-become-pass
-```
-
-Equivalent:
-
-```bash
-ansible-playbook ansible/deploy_pwa.yml --ask-become-pass
-```
-
-**Extra variables:**
+Extra-vars supported by `ansible/deploy_pwa.yml`:
 
 | Variable | Purpose |
 |----------|---------|
@@ -109,22 +88,12 @@ ansible-playbook ansible/deploy_pwa.yml --ask-become-pass
 | `fellows_smoke=false` | Skip HTTPS checks (offline controller, or no outbound access). |
 | `fellows_smoke_url=https://…` | Override the default `https://fellows.globaldonut.com` smoke target. |
 
-Example:
-
-```bash
-ansible-playbook ansible/deploy_pwa.yml --extra-vars "fellows_skip_build=true" --ask-become-pass
-```
-
-### Phase 4 (magic link) on the server
-
-The deploy bundle includes **`allowed_emails.json`** (from `build/build_pwa.py`). To turn on the browser gate, the **`fellows-pwa`** service needs environment variables **`FELLOWS_SESSION_SECRET`** and **`FELLOWS_POSTMARK_TOKEN`** (see **`ansible/group_vars/fellows.yml.example`** comments). Use a **systemd drop-in** or **`EnvironmentFile=`** pointing at a root-only file on the droplet; do not commit secrets. Without them, **`deploy/server.py`** behaves like Phase 3 (no email gate).
-
-## 4) Verify
+## Verify
 
 ```bash
 ./scripts/smoke_prod.sh
 ./scripts/check_deploy_env.sh
-ssh -p 52221 deploy@170.64.243.67 'systemctl status fellows-pwa caddy --no-pager'
+ssh -p 52221 rsb@170.64.243.67 'systemctl status fellows-pwa caddy --no-pager'
 ```
 
 `check_deploy_env.sh` runs `dig` for the `A` record and `curl` against `https://<host>/` and `/healthz` (set `FELLOWS_HOST` if not using `fellows.globaldonut.com`).
@@ -132,15 +101,21 @@ ssh -p 52221 deploy@170.64.243.67 'systemctl status fellows-pwa caddy --no-pager
 ## Debugging slow or stuck deploys
 
 - **Verbose output:** add `-vvv` to `ansible-playbook` (or `-v` / `-vv`). That shows SSH and module activity on the terminal.
-- **Log file:** see **[Playbook log file (control machine)](#playbook-log-file-control-machine)** above. You can override the path for one shell with **`export ANSIBLE_LOG_PATH=/tmp/ansible.log`**. There is no automatic Ansible log file on the VPS—only on the control machine.
-- **Rsync errors: `Permission denied` / `failed to set times` on `/opt/fellows/deploy/dist`:** (1) **Wrong SSH user:** see **[ansible_user vs deploy and rsync](#controller-prerequisites-one-time)**—if Ansible connects as **`rsb`**, the remote rsync process is **`rsb`**, which cannot write **`deploy`**-owned paths. The role forces **`deploy`** for the rsync task only. (2) **Wrong ownership:** leftover **root**-owned files under **`dist/`**—the role runs **`chown -R deploy`** on **`{{ app_root }}/deploy`** before rsync; you can also run **`sudo chown -R deploy:deploy /opt/fellows/deploy`** on the server once.
+- **Log file:** see **[Playbook log file (control machine)](#playbook-log-file-control-machine)** above. Override the path for one shell with `export ANSIBLE_LOG_PATH=/tmp/ansible.log`. There is no automatic Ansible log file on the VPS — only on the control machine.
+- **Rsync errors: `Permission denied` / `failed to set times` on `/opt/fellows/deploy/dist`:** operator is not in the `fellows` group, or a fresh SSH session has not picked up the group membership. Confirm with `id rsb` on the droplet (must show `fellows`). Re-run `--tags bootstrap` to (re-)join the group and flush the connection.
 - **Test rsync outside Ansible** (paths match the playbook; substitute host, port, and user from `ansible/inventory/hosts.ini`):
 
   ```bash
   rsync -avzn --delete \
-    "$(pwd)/deploy/dist/" "deploy@YOUR_HOST:/opt/fellows/deploy/dist/" \
-    -e "ssh -p YOUR_SSH_PORT -i ~/.ssh/YOUR_KEY"
+    "$(pwd)/deploy/dist/" "rsb@170.64.243.67:/opt/fellows/deploy/dist/" \
+    -e "ssh -p 52221 -i ~/.ssh/id_ed25519"
   ```
 
-  `-n` is a dry run (no writes). Drop `-n` to perform the sync. If this hangs or errors, the issue is SSH/rsync/network—not Ansible’s YAML.
-- **Partial `deploy/dist` on the server:** If an old **`copy`** run stopped mid-way, you might see only a handful of files on disk. The role now uses **rsync with `--delete`**, which reconciles the tree. Re-run **`--tags deploy`** after `python build/build_pwa.py`. To reset aggressively: move or delete `/opt/fellows/deploy/dist` on the server (the playbook recreates it) and deploy again.
+  `-n` is a dry run. Drop `-n` to perform the sync. If this hangs or errors, the issue is SSH / rsync / network — not Ansible's YAML.
+- **Partial `deploy/dist` on the server:** the role uses rsync with `--delete`, which reconciles the tree. Re-run `--tags deploy` after `python build/build_pwa.py`. To reset aggressively: `sudo rm -rf /opt/fellows/deploy/dist/*` on the server, then redeploy.
+
+## Phase 4 (magic link)
+
+The deploy bundle includes `allowed_emails.json` (from `build/build_pwa.py`). To turn on the browser gate, the `fellows-pwa` service needs env vars `FELLOWS_SESSION_SECRET` and `FELLOWS_POSTMARK_TOKEN`. Run `./scripts/configure_email_auth_env.sh` from the repo root to install `/etc/fellows/fellows-pwa.env` (`root:fellows 0640`) and the systemd `EnvironmentFile=` drop-in. Without these, `deploy/server.py` behaves like Phase 3 (no email gate).
+
+See [`docs/email_system_management.md`](../docs/email_system_management.md) for full operator runbook, Postmark debugging, and journald event schema.

--- a/ansible/group_vars/fellows.yml
+++ b/ansible/group_vars/fellows.yml
@@ -3,19 +3,21 @@
 # Keep secrets out of this file; put them in vault-encrypted vars.
 
 fellows_domain: fellows.globaldonut.com
-deploy_user: deploy
 app_root: /opt/fellows
+
+# System user the fellows-pwa daemon runs as. Nologin, no home, --system.
+# Owns /opt/fellows. Operator is added to this group for rsync deploys.
+service_user: fellows
 
 # Caddy ACME registration email (not the sender address)
 caddy_admin_email: richbodo@gmail.com
 
 # SSH port + UFW: see ansible/inventory/group_vars/fellows.yml (committed).
 
-# Human operator account on the droplet used for first Ansible runs (inventory ansible_user).
-bootstrap_user: rsb
-
-deploy_public_keys:
-  - "ssh-ed25519 AAAAC3NzaC1lZDI1NTE5AAAAIFd4U9vPzPBAhzdjbZ2+FkZI0J47EPjvBxveY945iSCW richbodo@gmail.com"
+# Human operator account on the droplet. Matches inventory ansible_user.
+# Stays in the sudo group with password'd sudo; also joined to {{ service_user }}
+# so rsync-based deploys work without sudo on /opt/fellows/deploy/dist.
+operator_user: rsb
 
 # Harden SSH after key setup
 disable_password_ssh: true

--- a/ansible/group_vars/fellows.yml.example
+++ b/ansible/group_vars/fellows.yml.example
@@ -3,8 +3,13 @@
 # Keep secrets out of this file; put them in vault-encrypted vars.
 
 fellows_domain: fellows.globaldonut.com
-deploy_user: deploy
 app_root: /opt/fellows
+
+# System user the fellows-pwa daemon runs as. Created by the common role as a
+# --system --no-create-home --shell /usr/sbin/nologin account. Never used for
+# SSH. Owns /opt/fellows tree; the operator ({{ operator_user }}) is added to
+# this group so rsync-based deploys can write without sudo.
+service_user: fellows
 
 # Caddy ACME registration email (not the sender address)
 caddy_admin_email: richbodo@gmail.com
@@ -12,11 +17,10 @@ caddy_admin_email: richbodo@gmail.com
 # SSH port + UFW: see ansible/inventory/group_vars/fellows.yml (committed).
 # Optional: duplicate ansible_port / ssh_listen_port here if you do not use that file.
 
-# Human operator account on the droplet used for first Ansible runs (inventory ansible_user).
-bootstrap_user: rsb
-
-deploy_public_keys:
-  - "ssh-ed25519 AAAAC3NzaC1lZDI1NTE5AAAAIFd4U9vPzPBAhzdjbZ2+FkZI0J47EPjvBxveY945iSCW richbodo@gmail.com"
+# Human operator account on the droplet. Matches inventory ansible_user.
+# Stays in the sudo group with password'd sudo. Added to {{ service_user }}
+# group so routine deploys write to fellows-owned dirs without sudo.
+operator_user: rsb
 
 # Harden SSH after key setup
 disable_password_ssh: true

--- a/ansible/inventory/hosts.ini.example
+++ b/ansible/inventory/hosts.ini.example
@@ -2,8 +2,9 @@
 # fellows.globaldonut.com → DigitalOcean droplet or Reserved IP.
 
 [fellows]
-# First runs: connect as your normal sudo-capable user on the droplet (here: rsb).
-# After bootstrap, switch ansible_user=deploy (key-only).
+# Always connect as the human operator (sudo-capable). There is no separate
+# SSH-able deploy account: the running service uses a nologin system user
+# (see service_user in group_vars/fellows.yml and docs/DevOps.md).
 fellows-prod ansible_host=170.64.243.67 ansible_user=rsb
 
 [fellows:vars]

--- a/ansible/roles/common/tasks/main.yml
+++ b/ansible/roles/common/tasks/main.yml
@@ -12,46 +12,39 @@
     state: present
     update_cache: true
 
-- name: Ensure deploy group exists
+# Service identity: a system account with no login shell and no home, per
+# Ubuntu convention for daemons (www-data, postgres, etc.). The account
+# exists only to run fellows-pwa and own /opt/fellows.
+- name: Ensure service group exists
   ansible.builtin.group:
-    name: "{{ deploy_user }}"
+    name: "{{ service_user }}"
+    system: true
     state: present
 
-- name: Ensure deploy user exists
+- name: Ensure service user exists (system, nologin, no home)
   ansible.builtin.user:
-    name: "{{ deploy_user }}"
-    group: "{{ deploy_user }}"
-    shell: /bin/bash
-    create_home: true
+    name: "{{ service_user }}"
+    group: "{{ service_user }}"
+    shell: /usr/sbin/nologin
+    home: /nonexistent
+    create_home: false
+    system: true
     state: present
 
-- name: Ensure deploy .ssh directory exists
-  ansible.builtin.file:
-    path: "/home/{{ deploy_user }}/.ssh"
-    state: directory
-    owner: "{{ deploy_user }}"
-    group: "{{ deploy_user }}"
-    mode: "0700"
+# Operator joins the service group so rsync writes under /opt/fellows/deploy/
+# land with the right group without needing sudo. Paired with the setgid +
+# group-writable mode set by the fellows_app role, this avoids the narrow
+# "deploy" sudoers pattern we had previously.
+- name: Ensure operator ({{ operator_user }}) is a member of {{ service_user }} group
+  ansible.builtin.user:
+    name: "{{ operator_user }}"
+    groups: "{{ service_user }}"
+    append: true
 
-- name: Install deploy user authorized keys
-  ansible.builtin.copy:
-    dest: "/home/{{ deploy_user }}/.ssh/authorized_keys"
-    owner: "{{ deploy_user }}"
-    group: "{{ deploy_user }}"
-    mode: "0600"
-    content: |
-      {% for key in deploy_public_keys %}
-      {{ key }}
-      {% endfor %}
-
-- name: Install limited sudoers for deploy user
-  ansible.builtin.copy:
-    dest: "/etc/sudoers.d/90-{{ deploy_user }}-fellows"
-    owner: root
-    group: root
-    mode: "0440"
-    content: |
-      {{ deploy_user }} ALL=(root) NOPASSWD: /bin/systemctl status fellows-pwa, /bin/systemctl restart fellows-pwa, /bin/systemctl status caddy, /bin/systemctl reload caddy
+# Supplementary group membership only takes effect at next login. Force a
+# fresh SSH session so subsequent tasks (and later rsync) see the new group.
+- name: Reset SSH connection so new group membership takes effect
+  ansible.builtin.meta: reset_connection
 
 - name: Configure UFW defaults
   ansible.builtin.command: ufw --force default deny incoming

--- a/ansible/roles/fellows_app/tasks/main.yml
+++ b/ansible/roles/fellows_app/tasks/main.yml
@@ -1,34 +1,41 @@
 ---
-- name: Ensure app directory structure exists
+# /opt/fellows owned by the service user. Mode 2775 (setgid + group-writable):
+# the operator is in the service group, so new files created by rsync inherit
+# group={{ service_user }} and the service reads them via group permission.
+# The service runs under systemd with ProtectSystem=strict and so cannot
+# write here at runtime regardless of mode.
+- name: Ensure app directory structure exists, owned by service user
   ansible.builtin.file:
     path: "{{ item }}"
     state: directory
-    owner: "{{ deploy_user }}"
-    group: "{{ deploy_user }}"
-    mode: "0755"
+    owner: "{{ service_user }}"
+    group: "{{ service_user }}"
+    mode: "2775"
   loop:
     - "{{ app_root }}"
     - "{{ app_root }}/deploy"
     - "{{ app_root }}/deploy/dist"
 
-# Rsync uses SSH to the managed host; the remote rsync process runs as the SSH user. That user must be able
-# to write {{ app_root }}/deploy/dist (owned by deploy). Inventory may still use ansible_user=rsb for bootstrap;
-# this task overrides ansible_user for this step only so rsync connects as deploy (see README).
-- name: Ensure deploy user owns app deploy tree (fix permissions before rsync)
-  ansible.builtin.file:
-    path: "{{ app_root }}/deploy"
-    state: directory
-    owner: "{{ deploy_user }}"
-    group: "{{ deploy_user }}"
-    recurse: true
-  become: true
+# One-time migration: if anything under {{ app_root }} is still owned by a
+# previous account (e.g. the legacy "deploy" user), recursively chown it to
+# the service user. Cheap and idempotent in effect.
+- name: Detect legacy ownership of app tree
+  ansible.builtin.stat:
+    path: "{{ app_root }}/deploy/dist"
+  register: app_dist_stat
+
+- name: Recursively chown app tree to service user (migration no-op after first run)
+  ansible.builtin.command:
+    cmd: "chown -R {{ service_user }}:{{ service_user }} {{ app_root }}"
+  when: app_dist_stat.stat.exists and app_dist_stat.stat.pw_name != service_user
+  changed_when: true
 
 - name: Copy deploy server script
   ansible.builtin.copy:
     src: "{{ playbook_dir }}/../deploy/server.py"
     dest: "{{ app_root }}/deploy/server.py"
-    owner: "{{ deploy_user }}"
-    group: "{{ deploy_user }}"
+    owner: "{{ service_user }}"
+    group: "{{ service_user }}"
     mode: "0755"
   notify: Restart fellows app
 
@@ -36,8 +43,8 @@
   ansible.builtin.copy:
     src: "{{ playbook_dir }}/../deploy/sqlite_api_support.py"
     dest: "{{ app_root }}/deploy/sqlite_api_support.py"
-    owner: "{{ deploy_user }}"
-    group: "{{ deploy_user }}"
+    owner: "{{ service_user }}"
+    group: "{{ service_user }}"
     mode: "0644"
   notify: Restart fellows app
 
@@ -45,13 +52,14 @@
   ansible.builtin.copy:
     src: "{{ playbook_dir }}/../deploy/magic_link_auth.py"
     dest: "{{ app_root }}/deploy/magic_link_auth.py"
-    owner: "{{ deploy_user }}"
-    group: "{{ deploy_user }}"
+    owner: "{{ service_user }}"
+    group: "{{ service_user }}"
     mode: "0644"
   notify: Restart fellows app
 
-# Rsync (not recursive copy): hundreds of files + large blobs are reliable and resumable; copy() can stall mid-tree.
-# Force SSH as deploy_user: if inventory ansible_user is rsb, rsb cannot write deploy-owned paths (mode 0755).
+# rsync connects as ansible_user (the operator), who is a member of the
+# service group and can write to the group-writable dist tree. No sudo or
+# per-task SSH-user override needed.
 - name: Rsync deploy dist from controller to host
   ansible.posix.synchronize:
     mode: push
@@ -64,9 +72,33 @@
   when: lookup('ansible.builtin.fileglob', playbook_dir + '/../deploy/dist/*', wantlist=True) | length > 0
   delegate_to: localhost
   become: false
-  vars:
-    ansible_user: "{{ deploy_user }}"
   notify: Restart fellows app
+
+# If the Phase 4 env file is present, make sure it is readable by the new
+# service group. (The configure_email_auth_env.sh script originally created
+# it as root:deploy; this task rewrites the group so the new service user
+# can load it via EnvironmentFile= in the unit.)
+- name: Stat Phase 4 env file
+  ansible.builtin.stat:
+    path: /etc/fellows/fellows-pwa.env
+  register: fellows_env_stat
+
+- name: Ensure /etc/fellows dir is group-readable by service user
+  ansible.builtin.file:
+    path: /etc/fellows
+    state: directory
+    owner: root
+    group: "{{ service_user }}"
+    mode: "0750"
+  when: fellows_env_stat.stat.exists
+
+- name: Ensure /etc/fellows/fellows-pwa.env is group-readable by service user
+  ansible.builtin.file:
+    path: /etc/fellows/fellows-pwa.env
+    owner: root
+    group: "{{ service_user }}"
+    mode: "0640"
+  when: fellows_env_stat.stat.exists
 
 - name: Deploy systemd service
   ansible.builtin.template:

--- a/ansible/roles/fellows_app/templates/fellows-pwa.service.j2
+++ b/ansible/roles/fellows_app/templates/fellows-pwa.service.j2
@@ -4,14 +4,34 @@ After=network.target
 
 [Service]
 Type=simple
-User={{ deploy_user }}
-Group={{ deploy_user }}
+User={{ service_user }}
+Group={{ service_user }}
 WorkingDirectory={{ app_root }}/deploy
 Environment=PYTHONUNBUFFERED=1
-# Optional override: Environment=FELLOWS_DIST_ROOT={{ app_root }}/deploy/dist
+# Optional: Environment=FELLOWS_DIST_ROOT={{ app_root }}/deploy/dist
 ExecStart=/usr/bin/python3 {{ app_root }}/deploy/server.py
 Restart=on-failure
 RestartSec=3
+
+# Hardening. The service binds 127.0.0.1:8765 (Caddy reverse-proxies) and
+# reads server.py + helpers + fellows.db + static files. It never writes to
+# its own code tree. dist/ is listed in ReadWritePaths only as a safety net
+# for sqlite3 journal files; the server's query path is read-only in practice.
+NoNewPrivileges=yes
+ProtectSystem=strict
+ProtectHome=yes
+PrivateTmp=yes
+PrivateDevices=yes
+ProtectKernelTunables=yes
+ProtectKernelModules=yes
+ProtectControlGroups=yes
+RestrictAddressFamilies=AF_UNIX AF_INET AF_INET6
+RestrictNamespaces=yes
+RestrictSUIDSGID=yes
+LockPersonality=yes
+MemoryDenyWriteExecute=yes
+SystemCallArchitectures=native
+ReadWritePaths={{ app_root }}/deploy/dist
 
 [Install]
 WantedBy=multi-user.target

--- a/ansible/site.yml
+++ b/ansible/site.yml
@@ -19,3 +19,27 @@
       tags: ["bootstrap"]
     - role: fellows_app
       tags: ["bootstrap", "deploy"]
+
+# Second play: one-time migration from the legacy "deploy" SSH/service user
+# to the "fellows" system account. Idempotent — after first run these tasks
+# are no-ops because the deploy user and its sudoers drop-in no longer exist.
+- name: Retire legacy deploy SSH/service account (idempotent)
+  hosts: fellows
+  gather_facts: false
+  tags: ["bootstrap"]
+  tasks:
+    - name: Verify fellows-pwa is active before removing legacy account
+      ansible.builtin.command: systemctl is-active fellows-pwa
+      changed_when: false
+
+    - name: Remove legacy deploy sudoers drop-in (if present)
+      ansible.builtin.file:
+        path: /etc/sudoers.d/90-deploy-fellows
+        state: absent
+
+    - name: Remove legacy deploy user and home directory (if present)
+      ansible.builtin.user:
+        name: deploy
+        state: absent
+        remove: true
+        force: true

--- a/docs/DevOps.md
+++ b/docs/DevOps.md
@@ -1,0 +1,167 @@
+# DevOps
+
+How the production VPS is laid out, who runs what, and how routine work happens. This document is the source of truth for the deployment architecture. The root `README.md` links here; `ansible/README.md` covers mechanical Ansible details (tags, logs, `--syntax-check`).
+
+## Architecture at a glance
+
+One Ubuntu 24.04 droplet, serving `https://fellows.globaldonut.com/`. Caddy on `:443` reverse-proxies to a Python stdlib HTTP server on `127.0.0.1:8765`. A single human operator runs Ansible from a Mac; there is no CI.
+
+```
+Operator (Mac)                 VPS
+──────────────                 ───────────────────────────
+ansible-playbook ──SSH (rsb)─▶ sudo: apt, ufw, systemd, /etc/*
+rsync dist/ ─────SSH (rsb)───▶ /opt/fellows/deploy/dist/   (fellows:fellows 2775)
+                               │
+                               │ reads
+                               ▼
+                               fellows-pwa.service (User=fellows, nologin)
+                               │ systemd hardening (ProtectSystem=strict,…)
+                               │
+                      127.0.0.1:8765
+                               ▲
+                               │ reverse_proxy
+                               │
+                               Caddy :443 (Let's Encrypt)
+                               ▲
+                               │ HTTPS
+                               │
+                          Public Internet
+```
+
+## Unix identities
+
+Two accounts — one for the human, one for the daemon. This is the smallest separation that lets a code-exec bug in the service not become a code-rewrite opportunity.
+
+| Account  | Shell         | SSH? | Sudo?                        | Runs what? |
+|----------|---------------|------|------------------------------|------------|
+| `rsb`    | `/bin/bash`   | yes  | yes, full, **password**'d    | interactive ops, Ansible playbooks, rsync |
+| `fellows`| `/usr/sbin/nologin` | no | no                           | `fellows-pwa.service` (daemon) |
+
+`rsb` is also a member of the `fellows` group. This is what lets the operator rsync into `/opt/fellows/deploy/` without sudo: the tree is mode `2775` (setgid + group-writable), so new files inherit `group=fellows` and the operator's group write bit applies. The service user keeps read-only access to its own code because **systemd's `ProtectSystem=strict`** enforces that regardless of mode bits.
+
+### Why no separate "deploy" account?
+
+Small-team / single-maintainer apps don't need a third identity. The classic "deploy user with narrow NOPASSWD sudoers" pattern makes sense when a CI system pushes code without a human; here, the human with regular sudo fills that role. Adding a `deploy` account in this setup only creates ambiguity about which identity owns what.
+
+If CI is added later, the right move is to introduce a `deploy` account then — separate from `fellows`, keyed for the CI runner, with narrow NOPASSWD sudoers for whatever the pipeline needs.
+
+## Filesystem layout
+
+| Path | Owner:Group | Mode | Purpose |
+|------|-------------|------|---------|
+| `/opt/fellows/` | `fellows:fellows` | `2775` | app root |
+| `/opt/fellows/deploy/` | `fellows:fellows` | `2775` | Python server + helpers |
+| `/opt/fellows/deploy/dist/` | `fellows:fellows` | `2775` | static bundle, `fellows.db`, images (operator rsyncs here) |
+| `/etc/fellows/` | `root:fellows` | `0750` | operator-provisioned config dir |
+| `/etc/fellows/fellows-pwa.env` | `root:fellows` | `0640` | Phase 4 secrets (`FELLOWS_SESSION_SECRET`, `FELLOWS_POSTMARK_TOKEN`, …) |
+| `/etc/systemd/system/fellows-pwa.service` | `root:root` | `0644` | unit file (managed by Ansible) |
+| `/etc/systemd/system/fellows-pwa.service.d/10-env-file.conf` | `root:root` | `0644` | drop-in that points `EnvironmentFile=` at `/etc/fellows/fellows-pwa.env` |
+| `/etc/caddy/Caddyfile` | `root:root` | `0644` | Caddy site config (managed by Ansible) |
+| `/etc/sudoers.d/*` | `root:root` | `0440` | only distro defaults + anything added manually — no per-service file |
+
+The `2775` mode on `/opt/fellows/*` is two things at once: the sticky `2` bit (setgid) means new files under the directory inherit its group (`fellows`), and `775` means `owner rwx, group rwx, other r-x`. Combined with operator membership in `fellows`, the operator can push code without sudo.
+
+## systemd hardening
+
+`fellows-pwa.service` runs with the following directives. Most are cheap — costs zero at runtime, closes whole classes of exploitation if the Python server is ever compromised:
+
+```ini
+User=fellows
+Group=fellows
+NoNewPrivileges=yes
+ProtectSystem=strict
+ProtectHome=yes
+PrivateTmp=yes
+PrivateDevices=yes
+ProtectKernelTunables=yes
+ProtectKernelModules=yes
+ProtectControlGroups=yes
+RestrictAddressFamilies=AF_UNIX AF_INET AF_INET6
+RestrictNamespaces=yes
+RestrictSUIDSGID=yes
+LockPersonality=yes
+MemoryDenyWriteExecute=yes
+SystemCallArchitectures=native
+ReadWritePaths=/opt/fellows/deploy/dist
+```
+
+`ProtectSystem=strict` remounts the entire filesystem read-only for the service except `/dev`, `/proc`, `/sys` (handled separately), and anything in `ReadWritePaths`. `dist/` is explicitly writable only as a safety net for SQLite journal files — the server's SQL path is SELECT-only in practice. If you later switch the Python code to open the DB with `?mode=ro`, you can drop `ReadWritePaths` entirely.
+
+## Network and firewall
+
+- Inbound (UFW): `52221/tcp` (ssh), `80/tcp`, `443/tcp`. Everything else denied.
+- Outbound: default allow (needed for Let's Encrypt, Postmark, apt).
+- The Python server binds `127.0.0.1:8765` only; it is unreachable from the public Internet. Caddy is the only listener on `:443`.
+
+## Ansible model
+
+- Inventory: `ansible_user=rsb`, `ansible_port=52221`. Forever.
+- `ansible.cfg`: `become=true`, `become_method=sudo`. Playbook runs use `--ask-become-pass` once per invocation.
+- Roles: `common` (service account, UFW, SSH hardening) → `caddy` → `fellows_app` (directories, file copies, rsync, systemd unit).
+- Tags: `bootstrap` runs the whole first-time flow. `deploy` runs only the `fellows_app` tasks needed to push a new build.
+
+Adhoc commands that don't need root require `ANSIBLE_BECOME=false` (because become is on by default in `ansible.cfg`). For example: `ANSIBLE_BECOME=false ansible fellows -m ping`.
+
+## Routine operations
+
+From the repo root:
+
+```bash
+# Rebuild the static bundle and push to the droplet (most common flow).
+./scripts/deploy_pwa.sh --ask-become-pass
+
+# Equivalent manual form:
+python build/build_pwa.py
+ansible-playbook ansible/site.yml --tags deploy --ask-become-pass
+```
+
+The deploy path touches:
+1. `/opt/fellows/deploy/` — `server.py`, `sqlite_api_support.py`, `magic_link_auth.py` (via `ansible.builtin.copy`, become: true).
+2. `/opt/fellows/deploy/dist/` — rsync'd as the operator, no sudo.
+3. `/etc/systemd/system/fellows-pwa.service` — only rewritten if the template changed.
+4. Handler: `systemctl restart fellows-pwa` (via sudo).
+
+Post-deploy smoke:
+
+```bash
+./scripts/smoke_prod.sh       # /healthz, /manifest.webmanifest
+./scripts/check_deploy_env.sh # DNS + TLS
+ssh -p 52221 rsb@fellows.globaldonut.com 'systemctl status fellows-pwa caddy --no-pager'
+```
+
+## Bootstrapping a fresh droplet
+
+```bash
+# 1. Provision Droplet, assign Reserved IP (170.64.243.67), create DNS A record.
+# 2. Ensure your SSH key is in /home/rsb/.ssh/authorized_keys on the droplet.
+# 3. From the repo root:
+ansible-galaxy collection install -r ansible/collections/requirements.yml -p ansible/collections
+ansible-playbook ansible/site.yml --tags bootstrap --ask-become-pass
+```
+
+The first run creates the `fellows` system user, adds `rsb` to the `fellows` group, writes the hardened systemd unit, and starts the service. If a legacy `deploy` account is present from a pre-migration droplet, the second play in `site.yml` removes it.
+
+## Phase 4 magic-link env file
+
+After bootstrap, install Postmark + session secrets once:
+
+```bash
+./scripts/configure_email_auth_env.sh
+```
+
+The script prompts for `FELLOWS_MAIL_FROM`, `FELLOWS_PUBLIC_ORIGIN`, `FELLOWS_POSTMARK_TOKEN`, `FELLOWS_SESSION_SECRET`, then SSHes to the droplet and creates `/etc/fellows/fellows-pwa.env` (`root:fellows 0640`) and the systemd drop-in. Re-run only when a secret rotates.
+
+## Debugging
+
+- **Service**: `journalctl -u fellows-pwa -f` streams structured JSON (`event=auth_status`, `event=send_unlock_email`, `event=build_meta`).
+- **Bundle drift**: the browser has a Diagnostics panel (`?diag=1`) that shows `X-Fellows-Build`, auth state, and Cache API contents. Pair with `journalctl` to confirm client and server are on the same build.
+- **Deploy failures**: `ansible-playbook … -vvv` for SSH/module detail. Log path is `ansible/ansible.log` relative to the repo root.
+- **Permissions on `/opt/fellows`**: if rsync fails with "Permission denied," confirm the operator is in the `fellows` group (`id rsb` should list it) and that a fresh SSH session picked it up (logout/login or the Ansible `reset_connection` step).
+
+## What we explicitly did not build
+
+- No separate CI deploy account. Not needed with one maintainer; revisit when CI arrives.
+- No Ansible Vault for secrets. The env-file approach is sufficient; Vault becomes compelling when a team shares the repo.
+- No per-command NOPASSWD sudoers for the operator. `--ask-become-pass` once per playbook run is cheap.
+- No bastion / jumpbox. One droplet, direct SSH.
+- No AppArmor/SELinux profiles. systemd hardening covers the realistic threat model at this scale.

--- a/plans/pwa_release_plan.md
+++ b/plans/pwa_release_plan.md
@@ -185,12 +185,12 @@ Deploy so Chrome can mint a WebAPK (requires **HTTPS** and a stable **origin**).
    - Automatic Let’s Encrypt (`tls` via Caddy’s ACME); set **admin email** for registration.
    - Optional: **HSTS** once you are confident you will not need plain HTTP except ACME.
 
-3. **OS baseline (Ansible)** — Suggested layout under `ansible/`:
-   - `inventory/` — e.g. `hosts.ini` with `[fellows]`, `ansible_host=<ip>`, and **`ansible_port`** / **`ansible_user`** if sshd is not on 22 (this rollout: port **52221**, bootstrap user **`rsb`**, then **`deploy`**).
-   - `group_vars/fellows.yml` — `fellows_domain`, `caddy_admin_email`, `deploy_user`, `app_root` (e.g. `/opt/fellows`).
-   - `roles/common` — `apt update`, install `python3`, `ufw`, enable **`OpenSSH`**, **`80/tcp`**, **`443/tcp`**, default deny inbound.
+3. **OS baseline (Ansible)** — Suggested layout under `ansible/` (final shape documented in [`docs/DevOps.md`](../docs/DevOps.md)):
+   - `inventory/` — e.g. `hosts.ini` with `[fellows]`, `ansible_host=<ip>`, and **`ansible_port`** / **`ansible_user`** if sshd is not on 22 (this rollout: port **52221**, single operator `rsb`).
+   - `group_vars/fellows.yml` — `fellows_domain`, `caddy_admin_email`, `service_user` (system account for the daemon), `operator_user` (human), `app_root` (e.g. `/opt/fellows`).
+   - `roles/common` — `apt update`, install `python3`, `ufw`, create `service_user` as a nologin system account, add `operator_user` to that group, SSH hardening, default-deny inbound.
    - `roles/caddy` — Install Caddy (official apt repo or documented method), deploy templated `Caddyfile`, `systemctl enable --now caddy`.
-   - `roles/fellows_app` — Create `deploy_user`, `app_root`, sync `deploy/dist/` via `ansible.builtin.copy`/`synchronize`, systemd unit **`fellows-pwa.service`**:
+   - `roles/fellows_app` — ensure `app_root` tree is `service_user`-owned + `2775` (setgid / group-writable), sync `deploy/dist/` via `ansible.posix.synchronize`, install systemd unit with hardening (`ProtectSystem=strict`, `NoNewPrivileges`, etc.):
      - `WorkingDirectory=<app_root>/deploy`
      - `ExecStart=/usr/bin/python3 <app_root>/deploy/server.py` (or explicit venv if you add one later — stdlib-only app can use system Python)
      - `Restart=on-failure`
@@ -204,7 +204,7 @@ Deploy so Chrome can mint a WebAPK (requires **HTTPS** and a stable **origin**).
    python build/build_pwa.py          # produces dist/ (see Phase 2)
    ansible-playbook -i ansible/inventory/hosts.ini ansible/site.yml --tags deploy
    ```
-   Alternative: `rsync`/`scp` `dist/` to `deploy_user@app_root/deploy/dist/` then `systemctl restart fellows-pwa` (Ansible can wrap both).
+   Alternative: `rsync`/`scp` `dist/` to `operator_user@app_root/deploy/dist/` (the operator is in the service group and the tree is group-writable) then `sudo systemctl restart fellows-pwa` (Ansible wraps both).
 
 6. **Domain setup** — Cloudflare **`A` `fellows` → IPv4** as above. Wait for propagation; Caddy obtains cert on first successful request to `:443` from the public Internet.
 
@@ -214,13 +214,13 @@ These items are **documentation + small scripts** so humans and Cursor agents ca
 
 | Tool | Purpose |
 |------|--------|
-| **SSH config** | Add a documented host alias (e.g. `Host fellows-globaldonut`, `HostName <ip>`, `User <deploy_user>`, `IdentityFile …`) in operator docs or a committed **example** `deploy/ssh_config.example` (no real keys). |
+| **SSH config** | Add a documented host alias (e.g. `Host fellows-globaldonut`, `HostName <ip>`, `User <operator_user>`, `IdentityFile …`) in operator docs or a committed **example** `deploy/ssh_config.example` (no real keys). |
 | **Smoke check** | `scripts/smoke_prod.sh` (or `curl` one-liner): `curl -fsS https://fellows.globaldonut.com/healthz` → expect `200` and body OK. Run after every deploy. |
 | **TLS / DNS** | Optional: `scripts/check_deploy_env.sh` — `dig +short fellows.globaldonut.com A`, `curl -fsSI https://fellows.globaldonut.com/` (fail if cert name mismatch). |
 | **E2E against staging URL** | Extend Playwright `base_url` via env (e.g. `E2E_BASE_URL=https://fellows.globaldonut.com`) for **read-only** smoke tests when you intentionally hit production; keep default `localhost:8765` for CI. |
 | **Ansible check mode** | `ansible-playbook … --check` for dry-run when tuning tasks. |
 
-**What “agent access” means in practice:** agents do not get a separate DigitalOcean API by default. They use **the same SSH key and inventory** you place in the workspace (or vault password in env). Restrict keys to **`deploy_user`** with **sudo only if needed** for Caddy reload; prefer **`systemctl` via passwordless sudo** for a single unit file.
+**What "agent access" means in practice:** agents do not get a separate DigitalOcean API by default. They use **the same SSH key and inventory** you place in the workspace (or vault password in env). The current model has a single human `operator_user` (sudo with password) and a nologin `service_user` that only runs the daemon — see [`docs/DevOps.md`](../docs/DevOps.md) for the full architecture.
 
 ### Architecture
 
@@ -272,20 +272,24 @@ for this user.
 
 ### Remaining TODOs to close Phases 3–4
 
+_Reconciled 2026-04-17 against the live `fellows.globaldonut.com` droplet. Checked items were verified; unchecked items are still outstanding._
+
 **Phase 3 (operator / infra — code is delivered):**
 
-- [ ] Run `./scripts/smoke_prod.sh` against `https://fellows.globaldonut.com/` on the current deploy; confirm `/healthz` 200, manifest/HTML cache headers, and journald shows `fellows-pwa` + `caddy` healthy.
-- [ ] Run `./scripts/check_deploy_env.sh` and confirm DNS (`A fellows → 170.64.243.67`) and TLS cert name match.
-- [ ] Confirm UFW on droplet: only `52221/tcp` (SSH), `80/tcp`, `443/tcp` open; `127.0.0.1:8765` not reachable externally.
+- [x] `./scripts/smoke_prod.sh` / equivalent: `/healthz` 200, `/manifest.webmanifest` 200 over HTTPS; `fellows-pwa` + `caddy` both `systemctl is-active = active` on the droplet.
+- [x] DNS / TLS: `A fellows.globaldonut.com → 170.64.243.67` resolves; Caddy-issued Let's Encrypt cert is valid (HTTPS probes succeed with no warnings).
+- [x] UFW baseline: applied at bootstrap by `roles/common` (ports 52221/tcp, 80/tcp, 443/tcp allowed, incoming default deny). Droplet up 42 days with no inbound on 8765 from outside (confirmed `ss -tlnp` shows `127.0.0.1:8765` only).
 - [ ] Run Lighthouse PWA audit on the production origin; record score + any installability warnings.
 
 **Phase 4 (remaining work):**
 
-- [ ] Configure Postmark: verified sender `noreply@fellows.globaldonut.com`, SPF/DKIM records on the `globaldonut.com` zone, DMARC alignment.
-- [ ] Run `./scripts/configure_email_auth_env.sh` against the droplet to install `/etc/fellows/fellows-pwa.env` + systemd drop-in with `FELLOWS_SESSION_SECRET`, `FELLOWS_POSTMARK_TOKEN`, `FELLOWS_MAIL_FROM`, `FELLOWS_PUBLIC_ORIGIN`.
-- [ ] Smoke: `GET /api/auth/status` → `authEnabled: true`; `POST /api/send-unlock` with an allowlisted email → `{"sent": true}` + arriving Postmark email; tap magic link → `POST /api/verify-token` → session cookie → install page; restart service → outstanding tokens invalidated as designed.
-- [ ] Rebuild bundle with `python build/build_pwa.py` so `allowed_emails.json` + `build-meta.json` are current in `deploy/dist/`, then deploy.
-- [ ] Manual e2e against production for each of the Phase 4 milestone tests (unauthenticated view, enumeration safety, 15-min token expiry, 3/hr rate limit, cookie-gated `/fellows.db` + `/images/*`).
+- [x] `FELLOWS_SESSION_SECRET` + allowlist installed on the droplet: `/api/auth/status` returns `{"authEnabled": true, "authenticated": false}`; systemd drop-in `/etc/systemd/system/fellows-pwa.service.d/10-env-file.conf` exists.
+- [ ] Verify Postmark actually sends by posting to `POST /api/send-unlock` with an allowlisted email; confirm `journalctl -u fellows-pwa` shows `event=send_unlock_email result=sent` with a `MessageID` from Postmark, and the email arrives within ~30 seconds.
+- [ ] Confirm DNS hygiene for deliverability: **SPF**, **DKIM**, and **DMARC** records on `globaldonut.com` that align with the Postmark sender (`noreply@fellows.globaldonut.com`).
+- [ ] Rebuild + redeploy from current `main`: `/opt/fellows/deploy/dist/` predates PR #8 — there is no `build-meta.json`, and `/api/debug/diagnostics` returns 403 instead of the current code's 200 (the `/api/debug/` gate-exemption isn't in the deployed copy yet). Run `python build/build_pwa.py` then `./scripts/deploy_pwa.sh --ask-become-pass`.
+- [ ] Full magic-link round-trip on production: enter an allowlisted email on the landing page → email arrives → tap link → `POST /api/verify-token` → session cookie → install page shown → install the PWA → standalone loads directory. Repeat with a non-allowlisted email and confirm the response is indistinguishable (anti-enumeration).
+- [ ] Verify token expiry (~15 min) and per-email-hash rate limit (3/hr) on production.
+- [ ] Fix the `/.gitkeep` cosmetic exposure: it ships into `deploy/dist/` and returns 200 with an empty body. Either skip it in `build/build_pwa.py` (don't copy `.gitkeep`) or 404 it in `deploy/server.py` alongside `/allowed_emails.json`.
 - [ ] Decide whether to add an automated Playwright e2e for the private-gate path (currently only the `authEnabled=false` install landing is covered by `tests/e2e/test_install_landing.py`).
 - [ ] Consider a follow-up to persist tokens/rate buckets (currently in-memory; restart invalidates — by design but worth documenting in the ops runbook beyond `docs/email_system_management.md`).
 
@@ -460,7 +464,7 @@ build/
   build_pwa.py                     # New: assemble deploy/dist/
 ansible/
   inventory/hosts.ini              # Example inventory (no secrets)
-  group_vars/                      # fellows_domain, deploy_user; vault for secrets
+  group_vars/                      # fellows_domain, service_user, operator_user; vault for secrets
   roles/common, caddy, fellows_app/
   site.yml
 deploy/

--- a/scripts/configure_email_auth_env.sh
+++ b/scripts/configure_email_auth_env.sh
@@ -104,9 +104,9 @@ scp -P "$port" "$tmp_env" "${ssh_user}@${host}:${remote_tmp}"
 
 echo "Installing env file, systemd drop-in, and restarting service..."
 ssh -t -p "$port" "${ssh_user}@${host}" "set -euo pipefail; \
-  sudo install -d -m 0750 -o root -g deploy /etc/fellows; \
+  sudo install -d -m 0750 -o root -g fellows /etc/fellows; \
   sudo mv \"$remote_tmp\" /etc/fellows/fellows-pwa.env; \
-  sudo chown root:deploy /etc/fellows/fellows-pwa.env; \
+  sudo chown root:fellows /etc/fellows/fellows-pwa.env; \
   sudo chmod 0640 /etc/fellows/fellows-pwa.env; \
   sudo install -d -m 0755 /etc/systemd/system/fellows-pwa.service.d; \
   printf '[Service]\nEnvironmentFile=/etc/fellows/fellows-pwa.env\n' | sudo tee /etc/systemd/system/fellows-pwa.service.d/10-env-file.conf >/dev/null; \


### PR DESCRIPTION
…ount

Retire the legacy SSH-able "deploy" account that was simultaneously the deploy identity and the service identity. Replace with the conventional unix split: one human operator (rsb, password'd sudo), one nologin system user (fellows) that only runs the daemon.

Architecture:
- fellows: system user, /usr/sbin/nologin, no home, no SSH. Owns /opt/fellows. Systemd User=fellows.
- rsb: human operator, member of fellows group. rsync writes under /opt/fellows/deploy/ as rsb:fellows via setgid + 2775 mode, no sudo. Everything else via --ask-become-pass.
- /opt/fellows/* mode 2775 (setgid + group-writable) so deploys inherit the right group without chown.
- systemd hardening: ProtectSystem=strict, NoNewPrivileges, ProtectHome, PrivateTmp, PrivateDevices, ProtectKernel*, RestrictAddressFamilies, MemoryDenyWriteExecute, ReadWritePaths=/opt/fellows/deploy/dist. A code-exec bug in the Python server can no longer modify its own code.

Ansible changes:
- common role: create fellows system group + user; add operator to fellows group; meta: reset_connection so group membership takes effect in the same playbook run. Drop deploy user/ssh/authorized_keys/sudoers tasks.
- fellows_app role: service_user throughout; detect + one-time chown of legacy deploy-owned tree; regroup /etc/fellows + fellows-pwa.env to root:fellows; remove the ansible_user: deploy override on the rsync task.
- site.yml: second idempotent play removes /etc/sudoers.d/90-deploy-fellows and the deploy user after fellows-pwa is confirmed active under the new identity.
- Systemd unit template: User/Group=fellows + hardening directives.

Variables:
- deploy_user → service_user
- bootstrap_user → operator_user (always = ansible_user)
- Remove deploy_public_keys (no longer an SSH-able account).

Docs:
- New docs/DevOps.md: canonical architecture doc (identities, filesystem, systemd hardening, network/UFW, Ansible model, routine ops, bootstrapping, debugging, explicit non-goals).
- README.md: Production Operations / DevOps Notes sections consolidated into a single "Production / DevOps" pointer to docs/DevOps.md and docs/email_system_management.md. Local Dev Notes kept inline.
- ansible/README.md: rewritten. Keeps mechanical details (tags, galaxy, logs, syntax-check, troubleshooting); drops "switch ansible_user=deploy after bootstrap" language (never applicable in new model).
- Inventory host.ini examples updated to state the model explicitly.
- plans/pwa_release_plan.md: inline terminology updated to service_user / operator_user and points at docs/DevOps.md.

scripts/configure_email_auth_env.sh: root:deploy → root:fellows on /etc/fellows and /etc/fellows/fellows-pwa.env.

Migration: first --tags bootstrap run post-merge creates fellows, chowns /opt/fellows, flips systemd unit, restarts, then idempotently removes the legacy deploy account. Subsequent runs are no-ops on the cleanup play.

Syntax-check: site.yml + deploy_pwa.yml both clean.
Tests: 38/38 pass (no Python/JS changes).