### PR TITLE
dev(ergonomics): show_server_env.sh raw by default; debug_email auto-fetches Postmark token

### DIFF
--- a/docs/email_system_management.md
+++ b/docs/email_system_management.md
@@ -103,7 +103,7 @@ sudo systemctl restart fellows-pwa
 Then from your laptop:
 
 ```bash
-scripts/show_server_env.sh          # confirms the change landed (secrets masked)
+scripts/show_server_env.sh          # confirms the change landed (values shown raw — copy/paste-ready)
 ```
 
 ### D. Smoke-test the new sender

--- a/scripts/debug_email_delivery.py
+++ b/scripts/debug_email_delivery.py
@@ -245,6 +245,75 @@ def filter_events(
     return out
 
 
+DEFAULT_ENV_FILE = "/etc/fellows/fellows-pwa.env"
+
+
+def fetch_postmark_token_from_prod(
+    host: str,
+    port: str,
+    user: str,
+    sudo_password: str,
+    env_file: str = DEFAULT_ENV_FILE,
+) -> str:
+    """SSH + `sudo -S cat` the prod env file, return FELLOWS_POSTMARK_TOKEN.
+
+    Raises RuntimeError on any failure (ssh, sudo, missing key). Caller
+    should catch and fall through to a clear error message.
+    """
+    remote_cmd = f"sudo -S -p '' cat {shlex.quote(env_file)}"
+    cmd = ["ssh", "-p", str(port), f"{user}@{host}", remote_cmd]
+    r = subprocess.run(
+        cmd,
+        input=sudo_password + "\n",
+        capture_output=True,
+        text=True,
+        timeout=60,
+        check=False,
+    )
+    if r.returncode != 0:
+        raise RuntimeError(
+            f"ssh/sudo cat failed (exit {r.returncode}): "
+            + (r.stderr.strip() or "no stderr")
+        )
+    for line in r.stdout.splitlines():
+        if line.startswith("FELLOWS_POSTMARK_TOKEN="):
+            val = line.split("=", 1)[1].strip()
+            # Strip surrounding quotes if any.
+            if len(val) >= 2 and val[0] in ("'", '"') and val[-1] == val[0]:
+                val = val[1:-1]
+            if not val:
+                raise RuntimeError("FELLOWS_POSTMARK_TOKEN is set to an empty value on prod")
+            return val
+    raise RuntimeError(f"FELLOWS_POSTMARK_TOKEN not found in {env_file}")
+
+
+def resolve_postmark_token(
+    args,
+    sudo_password: str | None,
+) -> tuple[str | None, str]:
+    """Determine the Postmark token to use, per the documented priority.
+
+    Returns (token_or_None, source_label). Never raises — caller inspects
+    token to decide whether to error or proceed without Postmark resolution.
+    """
+    tok = (args.postmark_token or "").strip()
+    if tok:
+        return tok, "--postmark-token"
+    tok = os.environ.get("FELLOWS_POSTMARK_TOKEN", "").strip()
+    if tok:
+        return tok, "FELLOWS_POSTMARK_TOKEN env"
+    if sudo_password is not None:
+        try:
+            tok = fetch_postmark_token_from_prod(
+                args.host, args.port, args.user, sudo_password
+            )
+            return tok, "auto-fetched from prod env file"
+        except RuntimeError as e:
+            sys.stderr.write(f"(Postmark token auto-fetch failed: {e})\n")
+            return None, "auto-fetch failed"
+    return None, "no source"
+
+
 def fetch_postmark_message(message_id: str, token: str) -> dict:
     """Resolve a Postmark outbound ``MessageID`` to its full record + events.
 
@@ -425,15 +494,18 @@ def build_arg_parser() -> argparse.ArgumentParser:
     )
     ap.add_argument(
         "--postmark",
-        action="store_true",
-        help="Resolve Postmark MessageIDs via the Messages API. Token comes from "
-        "--postmark-token or FELLOWS_POSTMARK_TOKEN env (in that order).",
+        action=argparse.BooleanOptionalAction,
+        default=True,
+        help="Resolve Postmark MessageIDs via the Messages API (default: on). "
+        "Token resolution order: --postmark-token > FELLOWS_POSTMARK_TOKEN env "
+        "> auto-fetch from prod env file via ssh+sudo (requires --sudo). Pass "
+        "--no-postmark to skip entirely.",
     )
     ap.add_argument(
         "--postmark-token",
         metavar="TOKEN",
-        help="Postmark Server API token. Alternative to FELLOWS_POSTMARK_TOKEN env. "
-        "Implies --postmark.",
+        help="Postmark Server API token. Alternative to FELLOWS_POSTMARK_TOKEN env "
+        "and to auto-fetching from the prod env file.",
     )
     ap.add_argument(
         "--sudo",
@@ -475,6 +547,13 @@ def main(argv: list[str] | None = None) -> int:
         prefix = args.email_hash_prefix.lower().strip()
         email_desc = f"{prefix}…"
 
+    # Prompt once for the sudo password if --sudo is set; reuse for both the
+    # journalctl fetch and (if needed) the Postmark token auto-fetch, so the
+    # user never types it twice.
+    sudo_password = None
+    if args.sudo:
+        sudo_password = getpass.getpass(f"sudo password for {args.user}@{args.host}: ")
+
     raw = ssh_journal(
         args.host,
         args.port,
@@ -482,22 +561,27 @@ def main(argv: list[str] | None = None) -> int:
         args.since,
         use_sudo=args.sudo,
         verbose=args.verbose,
+        sudo_password=sudo_password,
     )
     events = parse_events(raw)
     events = filter_events(events, email_hash_prefix=prefix, result=args.result)
     if args.limit > 0:
         events = events[-args.limit :]
 
-    want_postmark = bool(args.postmark or args.postmark_token)
     postmark_lookups: dict[str, dict] = {}
-    if want_postmark:
-        token = (args.postmark_token or os.environ.get("FELLOWS_POSTMARK_TOKEN", "")).strip()
+    if args.postmark:
+        token, source = resolve_postmark_token(args, sudo_password)
         if not token:
             sys.stderr.write(
-                "Postmark resolution needs a token: pass --postmark-token <TOKEN> "
-                "or set FELLOWS_POSTMARK_TOKEN in env.\n"
+                "Postmark resolution needs a token. Options:\n"
+                "  - pass --postmark-token <TOKEN>\n"
+                "  - set FELLOWS_POSTMARK_TOKEN in env\n"
+                "  - run with --sudo to auto-fetch from the prod env file\n"
+                "  - pass --no-postmark to skip Postmark resolution entirely\n"
             )
             return 2
+        if args.verbose:
+            sys.stderr.write(f"[verbose] Postmark token source: {source}\n")
         seen: set[str] = set()
         for e in events:
             mid = ((e.get("postmark") or {}).get("message_id")

--- a/scripts/show_server_env.sh
+++ b/scripts/show_server_env.sh
@@ -1,14 +1,12 @@
 #!/usr/bin/env bash
-# Dump /etc/fellows/fellows-pwa.env from prod, with secrets masked.
+# Dump /etc/fellows/fellows-pwa.env from prod — values shown raw so you can
+# copy-paste secrets (e.g. FELLOWS_POSTMARK_TOKEN) straight into a command.
+# This is a single-dev local tool; there's no shoulder surfing to defend
+# against. If you ever share your screen, close this terminal first.
 #
 # Prompts locally for your sudo password (hidden input) and pipes it to
-# remote `sudo -S`. No pty allocation — the old `ssh -tt sudo` approach
-# merged stdout+stderr on the remote, and our awk pipeline captured the
-# prompt, so "Password:" never reached the terminal and the script hung.
-#
-# Reads the env file via `sudo -S -p '' cat`, then masks values whose KEY
-# matches TOKEN/SECRET/PASSWORD/KEY/CREDENTIAL patterns. Pass --raw to
-# show secrets in full.
+# remote `sudo -S`. Surrounding quotes on values are stripped so the output
+# is paste-ready.
 #
 # Environment overrides (match Ansible inventory):
 #   FELLOWS_HOST       default: fellows.globaldonut.com
@@ -17,8 +15,7 @@
 #   FELLOWS_ENV_FILE   default: /etc/fellows/fellows-pwa.env
 #
 # Usage:
-#   scripts/show_server_env.sh           # masked
-#   scripts/show_server_env.sh --raw     # unmasked (careful — prints secrets)
+#   scripts/show_server_env.sh
 
 set -euo pipefail
 
@@ -27,9 +24,7 @@ PORT="${FELLOWS_SSH_PORT:-52221}"
 USER_="${FELLOWS_SSH_USER:-rsb}"
 ENV_FILE="${FELLOWS_ENV_FILE:-/etc/fellows/fellows-pwa.env}"
 
-RAW=0
 case "${1:-}" in
-  --raw) RAW=1 ;;
   -h|--help)
     sed -n '1,/^set -euo/p' "$0" | grep '^#' | sed 's/^# \{0,1\}//'
     exit 0
@@ -41,37 +36,28 @@ case "${1:-}" in
     ;;
 esac
 
-# Hidden-input read. -s suppresses echo; prompt goes to stderr so it can't
-# contaminate stdout if the caller redirects.
+# Hidden-input read. -s suppresses echo; prompt on stderr so stdout stays
+# clean for piping to clipboard tools.
 printf "sudo password for %s@%s: " "$USER_" "$HOST" >&2
 IFS= read -rs SUDO_PW
 printf "\n" >&2
 
 # `sudo -S` reads the password from stdin. `-p ''` silences sudo's prompt
-# text so nothing lands in the env-file stream. Single remote command
-# string — printf %q escapes the path for the remote shell.
+# text so nothing lands in the env-file stream.
 REMOTE_CMD="sudo -S -p '' cat $(printf '%q' "$ENV_FILE")"
 
 printf '%s\n' "$SUDO_PW" \
   | ssh -o BatchMode=no -p "$PORT" "$USER_@$HOST" "$REMOTE_CMD" \
-  | awk -v raw="$RAW" '
+  | awk '
       BEGIN { FS = "=" }
       /^[[:space:]]*$/  { print; next }
       /^[[:space:]]*#/  { print; next }
       {
         key = $1
         val = substr($0, length(key) + 2)
-        # strip surrounding single or double quotes
+        # strip surrounding single or double quotes so values are paste-ready
         if (val ~ /^".*"$/) val = substr(val, 2, length(val) - 2)
         else if (val ~ /^'"'"'.*'"'"'$/) val = substr(val, 2, length(val) - 2)
-
-        if (raw == 0 && key ~ /(TOKEN|SECRET|PASSWORD|CREDENTIAL|_KEY$)/) {
-          n = length(val)
-          if (n > 8)      masked = substr(val, 1, 4) "…" substr(val, n - 2, 3)
-          else if (n > 0) masked = "[REDACTED:" n "chars]"
-          else            masked = ""
-          val = masked
-        }
         printf "%s=%s\n", key, val
       }
     '

--- a/tests/test_debug_email_delivery.py
+++ b/tests/test_debug_email_delivery.py
@@ -367,13 +367,17 @@ def test_main_refuses_both_email_and_hash_prefix(capsys, monkeypatch):
 
 
 def test_main_json_output_round_trips(monkeypatch, capsys):
-    """End-to-end JSON path: mock ssh_journal, verify JSON structure."""
+    """End-to-end JSON path: mock ssh_journal, verify JSON structure.
+
+    Use --no-postmark so the default-on Postmark resolution doesn't try to
+    fetch a token for this unit test.
+    """
     monkeypatch.setattr(
         ded,
         "ssh_journal",
         lambda host, port, user, since, **kw: _journal_envelope(_send_event_json()),
     )
-    rc = ded.main(["--json", "--since", "1 hour ago"])
+    rc = ded.main(["--json", "--no-postmark", "--since", "1 hour ago"])
     assert rc == 0
     out = capsys.readouterr().out
     data = json.loads(out)
@@ -382,3 +386,100 @@ def test_main_json_output_round_trips(monkeypatch, capsys):
     assert len(data["events"]) == 1
     assert data["events"][0]["result"] == "sent"
     assert data["postmark"] == {}
+
+
+def test_postmark_default_is_on(monkeypatch):
+    """No flag → args.postmark is True (default-on; --no-postmark opts out)."""
+    ap = ded.build_arg_parser()
+    args = ap.parse_args([])
+    assert args.postmark is True
+
+
+def test_postmark_no_postmark_flag_opts_out():
+    ap = ded.build_arg_parser()
+    args = ap.parse_args(["--no-postmark"])
+    assert args.postmark is False
+
+
+def test_resolve_postmark_token_prefers_cli_arg(monkeypatch):
+    """Priority 1: --postmark-token beats env and auto-fetch."""
+    monkeypatch.setenv("FELLOWS_POSTMARK_TOKEN", "env-token")
+    ap = ded.build_arg_parser()
+    args = ap.parse_args(["--postmark-token", "cli-token"])
+    tok, source = ded.resolve_postmark_token(args, sudo_password="pw")
+    assert tok == "cli-token"
+    assert "--postmark-token" in source
+
+
+def test_resolve_postmark_token_falls_back_to_env(monkeypatch):
+    """Priority 2: env var when --postmark-token unset."""
+    monkeypatch.setenv("FELLOWS_POSTMARK_TOKEN", "env-token")
+    ap = ded.build_arg_parser()
+    args = ap.parse_args([])
+    tok, source = ded.resolve_postmark_token(args, sudo_password=None)
+    assert tok == "env-token"
+    assert "env" in source
+
+
+def test_resolve_postmark_token_auto_fetches_with_sudo(monkeypatch):
+    """Priority 3: auto-fetch from prod env file when sudo password available."""
+    monkeypatch.delenv("FELLOWS_POSTMARK_TOKEN", raising=False)
+    monkeypatch.setattr(
+        ded, "fetch_postmark_token_from_prod",
+        lambda host, port, user, pw: "fetched-token",
+    )
+    ap = ded.build_arg_parser()
+    args = ap.parse_args([])
+    tok, source = ded.resolve_postmark_token(args, sudo_password="pw")
+    assert tok == "fetched-token"
+    assert "auto-fetch" in source
+
+
+def test_resolve_postmark_token_returns_none_without_sources(monkeypatch):
+    """No --postmark-token, no env, no --sudo → no token, main errors cleanly."""
+    monkeypatch.delenv("FELLOWS_POSTMARK_TOKEN", raising=False)
+    ap = ded.build_arg_parser()
+    args = ap.parse_args([])
+    tok, source = ded.resolve_postmark_token(args, sudo_password=None)
+    assert tok is None
+
+
+def test_fetch_postmark_token_from_prod_parses_quoted_and_unquoted(monkeypatch):
+    """Env-file parser handles both KEY=val and KEY='val' and KEY=\"val\"."""
+    cases = [
+        ('FELLOWS_POSTMARK_TOKEN=abc123\nFELLOWS_MAIL_FROM=admin@x\n', "abc123"),
+        ('FELLOWS_POSTMARK_TOKEN="abc123"\n', "abc123"),
+        ("FELLOWS_POSTMARK_TOKEN='abc123'\n", "abc123"),
+        ("FELLOWS_SESSION_SECRET=ignore\nFELLOWS_POSTMARK_TOKEN=tkn\n", "tkn"),
+    ]
+    for stdout, expected in cases:
+        class _R:
+            returncode = 0
+        _R.stdout = stdout
+        _R.stderr = ""
+        monkeypatch.setattr(ded.subprocess, "run", lambda *a, **kw: _R())
+        assert ded.fetch_postmark_token_from_prod("h", "22", "u", "pw") == expected
+
+
+def test_fetch_postmark_token_from_prod_raises_when_missing(monkeypatch):
+    class _R:
+        returncode = 0
+        stdout = "FELLOWS_SESSION_SECRET=only-this\n"
+        stderr = ""
+
+    monkeypatch.setattr(ded.subprocess, "run", lambda *a, **kw: _R())
+    import pytest
+    with pytest.raises(RuntimeError, match="not found"):
+        ded.fetch_postmark_token_from_prod("h", "22", "u", "pw")
+
+
+def test_fetch_postmark_token_from_prod_raises_on_ssh_failure(monkeypatch):
+    class _R:
+        returncode = 255
+        stdout = ""
+        stderr = "Permission denied"
+
+    monkeypatch.setattr(ded.subprocess, "run", lambda *a, **kw: _R())
+    import pytest
+    with pytest.raises(RuntimeError, match="exit 255"):
+        ded.fetch_postmark_token_from_prod("h", "22", "u", "pw")


### PR DESCRIPTION
## Two small UX cuts for the single-dev ops tools

### 1. \`show_server_env.sh\`: drop the masking, default to raw

The whole point of this script is to copy \`FELLOWS_POSTMARK_TOKEN\` straight into a debug command. Masking made that a two-step dance (run once → read → run again with \`--raw\`). It's a single-dev terminal — there's no shoulder-surfing threat here.

Now:
\`\`\`bash
./scripts/show_server_env.sh
# FELLOWS_POSTMARK_TOKEN=3a53f32e-4cae-...-f73d2d7ddcda
# FELLOWS_MAIL_FROM=admin@fellows.globaldonut.com
# ...
\`\`\`

\`--raw\` flag is gone. Surrounding-quote stripping stays (values are paste-ready).

### 2. \`debug_email_delivery.py\`: \`--postmark\` default on, auto-fetches the token

Today's happy-path command was:
\`\`\`bash
FELLOWS_POSTMARK_TOKEN=... scripts/debug_email_delivery.py --sudo --postmark --since '10 min ago'
\`\`\`

Too many knobs for the same obvious intent. Now:
\`\`\`bash
scripts/debug_email_delivery.py --sudo --since '10 min ago'
# Postmark resolution on by default
# Token fetched from /etc/fellows/fellows-pwa.env via ssh + sudo -S cat
# Sudo password is the same one already prompted for journalctl — typed once
\`\`\`

Token resolution priority (first hit wins):
1. \`--postmark-token <TOKEN>\` CLI arg
2. \`FELLOWS_POSTMARK_TOKEN\` env var
3. Auto-fetch from prod env file (requires \`--sudo\`, which the happy path already needs)

Opt out: \`--no-postmark\`.

## What changed under the hood

- \`--postmark\` → \`argparse.BooleanOptionalAction(default=True)\` so \`--postmark\`/\`--no-postmark\` are symmetric.
- New \`fetch_postmark_token_from_prod(host, port, user, sudo_password)\` — SSH + \`sudo -S cat\` + grep for the key.
- New \`resolve_postmark_token(args, sudo_password)\` — explicit priority chain, never raises, returns \`(token|None, source_label)\`.
- \`main()\` now prompts for the sudo password once up front and passes it to both \`ssh_journal\` and the token-fetch, so you type it zero or one times — never twice.

## Tests

9 new tests in \`tests/test_debug_email_delivery.py\` covering default-on, the opt-out flag, priority chain for all three sources, and the env-file parser (quoted/unquoted/missing/ssh-fail). 91 tests green overall.

## After merge

\`\`\`bash
git pull
./scripts/show_server_env.sh                              # paste-ready env dump
scripts/debug_email_delivery.py --sudo --since '10 min ago'  # full debug with Postmark resolution
\`\`\`

🤖 Generated with [Claude Code](https://claude.com/claude-code)