### PR TITLE
feat(auth): rewrite email-gate algorithm (v2 cookie, install window, logout, ?gate=1)

### DIFF
--- a/app/server.py
+++ b/app/server.py
@@ -299,7 +299,14 @@ class Handler(BaseHTTPRequestHandler):
         # Returning a valid shape prevents the browser from showing the auth
         # failure panel in local development.
         if path == "/api/auth/status":
-            self.send_json({"authEnabled": False, "authenticated": False})
+            self.send_json(
+                {
+                    "authEnabled": False,
+                    "authenticated": False,
+                    "hasSessionCookie": False,
+                    "installRecentlyAllowed": False,
+                }
+            )
             return
 
         # API: stats

--- a/app/static/app.js
+++ b/app/static/app.js
@@ -39,6 +39,9 @@
   var iosHintEl = document.getElementById('install-ios-hint');
   var authDebugPrivateEl = document.getElementById('auth-debug-private');
   var authDebugInstallEl = document.getElementById('auth-debug-install');
+  var gateReasonBannerEl = document.getElementById('gate-reason-banner');
+  var installUnsupportedHintEl = document.getElementById('install-unsupported-hint');
+  var backToGateLinkEl = document.getElementById('back-to-gate-link');
   var swUpdateBannerEl = document.getElementById('sw-update-banner');
   var swUpdateReloadEl = document.getElementById('sw-update-reload');
   var siteHeaderEl = document.getElementById('site-header');
@@ -1115,6 +1118,8 @@
       e.preventDefault();
       deferredInstallPrompt = e;
       setInstallStatus('');
+      if (installUnsupportedHintEl) installUnsupportedHintEl.classList.add('hidden');
+      if (installButtonEl) installButtonEl.classList.remove('hidden');
     });
 
     window.addEventListener('appinstalled', function () {
@@ -1123,7 +1128,20 @@
       if (installButtonEl) installButtonEl.classList.add('hidden');
     });
 
-    if (installButtonEl) {
+    // Unsupported-browser detection: if after ~3s no beforeinstallprompt has
+    // fired AND we're not iOS Safari (which uses Share → Add to Home Screen),
+    // swap the install button for the "your browser doesn't support install"
+    // hint. The timer is long enough to avoid a flash on browsers that fire
+    // late, short enough that a dev doesn't think the page is broken.
+    setTimeout(function () {
+      if (deferredInstallPrompt) return;
+      if (isIosSafari()) return;
+      if (installUnsupportedHintEl) installUnsupportedHintEl.classList.remove('hidden');
+      if (installButtonEl) installButtonEl.classList.add('hidden');
+    }, 3000);
+
+    if (installButtonEl && !installButtonEl._wired) {
+      installButtonEl._wired = true;
       installButtonEl.addEventListener('click', function () {
         if (deferredInstallPrompt) {
           deferredInstallPrompt.prompt();
@@ -1137,16 +1155,51 @@
             .catch(function () {
               deferredInstallPrompt = null;
             });
+        } else if (isIosSafari()) {
+          setInstallStatus('Use Share → Add to Home Screen.');
         } else {
-          setInstallStatus(
-            'Use your browser’s install option (menu) or Add to Home Screen on iOS.'
-          );
+          if (installUnsupportedHintEl) installUnsupportedHintEl.classList.remove('hidden');
+          if (installButtonEl) installButtonEl.classList.add('hidden');
         }
+      });
+    }
+
+    if (backToGateLinkEl && !backToGateLinkEl._wired) {
+      backToGateLinkEl._wired = true;
+      backToGateLinkEl.addEventListener('click', function (ev) {
+        ev.preventDefault();
+        fetch('/api/logout', {
+          method: 'POST',
+          credentials: 'same-origin',
+          headers: { 'Content-Type': 'application/json' },
+          body: '{}'
+        })
+          .catch(function () {})
+          .then(function () {
+            window.location.replace('/?gate=1');
+          });
       });
     }
   }
 
-  function initPrivateGate(authPayload, httpStatus) {
+  function setGateReasonBanner(reason) {
+    if (!gateReasonBannerEl) return;
+    var text = '';
+    if (reason === 'expired') {
+      text = 'That link expired. Enter your email to get a new one.';
+    } else if (reason === 'invalid') {
+      text = "That link isn't valid. Enter your email to get a new one.";
+    }
+    if (text) {
+      gateReasonBannerEl.textContent = text;
+      gateReasonBannerEl.classList.remove('hidden');
+    } else {
+      gateReasonBannerEl.textContent = '';
+      gateReasonBannerEl.classList.add('hidden');
+    }
+  }
+
+  function initEmailGate(authPayload, httpStatus, reason) {
     if (installGatePrivateEl) installGatePrivateEl.classList.remove('hidden');
     if (installLandingEl) installLandingEl.classList.add('hidden');
     if (siteHeaderEl) siteHeaderEl.classList.add('hidden');
@@ -1154,15 +1207,19 @@
     showApp(false);
     if (connectionBannerEl) connectionBannerEl.classList.add('hidden');
 
+    setGateReasonBanner(reason);
+
     if (authPayload) {
       showAuthDebugPrivate(authPayload, httpStatus != null ? httpStatus : 200);
     }
 
-    if (unlockEmailFormEl) {
+    if (unlockEmailFormEl && !unlockEmailFormEl._wired) {
+      unlockEmailFormEl._wired = true;
       unlockEmailFormEl.addEventListener('submit', function (ev) {
         ev.preventDefault();
         var email = (unlockEmailInputEl && unlockEmailInputEl.value) || '';
         if (unlockStatusEl) unlockStatusEl.textContent = 'Sending…';
+        setGateReasonBanner('');
         fetch('/api/send-unlock', {
           method: 'POST',
           headers: { 'Content-Type': 'application/json' },
@@ -1183,14 +1240,6 @@
           });
       });
     }
-
-    if (sessionStorage.getItem('fellows_unlock_err')) {
-      sessionStorage.removeItem('fellows_unlock_err');
-      if (unlockStatusEl) {
-        unlockStatusEl.textContent =
-          'Link expired or invalid — request a new one from your fellowship email.';
-      }
-    }
   }
 
   function tryUnlockFromHash() {
@@ -1200,7 +1249,6 @@
       return Promise.resolve();
     }
     var token = m[1];
-    window.history.replaceState(null, '', window.location.pathname + window.location.search + '#/');
     return fetch('/api/verify-token', {
       method: 'POST',
       headers: { 'Content-Type': 'application/json' },
@@ -1209,13 +1257,23 @@
     })
       .then(function (r) {
         return r.json().then(function (j) {
-          if (!r.ok || !j.ok) {
-            sessionStorage.setItem('fellows_unlock_err', '1');
+          if (r.ok && j.ok) {
+            // Success: strip the token from the URL so reload doesn't re-submit,
+            // drop any ?gate=1&reason=… that may have been carried through, and
+            // let startBrowserUx run — it will see authenticated=true &
+            // installRecentlyAllowed=true and render the install landing.
+            window.history.replaceState(null, '', '/#/');
+            return;
           }
+          var reason = (j && j.error) === 'expired' ? 'expired' : 'invalid';
+          window.location.replace('/?gate=1&reason=' + reason);
+          // stall remaining chain — the replace will reload us
+          return new Promise(function () {});
         });
       })
       .catch(function () {
-        sessionStorage.setItem('fellows_unlock_err', '1');
+        window.location.replace('/?gate=1&reason=invalid');
+        return new Promise(function () {});
       });
   }
 
@@ -1233,9 +1291,21 @@
     return false;
   }
 
+  function parseGateOverride() {
+    try {
+      var u = new URL(window.location.href);
+      if (u.searchParams.get('gate') === '1') {
+        var reason = u.searchParams.get('reason') || '';
+        return { force: true, reason: reason };
+      }
+    } catch (e) {}
+    return { force: false, reason: '' };
+  }
+
   function startBrowserUx() {
     authDebugLines.length = 0;
     authDebugPush('startBrowserUx: begin auth status check');
+    var override = parseGateOverride();
     fetch('/api/auth/status', { credentials: 'same-origin' })
       .then(function (r) {
         authDebugPush('/api/auth/status HTTP ' + r.status);
@@ -1256,21 +1326,36 @@
           throw new Error('/api/auth/status returned invalid payload shape');
         }
         authDebugPush(
-          '/api/auth/status payload authEnabled=' + data.authEnabled + ' authenticated=' + data.authenticated
+          '/api/auth/status payload authEnabled=' + data.authEnabled +
+          ' authenticated=' + data.authenticated +
+          ' installRecentlyAllowed=' + (data.installRecentlyAllowed === true)
         );
         setBuildBadgeServer(data.buildGitSha, data.build);
+
+        // Decision tree per docs/email_gate.md:
+        // 1. Force-gate URL (?gate=1) overrides everything — explicit dev escape.
+        // 2. If auth isn't active on the server (local dev), skip the gate and
+        //    go straight to install mode as before.
+        // 3. Install landing only when authenticated AND inside the
+        //    install-recently-allowed window.
+        // 4. Otherwise: email gate.
+        if (override.force) {
+          authDebugPush('?gate=1 override: using email gate (reason=' + (override.reason || 'none') + ')');
+          initEmailGate(data, httpStatus, override.reason);
+          return;
+        }
         if (!data.authEnabled) {
           authDebugPush('auth disabled on server: using install mode');
           initBrowserInstallMode(data, httpStatus);
           return;
         }
-        if (data.authenticated) {
-          authDebugPush('session authenticated: using install mode');
+        if (data.authenticated && data.installRecentlyAllowed === true) {
+          authDebugPush('authenticated + recent-token-window: using install mode');
           initBrowserInstallMode(data, httpStatus);
           return;
         }
-        authDebugPush('auth enabled + unauthenticated: using private gate');
-        initPrivateGate(data, httpStatus);
+        authDebugPush('default: using email gate');
+        initEmailGate(data, httpStatus, '');
       })
       .catch(function (err) {
         authDebugPush('auth status check failed: ' + (err && err.message ? err.message : String(err)));

--- a/app/static/index.html
+++ b/app/static/index.html
@@ -47,6 +47,7 @@
     <div class="install-landing-inner">
       <div class="install-brand" aria-hidden="true">EHF</div>
       <h1 class="install-title">EHF Fellows Directory</h1>
+      <p id="gate-reason-banner" class="gate-reason-banner hidden" role="alert"></p>
       <p class="install-lead install-lead--private">
         This is a private app for EHF Fellows. Enter your fellowship email to receive a sign-in link.
       </p>
@@ -61,9 +62,10 @@
           autocomplete="email"
           required
         />
-        <button type="submit" class="install-pwa-button unlock-submit" id="unlock-submit">Get access</button>
+        <button type="submit" class="install-pwa-button unlock-submit" id="unlock-submit">Send link</button>
       </form>
       <p id="unlock-status" class="install-status" aria-live="polite"></p>
+      <p class="install-ttl-hint">Magic links expire in 30 minutes. Request a new one if yours has expired.</p>
       <p class="install-support">
         Having trouble with the app? Contact the EHF Communications Working Group.
       </p>
@@ -80,6 +82,14 @@
       <button type="button" id="install-pwa-button" class="install-pwa-button">Install app</button>
       <p id="install-ios-hint" class="install-ios-hint hidden">
         On iPhone or iPad: tap <strong>Share</strong>, then <strong>Add to Home Screen</strong>.
+      </p>
+      <p id="install-unsupported-hint" class="install-unsupported-hint hidden">
+        Your browser doesn't support install. We don't want to run this as SaaS, so please use Chrome,
+        Edge, Safari, or any other browser that supports installing a progressive web app. Thanks.
+      </p>
+      <p class="install-ttl-hint">Install within 30 minutes of requesting the link, or request a new one.</p>
+      <p class="install-back-gate">
+        <a href="/?gate=1" id="back-to-gate-link" class="install-back-gate-link">Back to email gate</a>
       </p>
       <p class="install-support">
         Having trouble with the app? Contact the EHF Communications Working Group.

--- a/app/static/styles.css
+++ b/app/static/styles.css
@@ -890,6 +890,57 @@ h1 {
   line-height: 1.4;
 }
 
+.install-ttl-hint {
+  margin: 1rem 0 0;
+  font-size: 0.85rem;
+  color: #5a4578;
+  line-height: 1.4;
+  font-style: italic;
+}
+
+.install-unsupported-hint {
+  margin: 1rem 0 0;
+  padding: 0.6rem 0.75rem;
+  font-size: 0.9rem;
+  color: #664d03;
+  background: #fff3cd;
+  border: 1px solid #ffe69c;
+  border-radius: 4px;
+  line-height: 1.45;
+  text-align: left;
+}
+
+.install-back-gate {
+  margin: 0.75rem 0 0;
+  font-size: 0.85rem;
+  color: #666;
+}
+
+.install-back-gate-link {
+  color: #4a2c6a;
+  text-decoration: underline;
+}
+
+.install-back-gate-link:hover {
+  color: #3d2460;
+}
+
+.gate-reason-banner {
+  margin: 0 0 1rem;
+  padding: 0.6rem 0.75rem;
+  font-size: 0.9rem;
+  color: #664d03;
+  background: #fff3cd;
+  border: 1px solid #ffe69c;
+  border-radius: 4px;
+  line-height: 1.4;
+  text-align: left;
+}
+
+.gate-reason-banner.hidden {
+  display: none;
+}
+
 .auth-debug-line {
   margin: 0 0 0.75rem;
   padding: 0.45rem 0.55rem;

--- a/deploy/magic_link_auth.py
+++ b/deploy/magic_link_auth.py
@@ -21,9 +21,11 @@ from typing import Optional
 
 SESSION_COOKIE = "fellows_session"
 SESSION_MAX_AGE = 7 * 24 * 3600
-TOKEN_TTL = 15 * 60
+TOKEN_TTL = 30 * 60
+INSTALL_WINDOW = TOKEN_TTL  # window (from token issue) during which install landing may show
 RATE_WINDOW = 3600
 RATE_MAX = 3
+SESSION_VERSION = "v2"
 
 _EMAIL_RE = re.compile(r"^[^@\s]+@[^@\s]+\.[^@\s]+$")
 
@@ -85,13 +87,38 @@ def issue_token() -> str:
     return tok
 
 
-def consume_token(tok: str) -> bool:
-    cleanup_stale_tokens()
+def consume_token(tok: str) -> dict:
+    """Consume a magic-link token.
+
+    Returns one of:
+      {"status": "ok", "issued_at": <epoch>} — token was valid and unexpired; caller
+          should use issued_at when signing the session cookie.
+      {"status": "expired"} — token existed but was past TTL. Shown to user as
+          "that link expired".
+      {"status": "invalid"} — token was never issued or already consumed. Shown
+          to user as "that link isn't valid".
+    """
     with AuthState.lock:
         exp = AuthState.tokens.pop(tok, None)
-    if exp is None or exp < time.time():
+    if exp is None:
+        return {"status": "invalid"}
+    now = time.time()
+    if exp < now:
+        return {"status": "expired"}
+    return {"status": "ok", "issued_at": exp - TOKEN_TTL}
+
+
+def install_recently_allowed(token_issued_at: Optional[float], now: Optional[float] = None) -> bool:
+    """True when the browser should still show the install landing.
+
+    Tied to the token-issue timestamp, not the click time: a user has
+    INSTALL_WINDOW seconds from the email being sent to finish installing.
+    """
+    if token_issued_at is None:
         return False
-    return True
+    if now is None:
+        now = time.time()
+    return (now - token_issued_at) < INSTALL_WINDOW
 
 
 def send_postmark_magic_link(to_email: str, magic_url: str) -> dict:
@@ -99,14 +126,23 @@ def send_postmark_magic_link(to_email: str, magic_url: str) -> dict:
     if not api_token:
         raise RuntimeError("FELLOWS_POSTMARK_TOKEN is not set")
     from_addr = os.environ.get("FELLOWS_MAIL_FROM", "noreply@fellows.globaldonut.com").strip()
+    text_body = (
+        "Tap or paste this link to open the install page:\n\n"
+        f"{magic_url}\n\n"
+        "This link will expire in 30 minutes. If it's expired, request a new one.\n"
+    )
+    html_body = (
+        "<p>Tap or paste this link to open the install page:</p>"
+        f'<p><a href="{magic_url}">{magic_url}</a></p>'
+        "<p><em>This link will expire in 30 minutes. "
+        "If it&rsquo;s expired, request a new one.</em></p>"
+    )
     body = {
         "From": from_addr,
         "To": to_email,
-        "Subject": "Your EHF Fellows Directory link",
-        "HtmlBody": (
-            "<p>Tap or paste this link to open the install page (expires in 15 minutes):</p>"
-            f'<p><a href="{magic_url}">{magic_url}</a></p>'
-        ),
+        "Subject": "Your EHF Fellows Directory link (expires in 30 minutes)",
+        "TextBody": text_body,
+        "HtmlBody": html_body,
         "MessageStream": "outbound",
     }
     req = urllib.request.Request(
@@ -137,34 +173,67 @@ def send_postmark_magic_link(to_email: str, magic_url: str) -> dict:
         }
 
 
-def sign_session_value(secret: bytes) -> str:
+def sign_session_value(secret: bytes, token_issued_at: Optional[float] = None) -> str:
+    """Sign a v2 session cookie carrying token_issued_at.
+
+    Payload format (utf-8): ``v2:<exp>:<token_issued_at>:<nonce>``
+    token_issued_at is ``int(time.time())`` of the magic-link token that granted
+    this session. Pass None only in legacy/test paths where no token context is
+    available — callers in production must always pass a value.
+    """
     exp = int(time.time()) + SESSION_MAX_AGE
     nonce = secrets.token_hex(16)
-    payload = f"{exp}:{nonce}".encode("utf-8")
+    tia = int(token_issued_at) if token_issued_at is not None else 0
+    payload = f"{SESSION_VERSION}:{exp}:{tia}:{nonce}".encode("utf-8")
     sig = hmac.new(secret, payload, hashlib.sha256).hexdigest()
     return (
         base64.urlsafe_b64encode(payload).decode("ascii").rstrip("=") + "." + sig
     )
 
 
-def verify_session_value(cookie_val: str, secret: bytes) -> bool:
+def verify_session_value(cookie_val: str, secret: bytes) -> Optional[dict]:
+    """Verify a v2 session cookie.
+
+    Returns ``{"token_issued_at": <int>}`` on success. Returns None on any
+    failure (bad signature, expired, malformed, v1 cookies). Callers relying on
+    boolean semantics still work because None is falsy and a dict is truthy.
+    """
     try:
         parts = cookie_val.strip().split(".", 1)
         if len(parts) != 2:
-            return False
+            return None
         b64payload, sig = parts
         pad = "=" * (-len(b64payload) % 4)
         payload = base64.urlsafe_b64decode(b64payload + pad)
         expect_sig = hmac.new(secret, payload, hashlib.sha256).hexdigest()
         if not hmac.compare_digest(expect_sig, sig):
-            return False
+            return None
         text = payload.decode("utf-8")
-        exp_s, _nonce = text.split(":", 1)
+        fields = text.split(":")
+        if len(fields) < 4 or fields[0] != SESSION_VERSION:
+            # v1 cookies (no version prefix) land here and are rejected by
+            # design — forces a clean re-login after this deploy.
+            return None
+        _ver, exp_s, tia_s, _nonce = fields[0], fields[1], fields[2], ":".join(fields[3:])
         if int(exp_s) < time.time():
-            return False
-        return True
+            return None
+        return {"token_issued_at": int(tia_s)}
     except (ValueError, UnicodeDecodeError):
-        return False
+        return None
+
+
+def clear_session_cookie_line(headers) -> str:
+    """A Set-Cookie header line that expires the session cookie immediately."""
+    parts = [
+        f"{SESSION_COOKIE}=",
+        "Path=/",
+        "HttpOnly",
+        "SameSite=Strict",
+        "Max-Age=0",
+    ]
+    if should_use_secure_cookie(headers):
+        parts.append("Secure")
+    return "; ".join(parts)
 
 
 def parse_cookie_header(cookie_header: Optional[str], name: str) -> Optional[str]:

--- a/deploy/server.py
+++ b/deploy/server.py
@@ -135,13 +135,23 @@ class Handler(SimpleHTTPRequestHandler):
         self.send_header("X-Fellows-Auth-Active", "1" if AUTH_ACTIVE else "0")
 
     def has_valid_session(self) -> bool:
+        return self.session_payload() is not None
+
+    def session_payload(self):
+        """Return ``{token_issued_at}`` for the verified cookie, else None.
+
+        When auth is disabled, returns an empty dict (truthy) so existing
+        guards keep working.
+        """
         if not AUTH_ACTIVE:
-            return True
+            return {}
         sec = ml.session_secret_bytes()
         if not sec:
-            return False
+            return None
         c = ml.parse_cookie_header(self.headers.get("Cookie"), ml.SESSION_COOKIE)
-        return bool(c and ml.verify_session_value(c, sec))
+        if not c:
+            return None
+        return ml.verify_session_value(c, sec)
 
     def do_GET(self):
         parsed = urllib.parse.urlparse(self.path)
@@ -164,7 +174,13 @@ class Handler(SimpleHTTPRequestHandler):
             has_cookie = bool(
                 ml.parse_cookie_header(self.headers.get("Cookie"), ml.SESSION_COOKIE)
             )
-            authed = self.has_valid_session()
+            session = self.session_payload()
+            authed = session is not None
+            install_allowed = False
+            if AUTH_ACTIVE and session and "token_issued_at" in session:
+                install_allowed = ml.install_recently_allowed(
+                    session.get("token_issued_at") or 0
+                )
             print(
                 json.dumps(
                     {
@@ -172,6 +188,7 @@ class Handler(SimpleHTTPRequestHandler):
                         "auth_active": AUTH_ACTIVE,
                         "authenticated": authed,
                         "has_session_cookie": has_cookie,
+                        "install_recently_allowed": install_allowed,
                         "user_agent": (self.headers.get("User-Agent") or "")[:240],
                     }
                 ),
@@ -181,6 +198,7 @@ class Handler(SimpleHTTPRequestHandler):
                 "authEnabled": AUTH_ACTIVE,
                 "authenticated": authed,
                 "hasSessionCookie": has_cookie,
+                "installRecentlyAllowed": install_allowed,
             }
             if BUILD_META:
                 payload["build"] = BUILD_META.get("built_at")
@@ -268,7 +286,19 @@ class Handler(SimpleHTTPRequestHandler):
         if path == "/api/verify-token":
             self._handle_verify_token(body)
             return
+        if path == "/api/logout":
+            self._handle_logout()
+            return
         self.send_error(HTTPStatus.NOT_FOUND, "Not Found")
+
+    def _handle_logout(self) -> None:
+        """Clear the session cookie regardless of current state.
+
+        Always 200 — we don't reveal whether the caller had a valid session.
+        Client navigates to ``/?gate=1`` after this.
+        """
+        cookie = ml.clear_session_cookie_line(self.headers)
+        self.send_json_with_headers({"ok": True}, 200, [("Set-Cookie", cookie)])
 
     def _handle_send_unlock(self, body: dict) -> None:
         # Anti-enumeration: always 200 {"sent": true}
@@ -346,14 +376,23 @@ class Handler(SimpleHTTPRequestHandler):
             self.send_json({"ok": True})
             return
         tok = (body.get("token") or "").strip()
-        if not tok or not ml.consume_token(tok):
-            self.send_json({"ok": False, "error": "invalid_or_expired"}, status=401)
+        if not tok:
+            self.send_json({"ok": False, "error": "invalid"}, status=401)
+            return
+        result = ml.consume_token(tok)
+        status = (result or {}).get("status")
+        if status != "ok":
+            # "expired" and "invalid" are both 401 but carry distinct error
+            # strings so the client can render "link expired" vs "link invalid"
+            # banners on the gate after a redirect.
+            err = status if status in ("expired", "invalid") else "invalid"
+            self.send_json({"ok": False, "error": err}, status=401)
             return
         sec = ml.session_secret_bytes()
         if not sec:
             self.send_json({"ok": False, "error": "server_misconfigured"}, status=500)
             return
-        val = ml.sign_session_value(sec)
+        val = ml.sign_session_value(sec, token_issued_at=result.get("issued_at"))
         cookie = ml.set_session_cookie_line(val, self.headers)
         self.send_json_with_headers({"ok": True}, 200, [("Set-Cookie", cookie)])
 

--- a/docs/email_gate.md
+++ b/docs/email_gate.md
@@ -1,0 +1,131 @@
+# Email Gate
+
+Authoritative specification of the email-gate / install-landing algorithm. The runtime (`app/static/app.js`, `deploy/server.py`, `deploy/magic_link_auth.py`) must match this document; if they drift, this document is what's right and the runtime is a bug.
+
+Operator procedures (Postmark, env file, Postmark response interpretation) stay in [`email_system_management.md`](email_system_management.md). This file is the behavioral spec.
+
+## Goals
+
+- The default view is the **email gate** — an empty form for requesting a magic link. Everything else requires affirmative state to appear.
+- The **install landing** exists only to capture a one-shot "install the PWA" gesture, inside a bounded window after a token was issued. It is not a logged-in home page.
+- A dev must always be able to return to the gate in one click, even if auth state is confusing.
+
+## Definitions
+
+- **Session cookie** — `fellows_session`, HttpOnly, HMAC-signed, carrying `token_issued_at` (epoch seconds). v2 format; v1 cookies are rejected on sight so prior sessions re-login cleanly after this ships.
+- **Magic-link token** — single-use, `TOKEN_TTL = 30 min` from issue. Random 32-byte hex.
+- **Install window** — `INSTALL_WINDOW = 30 min` measured from token issue (not from click). Same duration as token TTL by design: a user has 30 min from the email being sent to finish clicking and installing.
+- **Display mode** — *browser* (`display-mode != standalone`) vs *PWA* (`display-mode: standalone`).
+
+## Invariants
+
+1. **Email gate is the default.** The only exits from it are: (a) a URL carrying an unexpired magic-link token, or (b) an authenticated session *within* the install window, or (c) PWA mode with a valid session (→ directory).
+2. **Install landing never repeats.** It shows only inside the install window. Once the window closes, or the user explicitly logs out, the only path back is a fresh magic link.
+3. **Expired links are explicit.** Clicking an expired token lands on the email gate with a visible "that link expired" banner.
+4. **Invalid links are explicit.** Clicking a tampered or already-consumed token lands on the email gate with "that link isn't valid".
+5. **Magic-link emails state the TTL.** Body includes: "This link will expire in 30 minutes."
+6. **Session cookie TTL is long** (`SESSION_MAX_AGE = 7 days`) so installed PWAs persist; the install window is decoupled and short.
+7. **Dev escape hatch is always reachable.** Two layers:
+   - A **"Back to email gate"** control on the install landing, which `POST`s `/api/logout` (clears the cookie server-side) then navigates to `/?gate=1`.
+   - A **hardcoded URL override** `/?gate=1` that forces the gate UI regardless of cookie state. Works even when JS-driven logout fails.
+8. **Unsupported browsers are told so.** If `beforeinstallprompt` doesn't fire within ~3 seconds and the user isn't on iOS Safari (which installs via Share → Add to Home Screen), the install landing swaps to a panel asking them to use Chrome, Edge, Safari, or another browser that supports PWA install. No in-browser fallback to the directory — this is a PWA, not SaaS.
+
+## Browser-mode decision tree
+
+Evaluated on every page render (after auth-status fetch). Order matters — first match wins.
+
+```
+1. URL hash == "#/unlock/<token>"?
+     POST /api/verify-token {token}
+       → 200 ok        : cookie{token_issued_at=now} set by server; strip hash; fall through to #3
+       → 401 expired   : location.replace("/?gate=1&reason=expired")
+       → 401 invalid   : location.replace("/?gate=1&reason=invalid")
+       → network err   : location.replace("/?gate=1&reason=invalid")
+
+2. ?gate=1 in URL?
+     → EMAIL GATE
+       ?reason=expired → banner "That link expired. Enter your email to get a new one."
+       ?reason=invalid → banner "That link isn't valid. Enter your email to get a new one."
+       otherwise       → no banner
+
+3. authStatus.authEnabled == false  (local dev passthrough)
+     → INSTALL LANDING (dev has no real gate; this preserves the developer UX)
+
+4. authStatus.authenticated && authStatus.installRecentlyAllowed
+     → INSTALL LANDING
+       - Install button wired to beforeinstallprompt
+       - After 3s with no prompt and not iOS Safari: swap to unsupported-browser panel
+       - "Back to email gate" link: POST /api/logout then navigate /?gate=1
+
+5. default
+     → EMAIL GATE (no banner)
+```
+
+## PWA-mode decision tree
+
+Installed PWAs never see the install landing.
+
+```
+1. authStatus.authenticated?  → DIRECTORY
+2. otherwise                  → EMAIL GATE (same component as browser mode)
+```
+
+## State diagram
+
+```
+                      ┌──────────────────────┐
+                      │   EMAIL GATE         │◀────────────────────────┐
+                      │   (default)          │                         │
+                      └──────────┬───────────┘                         │
+            submit email         │                                     │
+                                 ▼                                     │
+                    Postmark sends magic link                          │
+                      (expires 30 min)                                 │
+                                 │                                     │
+     click link within 30 min    │     click expired link              │
+                                 │            │                        │
+                                 ▼            ▼                        │
+                  ┌───────────────────┐   gate + "expired" banner      │
+                  │ verify-token: ok  │                                │
+                  │ cookie{tia=now}   │                                │
+                  └──────────┬────────┘                                │
+                             ▼                                         │
+                  ┌──────────────────────────┐  logout / window expiry │
+                  │  INSTALL LANDING         │  / ?gate=1 URL          │
+                  │  (install window)        ├─────────────────────────┘
+                  │  [Back to email gate]    │
+                  └──────────┬───────────────┘
+                             │ click "Install app" → browser installs PWA
+                             ▼
+                  ┌────────────────────┐
+                  │  PWA (standalone)  │
+                  │  → DIRECTORY       │
+                  └────────────────────┘
+```
+
+## Endpoints
+
+| Method | Path                   | Purpose                                                       |
+|--------|------------------------|---------------------------------------------------------------|
+| GET    | `/api/auth/status`     | Returns `{authEnabled, authenticated, installRecentlyAllowed, hasSessionCookie, build, buildGitSha}`. Never gated. |
+| POST   | `/api/send-unlock`     | Accepts `{email}`. Always returns `{sent: true}` (anti-enumeration). Internally: validates shape, checks rate limit, checks allowlist, issues token, sends Postmark email. |
+| POST   | `/api/verify-token`    | Accepts `{token}`. Returns `{ok: true}` + Set-Cookie on success; `{ok: false, error: "expired"\|"invalid"}` otherwise (401). |
+| POST   | `/api/logout`          | Clears session cookie (Max-Age=0). Always returns `{ok: true}`. |
+
+## Cookie format (v2)
+
+Plaintext payload (utf-8): `v2:<session_expires_at>:<token_issued_at>:<nonce>`
+Cookie value: `base64url(payload) + "." + hex(hmac_sha256(secret, payload))`
+
+- `session_expires_at` = `int(time.time()) + SESSION_MAX_AGE`
+- `token_issued_at` = the `issued_at` of the magic-link token that granted this session (epoch seconds). `0` only in legacy/test paths.
+- Sig = `hmac_sha256(FELLOWS_SESSION_SECRET, payload)`.
+
+On every request the server recomputes HMAC, rejects on mismatch, and rejects if `session_expires_at < now`. The install-window check is *separate*: `now - token_issued_at < INSTALL_WINDOW`.
+
+## Security notes
+
+- Anti-enumeration: `/api/send-unlock` never reveals whether the email is on the allowlist.
+- Distinguishing "expired" vs "invalid" in verify-token leaks only the fact that the token existed at some point. Negligible vs UX win.
+- `/api/logout` is idempotent and doesn't require a valid session. That's intentional — the endpoint's job is to guarantee the cookie is cleared, not to validate the caller.
+- The URL override `?gate=1` does not bypass auth; it only forces the **UI** to render the gate. Protected endpoints (`/fellows.db`, `/images/*`, directory `/api/*`) still require a valid session.

--- a/tests/e2e/test_email_gate.py
+++ b/tests/e2e/test_email_gate.py
@@ -1,0 +1,163 @@
+"""E2E tests: email-gate decision tree (Playwright + route-mock).
+
+The dev server (``app/server.py``) returns ``authEnabled: false`` so the client
+takes the local-dev passthrough branch. These tests use Playwright's
+``page.route`` to return a synthetic ``/api/auth/status`` payload and exercise
+each branch of ``startBrowserUx``'s decision tree as specified in
+``docs/email_gate.md``.
+"""
+import json
+
+import pytest
+from playwright.sync_api import expect
+
+
+AUTH_STATUS_PATH = "**/api/auth/status"
+
+
+def _mock_auth_status(page, **overrides):
+    payload = {
+        "authEnabled": True,
+        "authenticated": False,
+        "hasSessionCookie": False,
+        "installRecentlyAllowed": False,
+    }
+    payload.update(overrides)
+
+    def _fulfill(route):
+        route.fulfill(
+            status=200,
+            content_type="application/json",
+            body=json.dumps(payload),
+            headers={"X-Fellows-Build": "e2e-mock"},
+        )
+
+    page.route(AUTH_STATUS_PATH, _fulfill)
+
+
+class TestEmailGate:
+    """Browser-mode decision tree per docs/email_gate.md."""
+
+    def test_default_unauthenticated_shows_email_gate(self, context, base_url_fixture):
+        page = context.new_page()
+        try:
+            _mock_auth_status(page, authEnabled=True, authenticated=False)
+            page.goto(base_url_fixture + "/", wait_until="domcontentloaded")
+            expect(page.locator("#install-gate-private")).to_be_visible()
+            expect(page.locator("#install-landing")).to_be_hidden()
+            expect(page.locator("#unlock-email-form")).to_be_visible()
+        finally:
+            page.close()
+
+    def test_authenticated_without_recent_click_shows_email_gate(self, context, base_url_fixture):
+        """Authenticated session alone does NOT grant install landing."""
+        page = context.new_page()
+        try:
+            _mock_auth_status(
+                page,
+                authEnabled=True,
+                authenticated=True,
+                installRecentlyAllowed=False,
+            )
+            page.goto(base_url_fixture + "/", wait_until="domcontentloaded")
+            expect(page.locator("#install-gate-private")).to_be_visible()
+            expect(page.locator("#install-landing")).to_be_hidden()
+        finally:
+            page.close()
+
+    def test_authenticated_with_recent_click_shows_install_landing(self, context, base_url_fixture):
+        page = context.new_page()
+        try:
+            _mock_auth_status(
+                page,
+                authEnabled=True,
+                authenticated=True,
+                installRecentlyAllowed=True,
+            )
+            page.goto(base_url_fixture + "/", wait_until="domcontentloaded")
+            expect(page.locator("#install-landing")).to_be_visible()
+            expect(page.locator("#install-gate-private")).to_be_hidden()
+        finally:
+            page.close()
+
+    def test_force_gate_query_overrides_authenticated_state(self, context, base_url_fixture):
+        """?gate=1 always takes you to the gate, even with a valid session."""
+        page = context.new_page()
+        try:
+            _mock_auth_status(
+                page,
+                authEnabled=True,
+                authenticated=True,
+                installRecentlyAllowed=True,
+            )
+            page.goto(base_url_fixture + "/?gate=1", wait_until="domcontentloaded")
+            expect(page.locator("#install-gate-private")).to_be_visible()
+            expect(page.locator("#install-landing")).to_be_hidden()
+        finally:
+            page.close()
+
+    def test_expired_reason_shows_expired_banner(self, context, base_url_fixture):
+        page = context.new_page()
+        try:
+            _mock_auth_status(page, authEnabled=True, authenticated=False)
+            page.goto(
+                base_url_fixture + "/?gate=1&reason=expired",
+                wait_until="domcontentloaded",
+            )
+            banner = page.locator("#gate-reason-banner")
+            expect(banner).to_be_visible()
+            expect(banner).to_contain_text("expired")
+        finally:
+            page.close()
+
+    def test_invalid_reason_shows_invalid_banner(self, context, base_url_fixture):
+        page = context.new_page()
+        try:
+            _mock_auth_status(page, authEnabled=True, authenticated=False)
+            page.goto(
+                base_url_fixture + "/?gate=1&reason=invalid",
+                wait_until="domcontentloaded",
+            )
+            banner = page.locator("#gate-reason-banner")
+            expect(banner).to_be_visible()
+            expect(banner).to_contain_text("isn't valid")
+        finally:
+            page.close()
+
+    def test_back_to_gate_link_posts_logout_and_navigates(self, context, base_url_fixture):
+        page = context.new_page()
+        logout_calls = []
+
+        def _intercept_logout(route):
+            logout_calls.append(route.request.method)
+            route.fulfill(
+                status=200,
+                content_type="application/json",
+                body='{"ok": true}',
+                headers={"Set-Cookie": "fellows_session=; Path=/; Max-Age=0"},
+            )
+
+        try:
+            _mock_auth_status(
+                page,
+                authEnabled=True,
+                authenticated=True,
+                installRecentlyAllowed=True,
+            )
+            page.route("**/api/logout", _intercept_logout)
+            page.goto(base_url_fixture + "/", wait_until="domcontentloaded")
+            expect(page.locator("#install-landing")).to_be_visible()
+
+            # Re-arm auth mock to return a gate state after logout.
+            _mock_auth_status(
+                page,
+                authEnabled=True,
+                authenticated=False,
+                installRecentlyAllowed=False,
+            )
+            page.locator("#back-to-gate-link").click()
+            page.wait_for_url("**/?gate=1", timeout=5000)
+            assert logout_calls == ["POST"], logout_calls
+            expect(page.locator("#install-gate-private")).to_be_visible()
+        finally:
+            page.close()

--- a/tests/test_api.py
+++ b/tests/test_api.py
@@ -112,6 +112,18 @@ class TestAPI:
         if status == 200:
             assert "image/" in ctype
 
+    def test_api_auth_status_shape_includes_install_recently_allowed(self):
+        """Dev server stub must include installRecentlyAllowed=false so the
+        client's decision tree stays on the local-dev passthrough path."""
+        status, ctype, body = get("/api/auth/status")
+        assert status == 200
+        assert "application/json" in ctype
+        data = json.loads(body)
+        assert data.get("authEnabled") is False
+        assert data.get("authenticated") is False
+        assert "installRecentlyAllowed" in data
+        assert data["installRecentlyAllowed"] is False
+
     def test_api_stats_returns_aggregates(self):
         status, ctype, body = get("/api/stats")
         assert status == 200

--- a/tests/test_magic_link_auth.py
+++ b/tests/test_magic_link_auth.py
@@ -1,5 +1,7 @@
 """Unit tests for deploy/magic_link_auth.py (no HTTP)."""
+import base64
 import sys
+import time
 from pathlib import Path
 
 import pytest
@@ -17,13 +19,74 @@ def test_sha256_email_normalizes():
     assert len(a) == 64
 
 
-def test_session_roundtrip(monkeypatch):
+def test_session_roundtrip_v2_carries_token_issued_at(monkeypatch):
     monkeypatch.setenv("FELLOWS_SESSION_SECRET", "unit-test-secret")
     sec = ml.session_secret_bytes()
     assert sec
-    v = ml.sign_session_value(sec)
-    assert ml.verify_session_value(v, sec)
-    assert not ml.verify_session_value(v + "x", sec)
+    tia = int(time.time()) - 60
+    v = ml.sign_session_value(sec, token_issued_at=tia)
+    payload = ml.verify_session_value(v, sec)
+    assert payload is not None
+    assert payload["token_issued_at"] == tia
+    assert ml.verify_session_value(v + "x", sec) is None
+
+
+def test_verify_rejects_v1_cookies(monkeypatch):
+    """Old v1 cookies must no longer verify — forces clean re-login on deploy."""
+    monkeypatch.setenv("FELLOWS_SESSION_SECRET", "unit-test-secret")
+    sec = ml.session_secret_bytes()
+    import hmac as _hmac
+    import hashlib as _hashlib
+
+    exp = int(time.time()) + 3600
+    payload = f"{exp}:deadbeef".encode("utf-8")
+    sig = _hmac.new(sec, payload, _hashlib.sha256).hexdigest()
+    v1_cookie = base64.urlsafe_b64encode(payload).decode("ascii").rstrip("=") + "." + sig
+
+    assert ml.verify_session_value(v1_cookie, sec) is None
+
+
+def test_install_recently_allowed_window_math():
+    now = 1_000_000.0
+    # Token just issued → inside the window.
+    assert ml.install_recently_allowed(now - 10, now=now) is True
+    # Token issued exactly at the boundary (30 min) → outside.
+    assert ml.install_recently_allowed(now - ml.INSTALL_WINDOW, now=now) is False
+    # Token issued 5 min ago → inside.
+    assert ml.install_recently_allowed(now - 300, now=now) is True
+    # None token (no session, or pre-v2 cookie) → never allowed.
+    assert ml.install_recently_allowed(None, now=now) is False
+
+
+def test_consume_token_distinguishes_invalid_expired_ok(monkeypatch):
+    # Unknown token → invalid.
+    r = ml.consume_token("no-such-token-1234567890")
+    assert r == {"status": "invalid"}
+
+    # Expire path: inject a token with past expiry and consume it.
+    with ml.AuthState.lock:
+        ml.AuthState.tokens["expired-token"] = time.time() - 10
+    r = ml.consume_token("expired-token")
+    assert r == {"status": "expired"}
+
+    # Happy path: issue then consume; check issued_at is populated.
+    tok = ml.issue_token()
+    r = ml.consume_token(tok)
+    assert r["status"] == "ok"
+    assert "issued_at" in r
+    # Second consume fails (single-use).
+    assert ml.consume_token(tok) == {"status": "invalid"}
+
+
+def test_clear_session_cookie_line_has_max_age_0():
+    class H:
+        def get(self, key, default=None):
+            return default
+
+    line = ml.clear_session_cookie_line(H())
+    assert ml.SESSION_COOKIE + "=" in line
+    assert "Max-Age=0" in line
+    assert "Path=/" in line
 
 
 def test_allowlist_load(tmp_path):


### PR DESCRIPTION
## Summary

Replaces the old "authenticated users permanently see install landing" flow with the bounded one specified in [\`docs/email_gate.md\`](docs/email_gate.md):

- **Email gate is the default view.** The only exits: a valid magic-link URL, or an authenticated session *within* the 30-min install window, or (in PWA standalone mode) a valid session for the directory.
- **Install landing is a one-shot.** Shown only for 30 min after token issue; never a persistent "home page."
- **Expired and invalid links are explicit.** Land on the gate with a banner telling the user which it was.
- **Dev always has an escape hatch.** \`?gate=1\` URL override + "Back to email gate" link (does \`POST /api/logout\` then navigates).
- **Unsupported browsers are told so.** If \`beforeinstallprompt\` doesn't fire within 3s and we're not on iOS Safari, swap the install button for a "please use Chrome/Edge/Safari" panel.

See the doc for the formal invariants, decision trees (browser + PWA), state diagram, endpoint table, and cookie format.

## Breaking change

Session cookie format bumped to **v2** (carries \`token_issued_at\`). v1 cookies are rejected on sight — every currently-logged-in user re-logs in via magic link after this ships. Acceptable for a dev preview; flag this in release notes when you promote past v0.1.0.

## Test coverage (all 56 green locally)

Unit (\`tests/test_magic_link_auth.py\`):
- \`test_session_roundtrip_v2_carries_token_issued_at\`
- \`test_verify_rejects_v1_cookies\`
- \`test_install_recently_allowed_window_math\`
- \`test_consume_token_distinguishes_invalid_expired_ok\`
- \`test_clear_session_cookie_line_has_max_age_0\`

API (\`tests/test_api.py\`):
- \`test_api_auth_status_shape_includes_install_recently_allowed\`

E2E (\`tests/e2e/test_email_gate.py\`, Playwright with route-mocked \`/api/auth/status\`):
- default unauthenticated → gate
- authenticated WITHOUT recent click → gate (the old flow showed install here; new spec says no)
- authenticated + recent click → install landing
- \`?gate=1\` overrides authenticated state
- \`?reason=expired\` renders "That link expired…" banner
- \`?reason=invalid\` renders "That link isn't valid…" banner
- "Back to email gate" link POSTs \`/api/logout\` then navigates to \`/?gate=1\`

## Manual QA for maintainer (post-merge, pre-release)

1. **Build + deploy**:
   \`\`\`bash
   python build/build_pwa.py
   ./scripts/deploy_pwa.sh --ask-become-pass
   ./scripts/smoke_prod.sh
   \`\`\`
2. **Cookie format burn-down**: any browser with a v1 session will land on the gate on first load post-deploy. Expected, not a bug.
3. **Gate default**: open \`https://fellows.globaldonut.com/\` in a fresh incognito. Should render the email gate immediately (no install landing).
4. **Happy path**: submit your email → receive Postmark email stating "30 minutes" → click link → install landing appears → "Install app" works (Chrome/Edge) or swaps to unsupported panel (Firefox) or shows iOS Share hint (Safari mobile).
5. **Expired banner**: wait >30 min after receiving a link, then click it. Should land on \`/?gate=1&reason=expired\` with the expired banner.
6. **Logout flow**: in a browser that's in the install window, click "Back to email gate". Should \`POST /api/logout\`, land at \`/?gate=1\`, gate visible. Reloading does not revert to install landing.
7. **\`?gate=1\` hardcoded override**: navigate to \`https://fellows.globaldonut.com/?gate=1\` from any state — gate should render regardless of session cookie.
8. **Install completion**: after clicking "Install app" in Chrome and accepting the prompt, the installed PWA should open straight to the directory (no gate, no install landing — session cookie carries across).

## Follow-ups (not in this PR)

- The build badge from #24 will surface the new \`FELLOWS_UI_DIAG\` value once both branches are on main; no change required here.
- Separate issue worth filing: surface recent \`event=send_unlock_email\` log lines in the Diagnostics panel so email-delivery debugging doesn't always require SSH.

🤖 Generated with [Claude Code](https://claude.com/claude-code)