### PR TITLE
fix: don't long-cache non-200 responses + cache-bust image URLs

### DIFF
--- a/app/static/app.js
+++ b/app/static/app.js
@@ -63,7 +63,7 @@
   /** Bump on every meaningful UI / diagnostics change. Rendered in the
    *  always-visible build badge so a dev can tell at a glance which app.js
    *  is actually running vs what the server was deployed with. */
-  var FELLOWS_UI_DIAG = 'diag-2026-04g-image-pending-state';
+  var FELLOWS_UI_DIAG = 'diag-2026-04h-image-cache-bust';
 
   function initBuildBadge() {
     var clientEl = document.getElementById('build-badge-client');
@@ -145,7 +145,9 @@
     function next() {
       var f = queue.shift();
       if (!f) return null;
-      var url = '/images/' + encodeURIComponent(f.slug) + '.jpg';
+      // Same cache-busting suffix as <img src> in renderDetail — keeps the
+      // prewarm and the on-demand render aligned so we hit one cache entry.
+      var url = '/images/' + encodeURIComponent(f.slug) + '.jpg?v=' + encodeURIComponent(FELLOWS_UI_DIAG);
       return fetch(url, { cache: 'default', credentials: 'same-origin' })
         .then(function (r) {
           if (r && r.ok) {
@@ -1498,9 +1500,15 @@
     if (demo) leftTop += '<p class="detail-demographics">' + escapeHtml(demo) + '</p>';
     var hasImage = fellow.has_image === 1 || fellow.has_image === true;
     if (hasImage && slug) {
+      // Cache-bust against stale 404s from before a fellow's photo existed.
+      // The HTTP cache has a long max-age for 200 images (good), but if a
+      // browser cached a 404 during a gap, it would persist for days. Adding
+      // ?v=<version> to the URL forces a fresh cache key on every release
+      // so a recovered image surfaces immediately after deploy.
+      var imgUrl = '/images/' + escapeHtml(slug) + '.jpg?v=' + escapeHtml(FELLOWS_UI_DIAG);
       leftTop +=
         '<div class="profile-image-wrap profile-image-wrap--loading" data-slug="' + escapeHtml(slug) + '">' +
-          '<img class="profile-image" data-slug="' + escapeHtml(slug) + '" src="/images/' + escapeHtml(slug) + '.jpg" alt="' + escapeHtml(name) + '">' +
+          '<img class="profile-image" data-slug="' + escapeHtml(slug) + '" src="' + imgUrl + '" alt="' + escapeHtml(name) + '">' +
           '<span class="profile-image-status profile-image-status--loading">Loading… just a sec.</span>' +
         '</div>';
     } else {
@@ -1617,7 +1625,7 @@
           function () {
             var s = img.getAttribute('data-slug');
             if (s && img.src.indexOf('.png') === -1) {
-              img.src = '/images/' + s + '.png';
+              img.src = '/images/' + s + '.png?v=' + FELLOWS_UI_DIAG;
               img.addEventListener('load', markLoaded, { once: true });
               img.addEventListener('error', markPending, { once: true });
             } else {

--- a/deploy/server.py
+++ b/deploy/server.py
@@ -396,9 +396,19 @@ class Handler(SimpleHTTPRequestHandler):
         cookie = ml.set_session_cookie_line(val, self.headers)
         self.send_json_with_headers({"ok": True}, 200, [("Set-Cookie", cookie)])
 
+    def send_response(self, code, message=None):
+        # Track status so end_headers can pick the right Cache-Control. A long
+        # max-age on a 404 is poison: a file that appears later gets shadowed
+        # by the stale 404 in every browser that requested it once during the
+        # 'missing' window. We learned this the hard way when missing fellow
+        # photos cached 7-day 404s then failed to render after the S3 recovery.
+        self._last_status = code
+        super().send_response(code, message)
+
     def end_headers(self):
         path = urllib.parse.urlparse(self.path).path
         pl = path.lower()
+        is_ok = getattr(self, "_last_status", 200) == 200
         if pl == "/" or pl.endswith(".html"):
             self.send_header("Cache-Control", "no-cache")
         elif pl.endswith("/sw.js") or pl.rsplit("/", 1)[-1] == "sw.js":
@@ -426,7 +436,13 @@ class Handler(SimpleHTTPRequestHandler):
                 ".json",
             )
         ):
-            self.send_header("Cache-Control", LONG_CACHE_CONTROL)
+            # Only apply the 7-day cache to successful responses. 404 / 403
+            # responses must NOT be long-cached — otherwise transient misses
+            # become permanent client-side.
+            if is_ok:
+                self.send_header("Cache-Control", LONG_CACHE_CONTROL)
+            else:
+                self.send_header("Cache-Control", "no-cache")
         self._telemetry_headers()
         super().end_headers()
 


### PR DESCRIPTION
## The stale-404 trap

After PR #42 recovered 264 photos via rsync, users still saw "Loading… try reloading" for those fellows. Reason: when the files didn't exist on prod, each request returned 404 — but the server was setting **`Cache-Control: public, max-age=604800` on every image response regardless of status**. A transient 404 became a 7-day negative cache per browser.

Side effect: About-page "photos cached locally: 0 / 515" — SW only got 404s, which it (correctly) doesn't cache into its Cache API, so the counter never populated.

## Fix — two parts, together they close the loop

### Server (`deploy/server.py`)

Track HTTP status in `send_response`, check it in `end_headers`. Long `max-age` only applies to 200 responses. Non-200 responses get `Cache-Control: no-cache` so stale negative caches can't accumulate. Prevents this bug from recurring the next time a file is briefly missing.

### Client (`app/static/app.js`)

Append `?v=<FELLOWS_UI_DIAG>` to image URLs (\`renderDetail\` and the prewarm loop). Every deploy bumps the constant → every image URL is a new cache key → browsers with stale 404s for the old URL are forced to fetch fresh for the new one. `FELLOWS_UI_DIAG` bumped to \`diag-2026-04h-image-cache-bust\`.

The server fix alone doesn't rescue existing browsers with a week-old 404 cache. The client fix does, in one reload.

## Tests

106 green.

## Deploy flow

\`\`\`bash
git pull
python build/build_pwa.py
./scripts/deploy_pwa.sh --ask-become-pass
\`\`\`

After deploy + hard-reload in the PWA:
- Image URLs in rendered HTML now carry \`?v=diag-2026-04h-image-cache-bust\`
- Browser fetches fresh (old 404 cache bypassed)
- Aaron Bird's photo renders
- About-page counter fills toward 515/515 as the prewarm runs

Build badge should flip from \`diag-2026-04g\` to \`diag-2026-04h\`.

## Related

- #36 (image UX) — this is the "why are photos still not loading after recovery" tail of it.
- #38 (images 403) — distinct auth-cookie concern. Unrelated to this bug.

🤖 Generated with [Claude Code](https://claude.com/claude-code)