### PR TITLE
fix(css): actually hide .sw-update-banner when .hidden class is applied

### DIFF
--- a/app/static/styles.css
+++ b/app/static/styles.css
@@ -809,6 +809,12 @@ h1 {
   flex-wrap: wrap;
 }
 
+/* Equal-specificity tie vs .hidden; both are 0,1,0 — .sw-update-banner is defined later
+   and would otherwise beat .hidden on source order. Needed to actually hide the banner. */
+.sw-update-banner.hidden {
+  display: none;
+}
+
 .sw-update-reload {
   padding: 0.35rem 0.75rem;
   font-size: 0.85rem;


### PR DESCRIPTION
## Summary

**This is the root cause of the permanent "New version available" banner**, found via the diagnostics added in #14.

\`.sw-update-banner\` and \`.hidden\` are both single-class selectors (specificity 0,1,0). \`.sw-update-banner { display: flex; }\` is declared at styles.css:797, *after* \`.hidden { display: none; }\` at line 123 — so on a specificity tie, source order wins and \`display: flex\` always beats \`display: none\`. The banner has been visible any time the element is in the DOM, regardless of whether JS ever called \`showSwUpdateBanner\`.

### Evidence from PR #14's diagnostics

Rich's browser reported:

\`\`\`
sw-update-banner visible=false shownReason=(none) shownAt=(never) hiddenAt=...
SW lifecycle log (5 events):
  window_load {"controllerAtLoad":null}
  register_resolved {"active":null,"waiting":null,"installing":"sw.js"}
  listen_start {"hadControllerAtRegister":false,...}
  controllerchange {...}
  banner_hide
\`\`\`

\`shownReason=(none)\`, \`shownAt=(never)\` — \`showSwUpdateBanner\` was **never called on that page load**. The classList-based \`visible=false\` says the \`.hidden\` class is on the element. But you see the banner. That can only be CSS not honoring \`.hidden\`.

### The fix

One rule, mirroring the pattern already used for \`.diag-panel.hidden\`, \`#app-wrap.hidden\`, \`.site-header.hidden\`, \`.install-landing.hidden\`:

\`\`\`css
.sw-update-banner.hidden {
  display: none;
}
\`\`\`

## Test plan

- [x] Playwright verification on local dev: \`#sw-update-banner\` with \`class="sw-update-banner hidden"\` now has computed \`display: none\` and \`offsetParent: null\` (previously \`display: flex\`, \`offsetParent\` the parent).
- [x] \`./scripts/ensure_port_8765_free.sh tests/e2e/ -v\` — 15/15 passed.
- [ ] **Maintainer manual QA after deploy**: visit \`https://fellows.globaldonut.com/\` in the browser that's been showing the banner; banner should be gone on the first fresh load.
- [ ] Optional: trigger the banner deliberately by deploying a byte-changing \`sw.js\` (e.g. bump \`CACHE_VERSION\` to \`v8\`) and verify the banner **does** appear on next visit as a genuine update notification.

## Related

- Diagnostic infrastructure that found this: #14
- Original PWA-unstick work that surfaced the symptom: #12

🤖 Generated with [Claude Code](https://claude.com/claude-code)