### PR TITLE
fix(pwa): redeem magic-link token before data load in standalone

### DIFF
--- a/app/static/app.js
+++ b/app/static/app.js
@@ -1767,7 +1767,8 @@
       });
     }
 
-    pickDataProvider()
+    tryUnlockFromHash()
+      .then(function () { return pickDataProvider(); })
       .then(function (provider) {
         dataProvider = provider;
         bootDebugPush('provider ready kind=' + provider.kind);


### PR DESCRIPTION
## Summary
- When the installed PWA is launched via a magic link, `app/static/app.js` took the standalone boot branch and skipped `tryUnlockFromHash()`, so `/api/verify-token` was never called, no session cookie was issued, and `/api/fellows` returned 403 — the directory failed to load with a boot-failure panel.
- Fix: gate `pickDataProvider()` behind `tryUnlockFromHash()` in the standalone branch so the token is redeemed and the session cookie is set before any API request.
- Also lands `scripts/repair_email_auth_env.sh` is **not** included here — it was a one-off server-side repair for a separate malformed `/etc/fellows/fellows-pwa.env` and doesn't belong in this PR.

## Manual QA (maintainer)
- [ ] `./scripts/deploy_pwa.sh --ask-become-pass` to push the new `app.js` to production.
- [ ] Reopen the installed PWA on desktop; accept the "New version available" banner.
- [ ] `curl -sS -X POST https://fellows.globaldonut.com/api/send-unlock -H 'content-type: application/json' -d '{"email":"<allowlisted>"}'` — or trigger via the unlock form.
- [ ] Click the magic link in the installed PWA. Expect: directory loads without a boot-failure panel.
- [ ] DevTools → Application → Cookies → `fellows.globaldonut.com`: `fellows_session` cookie is present (HttpOnly, Secure, SameSite=Strict).
- [ ] Confirm `/api/auth/status` reports `authenticated: true` after unlock.
- [ ] Non-standalone browser path still works (open `https://fellows.globaldonut.com/` in a regular tab, submit the email form, click link) — no regression.

🤖 Generated with [Claude Code](https://claude.com/claude-code)