### PR TITLE
fix(ops): debug_email_delivery.py — SSH arg quoting + --sudo + --postmark-token

### DIFF
--- a/scripts/debug_email_delivery.py
+++ b/scripts/debug_email_delivery.py
@@ -398,7 +398,14 @@ def build_arg_parser() -> argparse.ArgumentParser:
     ap.add_argument(
         "--postmark",
         action="store_true",
-        help="Resolve Postmark MessageIDs via the Messages API. Requires FELLOWS_POSTMARK_TOKEN.",
+        help="Resolve Postmark MessageIDs via the Messages API. Token comes from "
+        "--postmark-token or FELLOWS_POSTMARK_TOKEN env (in that order).",
+    )
+    ap.add_argument(
+        "--postmark-token",
+        metavar="TOKEN",
+        help="Postmark Server API token. Alternative to FELLOWS_POSTMARK_TOKEN env. "
+        "Implies --postmark.",
     )
     ap.add_argument(
         "--sudo",
@@ -438,11 +445,15 @@ def main(argv: list[str] | None = None) -> int:
     if args.limit > 0:
         events = events[-args.limit :]
 
+    want_postmark = bool(args.postmark or args.postmark_token)
     postmark_lookups: dict[str, dict] = {}
-    if args.postmark:
-        token = os.environ.get("FELLOWS_POSTMARK_TOKEN", "").strip()
+    if want_postmark:
+        token = (args.postmark_token or os.environ.get("FELLOWS_POSTMARK_TOKEN", "")).strip()
         if not token:
-            sys.stderr.write("--postmark requires FELLOWS_POSTMARK_TOKEN in env.\n")
+            sys.stderr.write(
+                "Postmark resolution needs a token: pass --postmark-token <TOKEN> "
+                "or set FELLOWS_POSTMARK_TOKEN in env.\n"
+            )
             return 2
         seen: set[str] = set()
         for e in events:

--- a/scripts/debug_email_delivery.py
+++ b/scripts/debug_email_delivery.py
@@ -35,6 +35,7 @@ import hashlib
 import json
 import os
 import re
+import shlex
 import subprocess
 import sys
 import urllib.error
@@ -56,38 +57,83 @@ def hash_email(email: str) -> str:
     return hashlib.sha256(email.strip().lower().encode("utf-8")).hexdigest()
 
 
-def ssh_journal(host: str, port: str, user: str, since: str, unit: str = UNIT) -> str:
+def build_ssh_cmd(
+    host: str,
+    port: str,
+    user: str,
+    since: str,
+    unit: str = UNIT,
+    use_sudo: bool = False,
+) -> list[str]:
+    """Build the ssh command list.
+
+    SSH concatenates argv with spaces on the wire and the remote shell
+    re-parses, so ``--since '2 hours ago'`` passed as separate argv entries
+    arrives on the remote as ``--since 2 hours ago`` and journalctl rejects
+    it with "Failed to parse timestamp: 2". Quote each remote arg and pass
+    the whole remote command as a single SSH argument.
+
+    When ``use_sudo=True``, prepend ``sudo`` to the remote command and force
+    a pty with ``-tt`` so sudo can prompt for a password interactively.
+    Needed when the operator isn't in the ``systemd-journal`` / ``adm``
+    group — non-privileged journalctl silently returns no rows for other
+    units' logs.
+    """
+    remote_argv = ["journalctl", "-u", unit, "--since", since, "-o", "json", "--no-pager"]
+    if use_sudo:
+        remote_argv = ["sudo"] + remote_argv
+    remote_cmd = " ".join(shlex.quote(a) for a in remote_argv)
+
+    ssh_flags: list[str] = ["-p", str(port)]
+    if use_sudo:
+        # Force a pty so the remote sudo can prompt on stderr; BatchMode would
+        # actively suppress that prompt and cause immediate failure.
+        ssh_flags.append("-tt")
+    else:
+        ssh_flags.extend(["-o", "BatchMode=yes"])
+
+    return ["ssh", *ssh_flags, f"{user}@{host}", remote_cmd]
+
+
+def ssh_journal(
+    host: str,
+    port: str,
+    user: str,
+    since: str,
+    unit: str = UNIT,
+    use_sudo: bool = False,
+) -> str:
     """Fetch journalctl JSON lines via SSH. Returns raw stdout."""
-    cmd = [
-        "ssh",
-        "-p",
-        str(port),
-        "-o",
-        "BatchMode=yes",
-        f"{user}@{host}",
-        "journalctl",
-        "-u",
-        unit,
-        "--since",
-        since,
-        "-o",
-        "json",
-        "--no-pager",
-    ]
+    cmd = build_ssh_cmd(host, port, user, since, unit=unit, use_sudo=use_sudo)
     try:
-        r = subprocess.run(cmd, capture_output=True, text=True, timeout=60, check=False)
+        if use_sudo:
+            # Let sudo's password prompt reach the user's terminal on stderr,
+            # and inherit stdin so they can type. Capture stdout only.
+            r = subprocess.run(
+                cmd,
+                stdout=subprocess.PIPE,
+                text=True,
+                timeout=120,
+                check=False,
+            )
+        else:
+            r = subprocess.run(cmd, capture_output=True, text=True, timeout=60, check=False)
     except FileNotFoundError:
         sys.stderr.write("ssh binary not found on PATH\n")
         sys.exit(2)
     except subprocess.TimeoutExpired:
-        sys.stderr.write("ssh/journalctl timed out after 60s\n")
+        sys.stderr.write("ssh/journalctl timed out\n")
         sys.exit(2)
     if r.returncode != 0:
         sys.stderr.write(f"ssh/journalctl failed (exit {r.returncode}):\n")
-        sys.stderr.write(r.stderr)
+        if not use_sudo:
+            sys.stderr.write(r.stderr or "")
         sys.stderr.write(
             "\nHints: is your SSH key loaded? Does "
             f"`ssh -p {port} {user}@{host} true` succeed interactively?\n"
+            "If journalctl returns no rows for the fellows-pwa unit, rerun "
+            "with --sudo (the operator needs to be in adm or systemd-journal "
+            "to read other users' unit logs without it).\n"
         )
         sys.exit(1)
     return r.stdout
@@ -355,6 +401,13 @@ def build_arg_parser() -> argparse.ArgumentParser:
         help="Resolve Postmark MessageIDs via the Messages API. Requires FELLOWS_POSTMARK_TOKEN.",
     )
     ap.add_argument(
+        "--sudo",
+        action="store_true",
+        help="Run journalctl under sudo on the remote (forces a tty for the prompt). "
+        "Needed when the operator isn't in adm / systemd-journal and so journalctl "
+        "silently returns no rows for the fellows-pwa unit.",
+    )
+    ap.add_argument(
         "--json",
         action="store_true",
         help="Emit raw JSON (for piping / jq). Suppresses the formatted report.",
@@ -379,7 +432,7 @@ def main(argv: list[str] | None = None) -> int:
         prefix = args.email_hash_prefix.lower().strip()
         email_desc = f"{prefix}…"
 
-    raw = ssh_journal(args.host, args.port, args.user, args.since)
+    raw = ssh_journal(args.host, args.port, args.user, args.since, use_sudo=args.sudo)
     events = parse_events(raw)
     events = filter_events(events, email_hash_prefix=prefix, result=args.result)
     if args.limit > 0:

--- a/tests/test_debug_email_delivery.py
+++ b/tests/test_debug_email_delivery.py
@@ -43,6 +43,48 @@ def _send_event_json(**overrides) -> str:
     return json.dumps(payload)
 
 
+def test_build_ssh_cmd_quotes_since_with_spaces():
+    """--since '2 hours ago' must survive SSH-then-remote-shell re-parse.
+
+    Regression: SSH concatenates argv with spaces on the wire, so unquoted
+    remote args get re-split by the remote shell. journalctl rejects the
+    resulting `--since 2` with "Failed to parse timestamp: 2".
+    """
+    cmd = ded.build_ssh_cmd("example.com", "52221", "rsb", "2 hours ago")
+    assert cmd[0] == "ssh"
+    assert cmd[-2] == "rsb@example.com"
+    remote = cmd[-1]
+    # Every remote token that journalctl would re-split must be shell-quoted.
+    assert "'2 hours ago'" in remote
+    assert "journalctl -u fellows-pwa --since '2 hours ago' -o json --no-pager" == remote
+
+
+def test_build_ssh_cmd_quotes_unit_and_simple_since():
+    """Simple args (no spaces) are safe to leave unquoted, but shlex.quote
+    is idempotent so the command shape is still deterministic."""
+    cmd = ded.build_ssh_cmd("h", "22", "u", "24h", unit="foo-pwa")
+    remote = cmd[-1]
+    assert "foo-pwa" in remote
+    assert " 24h " in remote + " "  # 24h appears as its own token
+
+
+def test_build_ssh_cmd_sudo_mode_forces_tty_and_prepends_sudo():
+    cmd = ded.build_ssh_cmd("example.com", "52221", "rsb", "2 hours ago", use_sudo=True)
+    # -tt forces pty so sudo can prompt; BatchMode must NOT be present.
+    assert "-tt" in cmd
+    assert "BatchMode=yes" not in " ".join(cmd)
+    # Remote command starts with sudo journalctl ...
+    assert cmd[-1].startswith("sudo journalctl ")
+    assert "'2 hours ago'" in cmd[-1]
+
+
+def test_build_ssh_cmd_default_uses_batchmode_no_sudo():
+    cmd = ded.build_ssh_cmd("h", "22", "u", "24h")
+    assert "-tt" not in cmd
+    assert "BatchMode=yes" in cmd
+    assert not cmd[-1].startswith("sudo ")
+
+
 def test_hash_email_matches_server_contract():
     a = ded.hash_email("  Test@Example.COM  ")
     b = ded.hash_email("test@example.com")
@@ -280,7 +322,7 @@ def test_main_json_output_round_trips(monkeypatch, capsys):
     monkeypatch.setattr(
         ded,
         "ssh_journal",
-        lambda host, port, user, since: _journal_envelope(_send_event_json()),
+        lambda host, port, user, since, **kw: _journal_envelope(_send_event_json()),
     )
     rc = ded.main(["--json", "--since", "1 hour ago"])
     assert rc == 0


### PR DESCRIPTION
## Summary

Two commits that landed on \`feat/debug-email-delivery-script\` **after** PR #27 was merged, and which never made it to main. Without them the deployed script is broken in two independent ways.

1. **\`fc095c3\` — SSH arg quoting + \`--sudo\`**
   - Fixes: \`--since '2 hours ago'\` → \`"Failed to parse timestamp: 2"\`. SSH concatenates argv with spaces on the wire and the remote shell re-splits, so \`--since 2 hours ago\` arrives as three tokens. \`shlex.quote\`-ing each remote arg + passing the whole remote command as one SSH argument fixes it.
   - Adds: \`--sudo\` flag. Non-privileged \`journalctl\` silently returns zero rows for other users' units (the \`fellows-pwa\` unit runs as \`fellows\`, \`rsb\` isn't in \`systemd-journal\` or \`adm\`). \`--sudo\` forces a pty via \`ssh -tt\` so the password prompt reaches the terminal, and prepends \`sudo\` to the remote \`journalctl\`. Without this you'll hit "No events in window" no matter how wide the time filter.

2. **\`71f7c17\` — \`--postmark-token TOKEN\`**
   - \`--postmark\` was a bare flag reading from \`FELLOWS_POSTMARK_TOKEN\` env; the natural reach for \`--postmark <TOKEN>\` hit \`argparse: unrecognized arguments\`. Adds \`--postmark-token TOKEN\` as an explicit inline alternative (implies \`--postmark\`).

Both live-tested end-to-end against the droplet during the debugging session. 20 unit tests cover arg quoting, sudo flag wiring, prefix matching, JSON output, and the full parse/filter pipeline; network paths (SSH + Postmark API) are integration-only by design.

## Why this is a separate PR

PR #27 got merged at its first commit only (\`8a23342\`), so these two follow-ups never reached main. They're the topic of PR #27 (debug script), not PR #28 (email sender), so bundling them into PR #28 would have been scope-mixing — this is the cleanest way to land them.

## No conflicts with main

The two commits only touch \`scripts/debug_email_delivery.py\` and \`tests/test_debug_email_delivery.py\`. PR #28 touched different files. Three-way merge is clean.

## Why land this now

Smoke-testing PR #28 needs \`--sudo\` — without it you'll see "No events in window" even when sends are firing.

🤖 Generated with [Claude Code](https://claude.com/claude-code)