### PR TITLE
feat(pwa): always-visible build badge + SW cache bump

### DIFF
--- a/app/static/app.js
+++ b/app/static/app.js
@@ -57,8 +57,47 @@
     finishedAt: null,
     reason: null
   };
-  /** Bump when changing diagnostics behavior (shown in Diagnostics panel). */
-  var FELLOWS_UI_DIAG = 'diag-2026-04e-image-prewarm';
+  /** Bump on every meaningful UI / diagnostics change. Rendered in the
+   *  always-visible build badge so a dev can tell at a glance which app.js
+   *  is actually running vs what the server was deployed with. */
+  var FELLOWS_UI_DIAG = 'diag-2026-04f-visible-build-marker';
+
+  function initBuildBadge() {
+    var clientEl = document.getElementById('build-badge-client');
+    if (clientEl) clientEl.textContent = 'app: ' + FELLOWS_UI_DIAG;
+  }
+
+  function setBuildBadgeServer(gitSha, builtAt) {
+    var serverEl = document.getElementById('build-badge-server');
+    var badgeEl = document.getElementById('build-badge');
+    if (!serverEl) return;
+    var label = gitSha || builtAt || 'unknown';
+    serverEl.textContent = 'server: ' + label;
+    if (badgeEl && gitSha) {
+      // Heuristic: when server exposes a sha, the client constant should have
+      // been bumped for any change that reached this server build. A mismatch
+      // between "what sha the server reports" and the client constant isn't a
+      // hard error, but the highlight class is reserved for future use when we
+      // add a client→server mapping.
+      badgeEl.classList.remove('build-badge--mismatch');
+    }
+  }
+
+  initBuildBadge();
+
+  // Populate the server-side label independently of the auth flow so a dev
+  // reading the badge still gets a signal when /api/auth/status is failing.
+  function primeServerBadgeFromBuildMeta() {
+    try {
+      fetch('/build-meta.json', { cache: 'no-cache', credentials: 'same-origin' })
+        .then(function (r) { return r.ok ? r.json() : null; })
+        .then(function (meta) {
+          if (meta) setBuildBadgeServer(meta.git_sha, meta.built_at);
+        })
+        .catch(function () {});
+    } catch (e) {}
+  }
+  primeServerBadgeFromBuildMeta();
 
   function logSwLifecycle(event, detail) {
     swLifecycleLog.push({
@@ -1219,6 +1258,7 @@
         authDebugPush(
           '/api/auth/status payload authEnabled=' + data.authEnabled + ' authenticated=' + data.authenticated
         );
+        setBuildBadgeServer(data.buildGitSha, data.build);
         if (!data.authEnabled) {
           authDebugPush('auth disabled on server: using install mode');
           initBrowserInstallMode(data, httpStatus);

--- a/app/static/index.html
+++ b/app/static/index.html
@@ -11,6 +11,16 @@
   <link rel="stylesheet" href="/styles.css" />
 </head>
 <body>
+  <div
+    id="build-badge"
+    class="build-badge"
+    role="status"
+    aria-live="polite"
+    title="app.js constant (what this tab is running) · server build SHA / timestamp (what was deployed)"
+  >
+    <span id="build-badge-client" class="build-badge-line">app: …</span>
+    <span id="build-badge-server" class="build-badge-line build-badge-line--muted">server: …</span>
+  </div>
   <button type="button" id="clear-app-cache-button" class="clear-app-cache-button">
     Clear App Cache & Reload
   </button>

--- a/app/static/styles.css
+++ b/app/static/styles.css
@@ -6,6 +6,41 @@ body {
   background: #f5f5f8;
 }
 
+.build-badge {
+  position: fixed;
+  top: 0.4rem;
+  right: 0.5rem;
+  z-index: 9999;
+  display: flex;
+  flex-direction: column;
+  align-items: flex-end;
+  gap: 0.1rem;
+  padding: 0.25rem 0.45rem;
+  font-family: ui-monospace, "Cascadia Code", Menlo, Monaco, Consolas, monospace;
+  font-size: 0.68rem;
+  line-height: 1.25;
+  color: #3d3550;
+  background: rgba(243, 240, 248, 0.9);
+  border: 1px solid #dcd6e8;
+  border-radius: 4px;
+  pointer-events: none;
+  max-width: 22rem;
+}
+
+.build-badge-line {
+  white-space: nowrap;
+}
+
+.build-badge-line--muted {
+  color: #7a6f91;
+}
+
+.build-badge--mismatch {
+  background: #fff3cd;
+  border-color: #ffe69c;
+  color: #664d03;
+}
+
 .clear-app-cache-button {
   position: fixed;
   right: 0.75rem;

--- a/app/static/sw.js
+++ b/app/static/sw.js
@@ -1,4 +1,4 @@
-const CACHE_VERSION = 'v7';
+const CACHE_VERSION = 'v8';
 const APP_SHELL_CACHE = `fellows-app-shell-${CACHE_VERSION}`;
 // Separate cache so shell-version bumps don't evict the ~34 MB of profile images.
 const IMAGES_CACHE = 'fellows-images-v1';

--- a/tests/e2e/test_directory.py
+++ b/tests/e2e/test_directory.py
@@ -34,6 +34,17 @@ class TestDirectoryPage:
         imgs_in_directory = page.locator("#directory img")
         assert imgs_in_directory.count() == 0
 
+    def test_build_badge_is_visible_with_client_constant(self, standalone_page, base_url_fixture):
+        """Always-visible build badge renders the client constant on boot, before any async response."""
+        page = standalone_page
+        page.goto(base_url_fixture + "/", wait_until="domcontentloaded")
+        badge = page.locator("#build-badge")
+        expect(badge).to_be_visible()
+        client_line = page.locator("#build-badge-client")
+        expect(client_line).to_contain_text("app: diag-")
+        server_line = page.locator("#build-badge-server")
+        expect(server_line).to_be_visible()
+
     def test_has_email_filter_default_on_and_toggles(self, standalone_page, base_url_fixture):
         """'has email' filter is checked by default, hides fellows without email, and persists across reload."""
         page = standalone_page


### PR DESCRIPTION
## Summary

- **Fixed top-right build badge** showing two lines:
  - `app: <FELLOWS_UI_DIAG>` — baked into app.js; tells you which code is actually running in the tab
  - `server: <git_sha>` or `<built_at>` — pulled from /api/auth/status and /build-meta.json; tells you what the server thinks was deployed
  When the two don't line up, the browser is running a stale bundle.
- **FELLOWS_UI_DIAG** bumped to \`diag-2026-04f-visible-build-marker\` so this release is distinguishable from the PR #19 (prewarm) UI mark.
- **sw.js CACHE_VERSION** bumped \`v7 → v8\`. The existing activate handler already deletes older shell caches and force-reloads controlled windows when a prior cache exists — bumping the version triggers that burn-down, which is how we rescue tabs stuck on old in-memory app.js.

## Why this now

Last deploy of PR #21 landed correctly on the server (allowlistHashCount=268, DB rebuilt, auth active) but a browser session was still running the old app.js, and the diagnostics UI mark wasn't bumped so there was no way to tell from the dump. This gives every future deploy an instant visual signal of client/server alignment.

## Test plan

Automated (44 tests, all green):

- [x] \`test_build_badge_is_visible_with_client_constant\` — badge renders on boot with the client constant, before async calls complete.

## Manual QA for maintainer

1. Deploy: \`./scripts/deploy_pwa.sh --ask-become-pass\`
2. Smoke: \`./scripts/smoke_prod.sh\`
3. In a fresh incognito window, load https://fellows.globaldonut.com/. The badge top-right should read roughly:
   \`\`\`
   app: diag-2026-04f-visible-build-marker
   server: <short-sha>
   \`\`\`
4. In your primary (stuck) browser, hard-reload. Expected behavior:
   - SW activate handler notices v7 → v8, deletes \`fellows-app-shell-v7\`, force-navigates the window
   - Next load shows the new badge with \`diag-2026-04f-…\`
5. If after (4) the client line still reads \`diag-2026-04e-…\`, the SW burn-down isn't firing — that's the next bug to chase.

Once the badge confirms fresh app.js is loading, we can circle back to the email-send debugging as a separate PR.

🤖 Generated with [Claude Code](https://claude.com/claude-code)