### PR TITLE
fix(pwa): unstick clients on stale shell JS; suppress false update banner

### DIFF
--- a/app/static/app.js
+++ b/app/static/app.js
@@ -777,14 +777,16 @@
 
   function listenForSwUpdate(reg) {
     if (!reg || typeof reg.addEventListener !== 'function') return;
-    if (reg.waiting && navigator.serviceWorker.controller) {
+    // Snapshot: null here means this is a first-time install, not an update.
+    var hadControllerAtRegister = !!navigator.serviceWorker.controller;
+    if (reg.waiting && hadControllerAtRegister) {
       showSwUpdateBanner();
     }
     reg.addEventListener('updatefound', function () {
       var nw = reg.installing;
       if (!nw) return;
       nw.addEventListener('statechange', function () {
-        if (nw.state === 'installed' && navigator.serviceWorker.controller) {
+        if (nw.state === 'installed' && hadControllerAtRegister) {
           showSwUpdateBanner();
         }
       });
@@ -984,12 +986,29 @@
       });
   }
 
+  function reloadIfBuildChanged(currentBuild) {
+    if (!currentBuild) return false;
+    var key = 'fellows_last_seen_build';
+    var prev = null;
+    try { prev = localStorage.getItem(key); } catch (e) { return false; }
+    try { localStorage.setItem(key, currentBuild); } catch (e) {}
+    if (prev && prev !== currentBuild) {
+      authDebugPush('build changed ' + prev + ' → ' + currentBuild + '; reloading once');
+      try { window.location.reload(); } catch (e) {}
+      return true;
+    }
+    return false;
+  }
+
   function startBrowserUx() {
     authDebugLines.length = 0;
     authDebugPush('startBrowserUx: begin auth status check');
     fetch('/api/auth/status', { credentials: 'same-origin' })
       .then(function (r) {
         authDebugPush('/api/auth/status HTTP ' + r.status);
+        if (reloadIfBuildChanged(r.headers.get('X-Fellows-Build'))) {
+          return new Promise(function () {});
+        }
         if (!r.ok) {
           throw new Error('/api/auth/status failed with HTTP ' + r.status);
         }

--- a/app/static/sw.js
+++ b/app/static/sw.js
@@ -1,4 +1,4 @@
-const CACHE_VERSION = 'v6';
+const CACHE_VERSION = 'v7';
 const APP_SHELL_CACHE = `fellows-app-shell-${CACHE_VERSION}`;
 
 // fellows.db is fetched only after magic-link session (Phase 4); not precached here.
@@ -47,21 +47,25 @@ self.addEventListener('install', (event) => {
 });
 
 self.addEventListener('activate', (event) => {
-  event.waitUntil(
-    caches
-      .keys()
-      .then((keys) =>
-        Promise.all(
-          keys.map((key) => {
-            if (key.startsWith('fellows-app-shell-') && key !== APP_SHELL_CACHE) {
-              return caches.delete(key);
-            }
-            return Promise.resolve(false);
-          })
-        )
-      )
-      .then(() => self.clients.claim())
-  );
+  event.waitUntil((async () => {
+    const keys = await caches.keys();
+    const oldShellCaches = keys.filter(
+      (k) => k.startsWith('fellows-app-shell-') && k !== APP_SHELL_CACHE
+    );
+    await Promise.all(oldShellCaches.map((k) => caches.delete(k)));
+    await self.clients.claim();
+    // Burn-down: only force-reload controlled windows when we're replacing a
+    // prior shell cache. Rescues tabs stuck on stale in-memory app.js from a
+    // previous cacheFirst SW. First-time installs skip this.
+    if (oldShellCaches.length > 0) {
+      const wins = await self.clients.matchAll({ type: 'window' });
+      await Promise.all(
+        wins.map((w) => {
+          try { return w.navigate(w.url); } catch (e) { return null; }
+        })
+      );
+    }
+  })());
 });
 
 function shellPathNetworkFirst(pathname) {


### PR DESCRIPTION
## Summary

Rescues fellows whose browsers are running pre-Phase-4 `app.js` from an old `cacheFirst` service worker (which never shows the email gate and silently ignores Clear Cache/Reload). Three targeted fixes:

- **`sw.js` v7 burn-down.** On activate, if we delete an older `fellows-app-shell-*` cache (i.e. we're upgrading, not installing fresh), navigate every controlled window so the tab reloads under the new SW and picks up fresh `app.js`. Gate on "evicted a prior cache" prevents unexpected reloads on first-install clients (including Playwright test contexts).
- **`app.js` — false "New version available" banner.** `listenForSwUpdate` now snapshots `navigator.serviceWorker.controller` at register time. First-time installs (where controller starts null) no longer flash the banner.
- **`app.js` — defensive build-mismatch reload.** `startBrowserUx` compares `X-Fellows-Build` against `localStorage['fellows_last_seen_build']` and calls `location.reload()` once on mismatch. Catches any client whose SW/bfcache is serving stale in-memory JS that the SW burn-down can't reach.

Debug notes: traced to a tab that had the pre-Phase-4 `app.js` still in JS memory after the old SW was cleared. `window.clearAllAppData === undefined` in the running context was the tell (current code exports it; old code didn't). `/api/auth/status` correctly returned `{authEnabled: true, authenticated: false}` but the stale in-memory code path always un-hid `install-landing` without consulting auth.

## Test plan

- [x] `node --check app/static/sw.js app/static/app.js`
- [x] `./scripts/ensure_port_8765_free.sh tests/e2e/ -v` — 15/15 passed
- [ ] **Maintainer manual QA after deploy** (`./scripts/deploy_pwa.sh --ask-become-pass`):
  - [ ] Open `https://fellows.globaldonut.com/` in a browser that was previously stuck → should auto-reload and show the email gate within one navigation.
  - [ ] Open in a Chrome Guest profile → email gate on first visit, no "New version available" banner flash.
  - [ ] Complete a full magic-link round-trip (email → magic link → install landing → install PWA) and confirm nothing regressed.
  - [ ] `curl -sSI https://fellows.globaldonut.com/api/auth/status | grep -i x-fellows-build` returns the new build id; `localStorage['fellows_last_seen_build']` updates in DevTools after first visit.
  - [ ] Open a fresh incognito tab, watch DevTools Application → Service Workers — v7 installs, old `fellows-app-shell-v6` cache (if any) is deleted on activate, no reload loops.

🤖 Generated with [Claude Code](https://claude.com/claude-code)