### PR TITLE
feat(pwa): source_name fallback + 'has email' filter

### DIFF
--- a/app/server.py
+++ b/app/server.py
@@ -75,12 +75,18 @@ def get_all_fellows(conn) -> list:
 
 
 def get_fellows_list(conn) -> list:
-    """Minimal list for instant directory: record_id, slug, name only."""
+    """Minimal list for instant directory: record_id, slug, name, has_contact_email."""
     cur = conn.execute(
-        "SELECT record_id, slug, name FROM fellows ORDER BY name ASC"
+        "SELECT record_id, slug, name,"
+        " CASE WHEN contact_email IS NOT NULL AND contact_email != '' THEN 1 ELSE 0 END"
+        " AS has_contact_email"
+        " FROM fellows ORDER BY name ASC"
     )
     rows = cur.fetchall()
-    return [{"record_id": r[0], "slug": r[1], "name": r[2]} for r in rows]
+    return [
+        {"record_id": r[0], "slug": r[1], "name": r[2], "has_contact_email": bool(r[3])}
+        for r in rows
+    ]
 
 
 def get_fellow_by_slug_or_id(conn, slug_or_id: str) -> dict | None:

--- a/app/static/app.js
+++ b/app/static/app.js
@@ -19,6 +19,10 @@
   var searchInputEl = document.getElementById('search-input');
   var searchStatusEl = document.getElementById('search-status');
   var searchDebounceId = null;
+  var hasEmailFilterEl = document.getElementById('has-email-filter');
+  var filterCountEl = document.getElementById('filter-count');
+  var HAS_EMAIL_FILTER_KEY = 'ehf_has_email_only';
+  var hasEmailOnly = loadHasEmailFilter();
   var nlSearchContainerEl = document.getElementById('nl-search-container');
   var nlSearchInputEl = document.getElementById('nl-search-input');
   var nlSearchButtonEl = document.getElementById('nl-search-button');
@@ -321,9 +325,22 @@
     return {
       kind: 'sqlite',
       getList: function () {
-        return Promise.resolve(
-          dbSelectAll(db, 'SELECT record_id, slug, name FROM fellows ORDER BY name ASC', null)
+        var rows = dbSelectAll(
+          db,
+          'SELECT record_id, slug, name,' +
+            " CASE WHEN contact_email IS NOT NULL AND contact_email != '' THEN 1 ELSE 0 END" +
+            ' AS has_contact_email' +
+            ' FROM fellows ORDER BY name ASC',
+          null
         );
+        return Promise.resolve(rows.map(function (r) {
+          return {
+            record_id: r.record_id,
+            slug: r.slug,
+            name: r.name,
+            has_contact_email: r.has_contact_email === 1 || r.has_contact_email === true
+          };
+        }));
       },
       getFull: function () {
         var rows = dbSelectAll(db, 'SELECT * FROM fellows ORDER BY name ASC', null);
@@ -1229,6 +1246,33 @@
     if (appWrapEl) appWrapEl.classList.toggle('hidden', !show);
   }
 
+  function loadHasEmailFilter() {
+    try {
+      var v = localStorage.getItem(HAS_EMAIL_FILTER_KEY);
+      if (v === '0') return false;
+      if (v === '1') return true;
+    } catch (e) {}
+    return true;
+  }
+
+  function saveHasEmailFilter(v) {
+    try { localStorage.setItem(HAS_EMAIL_FILTER_KEY, v ? '1' : '0'); } catch (e) {}
+  }
+
+  function fellowHasEmail(f) {
+    if (f.has_contact_email === true || f.has_contact_email === 1) return true;
+    return !!(f.contact_email && String(f.contact_email).trim());
+  }
+
+  function applyHasEmailFilter(items) {
+    if (!hasEmailOnly) return items;
+    return items.filter(fellowHasEmail);
+  }
+
+  function setFilterCount(msg) {
+    if (filterCountEl) filterCountEl.textContent = msg || '';
+  }
+
   function renderDirectoryList(items) {
     var ul = document.createElement('ul');
     items.forEach(function (f) {
@@ -1247,10 +1291,22 @@
   function renderDirectory() {
     if (!list.length) {
       directoryListEl.innerHTML = '<p class="placeholder">No fellows loaded.</p>';
+      setFilterCount('');
       return;
     }
-    renderDirectoryList(list);
-    displayedList = list;
+    var filtered = applyHasEmailFilter(list);
+    if (!filtered.length) {
+      directoryListEl.innerHTML = '<p class="placeholder">No fellows match the current filter.</p>';
+      displayedList = [];
+    } else {
+      renderDirectoryList(filtered);
+      displayedList = filtered;
+    }
+    setFilterCount(
+      filtered.length === list.length
+        ? list.length + ' fellows'
+        : filtered.length + ' of ' + list.length + ' fellows'
+    );
     if (loadingPanelEl) {
       loadingPanelEl.classList.add('hidden');
     }
@@ -1598,14 +1654,7 @@
               fellowsBySlug.set(f.record_id, f);
             }
           });
-          if (!results.length) {
-            directoryListEl.innerHTML = '<p class="placeholder">No fellows match that search.</p>';
-            setSearchStatus('');
-          } else {
-            renderDirectoryList(results);
-            displayedList = results;
-            setSearchStatus(results.length + ' result' + (results.length === 1 ? '' : 's') + ' found');
-          }
+          renderSearchResults(results, 'result');
         })
         .catch(function () {
           setSearchStatus('Search failed.');
@@ -1636,19 +1685,36 @@
             fellowsBySlug.set(f.record_id, f);
           }
         });
-        if (!results.length) {
-          directoryListEl.innerHTML = '<p class="placeholder">No fellows match that search.</p>';
-          setSearchStatus('');
-        } else {
-          renderDirectoryList(results);
-          displayedList = results;
-          setSearchStatus(results.length + ' result' + (results.length === 1 ? '' : 's') + ' found');
-        }
+        renderSearchResults(results, 'result');
       })
       .catch(function () {
         setSearchStatus('Network search failed. Trying cached data…');
         runLocalSearch(q);
       });
+  }
+
+  function renderSearchResults(results, label) {
+    var total = results.length;
+    var filtered = applyHasEmailFilter(results);
+    displayedList = filtered;
+    setFilterCount('');
+    if (!filtered.length) {
+      if (!total) {
+        directoryListEl.innerHTML = '<p class="placeholder">No fellows match that search.</p>';
+      } else {
+        directoryListEl.innerHTML =
+          '<p class="placeholder">No fellows match that search with the current filter.</p>';
+      }
+      setSearchStatus('');
+      return;
+    }
+    renderDirectoryList(filtered);
+    var suffix = filtered.length === 1 ? '' : 's';
+    var msg = filtered.length + ' ' + label + suffix + ' found';
+    if (filtered.length !== total) {
+      msg += ' (' + total + ' before filter)';
+    }
+    setSearchStatus(msg);
   }
 
   function runLocalSearch(q) {
@@ -1667,14 +1733,7 @@
           fellowsBySlug.set(f.record_id, f);
         }
       });
-      if (!results.length) {
-        directoryListEl.innerHTML = '<p class="placeholder">No fellows match that search in cached data.</p>';
-        setSearchStatus('');
-      } else {
-        renderDirectoryList(results);
-        displayedList = results;
-        setSearchStatus(results.length + ' offline result' + (results.length === 1 ? '' : 's') + ' found');
-      }
+      renderSearchResults(results, 'offline result');
     }).catch(function () {
       directoryListEl.innerHTML = '<p class="placeholder">Offline search failed.</p>';
       setSearchStatus('');
@@ -1970,6 +2029,20 @@
         searchDebounceId = setTimeout(function () {
           handleSearchInput();
         }, 250);
+      });
+    }
+
+    if (hasEmailFilterEl) {
+      hasEmailFilterEl.checked = hasEmailOnly;
+      hasEmailFilterEl.addEventListener('change', function () {
+        hasEmailOnly = !!hasEmailFilterEl.checked;
+        saveHasEmailFilter(hasEmailOnly);
+        var q = (searchInputEl && searchInputEl.value || '').trim();
+        if (q) {
+          runSearch(q);
+        } else {
+          renderDirectory();
+        }
       });
     }
 

--- a/app/static/index.html
+++ b/app/static/index.html
@@ -87,6 +87,13 @@
         placeholder="Search by name, tags, cohort…"
         autocomplete="off"
       />
+      <div class="filter-row">
+        <label class="filter-checkbox">
+          <input type="checkbox" id="has-email-filter" checked />
+          <span>has email</span>
+        </label>
+        <span id="filter-count" class="filter-count" aria-live="polite"></span>
+      </div>
       <p id="search-status" class="search-status" aria-live="polite"></p>
     </div>
     <nav class="site-nav">

--- a/app/static/styles.css
+++ b/app/static/styles.css
@@ -230,6 +230,33 @@ h1 {
   color: #555;
 }
 
+.filter-row {
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+  gap: 0.75rem;
+  margin: 0.4rem 0 0;
+  font-size: 0.85rem;
+  color: #333;
+}
+
+.filter-checkbox {
+  display: inline-flex;
+  align-items: center;
+  gap: 0.35rem;
+  cursor: pointer;
+  user-select: none;
+}
+
+.filter-checkbox input {
+  margin: 0;
+}
+
+.filter-count {
+  font-size: 0.8rem;
+  color: #555;
+}
+
 .nl-search-container {
   margin-top: 0.75rem;
 }

--- a/build/import_json_to_sqlite.py
+++ b/build/import_json_to_sqlite.py
@@ -91,21 +91,26 @@ def slugify(text: str) -> str:
 
 
 def get_slug(record: dict) -> str:
-    """Get slug from name or table_name; fallback to record_id."""
-    name = (record.get("name") or "").strip()
-    table_name = (record.get("table_name") or "").strip()
-    display = name or table_name
+    """Get slug from name, table_name, or source_name; fallback to record_id."""
+    display = (
+        (record.get("name") or "").strip()
+        or (record.get("table_name") or "").strip()
+        or (record.get("source_name") or "").strip()
+    )
     if display:
         return slugify(display)
     return (record.get("record_id") or "").strip() or "unknown"
 
 
 def get_name(record: dict) -> str:
-    """Display name: name or table_name."""
+    """Display name: name, table_name, or source_name (fallback for stub records)."""
     name = (record.get("name") or "").strip()
     if name:
         return name
-    return (record.get("table_name") or "").strip() or ""
+    table_name = (record.get("table_name") or "").strip()
+    if table_name:
+        return table_name
+    return (record.get("source_name") or "").strip() or ""
 
 
 def serialize_value(v):

--- a/deploy/sqlite_api_support.py
+++ b/deploy/sqlite_api_support.py
@@ -66,9 +66,17 @@ def get_all_fellows(conn) -> list:
 
 
 def get_fellows_list(conn) -> list:
-    cur = conn.execute("SELECT record_id, slug, name FROM fellows ORDER BY name ASC")
+    cur = conn.execute(
+        "SELECT record_id, slug, name,"
+        " CASE WHEN contact_email IS NOT NULL AND contact_email != '' THEN 1 ELSE 0 END"
+        " AS has_contact_email"
+        " FROM fellows ORDER BY name ASC"
+    )
     rows = cur.fetchall()
-    return [{"record_id": r[0], "slug": r[1], "name": r[2]} for r in rows]
+    return [
+        {"record_id": r[0], "slug": r[1], "name": r[2], "has_contact_email": bool(r[3])}
+        for r in rows
+    ]
 
 
 def get_fellow_by_slug_or_id(conn, slug_or_id: str) -> dict | None:

--- a/tests/e2e/test_directory.py
+++ b/tests/e2e/test_directory.py
@@ -33,3 +33,35 @@ class TestDirectoryPage:
         page.locator("#directory").wait_for(state="visible", timeout=5000)
         imgs_in_directory = page.locator("#directory img")
         assert imgs_in_directory.count() == 0
+
+    def test_has_email_filter_default_on_and_toggles(self, standalone_page, base_url_fixture):
+        """'has email' filter is checked by default, hides fellows without email, and persists across reload."""
+        page = standalone_page
+        page.goto(base_url_fixture + "/", wait_until="domcontentloaded")
+        page.locator("#loading").wait_for(state="hidden", timeout=10000)
+        page.locator("#directory").wait_for(state="visible", timeout=5000)
+
+        checkbox = page.locator("#has-email-filter")
+        expect(checkbox).to_be_checked()
+
+        links = page.locator("#directory a[href^='#/fellow/']")
+        filtered_count = links.count()
+        assert filtered_count >= 1
+
+        checkbox.click()
+        expect(checkbox).not_to_be_checked()
+        page.wait_for_function(
+            "(prev) => document.querySelectorAll(\"#directory a[href^='#/fellow/']\").length !== prev",
+            arg=filtered_count,
+            timeout=5000,
+        )
+        total_count = page.locator("#directory a[href^='#/fellow/']").count()
+        assert total_count > filtered_count, (
+            f"Expected unfiltered count ({total_count}) > filtered count ({filtered_count})"
+        )
+
+        page.reload(wait_until="domcontentloaded")
+        page.locator("#loading").wait_for(state="hidden", timeout=10000)
+        page.locator("#directory").wait_for(state="visible", timeout=5000)
+        expect(page.locator("#has-email-filter")).not_to_be_checked()
+        assert page.locator("#directory a[href^='#/fellow/']").count() == total_count

--- a/tests/test_api.py
+++ b/tests/test_api.py
@@ -58,8 +58,27 @@ class TestAPI:
         assert isinstance(data, list)
         assert len(data) >= 1
         first = data[0]
-        assert set(first.keys()) <= {"record_id", "slug", "name"}
+        assert set(first.keys()) <= {"record_id", "slug", "name", "has_contact_email"}
         assert "slug" in first and "name" in first
+        assert "has_contact_email" in first
+        assert isinstance(first["has_contact_email"], bool)
+
+    def test_api_fellows_list_has_contact_email_flag_is_consistent(self):
+        """has_contact_email in list should match the full record's contact_email presence."""
+        _, _, list_body = get("/api/fellows")
+        _, _, full_body = get("/api/fellows", query={"full": "1"})
+        list_data = json.loads(list_body)
+        full_data = json.loads(full_body)
+        full_by_id = {f["record_id"]: f for f in full_data}
+        mismatches = []
+        for entry in list_data:
+            full = full_by_id.get(entry["record_id"])
+            if not full:
+                continue
+            has_email_full = bool((full.get("contact_email") or "").strip())
+            if entry["has_contact_email"] != has_email_full:
+                mismatches.append(entry["record_id"])
+        assert not mismatches, f"has_contact_email mismatch for {mismatches[:5]}"
 
     def test_api_fellows_list_and_full_counts_match(self):
         """List and full endpoints should return the same number of records."""

--- a/tests/test_database.py
+++ b/tests/test_database.py
@@ -90,3 +90,26 @@ def test_has_image_is_boolean_and_consistent(db):
     with_image = db.execute("SELECT COUNT(*) FROM fellows WHERE has_image = 1").fetchone()[0]
     without_image = db.execute("SELECT COUNT(*) FROM fellows WHERE has_image = 0").fetchone()[0]
     assert with_image + without_image == total, "has_image must always be 0 or 1"
+
+
+def test_every_row_has_a_name(db):
+    """Every fellow must have a non-empty name after the source_name fallback lands."""
+    cur = db.execute(
+        "SELECT record_id, slug FROM fellows WHERE name IS NULL OR name = ''"
+    )
+    nameless = cur.fetchall()
+    assert not nameless, (
+        "Rows without name: " + ", ".join(f"{rid}({slug})" for rid, slug in nameless[:5])
+    )
+
+
+def test_slug_never_falls_back_to_record_id(db):
+    """Importer falls back to source_name before record_id; no slug should equal its record_id."""
+    cur = db.execute(
+        "SELECT record_id, slug FROM fellows WHERE slug = record_id"
+    )
+    rows = cur.fetchall()
+    assert not rows, (
+        "Slugs equal to record_id (importer fallback exhausted): "
+        + ", ".join(f"{rid}" for rid, _ in rows[:5])
+    )


### PR DESCRIPTION
## Summary

- **Importer fix**: `get_name()`/`get_slug()` in `build/import_json_to_sqlite.py` fall back to `source_name` after `table_name`. Resurrects 49 stub records that were showing up as "Unknown" with UUID-looking slugs (e.g. `60c66cc833ee78071b3cabab` → `jean_bennett`, "Jean Bennett").
- **Contactable flag in phase-1 API**: `/api/fellows` now returns `has_contact_email` (boolean) so the filter can apply before the phase-2 full fetch arrives. Same change in `deploy/sqlite_api_support.py` for production parity.
- **'has email' filter toggle**: new checkbox in the search container (top-center), default **on**, persisted in `localStorage`. Applies to directory view and search results. Shows live "N of M fellows" count in directory mode, "(M before filter)" suffix in search mode.

## Why default-on

An email-enabled fellow is contactable — the primary value of the directory. Stub records with only a source-scraped name and no email still surface when the filter is off, so no data is hidden; the default just emphasizes the people you can actually reach.

## Test plan

Automated (all green locally, 43 passing):

- [x] `test_every_row_has_a_name` — DB has zero empty-name rows after rebuild
- [x] `test_slug_never_falls_back_to_record_id` — no slug equals its `record_id`
- [x] `test_api_fellows_list_returns_minimal_keys` — list now includes `has_contact_email` bool
- [x] `test_api_fellows_list_has_contact_email_flag_is_consistent` — list flag matches full record's `contact_email` presence
- [x] `test_has_email_filter_default_on_and_toggles` (E2E) — default on, toggling grows the list, `localStorage` survives reload
- [x] `test_deploy_sqlite_helpers_match_app_db` — production helpers stay in sync with app server

## Manual QA for maintainer (post-merge, pre-release)

1. **Rebuild DB** — canonical JSON path is currently missing locally; the backup is at `final_fellows_set/ehf_fellow_profiles_deduped.json.bak.2026-04-08`. Either restore it to the expected filename or run the importer with the backup path:
   ```bash
   python build/import_json_to_sqlite.py final_fellows_set/ehf_fellow_profiles_deduped.json.bak.2026-04-08
   ```
2. **Verify no empty names**:
   ```bash
   sqlite3 app/fellows.db "SELECT COUNT(*) FROM fellows WHERE name IS NULL OR name='';"
   # expect 0
   ```
3. **Rebuild PWA bundle**:
   ```bash
   python build/build_pwa.py
   ```
4. **Smoke local**:
   ```bash
   python app/server.py
   # open http://localhost:8765/, confirm filter defaults to checked,
   # count reads "268 of 442 fellows", uncheck → "442 fellows",
   # reload keeps your choice
   ```
5. **Deploy to prod** (when ready for the `v0.1.0` release):
   ```bash
   ./scripts/deploy_pwa.sh --ask-become-pass
   ./scripts/smoke_prod.sh
   ```
6. **Browser QA on prod** — same flow as step 4, on `https://fellows.globaldonut.com/`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)