### PR TITLE
feat(ops): debug script surfaces allowlist MISS + --sudo default on

### DIFF
--- a/build/restore_from_knack_apr8.py
+++ b/build/restore_from_knack_apr8.py
@@ -1,0 +1,130 @@
+#!/usr/bin/env python3
+"""One-shot: restore app/fellows.db from the Apr 8 Knack-API snapshot.
+
+The current app/fellows.db is the demo-filtered subset (442 fellows, 268
+contact emails) — a regression from the Apr 8 full REST-API extraction
+(515 fellows, 515 emails). The regression dropped ~73 fellows and 247
+contact emails, breaking magic-link delivery for everyone not in the
+demo subset — including the operator.
+
+The Apr 8 backup (``app/fellows.db.backup.2026-04-08``) predates PR #19
+which added the ``has_image`` column, so we ALTER TABLE and backfill by
+scanning ``final_fellows_set/fellow_profile_images_by_name/`` using the
+same alpha-fuzzy match as ``import_json_to_sqlite.py:slug_has_image``.
+FTS5 is rebuilt defensively.
+
+After running this:
+
+    python build/build_pwa.py                      # regenerates dist + allowed_emails.json
+    ./scripts/deploy_pwa.sh --ask-become-pass      # deploys
+    scripts/debug_email_delivery.py --dump-allowlist  # verifies 515/515 in sync
+
+Idempotent: re-running is safe. Existing has_image values are
+recomputed; existing DB is backed up before overwrite.
+"""
+
+from __future__ import annotations
+
+import re
+import shutil
+import sqlite3
+import sys
+from datetime import date
+from pathlib import Path
+
+REPO_ROOT = Path(__file__).resolve().parent.parent
+SRC_DB = REPO_ROOT / "app" / "fellows.db.backup.2026-04-08"
+DST_DB = REPO_ROOT / "app" / "fellows.db"
+IMAGES_DIR_SOURCE = REPO_ROOT / "final_fellows_set" / "fellow_profile_images_by_name"
+IMAGES_DIR_APP = REPO_ROOT / "app" / "fellow_profile_images_by_name"
+
+
+def build_image_index() -> dict[str, Path]:
+    """Alpha-normalized filename stem → Path, mirroring import_json_to_sqlite."""
+    d = None
+    if IMAGES_DIR_SOURCE.is_dir():
+        d = IMAGES_DIR_SOURCE
+    elif IMAGES_DIR_APP.is_dir():
+        d = IMAGES_DIR_APP
+    if not d:
+        return {}
+    index: dict[str, Path] = {}
+    for p in d.iterdir():
+        if not p.is_file() or p.suffix.lower() not in (".jpg", ".jpeg", ".png"):
+            continue
+        stem_alpha = re.sub(r"[^a-z0-9]", "", p.stem.lower())
+        if stem_alpha and stem_alpha not in index:
+            index[stem_alpha] = p
+    return index
+
+
+def main() -> int:
+    if not SRC_DB.is_file():
+        print(f"Source DB not found: {SRC_DB}", file=sys.stderr)
+        print(
+            "This script restores from app/fellows.db.backup.2026-04-08 which "
+            "is the full Knack REST-API extraction snapshot. If that file is "
+            "absent, the only recovery path is to re-run the Knack ETL against "
+            "final_fellows_set/knack_api_detail_dump.json (see Fix B follow-up).",
+            file=sys.stderr,
+        )
+        return 1
+
+    if DST_DB.is_file():
+        backup_name = f"fellows.db.before-restore.{date.today().isoformat()}"
+        shutil.copy2(DST_DB, DST_DB.parent / backup_name)
+        print(f"Backed up existing DB to app/{backup_name}")
+
+    shutil.copy2(SRC_DB, DST_DB)
+    print(f"Copied {SRC_DB.name} → {DST_DB.name}")
+
+    conn = sqlite3.connect(DST_DB)
+    cols = {row[1] for row in conn.execute("PRAGMA table_info(fellows)").fetchall()}
+    if "has_image" not in cols:
+        conn.execute(
+            "ALTER TABLE fellows ADD COLUMN has_image INTEGER NOT NULL DEFAULT 0"
+        )
+        print("Added has_image column (was absent in Apr 8 schema)")
+
+    image_index = build_image_index()
+    if not image_index:
+        print(
+            "Warning: no images directory found; has_image will be 0 for everyone. "
+            "Run `ls final_fellows_set/fellow_profile_images_by_name` to confirm.",
+            file=sys.stderr,
+        )
+
+    rows = conn.execute("SELECT record_id, slug FROM fellows").fetchall()
+    for rid, slug in rows:
+        if not slug:
+            continue
+        base_alpha = re.sub(r"[^a-z0-9]", "", slug.split("/")[-1].split(".")[0].lower())
+        has_img = 1 if base_alpha and base_alpha in image_index else 0
+        conn.execute(
+            "UPDATE fellows SET has_image = ? WHERE record_id = ?", (has_img, rid)
+        )
+
+    # Defensive FTS5 rebuild — the backup's FTS index might not include new
+    # rows or the right columns given older schema. Cheap and safe.
+    conn.execute("INSERT INTO fellows_fts(fellows_fts) VALUES('rebuild')")
+    conn.commit()
+
+    count = conn.execute("SELECT COUNT(*) FROM fellows").fetchone()[0]
+    with_image = conn.execute(
+        "SELECT COUNT(*) FROM fellows WHERE has_image = 1"
+    ).fetchone()[0]
+    with_email = conn.execute(
+        "SELECT COUNT(*) FROM fellows "
+        "WHERE contact_email IS NOT NULL AND trim(contact_email) != ''"
+    ).fetchone()[0]
+    conn.close()
+
+    print(
+        f"Restored {count} fellows ({with_image} with image, {with_email} with email)"
+    )
+    print("Next: python build/build_pwa.py && ./scripts/deploy_pwa.sh --ask-become-pass")
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/scripts/debug_email_delivery.py
+++ b/scripts/debug_email_delivery.py
@@ -297,23 +297,33 @@ def fetch_fellow_emails_from_prod(
     user: str,
     db_path: str = DEFAULT_FELLOWS_DB,
 ) -> list[dict]:
-    """SSH + remote `sqlite3 -json` to pull fellow records with contact emails.
+    """SSH + remote Python to pull fellow records with contact emails.
+
+    Prod droplet runs the app on Python, so ``python3`` + stdlib ``sqlite3`` is
+    always available. The ``sqlite3`` CLI binary is NOT installed (it's not a
+    fellows-pwa dep) so we use Python directly — one-liner, JSON out.
 
     Same path as the allowlist (group-readable, no sudo needed). Returns a list
     of ``{"record_id", "name", "email"}`` dicts with email lowercased+trimmed,
     matching the build_pwa hashing recipe.
     """
-    query = (
-        "SELECT record_id, name, lower(trim(contact_email)) AS email "
-        "FROM fellows "
-        "WHERE contact_email IS NOT NULL AND trim(contact_email) != '';"
+    py_code = (
+        "import json, sqlite3; "
+        f"c = sqlite3.connect({db_path!r}); "
+        "c.row_factory = sqlite3.Row; "
+        "rows = c.execute("
+        "\"SELECT record_id, name, lower(trim(contact_email)) AS email "
+        "FROM fellows WHERE contact_email IS NOT NULL "
+        "AND trim(contact_email) != ''\""
+        ").fetchall(); "
+        "print(json.dumps([dict(r) for r in rows]))"
     )
-    remote_cmd = f"sqlite3 -json {shlex.quote(db_path)} {shlex.quote(query)}"
+    remote_cmd = f"python3 -c {shlex.quote(py_code)}"
     cmd = ["ssh", "-o", "BatchMode=yes", "-p", str(port), f"{user}@{host}", remote_cmd]
     r = subprocess.run(cmd, capture_output=True, text=True, timeout=30, check=False)
     if r.returncode != 0:
         raise RuntimeError(
-            f"ssh/sqlite3 failed (exit {r.returncode}): "
+            f"ssh/python3 query failed (exit {r.returncode}): "
             + (r.stderr.strip() or "no stderr")
         )
     if not r.stdout.strip():

--- a/scripts/debug_email_delivery.py
+++ b/scripts/debug_email_delivery.py
@@ -288,6 +288,122 @@ def check_allowlist(email: str, allowlist: set[str]) -> dict:
     }
 
 
+DEFAULT_FELLOWS_DB = "/opt/fellows/deploy/dist/fellows.db"
+
+
+def fetch_fellow_emails_from_prod(
+    host: str,
+    port: str,
+    user: str,
+    db_path: str = DEFAULT_FELLOWS_DB,
+) -> list[dict]:
+    """SSH + remote `sqlite3 -json` to pull fellow records with contact emails.
+
+    Same path as the allowlist (group-readable, no sudo needed). Returns a list
+    of ``{"record_id", "name", "email"}`` dicts with email lowercased+trimmed,
+    matching the build_pwa hashing recipe.
+    """
+    query = (
+        "SELECT record_id, name, lower(trim(contact_email)) AS email "
+        "FROM fellows "
+        "WHERE contact_email IS NOT NULL AND trim(contact_email) != '';"
+    )
+    remote_cmd = f"sqlite3 -json {shlex.quote(db_path)} {shlex.quote(query)}"
+    cmd = ["ssh", "-o", "BatchMode=yes", "-p", str(port), f"{user}@{host}", remote_cmd]
+    r = subprocess.run(cmd, capture_output=True, text=True, timeout=30, check=False)
+    if r.returncode != 0:
+        raise RuntimeError(
+            f"ssh/sqlite3 failed (exit {r.returncode}): "
+            + (r.stderr.strip() or "no stderr")
+        )
+    if not r.stdout.strip():
+        return []
+    try:
+        data = json.loads(r.stdout)
+    except json.JSONDecodeError as e:
+        raise RuntimeError(f"sqlite3 JSON parse failed: {e}")
+    return data if isinstance(data, list) else []
+
+
+def dump_allowlist_report(host: str, port: str, user: str) -> dict:
+    """Cross-reference allowlist hashes against the fellows DB.
+
+    Returns a structured summary and writes a human-readable report to stdout.
+    Flags two invariants:
+      - every fellow with a contact_email should have their hash on the allowlist
+      - every hash on the allowlist should map back to at least one fellow email
+    Both should be true whenever build_pwa.py runs over the same DB. Drift
+    means the allowlist and DB were built from different sources.
+    """
+    allow = fetch_allowlist_from_prod(host, port, user)
+    fellows = fetch_fellow_emails_from_prod(host, port, user)
+
+    fellow_hash_to_fellow: dict[str, dict] = {}
+    for f in fellows:
+        email = (f.get("email") or "").strip().lower()
+        if not email:
+            continue
+        fellow_hash_to_fellow.setdefault(hash_email(email), f)
+
+    fellow_hashes = set(fellow_hash_to_fellow.keys())
+
+    missing_from_allowlist = [
+        fellow_hash_to_fellow[h] for h in fellow_hashes if h not in allow
+    ]
+    orphans_in_allowlist = sorted(allow - fellow_hashes)
+
+    summary = {
+        "allowlist_size": len(allow),
+        "fellows_with_email": len(fellows),
+        "fellow_distinct_email_hashes": len(fellow_hashes),
+        "missing_from_allowlist": missing_from_allowlist,
+        "orphans_in_allowlist": orphans_in_allowlist,
+        "in_sync": not missing_from_allowlist and not orphans_in_allowlist,
+    }
+    return summary
+
+
+def format_dump_report(host: str, summary: dict) -> str:
+    lines = [f"Allowlist state on {host}:"]
+    lines.append(f"  Allowlist hashes:             {summary['allowlist_size']}")
+    lines.append(f"  Fellows with contact_email:   {summary['fellows_with_email']}")
+    lines.append(
+        f"  Distinct email hashes from DB: {summary['fellow_distinct_email_hashes']}"
+    )
+    if summary["in_sync"]:
+        lines.append("  ✓ In sync — every email hash is on the allowlist and vice versa.")
+        return "\n".join(lines) + "\n"
+
+    lines.append("  ✗ Drift detected.")
+    missing = summary["missing_from_allowlist"]
+    orphans = summary["orphans_in_allowlist"]
+    if missing:
+        lines.append("")
+        lines.append(
+            f"  Fellows with email NOT on allowlist ({len(missing)}) — they can't get magic links:"
+        )
+        for f in missing[:50]:
+            lines.append(f"    {f.get('name', '?')}  <{f.get('email', '?')}>")
+        if len(missing) > 50:
+            lines.append(f"    … {len(missing) - 50} more")
+    if orphans:
+        lines.append("")
+        lines.append(
+            f"  Hashes on allowlist with no matching fellow email ({len(orphans)}):"
+        )
+        for h in orphans[:20]:
+            lines.append(f"    {h[:16]}…")
+        if len(orphans) > 20:
+            lines.append(f"    … {len(orphans) - 20} more")
+    lines.append("")
+    lines.append(
+        "  Drift usually means allowed_emails.json and fellows.db were "
+        "generated from different sources. Rebuild both together via "
+        "`python build/build_pwa.py` and redeploy."
+    )
+    return "\n".join(lines) + "\n"
+
+
 def fetch_postmark_token_from_prod(
     host: str,
     port: str,
@@ -594,6 +710,15 @@ def build_arg_parser() -> argparse.ArgumentParser:
         "the sudo password — that's piped in separately).",
     )
     ap.add_argument(
+        "--dump-allowlist",
+        action="store_true",
+        help="Dump the allowlist and cross-reference against the fellows DB on "
+        "prod. Doesn't fetch journal events; doesn't need --sudo. Flags drift "
+        "(fellow emails missing from allowlist, or allowlist hashes without a "
+        "matching fellow email) — both are invariants that should never hold "
+        "if allowed_emails.json and fellows.db were built from the same DB.",
+    )
+    ap.add_argument(
         "--json",
         action="store_true",
         help="Emit raw JSON (for piping / jq). Suppresses the formatted report.",
@@ -607,6 +732,20 @@ def main(argv: list[str] | None = None) -> int:
 
     if args.email and args.email_hash_prefix:
         ap.error("pass one of --email or --email-hash-prefix, not both")
+
+    if args.dump_allowlist:
+        # Short-circuit: no journal fetch, no sudo, no Postmark. Just the
+        # allowlist ↔ DB consistency report.
+        try:
+            summary = dump_allowlist_report(args.host, args.port, args.user)
+        except RuntimeError as e:
+            sys.stderr.write(f"dump failed: {e}\n")
+            return 1
+        if args.json:
+            print(json.dumps(summary, indent=2, default=str))
+        else:
+            sys.stdout.write(format_dump_report(args.host, summary))
+        return 0 if summary["in_sync"] else 1
 
     prefix = None
     email_desc = None

--- a/scripts/debug_email_delivery.py
+++ b/scripts/debug_email_delivery.py
@@ -246,6 +246,46 @@ def filter_events(
 
 
 DEFAULT_ENV_FILE = "/etc/fellows/fellows-pwa.env"
+DEFAULT_ALLOWLIST_PATH = "/opt/fellows/deploy/dist/allowed_emails.json"
+
+
+def fetch_allowlist_from_prod(
+    host: str,
+    port: str,
+    user: str,
+    allowlist_path: str = DEFAULT_ALLOWLIST_PATH,
+) -> set[str]:
+    """SSH + plain `cat` the allowlist JSON; no sudo needed.
+
+    ``/opt/fellows/deploy/dist/`` is mode 2775 owned by ``fellows:fellows``,
+    and the operator (``rsb``) is in the ``fellows`` group, so we can read it
+    directly. Returns a set of hex SHA-256 hashes.
+    """
+    remote_cmd = f"cat {shlex.quote(allowlist_path)}"
+    cmd = ["ssh", "-o", "BatchMode=yes", "-p", str(port), f"{user}@{host}", remote_cmd]
+    r = subprocess.run(cmd, capture_output=True, text=True, timeout=30, check=False)
+    if r.returncode != 0:
+        raise RuntimeError(
+            f"ssh/cat allowlist failed (exit {r.returncode}): "
+            + (r.stderr.strip() or "no stderr")
+        )
+    try:
+        data = json.loads(r.stdout)
+    except json.JSONDecodeError as e:
+        raise RuntimeError(f"allowlist JSON parse failed: {e}")
+    hashes = data.get("hashes") or []
+    return {str(h).lower() for h in hashes if h}
+
+
+def check_allowlist(email: str, allowlist: set[str]) -> dict:
+    """Return {email, hash, hit, allowlist_size} for the given email."""
+    h = hash_email(email)
+    return {
+        "email": email,
+        "hash": h,
+        "hit": h in allowlist,
+        "allowlist_size": len(allowlist),
+    }
 
 
 def fetch_postmark_token_from_prod(
@@ -343,10 +383,35 @@ def fetch_postmark_message(message_id: str, token: str) -> dict:
         return {"_error": str(e)}
 
 
+def _format_allowlist_status(chk: dict) -> list[str]:
+    """Render the allowlist check block for the human-readable report."""
+    out = ["Allowlist status:"]
+    hp = chk["hash"][:16]
+    if chk["hit"]:
+        out.append(
+            f"  HIT — {chk['email']} (hash {hp}…) is in the {chk['allowlist_size']}-entry allowlist."
+        )
+    else:
+        out.append(
+            f"  MISS — {chk['email']} (hash {hp}…) is NOT in the {chk['allowlist_size']}-entry allowlist."
+        )
+        out.append(
+            "  The server silently returns {sent: true} for non-allowlisted emails"
+        )
+        out.append(
+            "  (anti-enumeration). No send event is ever logged. This explains"
+        )
+        out.append(
+            "  'no events found' for this address."
+        )
+    return out
+
+
 def format_report(
     events: list[dict],
     postmark_lookups: dict[str, dict],
     header_meta: dict,
+    allowlist_check: dict | None = None,
 ) -> str:
     """Human-readable report. Newest-first events + summary."""
     lines: list[str] = []
@@ -355,6 +420,10 @@ def format_report(
     if header_meta.get("filter_desc"):
         lines.append(f"Filter: {header_meta['filter_desc']}")
     lines.append("")
+    if allowlist_check is not None:
+        lines.extend(_format_allowlist_status(allowlist_check))
+        lines.append("")
+
     if not events:
         lines.append("No events in window.")
         return "\n".join(lines) + "\n"
@@ -509,11 +578,13 @@ def build_arg_parser() -> argparse.ArgumentParser:
     )
     ap.add_argument(
         "--sudo",
-        action="store_true",
-        help="Run journalctl under sudo on the remote. Prompts locally for the "
-        "password via getpass, then pipes to `sudo -S`. Needed when the operator "
-        "isn't in adm / systemd-journal (journalctl silently hides other users' "
-        "unit logs otherwise).",
+        action=argparse.BooleanOptionalAction,
+        default=True,
+        help="Run journalctl under sudo on the remote (default: on). Prompts "
+        "locally for the password via getpass, then pipes to `sudo -S`. Needed "
+        "when the operator isn't in adm / systemd-journal — journalctl silently "
+        "hides other users' unit logs otherwise. Pass --no-sudo only if you've "
+        "added the operator to the systemd-journal group on prod.",
     )
     ap.add_argument(
         "-v",
@@ -568,6 +639,16 @@ def main(argv: list[str] | None = None) -> int:
     if args.limit > 0:
         events = events[-args.limit :]
 
+    # Allowlist check: cheap (no sudo, group-readable file) and answers the
+    # single most common "no events, no email, why?" question directly.
+    allowlist_check: dict | None = None
+    if args.email:
+        try:
+            allow = fetch_allowlist_from_prod(args.host, args.port, args.user)
+            allowlist_check = check_allowlist(args.email, allow)
+        except RuntimeError as e:
+            sys.stderr.write(f"(allowlist check skipped: {e})\n")
+
     postmark_lookups: dict[str, dict] = {}
     if args.postmark:
         token, source = resolve_postmark_token(args, sudo_password)
@@ -607,6 +688,7 @@ def main(argv: list[str] | None = None) -> int:
             },
             "events": events,
             "postmark": postmark_lookups,
+            "allowlist": allowlist_check,
         }
         print(json.dumps(out, indent=2, default=str))
     else:
@@ -618,6 +700,7 @@ def main(argv: list[str] | None = None) -> int:
                 "since": args.since,
                 "filter_desc": filter_desc,
             },
+            allowlist_check=allowlist_check,
         )
         sys.stdout.write(report)
 

--- a/tests/e2e/test_directory.py
+++ b/tests/e2e/test_directory.py
@@ -61,14 +61,15 @@ class TestDirectoryPage:
 
         checkbox.click()
         expect(checkbox).not_to_be_checked()
-        page.wait_for_function(
-            "(prev) => document.querySelectorAll(\"#directory a[href^='#/fellow/']\").length !== prev",
-            arg=filtered_count,
-            timeout=5000,
-        )
+        # Filter may or may not change the count — depends on whether any
+        # fellow in the current dataset lacks a contact_email. When every
+        # fellow has one (the full Apr 8 Knack extraction → 515/515), the
+        # filter is a no-op against the visible list and that's fine.
+        # Invariant: unfiltered count is >= filtered count, never below.
+        page.wait_for_timeout(300)
         total_count = page.locator("#directory a[href^='#/fellow/']").count()
-        assert total_count > filtered_count, (
-            f"Expected unfiltered count ({total_count}) > filtered count ({filtered_count})"
+        assert total_count >= filtered_count, (
+            f"Expected unfiltered count ({total_count}) >= filtered count ({filtered_count})"
         )
 
         page.reload(wait_until="domcontentloaded")

--- a/tests/test_database.py
+++ b/tests/test_database.py
@@ -103,6 +103,29 @@ def test_every_row_has_a_name(db):
     )
 
 
+def test_email_coverage_ratio_catches_demo_filter_regression(db):
+    """Regression: >90% of fellows should have contact_email.
+
+    If a demo-filter JSON (which drops fellows without profile images AND
+    strips emails from the remainder) gets used as the rebuild source,
+    the ratio falls to ~60%. This test is the tripwire.
+
+    The full Apr 8 Knack REST-API extraction gives 100% coverage — any
+    fellow in the dataset has their email.
+    """
+    total = db.execute("SELECT COUNT(*) FROM fellows").fetchone()[0]
+    with_email = db.execute(
+        "SELECT COUNT(*) FROM fellows "
+        "WHERE contact_email IS NOT NULL AND trim(contact_email) != ''"
+    ).fetchone()[0]
+    ratio = with_email / total if total else 0
+    assert ratio > 0.9, (
+        f"Only {with_email}/{total} fellows have contact_email ({ratio:.0%}). "
+        "Likely rebuilt from the demo-filtered .bak JSON. Re-run "
+        "`python build/restore_from_knack_apr8.py`."
+    )
+
+
 def test_slug_never_falls_back_to_record_id(db):
     """Importer falls back to source_name before record_id; no slug should equal its record_id."""
     cur = db.execute(

--- a/tests/test_debug_email_delivery.py
+++ b/tests/test_debug_email_delivery.py
@@ -607,9 +607,11 @@ def test_fetch_fellow_emails_from_prod_parses_sqlite_json(monkeypatch):
     rows = ded.fetch_fellow_emails_from_prod("h", "22", "u")
     assert len(rows) == 2
     assert rows[0]["email"] == "alice@example.com"
-    # Remote query uses -json for safe parsing; BatchMode=yes; no sudo.
+    # Remote command uses Python (prod lacks the sqlite3 CLI; it's not a
+    # fellows-pwa dependency). BatchMode=yes; no sudo.
     remote = captured["cmd"][-1]
-    assert "sqlite3 -json" in remote
+    assert "python3 -c" in remote
+    assert "sqlite3" in remote  # stdlib module is used inside the Python snippet
     assert "sudo" not in remote
     assert "BatchMode=yes" in " ".join(captured["cmd"])
 

--- a/tests/test_debug_email_delivery.py
+++ b/tests/test_debug_email_delivery.py
@@ -369,15 +369,15 @@ def test_main_refuses_both_email_and_hash_prefix(capsys, monkeypatch):
 def test_main_json_output_round_trips(monkeypatch, capsys):
     """End-to-end JSON path: mock ssh_journal, verify JSON structure.
 
-    Use --no-postmark so the default-on Postmark resolution doesn't try to
-    fetch a token for this unit test.
+    --no-sudo so getpass doesn't prompt, --no-postmark so we don't try to
+    fetch a token. No --email so the allowlist check isn't triggered.
     """
     monkeypatch.setattr(
         ded,
         "ssh_journal",
         lambda host, port, user, since, **kw: _journal_envelope(_send_event_json()),
     )
-    rc = ded.main(["--json", "--no-postmark", "--since", "1 hour ago"])
+    rc = ded.main(["--json", "--no-sudo", "--no-postmark", "--since", "1 hour ago"])
     assert rc == 0
     out = capsys.readouterr().out
     data = json.loads(out)
@@ -471,6 +471,119 @@ def test_fetch_postmark_token_from_prod_raises_when_missing(monkeypatch):
     import pytest
     with pytest.raises(RuntimeError, match="not found"):
         ded.fetch_postmark_token_from_prod("h", "22", "u", "pw")
+
+
+def test_sudo_default_is_on():
+    """No flag → args.sudo is True (default-on; --no-sudo opts out).
+
+    Zero-flag happy path needs sudo: the operator isn't in systemd-journal
+    on prod, so journalctl silently returns empty otherwise.
+    """
+    ap = ded.build_arg_parser()
+    args = ap.parse_args([])
+    assert args.sudo is True
+
+
+def test_sudo_no_sudo_flag_opts_out():
+    ap = ded.build_arg_parser()
+    args = ap.parse_args(["--no-sudo"])
+    assert args.sudo is False
+
+
+def test_fetch_allowlist_from_prod_parses_and_normalises(monkeypatch):
+    class _R:
+        returncode = 0
+        stdout = '{"hashes": ["AABBCC", "ddEEff", "1234"]}'
+        stderr = ""
+
+    captured = {}
+
+    def fake_run(cmd, **kw):
+        captured["cmd"] = cmd
+        return _R()
+
+    monkeypatch.setattr(ded.subprocess, "run", fake_run)
+    allow = ded.fetch_allowlist_from_prod("h", "22", "u")
+    # lowercased for consistent comparison with sha256().hexdigest()
+    assert allow == {"aabbcc", "ddeeff", "1234"}
+    # No sudo involved — must use BatchMode=yes to fail fast on auth prompts.
+    assert "BatchMode=yes" in " ".join(captured["cmd"])
+    # And we didn't smuggle sudo into the remote command.
+    assert "sudo" not in captured["cmd"][-1]
+
+
+def test_fetch_allowlist_from_prod_raises_on_ssh_failure(monkeypatch):
+    class _R:
+        returncode = 255
+        stdout = ""
+        stderr = "Permission denied"
+
+    monkeypatch.setattr(ded.subprocess, "run", lambda *a, **kw: _R())
+    import pytest
+    with pytest.raises(RuntimeError, match="exit 255"):
+        ded.fetch_allowlist_from_prod("h", "22", "u")
+
+
+def test_fetch_allowlist_from_prod_raises_on_bad_json(monkeypatch):
+    class _R:
+        returncode = 0
+        stdout = "not json {"
+        stderr = ""
+
+    monkeypatch.setattr(ded.subprocess, "run", lambda *a, **kw: _R())
+    import pytest
+    with pytest.raises(RuntimeError, match="parse failed"):
+        ded.fetch_allowlist_from_prod("h", "22", "u")
+
+
+def test_check_allowlist_hit_and_miss():
+    allow = {
+        ded.hash_email("a@example.com"),
+        ded.hash_email("b@example.com"),
+    }
+    hit = ded.check_allowlist("a@example.com", allow)
+    assert hit["hit"] is True
+    assert hit["allowlist_size"] == 2
+    assert hit["hash"] == ded.hash_email("a@example.com")
+    miss = ded.check_allowlist("c@example.com", allow)
+    assert miss["hit"] is False
+
+
+def test_format_report_surfaces_allowlist_miss_as_root_cause():
+    """When --email is passed and the hash isn't on the list, the report
+    must explicitly explain why no events showed up — otherwise the user
+    chases 'is the debug script broken?' instead of 'is the email
+    allowlisted?'."""
+    chk = {
+        "email": "c@example.com",
+        "hash": "a" * 64,
+        "hit": False,
+        "allowlist_size": 268,
+    }
+    out = ded.format_report(
+        [], {}, {"host": "h", "since": "s", "filter_desc": "email hash aaaa…"},
+        allowlist_check=chk,
+    )
+    assert "MISS" in out
+    assert "268-entry" in out
+    assert "anti-enumeration" in out
+
+
+def test_format_report_allowlist_hit_does_not_misleadingly_explain_empty_events():
+    chk = {
+        "email": "a@example.com",
+        "hash": "b" * 64,
+        "hit": True,
+        "allowlist_size": 268,
+    }
+    out = ded.format_report(
+        [], {}, {"host": "h", "since": "s", "filter_desc": None},
+        allowlist_check=chk,
+    )
+    assert "HIT" in out
+    # The "explains empty" prose must NOT appear on a hit — empty events with
+    # a hit means something else is wrong (not the allowlist).
+    assert "anti-enumeration" not in out
 
 
 def test_fetch_postmark_token_from_prod_raises_on_ssh_failure(monkeypatch):

--- a/tests/test_debug_email_delivery.py
+++ b/tests/test_debug_email_delivery.py
@@ -586,6 +586,99 @@ def test_format_report_allowlist_hit_does_not_misleadingly_explain_empty_events(
     assert "anti-enumeration" not in out
 
 
+def test_fetch_fellow_emails_from_prod_parses_sqlite_json(monkeypatch):
+    class _R:
+        returncode = 0
+        stdout = json.dumps(
+            [
+                {"record_id": "abc", "name": "Alice", "email": "alice@example.com"},
+                {"record_id": "def", "name": "Bob", "email": "bob@example.com"},
+            ]
+        )
+        stderr = ""
+
+    captured = {}
+
+    def fake_run(cmd, **kw):
+        captured["cmd"] = cmd
+        return _R()
+
+    monkeypatch.setattr(ded.subprocess, "run", fake_run)
+    rows = ded.fetch_fellow_emails_from_prod("h", "22", "u")
+    assert len(rows) == 2
+    assert rows[0]["email"] == "alice@example.com"
+    # Remote query uses -json for safe parsing; BatchMode=yes; no sudo.
+    remote = captured["cmd"][-1]
+    assert "sqlite3 -json" in remote
+    assert "sudo" not in remote
+    assert "BatchMode=yes" in " ".join(captured["cmd"])
+
+
+def test_fetch_fellow_emails_from_prod_handles_empty_result(monkeypatch):
+    class _R:
+        returncode = 0
+        stdout = ""
+        stderr = ""
+
+    monkeypatch.setattr(ded.subprocess, "run", lambda *a, **kw: _R())
+    assert ded.fetch_fellow_emails_from_prod("h", "22", "u") == []
+
+
+def test_dump_allowlist_in_sync_when_fellows_hashes_match_allowlist(monkeypatch):
+    fellows = [
+        {"record_id": "r1", "name": "Alice", "email": "alice@example.com"},
+        {"record_id": "r2", "name": "Bob", "email": "bob@example.com"},
+    ]
+    allow = {ded.hash_email(f["email"]) for f in fellows}
+
+    monkeypatch.setattr(ded, "fetch_allowlist_from_prod", lambda *a, **kw: allow)
+    monkeypatch.setattr(ded, "fetch_fellow_emails_from_prod", lambda *a, **kw: fellows)
+    summary = ded.dump_allowlist_report("h", "22", "u")
+    assert summary["in_sync"] is True
+    assert summary["allowlist_size"] == 2
+    assert summary["fellows_with_email"] == 2
+    assert summary["missing_from_allowlist"] == []
+    assert summary["orphans_in_allowlist"] == []
+
+
+def test_dump_allowlist_surfaces_fellow_missing_from_allowlist(monkeypatch):
+    """The exact failure mode that broke Rich's testing on Apr 20."""
+    fellows = [
+        {"record_id": "r1", "name": "Richard Bodo", "email": "richbodo@gmail.com"},
+        {"record_id": "r2", "name": "Bob", "email": "bob@example.com"},
+    ]
+    # Only Bob's hash on the allowlist — Rich's missing.
+    allow = {ded.hash_email("bob@example.com")}
+
+    monkeypatch.setattr(ded, "fetch_allowlist_from_prod", lambda *a, **kw: allow)
+    monkeypatch.setattr(ded, "fetch_fellow_emails_from_prod", lambda *a, **kw: fellows)
+    summary = ded.dump_allowlist_report("h", "22", "u")
+    assert summary["in_sync"] is False
+    assert len(summary["missing_from_allowlist"]) == 1
+    assert summary["missing_from_allowlist"][0]["name"] == "Richard Bodo"
+    report = ded.format_dump_report("fellows.example", summary)
+    assert "Drift detected" in report
+    assert "Richard Bodo" in report
+    assert "richbodo@gmail.com" in report
+
+
+def test_dump_allowlist_surfaces_orphan_hashes(monkeypatch):
+    """Hashes on the allowlist that don't correspond to any fellow's email."""
+    fellows = [{"record_id": "r1", "name": "Alice", "email": "alice@example.com"}]
+    allow = {
+        ded.hash_email("alice@example.com"),
+        ded.hash_email("stale@example.com"),  # no fellow with this email
+    }
+
+    monkeypatch.setattr(ded, "fetch_allowlist_from_prod", lambda *a, **kw: allow)
+    monkeypatch.setattr(ded, "fetch_fellow_emails_from_prod", lambda *a, **kw: fellows)
+    summary = ded.dump_allowlist_report("h", "22", "u")
+    assert summary["in_sync"] is False
+    assert len(summary["orphans_in_allowlist"]) == 1
+    report = ded.format_dump_report("fellows.example", summary)
+    assert "no matching fellow email (1)" in report
+
+
 def test_fetch_postmark_token_from_prod_raises_on_ssh_failure(monkeypatch):
     class _R:
         returncode = 255


### PR DESCRIPTION
## Summary

Three changes, all surfacing or fixing the same underlying bug: \`richbodo@gmail.com\` stopped getting magic links because the DB got silently demoted from 515 fellows/emails (Apr 8 full Knack extraction) to 442/268 (demo-filtered subset) somewhere between Apr 8 and Apr 18.

1. **\`build/restore_from_knack_apr8.py\`** — one-shot restore from \`app/fellows.db.backup.2026-04-08\`, adds the post-Apr-8 \`has_image\` column, backfills from the images dir, rebuilds FTS5. Idempotent. Local run gives 515 fellows / 251 with image / 515 with email, Rich's record back with his email populated.

2. **\`scripts/debug_email_delivery.py --dump-allowlist\`** — cross-references prod's \`allowed_emails.json\` against prod's \`fellows.db\` contact_emails. Flags drift (fellows with email not on allowlist, or hashes without matching fellows). Would have caught the regression in one command the moment it happened. No sudo needed (both files are group-readable).

3. **Regression tripwire**: \`test_email_coverage_ratio_catches_demo_filter_regression\` — if fellows-with-email ratio drops below 90%, tests fail. Full data gives 100%, demo-filtered gives ~60%.

Also carried over \`--sudo default on\` which didn't land in PR #32's merge, plus the allowlist-check-on-\`--email\` feature.

## After merge, operator steps

\`\`\`bash
git pull
python build/restore_from_knack_apr8.py     # idempotent
python build/build_pwa.py                   # regenerates dist + allowed_emails.json
./scripts/deploy_pwa.sh --ask-become-pass   # ships
scripts/debug_email_delivery.py --dump-allowlist  # verifies 515/515 in sync
\`\`\`

Then test the magic-link flow with \`richbodo@gmail.com\` in a fresh incognito.

## Directory impact

Fellow count: 442 → 515 (+73 fellows without profile images come back). The \`has email\` filter still defaults on and hides fellows without email, but the 73 newly-visible fellows *do* have emails per this dataset, so they show up for everyone. Consistent with your stated principle: "getting in contact is the primary use of a tool like this" — email presence matters, photo presence doesn't.

## Tests

105 green. New coverage:
- DB: email coverage ratio tripwire
- unit: fetch_fellow_emails_from_prod, dump_allowlist_report (in-sync, missing-from-allowlist, orphan hashes)
- e2e: has-email-filter test made data-tolerant (100% email coverage is a valid state)
- script: --sudo default on / --no-sudo opt out

## Follow-up issues worth filing (not in this PR)

- **Fix B**: proper ETL from \`knack_api_detail_dump.json\` so \`fellows.db\` is rebuildable from data the repo has on disk (today the Apr 8 backup DB is our only source of truth for the 515-fellow emails).
- **Fix C**: \`FELLOWS_DEV_ALLOWLIST_EMAILS\` env var for operator/test emails that aren't real fellow records.

Happy to open both if you want them tracked.

🤖 Generated with [Claude Code](https://claude.com/claude-code)