### PR TITLE
feat(pwa): image prewarm + three-state image UX + images-cache diagnostics

### DIFF
--- a/app/server.py
+++ b/app/server.py
@@ -29,6 +29,7 @@ FELLOW_COLUMNS = [
     "contact_email", "key_links", "key_links_urls", "image_url",
     "currently_based_in", "search_tags", "fellow_status", "gender_pronouns",
     "ethnicity", "primary_citizenship", "global_regions_currently_based_in",
+    "has_image",
 ]
 
 

--- a/app/static/app.js
+++ b/app/static/app.js
@@ -44,14 +44,100 @@
   var bootDebugLines = [];
   var authDebugLines = [];
   var swLifecycleLog = [];
+  var imagePrewarmState = {
+    status: 'idle',
+    total: 0,
+    loaded: 0,
+    errors: 0,
+    startedAt: null,
+    finishedAt: null,
+    reason: null
+  };
   /** Bump when changing diagnostics behavior (shown in Diagnostics panel). */
-  var FELLOWS_UI_DIAG = 'diag-2026-04d-sw-trace';
+  var FELLOWS_UI_DIAG = 'diag-2026-04e-image-prewarm';
 
   function logSwLifecycle(event, detail) {
     swLifecycleLog.push({
       t: new Date().toISOString(),
       event: event,
       detail: detail != null ? detail : null
+    });
+  }
+
+  function prewarmProfileImages(fellows) {
+    if (!Array.isArray(fellows) || !fellows.length) {
+      imagePrewarmState.status = 'skipped-empty';
+      return Promise.resolve();
+    }
+    try {
+      var conn = navigator.connection || navigator.mozConnection || navigator.webkitConnection;
+      if (conn && conn.saveData) {
+        imagePrewarmState.status = 'skipped-save-data';
+        imagePrewarmState.reason = 'navigator.connection.saveData=true';
+        return Promise.resolve();
+      }
+    } catch (e) {}
+
+    var eligible = fellows.filter(function (f) {
+      return (f.has_image === 1 || f.has_image === true) && f.slug;
+    });
+    imagePrewarmState.total = eligible.length;
+    imagePrewarmState.loaded = 0;
+    imagePrewarmState.errors = 0;
+    imagePrewarmState.status = 'running';
+    imagePrewarmState.startedAt = new Date().toISOString();
+
+    if (!eligible.length) {
+      imagePrewarmState.status = 'done';
+      imagePrewarmState.finishedAt = new Date().toISOString();
+      return Promise.resolve();
+    }
+
+    var queue = eligible.slice();
+    var CONCURRENCY = 6;
+
+    function next() {
+      var f = queue.shift();
+      if (!f) return null;
+      var url = '/images/' + encodeURIComponent(f.slug) + '.jpg';
+      return fetch(url, { cache: 'default', credentials: 'same-origin' })
+        .then(function (r) {
+          if (r && r.ok) {
+            imagePrewarmState.loaded += 1;
+          } else {
+            imagePrewarmState.errors += 1;
+          }
+        })
+        .catch(function () {
+          imagePrewarmState.errors += 1;
+        })
+        .then(next);
+    }
+
+    var starters = [];
+    for (var i = 0; i < CONCURRENCY; i++) starters.push(next());
+    return Promise.all(starters).then(function () {
+      imagePrewarmState.status = 'done';
+      imagePrewarmState.finishedAt = new Date().toISOString();
+    });
+  }
+
+  function countCachedImages() {
+    if (!('caches' in self)) return Promise.resolve(null);
+    return caches.keys().then(function (keys) {
+      var imagesKey = keys.indexOf('fellows-images-v1') !== -1
+        ? 'fellows-images-v1'
+        : keys.filter(function (k) { return k.indexOf('fellows-') === 0; })[0];
+      if (!imagesKey) return { key: null, count: 0 };
+      return caches.open(imagesKey).then(function (c) {
+        return c.keys().then(function (reqs) {
+          var count = 0;
+          for (var i = 0; i < reqs.length; i++) {
+            if (reqs[i].url.indexOf('/images/') !== -1) count += 1;
+          }
+          return { key: imagesKey, count: count };
+        });
+      });
     });
   }
 
@@ -72,7 +158,8 @@
     'gender_pronouns',
     'ethnicity',
     'primary_citizenship',
-    'global_regions_currently_based_in'
+    'global_regions_currently_based_in',
+    'has_image'
   ];
 
   function rowSqliteToFellow(row) {
@@ -605,6 +692,26 @@
       } catch (e4) {
         lines.push('caches.keys error: ' + String(e4 && e4.message));
       }
+      try {
+        var imgStat = await countCachedImages();
+        if (imgStat) {
+          lines.push(
+            'Profile images cached: ' + imgStat.count +
+              ' (cache=' + (imgStat.key || '(none)') + ')'
+          );
+        }
+      } catch (e5) {
+        lines.push('image-cache count error: ' + String(e5 && e5.message));
+      }
+      lines.push(
+        'Image prewarm: status=' + imagePrewarmState.status +
+          ' loaded=' + imagePrewarmState.loaded +
+          '/' + imagePrewarmState.total +
+          ' errors=' + imagePrewarmState.errors +
+          (imagePrewarmState.reason ? ' reason=' + imagePrewarmState.reason : '') +
+          (imagePrewarmState.startedAt ? ' started=' + imagePrewarmState.startedAt : '') +
+          (imagePrewarmState.finishedAt ? ' finished=' + imagePrewarmState.finishedAt : '')
+      );
     }
     lines.push('');
     lines.push(
@@ -1208,7 +1315,19 @@
     var demo = [fellow.gender_pronouns, fellow.ethnicity].filter(Boolean).join(' | ');
     leftTop += '<h2 class="detail-name">' + escapeHtml(name) + '</h2>';
     if (demo) leftTop += '<p class="detail-demographics">' + escapeHtml(demo) + '</p>';
-    leftTop += '<div class="profile-image-wrap"><img class="profile-image" data-slug="' + escapeHtml(slug) + '" src="/images/' + escapeHtml(slug) + '.jpg" alt="' + escapeHtml(name) + '"></div>';
+    var hasImage = fellow.has_image === 1 || fellow.has_image === true;
+    if (hasImage && slug) {
+      leftTop +=
+        '<div class="profile-image-wrap profile-image-wrap--loading" data-slug="' + escapeHtml(slug) + '">' +
+          '<img class="profile-image" data-slug="' + escapeHtml(slug) + '" src="/images/' + escapeHtml(slug) + '.jpg" alt="' + escapeHtml(name) + '">' +
+          '<span class="profile-image-status profile-image-status--loading">Loading… just a sec.</span>' +
+        '</div>';
+    } else {
+      leftTop +=
+        '<div class="profile-image-wrap profile-image-wrap--none" data-slug="' + escapeHtml(slug) + '">' +
+          '<span class="profile-image-status profile-image-status--none">Not Submitted</span>' +
+        '</div>';
+    }
     if (fellow.bio_tagline) leftTop += '<p class="detail-tagline">' + escapeHtml(fellow.bio_tagline) + '</p>';
 
     var howRows = [];
@@ -1289,25 +1408,44 @@
 
     var img = detailEl.querySelector('.profile-image');
     if (img) {
-      img.onerror = function () {
-        var s = img.getAttribute('data-slug');
-        if (img.src.indexOf('.png') === -1 && s) {
-          img.src = '/images/' + s + '.png';
-          img.onerror = function () { showImagePlaceholder(img); };
-        } else {
-          showImagePlaceholder(img);
+      var wrap = img.parentNode;
+      var markLoaded = function () {
+        wrap.classList.remove('profile-image-wrap--loading');
+        wrap.classList.add('profile-image-wrap--loaded');
+      };
+      var markNone = function () {
+        wrap.classList.remove('profile-image-wrap--loading');
+        wrap.classList.add('profile-image-wrap--none');
+        var status = wrap.querySelector('.profile-image-status');
+        if (status) {
+          status.className = 'profile-image-status profile-image-status--none';
+          status.textContent = 'Not Submitted';
         }
       };
+      // Image already decoded (served from Cache Storage / memory) — skip the
+      // loading flash entirely.
+      if (img.complete && img.naturalWidth > 0) {
+        markLoaded();
+      } else if (img.complete) {
+        markNone();
+      } else {
+        img.addEventListener('load', markLoaded, { once: true });
+        img.addEventListener(
+          'error',
+          function () {
+            var s = img.getAttribute('data-slug');
+            if (s && img.src.indexOf('.png') === -1) {
+              img.src = '/images/' + s + '.png';
+              img.addEventListener('load', markLoaded, { once: true });
+              img.addEventListener('error', markNone, { once: true });
+            } else {
+              markNone();
+            }
+          },
+          { once: true }
+        );
+      }
     }
-  }
-
-  function showImagePlaceholder(imgEl) {
-    imgEl.onerror = null;
-    imgEl.style.display = 'none';
-    var p = document.createElement('span');
-    p.className = 'placeholder';
-    p.textContent = 'No image';
-    imgEl.parentNode.appendChild(p);
   }
 
   function escapeHtml(s) {
@@ -1800,6 +1938,12 @@
           });
         }
         route();
+        // Kick off image prewarm in the background — does not block UI.
+        if (Array.isArray(full)) {
+          setTimeout(function () {
+            prewarmProfileImages(full).catch(function () {});
+          }, 0);
+        }
       })
       .catch(function (err) {
         showBootFailure(err);

--- a/app/static/styles.css
+++ b/app/static/styles.css
@@ -468,6 +468,9 @@ h1 {
 
 .profile-image-wrap {
   margin-bottom: 0.75rem;
+  position: relative;
+  width: 200px;
+  height: 200px;
 }
 
 .detail img.profile-image {
@@ -476,6 +479,51 @@ h1 {
   height: 200px;
   object-fit: cover;
   display: block;
+}
+
+/* Hide the image while loading so the status label occupies the box. */
+.profile-image-wrap--loading .profile-image {
+  visibility: hidden;
+}
+
+.profile-image-wrap--loaded .profile-image-status {
+  display: none;
+}
+
+.profile-image-wrap--none .profile-image {
+  display: none;
+}
+
+.profile-image-status {
+  position: absolute;
+  inset: 0;
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  padding: 0.75rem;
+  border: 1px solid #c9c2d4;
+  border-radius: 4px;
+  background: #faf8fc;
+  font-size: 0.9rem;
+  text-align: center;
+  box-sizing: border-box;
+}
+
+.profile-image-status--loading {
+  color: #5a4578;
+  font-style: italic;
+  animation: profile-image-pulse 1.6s ease-in-out infinite;
+}
+
+.profile-image-status--none {
+  color: #8a7c9f;
+  background: #f2eff7;
+  font-weight: 500;
+}
+
+@keyframes profile-image-pulse {
+  0%, 100% { opacity: 0.55; }
+  50% { opacity: 1; }
 }
 
 .detail .field {

--- a/app/static/sw.js
+++ b/app/static/sw.js
@@ -1,5 +1,7 @@
 const CACHE_VERSION = 'v7';
 const APP_SHELL_CACHE = `fellows-app-shell-${CACHE_VERSION}`;
+// Separate cache so shell-version bumps don't evict the ~34 MB of profile images.
+const IMAGES_CACHE = 'fellows-images-v1';
 
 // fellows.db is fetched only after magic-link session (Phase 4); not precached here.
 const APP_SHELL_ASSETS = [
@@ -95,10 +97,16 @@ self.addEventListener('fetch', (event) => {
     return;
   }
 
-  event.respondWith(cacheFirst(request));
+  // Profile images get their own long-lived cache.
+  if (url.pathname.startsWith('/images/')) {
+    event.respondWith(cacheFirstInto(request, IMAGES_CACHE));
+    return;
+  }
+
+  event.respondWith(cacheFirstInto(request, APP_SHELL_CACHE));
 });
 
-function cacheFirst(request) {
+function cacheFirstInto(request, cacheName) {
   return caches.match(request).then((cached) => {
     if (cached) {
       return cached;
@@ -108,7 +116,7 @@ function cacheFirst(request) {
         return response;
       }
       const responseToCache = response.clone();
-      caches.open(APP_SHELL_CACHE).then((cache) => {
+      caches.open(cacheName).then((cache) => {
         cache.put(request, responseToCache);
       });
       return response;

--- a/build/import_json_to_sqlite.py
+++ b/build/import_json_to_sqlite.py
@@ -20,6 +20,8 @@ from pathlib import Path
 REPO_ROOT = Path(__file__).resolve().parent.parent
 JSON_PATH = Path(sys.argv[1]) if len(sys.argv) > 1 else REPO_ROOT / "final_fellows_set" / "ehf_fellow_profiles_deduped.json"
 DB_PATH = REPO_ROOT / "app" / "fellows.db"
+IMAGES_DIR_SOURCE = REPO_ROOT / "final_fellows_set" / "fellow_profile_images_by_name"
+IMAGES_DIR_APP = REPO_ROOT / "app" / "fellow_profile_images_by_name"
 
 # Columns we store explicitly for display/search; rest go into extra_json
 FELLOW_COLUMNS = [
@@ -40,8 +42,43 @@ FELLOW_COLUMNS = [
     "ethnicity",
     "primary_citizenship",
     "global_regions_currently_based_in",
+    "has_image",
 ]
 EXTRA_JSON_KEYS = None  # All keys not in FELLOW_COLUMNS go into extra_json
+
+
+def _pick_images_dir():
+    if IMAGES_DIR_SOURCE.is_dir():
+        return IMAGES_DIR_SOURCE
+    if IMAGES_DIR_APP.is_dir():
+        return IMAGES_DIR_APP
+    return None
+
+
+def build_image_index():
+    """Map alpha-normalized filename stem → Path for O(1) slug lookup.
+
+    Mirrors app/server.py:find_image() behavior: prefer exact stem, else fuzzy
+    alpha-only match (handles slug/filename underscore/hyphen differences).
+    """
+    images_dir = _pick_images_dir()
+    if images_dir is None:
+        return {}
+    index = {}
+    for p in images_dir.iterdir():
+        if not p.is_file() or p.suffix.lower() not in (".jpg", ".jpeg", ".png"):
+            continue
+        stem_alpha = re.sub(r"[^a-z0-9]", "", p.stem.lower())
+        if stem_alpha and stem_alpha not in index:
+            index[stem_alpha] = p
+    return index
+
+
+def slug_has_image(slug: str, image_index: dict) -> int:
+    if not slug or not image_index:
+        return 0
+    base_alpha = re.sub(r"[^a-z0-9]", "", slug.split("/")[-1].split(".")[0].lower())
+    return 1 if base_alpha in image_index else 0
 
 
 def slugify(text: str) -> str:
@@ -80,7 +117,7 @@ def serialize_value(v):
     return str(v).strip() or None
 
 
-def build_row(record: dict) -> tuple:
+def build_row(record: dict, image_index: dict) -> tuple:
     """Build a single row for fellows table (order matches FELLOW_COLUMNS + extra_json)."""
     slug = record.get("_slug") or get_slug(record)
     name = get_name(record)
@@ -102,6 +139,7 @@ def build_row(record: dict) -> tuple:
         "ethnicity": serialize_value(record.get("ethnicity")),
         "primary_citizenship": serialize_value(record.get("primary_citizenship")),
         "global_regions_currently_based_in": serialize_value(record.get("global_regions_currently_based_in")),
+        "has_image": slug_has_image(slug, image_index),
     }
     extra = {k: v for k, v in record.items() if k not in FELLOW_COLUMNS}
     row["extra_json"] = json.dumps(extra) if extra else None
@@ -149,9 +187,11 @@ def main():
     conn = sqlite3.connect(DB_PATH)
     conn.row_factory = sqlite3.Row
 
-    # Create fellows table
+    # Drop + recreate so schema changes (e.g. new columns) apply cleanly.
+    conn.execute("DROP TABLE IF EXISTS fellows_fts")
+    conn.execute("DROP TABLE IF EXISTS fellows")
     conn.execute("""
-        CREATE TABLE IF NOT EXISTS fellows (
+        CREATE TABLE fellows (
             record_id TEXT PRIMARY KEY,
             slug TEXT NOT NULL,
             name TEXT,
@@ -169,23 +209,24 @@ def main():
             ethnicity TEXT,
             primary_citizenship TEXT,
             global_regions_currently_based_in TEXT,
+            has_image INTEGER NOT NULL DEFAULT 0,
             extra_json TEXT
         )
     """)
     conn.execute("CREATE UNIQUE INDEX IF NOT EXISTS idx_fellows_slug ON fellows(slug)")
 
-    conn.execute("DELETE FROM fellows")
+    image_index = build_image_index()
+
     cols = FELLOW_COLUMNS + ["extra_json"]
     placeholders = ",".join("?" * len(cols))
     for r in records:
-        row = build_row(r)
+        row = build_row(r, image_index)
         conn.execute(
             f"INSERT OR REPLACE INTO fellows ({','.join(cols)}) VALUES ({placeholders})",
             row,
         )
 
     # FTS5 virtual table (external content) over fellows
-    conn.execute("DROP TABLE IF EXISTS fellows_fts")
     conn.execute("""
         CREATE VIRTUAL TABLE fellows_fts USING fts5(
             name,
@@ -202,9 +243,10 @@ def main():
 
     conn.commit()
     count = conn.execute("SELECT COUNT(*) FROM fellows").fetchone()[0]
+    with_image = conn.execute("SELECT COUNT(*) FROM fellows WHERE has_image = 1").fetchone()[0]
     conn.close()
 
-    print(f"Imported {count} fellows into {DB_PATH}")
+    print(f"Imported {count} fellows into {DB_PATH} ({with_image} with profile image)")
     print("Verify: sqlite3 app/fellows.db \"SELECT name, slug FROM fellows ORDER BY name LIMIT 3;\"")
     print("FTS5:   sqlite3 app/fellows.db \"SELECT rowid, name FROM fellows_fts WHERE fellows_fts MATCH 'Aaron';\"")
     return 0

--- a/deploy/sqlite_api_support.py
+++ b/deploy/sqlite_api_support.py
@@ -25,6 +25,7 @@ FELLOW_COLUMNS = [
     "ethnicity",
     "primary_citizenship",
     "global_regions_currently_based_in",
+    "has_image",
 ]
 
 

--- a/tests/e2e/test_detail_view.py
+++ b/tests/e2e/test_detail_view.py
@@ -19,7 +19,7 @@ class TestDetailView:
         assert has_image or has_placeholder or "Aaron Bird" in detail.inner_text()
 
     def test_direct_hash_shows_fellow_detail(self, standalone_page, base_url_fixture):
-        """Navigate to #/fellow/aaron_bird - name, at least one other field, image or placeholder."""
+        """Navigate to #/fellow/aaron_bird — name, at least one other field, image box present."""
         standalone_page.goto(base_url_fixture + "/#/fellow/aaron_bird", wait_until="networkidle")
         standalone_page.locator("#loading").wait_for(state="hidden", timeout=10000)
         detail = standalone_page.locator("#detail")
@@ -29,29 +29,30 @@ class TestDetailView:
         assert any(
             label in text for label in ["Tagline", "Cohort", "Type", "Email", "Based in", "Links"]
         ), "Detail should show at least one field (Tagline, Cohort, Type, etc.)"
-        has_img = standalone_page.locator("#detail .profile-image").count() >= 1
-        has_placeholder = "No image" in text or "Select a fellow" in text
-        assert has_img or has_placeholder, "Detail should show profile image or 'No image' placeholder"
+        # Contract: a .profile-image-wrap is rendered for every fellow detail.
+        assert standalone_page.locator("#detail .profile-image-wrap").count() == 1
 
-    def test_detail_shows_placeholder_when_no_image(self, standalone_page, base_url_fixture):
-        """Fellow without image shows placeholder (image 404 -> 'No image')."""
+    def test_detail_image_settles_into_terminal_state(self, standalone_page, base_url_fixture):
+        """Image box settles into either loaded (image visible) or none ('Not Submitted');
+        never stuck in loading after a short wait."""
         standalone_page.goto(base_url_fixture + "/#/fellow/aaron_bird", wait_until="networkidle")
         standalone_page.locator("#loading").wait_for(state="hidden", timeout=10000)
         detail = standalone_page.locator("#detail")
         detail.wait_for(state="visible", timeout=5000)
         standalone_page.wait_for_function(
             """() => {
-              const d = document.getElementById('detail');
-              if (!d) return false;
-              const img = d.querySelector('.profile-image');
-              const ph = d.querySelector('.placeholder');
-              return (img && img.offsetParent !== null) || (ph && ph.textContent.includes('No image'));
+              const wrap = document.querySelector('#detail .profile-image-wrap');
+              if (!wrap) return false;
+              return wrap.classList.contains('profile-image-wrap--loaded')
+                  || wrap.classList.contains('profile-image-wrap--none');
             }""",
             timeout=5000,
         )
         text = detail.inner_text()
         assert "Aaron Bird" in text
-        assert standalone_page.locator("#detail .profile-image").is_visible() or "No image" in text
+        has_loaded = standalone_page.locator("#detail .profile-image-wrap--loaded").count() == 1
+        has_not_submitted = "Not Submitted" in text
+        assert has_loaded or has_not_submitted
 
     def test_nav_arrows_visible_on_screen(self, standalone_page, base_url_fixture):
         """Both arrows are rendered, visually visible, and appear in a screenshot."""

--- a/tests/test_database.py
+++ b/tests/test_database.py
@@ -79,6 +79,14 @@ def test_schema_has_expected_columns(db):
         "contact_email", "key_links", "key_links_urls", "image_url",
         "currently_based_in", "search_tags", "fellow_status", "gender_pronouns",
         "ethnicity", "primary_citizenship", "global_regions_currently_based_in",
-        "extra_json",
+        "has_image", "extra_json",
     }
     assert expected.issubset(columns), f"Missing columns: {expected - columns}"
+
+
+def test_has_image_is_boolean_and_consistent(db):
+    """has_image is always 0 or 1; counts partition the table."""
+    total = db.execute("SELECT COUNT(*) FROM fellows").fetchone()[0]
+    with_image = db.execute("SELECT COUNT(*) FROM fellows WHERE has_image = 1").fetchone()[0]
+    without_image = db.execute("SELECT COUNT(*) FROM fellows WHERE has_image = 0").fetchone()[0]
+    assert with_image + without_image == total, "has_image must always be 0 or 1"


### PR DESCRIPTION
## Summary

Makes the PWA fully offline-capable for fellow photos and gives the detail view an unambiguous signal for every fellow: **loaded image**, **"Loading… just a sec."**, or **"Not Submitted"**. No more guessing whether to wait.

### Schema
- New \`has_image INTEGER\` column on \`fellows\`, populated at import time by matching each slug against files in \`final_fellows_set/fellow_profile_images_by_name/\` using the same alpha-normalized fuzzy match the server already does.
- Build script now \`DROP + CREATE\`s the table so schema changes apply on rebuild without silent drift.

### Client UX
- Detail view always renders a \`.profile-image-wrap\` with exactly one of three state classes:
  - \`--loading\` → \`<img>\` with \`visibility: hidden\`, pulsing "Loading… just a sec." overlay until \`onload\` fires.
  - \`--loaded\` → image visible, overlay gone.
  - \`--none\` → "Not Submitted" overlay, no network request.
- Already-cached images paint instantly: \`img.complete && img.naturalWidth > 0\` at mount skips the loading flash.
- Background prewarm after DB bootstrap: \`prewarmProfileImages()\` fetches every \`/images/<slug>.jpg\` for \`has_image=1\` fellows with concurrency cap 6. Respects \`navigator.connection.saveData\`. Non-blocking.

### Service worker
- New \`IMAGES_CACHE = 'fellows-images-v1'\` separate from the shell cache. Bumping \`CACHE_VERSION\` now only evicts \`fellows-app-shell-*\` — the ~34 MB of profile images survive shell upgrades.
- \`/images/*\` requests route to their own \`cacheFirstInto(IMAGES_CACHE)\`.

### Diagnostics (\`FELLOWS_UI_DIAG = diag-2026-04e-image-prewarm\`)
- \`Profile images cached: <n> (cache=fellows-images-v1)\`
- \`Image prewarm: status=<idle|running|done|skipped-save-data|skipped-empty> loaded=<n>/<total> errors=<n> [reason=…] [started=…] [finished=…]\`

### Bandwidth rationale
34 MB one-shot on install is fine on broadband and acceptable on cellular. Browser's own 6-per-origin HTTP/1.1 connection cap is the concurrency ceiling; \`saveData\` is the opt-out. No byte-rate throttling — premature for this size.

## Test plan

- [x] \`./scripts/ensure_port_8765_free.sh tests/ -v\` — 39/39 passed (added \`test_has_image_is_boolean_and_consistent\` and updated two e2e detail tests to the new contract).
- [x] Rebuilt local \`app/fellows.db\` with the new column: 442 fellows, 128 with \`has_image=1\` (reflects the subset of images available in this clone).
- [x] \`node --check\` clean on \`app.js\` and \`sw.js\`; Python \`ast.parse\` clean on build + server + helper.
- [ ] **Maintainer manual QA after deploy**:
  - [ ] Fresh install (new profile / incognito PWA install). Open Diagnostics during and after first launch; \`Image prewarm\` should progress \`running → done\` with \`loaded ≈ total\`.
  - [ ] Visit a fellow with a photo — image should either paint instantly (already cached) or show "Loading… just a sec." briefly.
  - [ ] Visit a fellow known to have no photo — box reads "Not Submitted" immediately, no network request for images.
  - [ ] Toggle OS-level Data Saver / airplane mode before first launch; prewarm status should read \`skipped-save-data\` or \`errors>0\` without crashing.
  - [ ] Bump \`CACHE_VERSION\` to \`v8\` in a follow-up, deploy, observe that profile images stay cached across the upgrade (Diagnostics: cache key remains \`fellows-images-v1\`).

## Related

- Sets up the "fully offline" use case Rich described when asking how to check image coverage.
- Builds on diagnostics infrastructure from #14.

🤖 Generated with [Claude Code](https://claude.com/claude-code)