### PR TITLE
Fix deploy rsync: normalize dist tree + preflight write-probe

### DIFF
--- a/ansible/roles/fellows_app/tasks/main.yml
+++ b/ansible/roles/fellows_app/tasks/main.yml
@@ -107,6 +107,8 @@
       fi
       rm -f "$p"
     done < <(find "{{ app_root }}/deploy/dist" -mindepth 1 -type d)
+  args:
+    executable: /bin/bash
   register: fellows_write_probe
   changed_when: false
   become: false

--- a/ansible/roles/fellows_app/tasks/main.yml
+++ b/ansible/roles/fellows_app/tasks/main.yml
@@ -88,6 +88,29 @@
     mode: "0644"
   notify: Restart fellows app
 
+# Preflight: confirm the operator (ansible_user, not root) can actually write
+# into every dist subdirectory before rsync tries. If normalization above
+# didn't take — filesystem ACLs, mount options, something unexpected — we
+# want a readable failure message here instead of rsync's cryptic
+# "mkstemp ... Permission denied (13)" at the generator/receiver layer.
+# Runs as the operator (become: false); if this passes, rsync will too.
+- name: Preflight - verify operator can write to dist tree
+  ansible.builtin.shell: |
+    set -e
+    probe="{{ app_root }}/deploy/dist/.__ansible_write_probe__"
+    touch "$probe" && rm -f "$probe"
+    while IFS= read -r d; do
+      p="$d/.__ansible_write_probe__"
+      if ! ( : > "$p" ) 2>/dev/null; then
+        echo "FAIL: operator cannot write to $d" >&2
+        exit 1
+      fi
+      rm -f "$p"
+    done < <(find "{{ app_root }}/deploy/dist" -mindepth 1 -type d)
+  register: fellows_write_probe
+  changed_when: false
+  become: false
+
 # rsync connects as ansible_user (the operator), who is a member of the
 # service group and can write to the group-writable dist tree. No sudo or
 # per-task SSH-user override needed.

--- a/ansible/roles/fellows_app/tasks/main.yml
+++ b/ansible/roles/fellows_app/tasks/main.yml
@@ -61,12 +61,13 @@
 # service group and can write to the group-writable dist tree. No sudo or
 # per-task SSH-user override needed.
 #
-# --omit-dir-times: rsync with --archive tries to preserve mtimes on
-# directories, but setting arbitrary times on a fellows-owned dir (even if
-# group-writable) requires ownership or CAP_FOWNER — operator group
-# membership isn't enough. Skipping directory mtime preservation avoids
-# EPERM; file mtimes are still preserved (those files are rsb-owned after
-# rsync writes them).
+# Two flags from --archive (-a) fail for a non-owner even with group write:
+#   -p (perms): chmod(2) requires ownership or CAP_FOWNER. Worse, preserving
+#               source perms would strip the setgid bit (2775 → 755) and
+#               silently break group-inheritance for new files.
+#   -t (times): utime requires ownership or CAP_FOWNER.
+# perms: false adds --no-perms. --omit-dir-times skips utime on directories.
+# File mtimes are still preserved (rsync-created files are rsb-owned).
 - name: Rsync deploy dist from controller to host
   ansible.posix.synchronize:
     mode: push
@@ -76,6 +77,7 @@
     compress: true
     partial: true
     times: true
+    perms: false
     rsync_opts:
       - "--omit-dir-times"
   when: lookup('ansible.builtin.fileglob', playbook_dir + '/../deploy/dist/*', wantlist=True) | length > 0

--- a/ansible/roles/fellows_app/tasks/main.yml
+++ b/ansible/roles/fellows_app/tasks/main.yml
@@ -16,19 +16,50 @@
     - "{{ app_root }}/deploy"
     - "{{ app_root }}/deploy/dist"
 
-# One-time migration: if anything under {{ app_root }} is still owned by a
-# previous account (e.g. the legacy "deploy" user), recursively chown it to
-# the service user. Cheap and idempotent in effect.
-- name: Detect legacy ownership of app tree
-  ansible.builtin.stat:
-    path: "{{ app_root }}/deploy/dist"
-  register: app_dist_stat
+# Normalize the app tree ownership and modes on every run. This replaces the
+# earlier "stat the top dir and maybe chown recursively" check, which missed
+# the real failure mode: subdirectories (dist/vendor, dist/images, dist/icons)
+# left behind by the legacy "deploy" account with orphan UID/GID and mode 0755
+# after that account was removed. The top-level {{ app_root }}/deploy/dist
+# stat'd as {{ service_user }} (the earlier file task above had fixed it), so
+# the old check skipped — but the subtree was still unwritable by the
+# operator. Idempotent: only fires chown/chmod when `find` reports drift, so
+# task results honestly report ok vs changed.
+- name: Find entries under app tree not owned by {{ service_user }}
+  ansible.builtin.command:
+    cmd: "find {{ app_root }} \\( ! -user {{ service_user }} -o ! -group {{ service_user }} \\) -print"
+  register: fellows_wrong_owner
+  changed_when: false
+  check_mode: false
 
-- name: Recursively chown app tree to service user (migration no-op after first run)
+- name: Normalize app tree ownership to {{ service_user }}:{{ service_user }}
   ansible.builtin.command:
     cmd: "chown -R {{ service_user }}:{{ service_user }} {{ app_root }}"
-  when: app_dist_stat.stat.exists and app_dist_stat.stat.pw_name != service_user
-  changed_when: true
+  when: fellows_wrong_owner.stdout | length > 0
+
+- name: Find dist directories not mode 2775
+  ansible.builtin.command:
+    cmd: "find {{ app_root }}/deploy/dist -type d ! -perm 2775 -print"
+  register: fellows_wrong_dir_mode
+  changed_when: false
+  check_mode: false
+
+- name: Normalize dist directory modes to 2775 (setgid + group-writable)
+  ansible.builtin.command:
+    cmd: "find {{ app_root }}/deploy/dist -type d ! -perm 2775 -exec chmod 2775 {} +"
+  when: fellows_wrong_dir_mode.stdout | length > 0
+
+- name: Find dist files without group-write bit
+  ansible.builtin.command:
+    cmd: "find {{ app_root }}/deploy/dist -type f ! -perm -g+w -print"
+  register: fellows_wrong_file_mode
+  changed_when: false
+  check_mode: false
+
+- name: Normalize dist files to group-writable (0664)
+  ansible.builtin.command:
+    cmd: "find {{ app_root }}/deploy/dist -type f ! -perm -g+w -exec chmod 0664 {} +"
+  when: fellows_wrong_file_mode.stdout | length > 0
 
 - name: Copy deploy server script
   ansible.builtin.copy:

--- a/ansible/roles/fellows_app/tasks/main.yml
+++ b/ansible/roles/fellows_app/tasks/main.yml
@@ -60,6 +60,13 @@
 # rsync connects as ansible_user (the operator), who is a member of the
 # service group and can write to the group-writable dist tree. No sudo or
 # per-task SSH-user override needed.
+#
+# --omit-dir-times: rsync with --archive tries to preserve mtimes on
+# directories, but setting arbitrary times on a fellows-owned dir (even if
+# group-writable) requires ownership or CAP_FOWNER — operator group
+# membership isn't enough. Skipping directory mtime preservation avoids
+# EPERM; file mtimes are still preserved (those files are rsb-owned after
+# rsync writes them).
 - name: Rsync deploy dist from controller to host
   ansible.posix.synchronize:
     mode: push
@@ -69,6 +76,8 @@
     compress: true
     partial: true
     times: true
+    rsync_opts:
+      - "--omit-dir-times"
   when: lookup('ansible.builtin.fileglob', playbook_dir + '/../deploy/dist/*', wantlist=True) | length > 0
   delegate_to: localhost
   become: false

--- a/docs/DevOps.md
+++ b/docs/DevOps.md
@@ -61,6 +61,8 @@ If CI is added later, the right move is to introduce a `deploy` account then —
 
 The `2775` mode on `/opt/fellows/*` is two things at once: the sticky `2` bit (setgid) means new files under the directory inherit its group (`fellows`), and `775` means `owner rwx, group rwx, other r-x`. Combined with operator membership in `fellows`, the operator can push code without sudo.
 
+**Gotcha: group write ≠ utime.** Being in the group lets you create, modify, and delete files, but setting arbitrary timestamps on a file you don't own requires ownership or `CAP_FOWNER` — group-write is not enough. This matters for `rsync -a`, which tries to preserve directory mtimes. The Ansible synchronize task passes `--omit-dir-times` so rsync doesn't try to `utime` fellows-owned directories; file mtimes are still preserved because the files rsync creates are operator-owned.
+
 ## systemd hardening
 
 `fellows-pwa.service` runs with the following directives. Most are cheap — costs zero at runtime, closes whole classes of exploitation if the Python server is ever compromised:

--- a/docs/DevOps.md
+++ b/docs/DevOps.md
@@ -61,7 +61,7 @@ If CI is added later, the right move is to introduce a `deploy` account then —
 
 The `2775` mode on `/opt/fellows/*` is two things at once: the sticky `2` bit (setgid) means new files under the directory inherit its group (`fellows`), and `775` means `owner rwx, group rwx, other r-x`. Combined with operator membership in `fellows`, the operator can push code without sudo.
 
-**Gotcha: group write ≠ utime.** Being in the group lets you create, modify, and delete files, but setting arbitrary timestamps on a file you don't own requires ownership or `CAP_FOWNER` — group-write is not enough. This matters for `rsync -a`, which tries to preserve directory mtimes. The Ansible synchronize task passes `--omit-dir-times` so rsync doesn't try to `utime` fellows-owned directories; file mtimes are still preserved because the files rsync creates are operator-owned.
+**Gotcha: group write ≠ utime or chmod.** Being in the group lets you create, modify, and delete files, but setting timestamps (`utime`) or permissions (`chmod`) on a file you don't own requires ownership or `CAP_FOWNER` — group-write is not enough. This matters for `rsync -a`, which tries to preserve both directory mtimes and perms. The Ansible synchronize task therefore passes `--omit-dir-times` and `--no-perms` (via `perms: false`). File mtimes are still preserved (rsync-created files are operator-owned and can be `utime`'d), and new files get umask-default perms (644/755) which matches what we want. `--no-perms` is also load-bearing for a second reason: if rsync preserved perms, it would `chmod` `dist/.` from the target's `2775` down to the source's `755`, silently stripping the setgid bit and breaking group inheritance for new files.
 
 ## systemd hardening
 

--- a/scripts/diagnose_deploy_perms.sh
+++ b/scripts/diagnose_deploy_perms.sh
@@ -1,0 +1,103 @@
+#!/usr/bin/env bash
+# Read-only diagnostic for the deploy rsync permission issue.
+#
+# SSHes to the fellows host as the operator user (rsb) and reports everything
+# we need to decide whether the failure is group membership, directory modes,
+# ACLs, or something else. Does not modify remote state; the write probe
+# creates and immediately deletes a single file under dist/ and dist/vendor/.
+#
+# Usage: ./scripts/diagnose_deploy_perms.sh [host]
+#   host defaults to the ansible inventory target.
+
+set -euo pipefail
+
+HOST="${1:-170.64.243.67}"
+PORT="${SSH_PORT:-52221}"
+USER="${SSH_USER:-rsb}"
+
+ssh -p "$PORT" -o StrictHostKeyChecking=accept-new "$USER@$HOST" bash -s <<'REMOTE'
+set -u
+APP=/opt/fellows
+DIST=$APP/deploy/dist
+
+say() { printf '\n=== %s ===\n' "$1"; }
+
+say "whoami / id"
+whoami
+id
+
+say "getent group fellows"
+getent group fellows || true
+
+say "umask"
+umask
+
+say "mount options for /opt"
+awk '$2 ~ /^\/opt($|\/)/ || $2 == "/" {print}' /proc/mounts
+
+say "stat on key paths (mode / owner / group)"
+for p in "$APP" "$APP/deploy" "$DIST" "$DIST/vendor" "$DIST/images"; do
+  if [ -e "$p" ]; then
+    stat -c '%a %U:%G  %n' "$p"
+  else
+    echo "MISSING  $p"
+  fi
+done
+
+say "ls -la $DIST"
+ls -la "$DIST" || true
+
+say "ls -la $DIST/vendor"
+ls -la "$DIST/vendor" 2>/dev/null || echo "(no vendor dir)"
+
+say "ls -la $DIST/images  (first 5)"
+ls -la "$DIST/images" 2>/dev/null | head -n 5 || echo "(no images dir)"
+
+say "getfacl (if acl tools present)"
+if command -v getfacl >/dev/null 2>&1; then
+  getfacl -p "$DIST" 2>/dev/null || true
+  getfacl -p "$DIST/vendor" 2>/dev/null || true
+else
+  echo "getfacl not installed"
+fi
+
+say "find dirs NOT mode 2775 under dist"
+find "$DIST" -type d \! -perm 2775 -printf '%m %u:%g %p\n' | head -n 40
+
+say "find files NOT group-writable under dist"
+find "$DIST" -type f \! -perm -g+w -printf '%m %u:%g %p\n' | head -n 40
+
+say "write probe: can rsb create a file under dist/ ?"
+PROBE="$DIST/.__rsb_write_probe__.$$"
+if ( : > "$PROBE" ) 2>/tmp/probe.err; then
+  echo "OK: created $PROBE"
+  rm -f "$PROBE"
+else
+  echo "FAIL: cannot create $PROBE"
+  cat /tmp/probe.err
+fi
+
+say "write probe: can rsb create a file under dist/vendor/ ?"
+PROBE="$DIST/vendor/.__rsb_write_probe__.$$"
+if ( : > "$PROBE" ) 2>/tmp/probe.err; then
+  echo "OK: created $PROBE"
+  rm -f "$PROBE"
+else
+  echo "FAIL: cannot create $PROBE"
+  cat /tmp/probe.err
+fi
+
+say "utime probe: can rsb set mtime on dist/vendor/sqlite3.js ?"
+if [ -f "$DIST/vendor/sqlite3.js" ]; then
+  if touch -d '2024-01-01 00:00' "$DIST/vendor/sqlite3.js" 2>/tmp/probe.err; then
+    echo "OK"
+  else
+    echo "FAIL"
+    cat /tmp/probe.err
+  fi
+else
+  echo "(target file missing; skipping)"
+fi
+
+say "done"
+REMOTE


### PR DESCRIPTION
## Summary

Fix for the rsync permission failures seen on `./scripts/deploy_pwa.sh` after the two-identity migration. Two classes of errors were getting emitted together, which made the root cause hard to see:

- **`failed to set times on dist/., images, vendor`** — EPERM on `utime(2)`. Cosmetic, but noisy.
- **`mkstemp ".../vendor/..." Permission denied`** — EACCES on actual file writes. This was the real blocker.

### Root cause

Two independent drift issues, stacked:

1. **Orphan-UID subdirectories.** When the legacy `deploy` system user was removed in `site.yml`'s second play, its files stayed on disk but lost their user/group mapping. `dist/vendor/`, `dist/images/`, `dist/icons/` remained mode `0755` owned by orphan UID/GID `1001`. The role's "Detect legacy ownership" task only stat'd `/opt/fellows/deploy/dist` itself — which was healed by the earlier `file` task every run — so the recursive chown never fired.
2. **`rsync -a` strips setgid.** Even after ownership is fixed, `rsync -a` preserves source perms, which would chmod `dist/.` from `2775` down to the Mac source's `755`, silently breaking group-inheritance for new files on the next run.

### Changes

Six commits:

1. `fix(ansible): rsync --omit-dir-times …` — skips `utime(2)` on directories (silences the cosmetic EPERM).
2. `fix(ansible): rsync --no-perms …` — stops rsync from propagating source perms; preserves the `2775` setgid bit on the destination. Also stops EPERM on `chmod(2)` for non-owned files.
3. `fix(ansible): normalize dist tree ownership/modes on every deploy` — replaces the broken stat-based migration check with `find`-based detection that actually catches orphan-UID subtrees. Idempotent: only chowns/chmods entries that drift.
4. `feat(ansible): preflight write-probe before rsync` — runs as the operator (not root), creates+deletes a temp file in `dist/` and every subdirectory. Fails fast with the exact unwritable path instead of rsync's cryptic generator/receiver errors.
5. `chore(scripts): add diagnose_deploy_perms.sh` — read-only drift diagnostic that dumps id + mount + stat + find-drift + write/utime probes. No sudo, no state change.
6. `fix(ansible): preflight uses /bin/bash, not dash` — `executable: /bin/bash` so the bash process-substitution in the probe runs correctly on Ubuntu (where `/bin/sh` is dash).

### How this was verified

After applying a one-time unblock on the droplet (`chown -R fellows:fellows && find -type d -exec chmod 2775 + && find -type f -exec chmod 0664 +`), `./scripts/deploy_pwa.sh --ask-become-pass` now completes cleanly:

- Normalization reports `ok` / `skipping` (tree is already correct — idempotent).
- Preflight probe reports `ok`.
- Rsync: `changed` (files synced).
- Service restart handler fires.
- Smoke tests pass: `GET /healthz` → `ok`, `GET /manifest.webmanifest` → 200.

## Manual QA for the maintainer (post-merge)

- Re-run `./scripts/deploy_pwa.sh --ask-become-pass` from a clean checkout. Expect all normalization tasks to report `ok` / `skipping` (no drift), preflight to pass, rsync to report `ok` (no file changes), and the handler not to fire.
- Optional drift test: `ssh -p 52221 rsb@fellows.globaldonut.com 'sudo chmod 0755 /opt/fellows/deploy/dist/vendor'`, re-deploy, confirm the "Normalize dist directory modes" task reports `changed` and the deploy still succeeds.
- Optional sanity: `./scripts/diagnose_deploy_perms.sh` should now print no drift and both write probes should report OK.

🤖 Generated with [Claude Code](https://claude.com/claude-code)