### PR TITLE
fix(ops): show_server_env.sh hang (same pty-PIPE bug as PR #30)

### DIFF
--- a/scripts/show_server_env.sh
+++ b/scripts/show_server_env.sh
@@ -1,8 +1,12 @@
 #!/usr/bin/env bash
 # Dump /etc/fellows/fellows-pwa.env from prod, with secrets masked.
 #
-# Requires sudo on the droplet (same permissions as restarting the service).
-# Reads the env file via `ssh -tt sudo cat`, then masks values whose KEY
+# Prompts locally for your sudo password (hidden input) and pipes it to
+# remote `sudo -S`. No pty allocation — the old `ssh -tt sudo` approach
+# merged stdout+stderr on the remote, and our awk pipeline captured the
+# prompt, so "Password:" never reached the terminal and the script hung.
+#
+# Reads the env file via `sudo -S -p '' cat`, then masks values whose KEY
 # matches TOKEN/SECRET/PASSWORD/KEY/CREDENTIAL patterns. Pass --raw to
 # show secrets in full.
 #
@@ -37,10 +41,19 @@ case "${1:-}" in
     ;;
 esac
 
-# -tt forces a pty so sudo's password prompt reaches the terminal.
-# tr -d '\r' strips the CRs the pty introduces so we can parse cleanly.
-ssh -tt -p "$PORT" "$USER_@$HOST" "sudo cat $(printf '%q' "$ENV_FILE")" \
-  | tr -d '\r' \
+# Hidden-input read. -s suppresses echo; prompt goes to stderr so it can't
+# contaminate stdout if the caller redirects.
+printf "sudo password for %s@%s: " "$USER_" "$HOST" >&2
+IFS= read -rs SUDO_PW
+printf "\n" >&2
+
+# `sudo -S` reads the password from stdin. `-p ''` silences sudo's prompt
+# text so nothing lands in the env-file stream. Single remote command
+# string — printf %q escapes the path for the remote shell.
+REMOTE_CMD="sudo -S -p '' cat $(printf '%q' "$ENV_FILE")"
+
+printf '%s\n' "$SUDO_PW" \
+  | ssh -o BatchMode=no -p "$PORT" "$USER_@$HOST" "$REMOTE_CMD" \
   | awk -v raw="$RAW" '
       BEGIN { FS = "=" }
       /^[[:space:]]*$/  { print; next }


### PR DESCRIPTION
## Same bug, different file

\`\`\`
$ ./scripts/show_server_env.sh
  ← silent hang
^C
[sudo] password for rsb: sudo: a password is required
Connection to fellows.globaldonut.com closed.
\`\`\`

Identical root cause to PR #30's \`debug_email_delivery.py\` fix:

- \`ssh -tt\` forces a pty
- Pty merges stdout + stderr on the remote
- Our \`awk\` pipeline captured the stdout
- sudo's \"Password:\" prompt never reached the terminal
- User sat staring at a blank line

## Fix

Same pattern as PR #30 — drop \`-tt\`, prompt locally with \`read -rs\` (hidden input, stderr side), pipe the password to remote \`sudo -S -p '' cat …\` over stdin. Empty \`-p\` silences sudo's prompt so nothing contaminates the env-file stream.

## After this lands

\`\`\`bash
git pull
./scripts/show_server_env.sh
# "sudo password for rsb@fellows.globaldonut.com:" prompt appears immediately
# type password, Enter, env file prints with secrets masked
\`\`\`

Follow-up worth filing (mentioned in earlier PR, not done yet): one-line Ansible change to add \`rsb\` to the \`systemd-journal\` group. Wouldn't remove the need for sudo here (this reads `/etc/fellows/fellows-pwa.env` which is `0640 root:fellows`), but would drop the sudo need for \`debug_email_delivery.py\`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)