### PR TITLE
feat(email): admin@ sender + Reply-To header + env-dump script (Phase 1)

### DIFF
--- a/deploy/magic_link_auth.py
+++ b/deploy/magic_link_auth.py
@@ -121,21 +121,32 @@ def install_recently_allowed(token_issued_at: Optional[float], now: Optional[flo
     return (now - token_issued_at) < INSTALL_WINDOW
 
 
-def send_postmark_magic_link(to_email: str, magic_url: str) -> dict:
-    api_token = os.environ.get("FELLOWS_POSTMARK_TOKEN", "").strip()
-    if not api_token:
-        raise RuntimeError("FELLOWS_POSTMARK_TOKEN is not set")
-    from_addr = os.environ.get("FELLOWS_MAIL_FROM", "noreply@fellows.globaldonut.com").strip()
+DEFAULT_MAIL_FROM = "admin@fellows.globaldonut.com"
+
+
+def build_postmark_body(to_email: str, magic_url: str) -> dict:
+    """Construct the Postmark /email payload. Pure function; no network.
+
+    From address defaults to admin@fellows.globaldonut.com. Override via
+    FELLOWS_MAIL_FROM. Reply-To is taken from FELLOWS_REPLY_TO when set —
+    useful when admin@ doesn't route to a human mailbox yet and replies
+    should land with the operator directly.
+    """
+    from_addr = os.environ.get("FELLOWS_MAIL_FROM", DEFAULT_MAIL_FROM).strip()
+    reply_to = os.environ.get("FELLOWS_REPLY_TO", "").strip()
     text_body = (
         "Tap or paste this link to open the install page:\n\n"
         f"{magic_url}\n\n"
         "This link will expire in 30 minutes. If it's expired, request a new one.\n"
+        "\n"
+        "— EHF Fellows Directory\n"
     )
     html_body = (
         "<p>Tap or paste this link to open the install page:</p>"
         f'<p><a href="{magic_url}">{magic_url}</a></p>'
         "<p><em>This link will expire in 30 minutes. "
         "If it&rsquo;s expired, request a new one.</em></p>"
+        "<p>&mdash; EHF Fellows Directory</p>"
     )
     body = {
         "From": from_addr,
@@ -145,6 +156,16 @@ def send_postmark_magic_link(to_email: str, magic_url: str) -> dict:
         "HtmlBody": html_body,
         "MessageStream": "outbound",
     }
+    if reply_to:
+        body["ReplyTo"] = reply_to
+    return body
+
+
+def send_postmark_magic_link(to_email: str, magic_url: str) -> dict:
+    api_token = os.environ.get("FELLOWS_POSTMARK_TOKEN", "").strip()
+    if not api_token:
+        raise RuntimeError("FELLOWS_POSTMARK_TOKEN is not set")
+    body = build_postmark_body(to_email, magic_url)
     req = urllib.request.Request(
         "https://api.postmarkapp.com/email",
         data=json.dumps(body).encode("utf-8"),

--- a/docs/email_system_management.md
+++ b/docs/email_system_management.md
@@ -1,10 +1,18 @@
 # Email System Management
 
-The production email system is a magic-link gate on `deploy/server.py`: users submit an email to `POST /api/send-unlock`, the server checks a SHA-256 hash against `deploy/dist/allowed_emails.json`, issues a short-lived token (15 minutes), and sends a Postmark email with a `/#/unlock/<token>` link. When that token is posted to `POST /api/verify-token`, the server sets a signed session cookie and the browser can access protected directory assets (`/fellows.db`, `/images/*`, directory `/api/*`). The system is stateless at deploy-time except for in-memory tokens/rate buckets, so restarts invalidate outstanding tokens by design.
+The production email system is a magic-link gate on `deploy/server.py`: users submit an email to `POST /api/send-unlock`, the server checks a SHA-256 hash against `deploy/dist/allowed_emails.json`, issues a short-lived token (30 minutes — see [`email_gate.md`](email_gate.md)), and sends a Postmark email with a `/#/unlock/<token>` link. When that token is posted to `POST /api/verify-token`, the server sets a signed session cookie and the browser can access protected directory assets (`/fellows.db`, `/images/*`, directory `/api/*`). The system is stateless at deploy-time except for in-memory tokens/rate buckets, so restarts invalidate outstanding tokens by design.
 
 ## Production Setup
 
-Environment variables used in this section: `FELLOWS_SESSION_SECRET` (long random signing key; generate with `python -c "import secrets; print(secrets.token_urlsafe(48))"`), `FELLOWS_POSTMARK_TOKEN` (Postmark Server API token from your Postmark server settings), `FELLOWS_MAIL_FROM` (verified sender signature/domain in Postmark), and `FELLOWS_PUBLIC_ORIGIN` (public HTTPS origin for your deployed app, for example `https://fellows.globaldonut.com`).
+Environment variables used in this section:
+
+| Variable | Purpose |
+|---|---|
+| `FELLOWS_SESSION_SECRET` | Long random signing key. Generate with `python -c "import secrets; print(secrets.token_urlsafe(48))"`. |
+| `FELLOWS_POSTMARK_TOKEN` | Postmark Server API token from the server's settings page. |
+| `FELLOWS_MAIL_FROM` | Sender address that users see on the magic-link email. Defaults to `admin@fellows.globaldonut.com` — must be a verified Sender Signature (or an address on a domain-verified domain) in Postmark. **Do not use `noreply@` addresses** — Postmark actively refuses them and they hurt your sender reputation. |
+| `FELLOWS_REPLY_TO` | Optional. When set, becomes the `Reply-To` header. Use this to route replies to a real operator mailbox (e.g. `richbodo+fellows@gmail.com`) while `admin@fellows.globaldonut.com` is the visible sender. When unset, replies go to `FELLOWS_MAIL_FROM`. |
+| `FELLOWS_PUBLIC_ORIGIN` | Public HTTPS origin for the deployed app, for example `https://fellows.globaldonut.com`. Used to build the magic-link URL in the email body. |
 
 1. **[Machine: local dev machine] Build fresh bundle with allowlist**
    ```bash
@@ -61,6 +69,49 @@ Environment variables used in this section: `FELLOWS_SESSION_SECRET` (long rando
    ./scripts/deploy_pwa.sh --ask-become-pass
    ```
    Then repeat steps 4-5 if env changes were made.
+
+## Sender Setup In Postmark (one-time per sender address)
+
+This section is the operator walkthrough for adding `admin@fellows.globaldonut.com` (or any other from-address on the verified `fellows.globaldonut.com` domain). Postmark's UI buries these steps — follow them verbatim.
+
+### A. Confirm the domain is verified
+
+1. Sign in at <https://account.postmarkapp.com/>.
+2. Top menu: **Sender Signatures**.
+3. Tab: **Domains** (not "Signatures").
+4. Look for `fellows.globaldonut.com`.
+   - Green "Verified" badge on all three columns (**SPF**, **DKIM**, **Return-Path**) → proceed to step B.
+   - Anything yellow or red → click the domain name, copy the DNS records Postmark shows, and add them to Cloudflare DNS for `globaldonut.com`. SPF is a TXT record at `fellows.globaldonut.com` containing `v=spf1 include:spf.mtasv.net ~all`. DKIM is a TXT at `<postmark-selector>._domainkey.fellows.globaldonut.com`. Return-Path is a CNAME `pm-bounces.fellows.globaldonut.com → pm.mtasv.net`. Wait a few minutes after saving in Cloudflare, then hit "Verify" in Postmark.
+
+### B. Send from a new address on the verified domain
+
+If the whole domain is verified, **no additional Sender Signature is required** — you can send from any address on `fellows.globaldonut.com` just by setting `FELLOWS_MAIL_FROM`. Postmark's "Add a Signature" flow is for single-address verification on *unverified* domains; you don't need it here.
+
+If you do want the address to appear in Postmark's Signatures list (so the dashboard shows a friendly name), add it via **Sender Signatures → Signatures → Add Sender Signature** using `admin` (not `noreply` — Postmark blocks the no-reply pattern by policy). Postmark will send a verification email, which lands in the account's default Inbound stream; confirm from the Activity → Inbound tab.
+
+### C. Rotate `FELLOWS_MAIL_FROM` on prod
+
+```bash
+ssh -p 52221 rsb@fellows.globaldonut.com
+sudo nano /etc/fellows/fellows-pwa.env
+# Edit:
+#   FELLOWS_MAIL_FROM=admin@fellows.globaldonut.com
+#   FELLOWS_REPLY_TO=richbodo+fellows@gmail.com   # or any mailbox you check
+sudo systemctl restart fellows-pwa
+```
+
+Then from your laptop:
+
+```bash
+scripts/show_server_env.sh          # confirms the change landed (secrets masked)
+```
+
+### D. Smoke-test the new sender
+
+1. Open `https://fellows.globaldonut.com/?gate=1` in a fresh incognito window (forces the email gate even if you already have a session cookie).
+2. Submit a known-allowlisted address.
+3. Check the inbox — the `From:` header should read `admin@fellows.globaldonut.com`. If you click Reply, your MUA should pre-fill `FELLOWS_REPLY_TO`.
+4. From your laptop: `scripts/debug_email_delivery.py --sudo --since '10 minutes ago'` should show a `result=sent` event with a Postmark MessageID.
 
 ## Email Debugging In Production (Postmark + Server Logs)
 

--- a/scripts/show_server_env.sh
+++ b/scripts/show_server_env.sh
@@ -1,0 +1,64 @@
+#!/usr/bin/env bash
+# Dump /etc/fellows/fellows-pwa.env from prod, with secrets masked.
+#
+# Requires sudo on the droplet (same permissions as restarting the service).
+# Reads the env file via `ssh -tt sudo cat`, then masks values whose KEY
+# matches TOKEN/SECRET/PASSWORD/KEY/CREDENTIAL patterns. Pass --raw to
+# show secrets in full.
+#
+# Environment overrides (match Ansible inventory):
+#   FELLOWS_HOST       default: fellows.globaldonut.com
+#   FELLOWS_SSH_PORT   default: 52221
+#   FELLOWS_SSH_USER   default: rsb
+#   FELLOWS_ENV_FILE   default: /etc/fellows/fellows-pwa.env
+#
+# Usage:
+#   scripts/show_server_env.sh           # masked
+#   scripts/show_server_env.sh --raw     # unmasked (careful — prints secrets)
+
+set -euo pipefail
+
+HOST="${FELLOWS_HOST:-fellows.globaldonut.com}"
+PORT="${FELLOWS_SSH_PORT:-52221}"
+USER_="${FELLOWS_SSH_USER:-rsb}"
+ENV_FILE="${FELLOWS_ENV_FILE:-/etc/fellows/fellows-pwa.env}"
+
+RAW=0
+case "${1:-}" in
+  --raw) RAW=1 ;;
+  -h|--help)
+    sed -n '1,/^set -euo/p' "$0" | grep '^#' | sed 's/^# \{0,1\}//'
+    exit 0
+    ;;
+  "") : ;;
+  *)
+    echo "unknown argument: $1" >&2
+    exit 2
+    ;;
+esac
+
+# -tt forces a pty so sudo's password prompt reaches the terminal.
+# tr -d '\r' strips the CRs the pty introduces so we can parse cleanly.
+ssh -tt -p "$PORT" "$USER_@$HOST" "sudo cat $(printf '%q' "$ENV_FILE")" \
+  | tr -d '\r' \
+  | awk -v raw="$RAW" '
+      BEGIN { FS = "=" }
+      /^[[:space:]]*$/  { print; next }
+      /^[[:space:]]*#/  { print; next }
+      {
+        key = $1
+        val = substr($0, length(key) + 2)
+        # strip surrounding single or double quotes
+        if (val ~ /^".*"$/) val = substr(val, 2, length(val) - 2)
+        else if (val ~ /^'"'"'.*'"'"'$/) val = substr(val, 2, length(val) - 2)
+
+        if (raw == 0 && key ~ /(TOKEN|SECRET|PASSWORD|CREDENTIAL|_KEY$)/) {
+          n = length(val)
+          if (n > 8)      masked = substr(val, 1, 4) "…" substr(val, n - 2, 3)
+          else if (n > 0) masked = "[REDACTED:" n "chars]"
+          else            masked = ""
+          val = masked
+        }
+        printf "%s=%s\n", key, val
+      }
+    '

--- a/tests/test_magic_link_auth.py
+++ b/tests/test_magic_link_auth.py
@@ -102,3 +102,41 @@ def test_gated_paths():
     assert not ml.is_gated_api_path("/api/debug/diagnostics")
     assert ml.is_protected_data_path("/fellows.db")
     assert ml.is_protected_data_path("/images/foo.jpg")
+
+
+def test_build_postmark_body_default_sender_is_admin(monkeypatch):
+    """Default FELLOWS_MAIL_FROM is admin@… (no-reply retired per Postmark guidance)."""
+    monkeypatch.delenv("FELLOWS_MAIL_FROM", raising=False)
+    monkeypatch.delenv("FELLOWS_REPLY_TO", raising=False)
+    body = ml.build_postmark_body("user@example.com", "https://fellows.globaldonut.com/#/unlock/tok")
+    assert body["From"] == "admin@fellows.globaldonut.com"
+    assert body["To"] == "user@example.com"
+    assert body["MessageStream"] == "outbound"
+    assert "expires in 30 minutes" in body["Subject"]
+    assert "30 minutes" in body["TextBody"]
+    assert "30 minutes" in body["HtmlBody"]
+    # Reply-To absent when env var unset — Postmark defaults reply to From.
+    assert "ReplyTo" not in body
+
+
+def test_build_postmark_body_reply_to_env_wins(monkeypatch):
+    """FELLOWS_REPLY_TO becomes the ReplyTo header when set."""
+    monkeypatch.setenv("FELLOWS_MAIL_FROM", "admin@fellows.globaldonut.com")
+    monkeypatch.setenv("FELLOWS_REPLY_TO", "richbodo+fellows@gmail.com")
+    body = ml.build_postmark_body("u@x.com", "https://example/#/unlock/tok")
+    assert body["From"] == "admin@fellows.globaldonut.com"
+    assert body["ReplyTo"] == "richbodo+fellows@gmail.com"
+
+
+def test_build_postmark_body_reply_to_empty_string_is_ignored(monkeypatch):
+    """Empty FELLOWS_REPLY_TO is treated as unset, not as an empty Reply-To header."""
+    monkeypatch.setenv("FELLOWS_REPLY_TO", "   ")
+    body = ml.build_postmark_body("u@x.com", "https://example/#/unlock/tok")
+    assert "ReplyTo" not in body
+
+
+def test_build_postmark_body_mail_from_override(monkeypatch):
+    """FELLOWS_MAIL_FROM overrides the default."""
+    monkeypatch.setenv("FELLOWS_MAIL_FROM", "hello@fellows.globaldonut.com")
+    body = ml.build_postmark_body("u@x.com", "https://example/#/unlock/tok")
+    assert body["From"] == "hello@fellows.globaldonut.com"


### PR DESCRIPTION
## Summary

- **From address**: default flips from `noreply@fellows.globaldonut.com` to `admin@fellows.globaldonut.com` (Postmark blocks `noreply` per policy; it also tanks sender reputation and breaks the reply-capable support path).
- **Reply-To header**: new \`FELLOWS_REPLY_TO\` env. When set, outbound magic-link emails carry a `Reply-To:` so replies route to a real operator mailbox while the visible sender stays `admin@fellows...`. Empty/unset → no header, Postmark defaults replies to From.
- **Operator env inspector**: \`scripts/show_server_env.sh\` SSHes + sudo cats `/etc/fellows/fellows-pwa.env` with secrets masked by default. `--raw` opts into unmasked. Saves remembering the path + awk mask.
- **Docs**: \`docs/email_system_management.md\` gains a "Sender Setup In Postmark" section walking through domain-verification check → sending from a new address on a verified domain (no per-address signature needed) → env rotation → smoke. Env vars switched to a reference table.

No behavioral change for existing successful sends — today's Postmark-delivered mail would continue to deliver. The change is about the *sender identity* users see (which Gmail + industry best practice care about) and about giving replies a real destination.

## What this leaves for later

- **Phase 2 (bounce/complaint webhook)**: your call whether to build next.
- **Phase 3 (inbound webhook for `admin@` mail manually typed by users)**: deferred until there's evidence someone's sending to it; for now replies handle the legitimate case via `FELLOWS_REPLY_TO`.
- **#26 (in-app Diagnostics panel for send events)**: still open.

## Operator walkthrough (post-merge)

Follow \`docs/email_system_management.md § Sender Setup In Postmark\` step-by-step. Short version:

1. **Confirm domain verification in Postmark**: <https://account.postmarkapp.com/> → Sender Signatures → **Domains** tab → `fellows.globaldonut.com` should show green "Verified" on SPF, DKIM, and Return-Path. Your existing Cloudflare DNS already has the DKIM selector (`…_domainkey.fellows`) and `pm-bounces.fellows` CNAME, so this is almost certainly already done — just confirm.
2. **Sender Signature for `admin@`**: not needed if the domain is fully verified (you can send from any address on it). Optional: add it to the Signatures list for dashboard friendliness.
3. **Deploy** (no manual Ansible step — all code deploys via the usual path):
   \`\`\`bash
   ./scripts/deploy_pwa.sh --ask-become-pass
   \`\`\`
4. **Update env on prod**:
   \`\`\`bash
   ssh -p 52221 rsb@fellows.globaldonut.com
   sudo nano /etc/fellows/fellows-pwa.env
   # Set:
   #   FELLOWS_MAIL_FROM=admin@fellows.globaldonut.com
   #   FELLOWS_REPLY_TO=richbodo+fellows@gmail.com
   sudo systemctl restart fellows-pwa
   \`\`\`
5. **Verify env landed**:
   \`\`\`bash
   scripts/show_server_env.sh
   \`\`\`
   Should show \`FELLOWS_MAIL_FROM=admin@fellows.globaldonut.com\` and `FELLOWS_REPLY_TO=richbodo+fellows@gmail.com`. Secrets masked.
6. **Smoke test**: open <https://fellows.globaldonut.com/?gate=1> in a fresh incognito, submit your email, confirm the received message's `From:` reads `admin@fellows...` and Reply pre-fills `richbodo+fellows@gmail.com`. Then from laptop: \`scripts/debug_email_delivery.py --sudo --since '10 minutes ago'\` should show a `result=sent` event.

## Tests

4 new unit tests in \`tests/test_magic_link_auth.py\` cover: default From is admin@, Reply-To set from env, empty Reply-To ignored, MAIL_FROM override. All 76 tests green.

🤖 Generated with [Claude Code](https://claude.com/claude-code)