### PR TITLE
fix(ops): debug_email_delivery.py --sudo hang (pty + PIPE swallowed the prompt)

### DIFF
--- a/scripts/debug_email_delivery.py
+++ b/scripts/debug_email_delivery.py
@@ -31,6 +31,7 @@ the send half of that flow.
 from __future__ import annotations
 
 import argparse
+import getpass
 import hashlib
 import json
 import os
@@ -73,23 +74,20 @@ def build_ssh_cmd(
     it with "Failed to parse timestamp: 2". Quote each remote arg and pass
     the whole remote command as a single SSH argument.
 
-    When ``use_sudo=True``, prepend ``sudo`` to the remote command and force
-    a pty with ``-tt`` so sudo can prompt for a password interactively.
-    Needed when the operator isn't in the ``systemd-journal`` / ``adm``
-    group — non-privileged journalctl silently returns no rows for other
-    units' logs.
+    When ``use_sudo=True``, prepend ``sudo -S -p ''`` on the remote. Caller
+    is responsible for supplying the password on the subprocess's stdin.
+    ``-S`` reads the password from stdin; ``-p ''`` silences the prompt
+    text so nothing contaminates the journalctl JSON stream. No pty
+    allocation (no ``-tt``) — that swallowed the prompt into captured
+    stdout and caused indefinite hangs.
     """
     remote_argv = ["journalctl", "-u", unit, "--since", since, "-o", "json", "--no-pager"]
     if use_sudo:
-        remote_argv = ["sudo"] + remote_argv
+        remote_argv = ["sudo", "-S", "-p", ""] + remote_argv
     remote_cmd = " ".join(shlex.quote(a) for a in remote_argv)
 
     ssh_flags: list[str] = ["-p", str(port)]
-    if use_sudo:
-        # Force a pty so the remote sudo can prompt on stderr; BatchMode would
-        # actively suppress that prompt and cause immediate failure.
-        ssh_flags.append("-tt")
-    else:
+    if not use_sudo:
         ssh_flags.extend(["-o", "BatchMode=yes"])
 
     return ["ssh", *ssh_flags, f"{user}@{host}", remote_cmd]
@@ -102,40 +100,70 @@ def ssh_journal(
     since: str,
     unit: str = UNIT,
     use_sudo: bool = False,
+    verbose: bool = False,
+    sudo_password: str | None = None,
 ) -> str:
-    """Fetch journalctl JSON lines via SSH. Returns raw stdout."""
+    """Fetch journalctl JSON lines via SSH. Returns raw stdout.
+
+    With ``use_sudo=True``, prompts locally for the sudo password via
+    ``getpass`` (unless ``sudo_password`` is supplied, mostly for tests)
+    and pipes it to the remote ``sudo -S`` via the subprocess's stdin.
+    """
+    if use_sudo and sudo_password is None:
+        sudo_password = getpass.getpass(f"sudo password for {user}@{host}: ")
+
     cmd = build_ssh_cmd(host, port, user, since, unit=unit, use_sudo=use_sudo)
+
+    # Always print a one-line breadcrumb so a hang is obviously a hang on a
+    # known line, not a silent wedge. --verbose echoes the full quoted cmd.
+    sys.stderr.write(f"→ SSH {user}@{host}:{port} journalctl (use_sudo={use_sudo})…\n")
+    sys.stderr.flush()
+    if verbose:
+        sys.stderr.write(
+            "[verbose] " + " ".join(shlex.quote(a) for a in cmd) + "\n"
+        )
+        sys.stderr.flush()
+
     try:
-        if use_sudo:
-            # Let sudo's password prompt reach the user's terminal on stderr,
-            # and inherit stdin so they can type. Capture stdout only.
-            r = subprocess.run(
-                cmd,
-                stdout=subprocess.PIPE,
-                text=True,
-                timeout=120,
-                check=False,
-            )
-        else:
-            r = subprocess.run(cmd, capture_output=True, text=True, timeout=60, check=False)
+        r = subprocess.run(
+            cmd,
+            input=(sudo_password + "\n") if use_sudo else None,
+            capture_output=True,
+            text=True,
+            timeout=120,
+            check=False,
+        )
     except FileNotFoundError:
         sys.stderr.write("ssh binary not found on PATH\n")
         sys.exit(2)
     except subprocess.TimeoutExpired:
-        sys.stderr.write("ssh/journalctl timed out\n")
+        sys.stderr.write("ssh/journalctl timed out after 120s\n")
         sys.exit(2)
+
     if r.returncode != 0:
         sys.stderr.write(f"ssh/journalctl failed (exit {r.returncode}):\n")
-        if not use_sudo:
-            sys.stderr.write(r.stderr or "")
+        if r.stderr:
+            sys.stderr.write(r.stderr)
+            if not r.stderr.endswith("\n"):
+                sys.stderr.write("\n")
         sys.stderr.write(
             "\nHints: is your SSH key loaded? Does "
             f"`ssh -p {port} {user}@{host} true` succeed interactively?\n"
-            "If journalctl returns no rows for the fellows-pwa unit, rerun "
-            "with --sudo (the operator needs to be in adm or systemd-journal "
-            "to read other users' unit logs without it).\n"
         )
+        if use_sudo:
+            sys.stderr.write(
+                "If sudo failed: check the password. Alternatively, add "
+                f"{user} to the systemd-journal group on prod to drop the "
+                "--sudo requirement entirely.\n"
+            )
+        else:
+            sys.stderr.write(
+                "If journalctl returned no rows for fellows-pwa, rerun with "
+                "--sudo — non-privileged journalctl silently hides other "
+                "users' unit logs.\n"
+            )
         sys.exit(1)
+
     return r.stdout
 
 
@@ -410,9 +438,17 @@ def build_arg_parser() -> argparse.ArgumentParser:
     ap.add_argument(
         "--sudo",
         action="store_true",
-        help="Run journalctl under sudo on the remote (forces a tty for the prompt). "
-        "Needed when the operator isn't in adm / systemd-journal and so journalctl "
-        "silently returns no rows for the fellows-pwa unit.",
+        help="Run journalctl under sudo on the remote. Prompts locally for the "
+        "password via getpass, then pipes to `sudo -S`. Needed when the operator "
+        "isn't in adm / systemd-journal (journalctl silently hides other users' "
+        "unit logs otherwise).",
+    )
+    ap.add_argument(
+        "-v",
+        "--verbose",
+        action="store_true",
+        help="Echo the SSH command to stderr before running (doesn't include "
+        "the sudo password — that's piped in separately).",
     )
     ap.add_argument(
         "--json",
@@ -439,7 +475,14 @@ def main(argv: list[str] | None = None) -> int:
         prefix = args.email_hash_prefix.lower().strip()
         email_desc = f"{prefix}…"
 
-    raw = ssh_journal(args.host, args.port, args.user, args.since, use_sudo=args.sudo)
+    raw = ssh_journal(
+        args.host,
+        args.port,
+        args.user,
+        args.since,
+        use_sudo=args.sudo,
+        verbose=args.verbose,
+    )
     events = parse_events(raw)
     events = filter_events(events, email_hash_prefix=prefix, result=args.result)
     if args.limit > 0:

--- a/tests/test_debug_email_delivery.py
+++ b/tests/test_debug_email_delivery.py
@@ -68,14 +68,21 @@ def test_build_ssh_cmd_quotes_unit_and_simple_since():
     assert " 24h " in remote + " "  # 24h appears as its own token
 
 
-def test_build_ssh_cmd_sudo_mode_forces_tty_and_prepends_sudo():
+def test_build_ssh_cmd_sudo_mode_uses_sudo_s_not_pty():
+    """--sudo uses `sudo -S -p ''` + piped stdin password, not a pty.
+
+    Regression: the old `-tt` pty approach swallowed sudo's prompt into the
+    captured stdout stream so the user never saw "Password:" and the script
+    hung waiting for input they didn't know to provide.
+    """
     cmd = ded.build_ssh_cmd("example.com", "52221", "rsb", "2 hours ago", use_sudo=True)
-    # -tt forces pty so sudo can prompt; BatchMode must NOT be present.
-    assert "-tt" in cmd
+    assert "-tt" not in cmd
     assert "BatchMode=yes" not in " ".join(cmd)
-    # Remote command starts with sudo journalctl ...
-    assert cmd[-1].startswith("sudo journalctl ")
-    assert "'2 hours ago'" in cmd[-1]
+    remote = cmd[-1]
+    # `sudo -S -p '' journalctl ...` — the empty -p silences the prompt text
+    # so it doesn't contaminate the journalctl JSON output.
+    assert remote.startswith("sudo -S -p '' journalctl ")
+    assert "'2 hours ago'" in remote
 
 
 def test_build_ssh_cmd_default_uses_batchmode_no_sudo():
@@ -83,6 +90,48 @@ def test_build_ssh_cmd_default_uses_batchmode_no_sudo():
     assert "-tt" not in cmd
     assert "BatchMode=yes" in cmd
     assert not cmd[-1].startswith("sudo ")
+
+
+def test_ssh_journal_sudo_pipes_password_to_stdin(monkeypatch):
+    """--sudo path should pipe the password to subprocess stdin, not rely on a tty."""
+    captured = {}
+
+    class _FakeResult:
+        returncode = 0
+        stdout = ""
+        stderr = ""
+
+    def fake_run(cmd, **kwargs):
+        captured["cmd"] = cmd
+        captured["input"] = kwargs.get("input")
+        captured["capture_output"] = kwargs.get("capture_output")
+        return _FakeResult()
+
+    monkeypatch.setattr(ded.subprocess, "run", fake_run)
+    ded.ssh_journal(
+        "h", "22", "u", "24h", use_sudo=True, sudo_password="secret-pw"
+    )
+    assert captured["input"] == "secret-pw\n"
+    assert captured["capture_output"] is True
+    # Password never ends up in argv itself.
+    assert "secret-pw" not in " ".join(captured["cmd"])
+
+
+def test_ssh_journal_non_sudo_does_not_write_stdin(monkeypatch):
+    captured = {}
+
+    class _FakeResult:
+        returncode = 0
+        stdout = ""
+        stderr = ""
+
+    def fake_run(cmd, **kwargs):
+        captured["input"] = kwargs.get("input")
+        return _FakeResult()
+
+    monkeypatch.setattr(ded.subprocess, "run", fake_run)
+    ded.ssh_journal("h", "22", "u", "24h", use_sudo=False)
+    assert captured["input"] is None
 
 
 def test_hash_email_matches_server_contract():


### PR DESCRIPTION
## The hang

\`\`\`
$ scripts/debug_email_delivery.py --sudo --since '10 minutes ago'
  ← silent indefinitely, nothing to type
\`\`\`

## Root cause

The \`--sudo\` path used \`ssh -tt\` to force a pty on the remote so sudo could prompt interactively. On a pty, stdout and stderr are merged into one stream. We were running \`subprocess.run(stdout=PIPE)\` to capture the journalctl JSON — which also captured the \`"Password:"\` prompt. You saw nothing; sudo was waiting for a password on the other end of the pipe.

## Fix

Drop \`-tt\` entirely. Read the password locally via \`getpass.getpass(...)\` (hidden input, reaches your real terminal), then pipe it to remote \`sudo -S -p ''\` via subprocess stdin. \`sudo -S\` is specifically designed for non-interactive password input; \`-p ''\` silences the prompt text so nothing contaminates the JSON stream.

No pty, no merged streams, no prompt to swallow.

## New flags

- **\`-v\` / \`--verbose\`** — echoes the full shlex-quoted SSH command to stderr before running. The password isn't in argv (it's on stdin), so this is safe.
- **Breadcrumb**: a single \`→ SSH …\` line always prints to stderr before the subprocess call, so a hang is visibly at a known point, not a silent wedge.

## Tests

- \`test_build_ssh_cmd_sudo_mode_uses_sudo_s_not_pty\` — no \`-tt\`, remote command starts with \`sudo -S -p '' journalctl …\`.
- \`test_ssh_journal_sudo_pipes_password_to_stdin\` — password ends up in \`subprocess.run(input=…)\`, never in argv. 82 tests green.

## Try it

\`\`\`bash
git pull
scripts/debug_email_delivery.py --sudo --since '10 minutes ago'
# getpass prompts "sudo password for rsb@fellows.globaldonut.com:"
# you type, hidden; hit Enter; the rest runs fast
\`\`\`

If it hangs again, add \`-v\`. You'll see the exact SSH command on stderr the moment it fires, so you can see whether we're wedged on SSH vs on something downstream.

🤖 Generated with [Claude Code](https://claude.com/claude-code)