### PR TITLE
feat(pwa): offline resilience — auth fallback + prewarm resume (Phase 1)

### DIFF
--- a/app/static/app.js
+++ b/app/static/app.js
@@ -63,7 +63,22 @@
   /** Bump on every meaningful UI / diagnostics change. Rendered in the
    *  always-visible build badge so a dev can tell at a glance which app.js
    *  is actually running vs what the server was deployed with. */
-  var FELLOWS_UI_DIAG = 'diag-2026-04h-image-cache-bust';
+  var FELLOWS_UI_DIAG = 'diag-2026-04i-offline-fallback';
+
+  // Persistent marker: "this origin has been authenticated successfully at
+  // least once." Preserved across clearAllAppData. Used by startBrowserUx's
+  // catch path so a transient /api/auth/status failure (e.g. 503 during a
+  // deploy, or flaky mobile data) does NOT block a previously-authed user
+  // behind the scary 'Authentication check failed' panel.
+  var AUTH_ONCE_KEY = 'fellows_authenticated_once';
+
+  function markAuthenticatedOnce() {
+    try { localStorage.setItem(AUTH_ONCE_KEY, '1'); } catch (e) {}
+  }
+
+  function hasAuthenticatedOnce() {
+    try { return localStorage.getItem(AUTH_ONCE_KEY) === '1'; } catch (e) { return false; }
+  }
 
   function initBuildBadge() {
     var clientEl = document.getElementById('build-badge-client');
@@ -84,6 +99,15 @@
       // add a client→server mapping.
       badgeEl.classList.remove('build-badge--mismatch');
     }
+  }
+
+  function setBuildBadgeServerUnreachable() {
+    // Called from the auth-status fallback path when the server is 5xx or
+    // network-unreachable. Low-drama label: non-technical users should not
+    // read this as "something is broken" — the app continues to work from
+    // cached state.
+    var serverEl = document.getElementById('build-badge-server');
+    if (serverEl) serverEl.textContent = 'server: unreachable';
   }
 
   initBuildBadge();
@@ -169,6 +193,26 @@
       imagePrewarmState.finishedAt = new Date().toISOString();
     });
   }
+
+  // Throttled resume hook. When the browser transitions to online, re-run
+  // the prewarm so any images that failed during a flaky-network window
+  // get another chance. Browser + SW cache mean already-cached images
+  // resolve fast without network; only misses actually hit prod.
+  //
+  // Floor of 60s between attempts so mobile radio flapping doesn't hammer
+  // the server. Only runs if we have fellows data loaded AND the previous
+  // attempt finished with errors (or was mid-flight but stalled).
+  var _lastPrewarmAttempt = 0;
+  function maybeResumePrewarm() {
+    if (!Array.isArray(fullFellowsCache) || !fullFellowsCache.length) return;
+    var now = Date.now();
+    if (now - _lastPrewarmAttempt < 60000) return;
+    // Don't bother re-running if everything was already captured.
+    if (imagePrewarmState.status === 'done' && imagePrewarmState.errors === 0) return;
+    _lastPrewarmAttempt = now;
+    prewarmProfileImages(fullFellowsCache).catch(function () {});
+  }
+  window.addEventListener('online', maybeResumePrewarm);
 
   function countCachedImages() {
     if (!('caches' in self)) return Promise.resolve(null);
@@ -602,8 +646,18 @@
 
   async function clearAllAppData() {
     try {
+      // Preserve the "has ever been authenticated" marker across full reset.
+      // Rationale: Clear App Cache is meant to fix "my app is broken," not
+      // "log me out of an installed PWA I was happily using." Without this,
+      // an intermittent server error after clear + reload drops users into
+      // the email gate unnecessarily.
+      var preservedAuthMarker = null;
+      try { preservedAuthMarker = localStorage.getItem(AUTH_ONCE_KEY); } catch (e) {}
       localStorage.clear();
       sessionStorage.clear();
+      if (preservedAuthMarker === '1') {
+        try { localStorage.setItem(AUTH_ONCE_KEY, '1'); } catch (e) {}
+      }
 
       if (window.indexedDB && typeof window.indexedDB.deleteDatabase === 'function') {
         try {
@@ -1353,15 +1407,39 @@
         }
         if (data.authenticated && data.installRecentlyAllowed === true) {
           authDebugPush('authenticated + recent-token-window: using install mode');
+          markAuthenticatedOnce();
           initBrowserInstallMode(data, httpStatus);
           return;
+        }
+        if (data.authenticated) {
+          // Authenticated but outside the install window. Record the marker
+          // so future transient failures fall through gracefully.
+          markAuthenticatedOnce();
         }
         authDebugPush('default: using email gate');
         initEmailGate(data, httpStatus, '');
       })
       .catch(function (err) {
-        authDebugPush('auth status check failed: ' + (err && err.message ? err.message : String(err)));
-        showAuthFailure('Unable to validate auth status; refusing install-mode fallback', err && err.message);
+        var errMsg = err && err.message ? err.message : String(err);
+        authDebugPush('auth status check failed: ' + errMsg);
+        // If this origin has been authenticated successfully at least once, a
+        // transient auth-status failure (5xx, network error) must NOT block
+        // the app behind a scary "Authentication check failed" panel.
+        // Quiet fallback: label the server as unreachable on the build badge
+        // and show the email gate as the default view. The user still has
+        // the option to submit a new email if they want a fresh token; most
+        // will just reload when the server is back.
+        if (hasAuthenticatedOnce()) {
+          authDebugPush('fallback: marker set → quiet email-gate (no auth-failure panel)');
+          setBuildBadgeServerUnreachable();
+          initEmailGate(
+            { authEnabled: true, authenticated: false, _offline: true },
+            0,
+            ''
+          );
+          return;
+        }
+        showAuthFailure('Unable to validate auth status; refusing install-mode fallback', errMsg);
       });
   }
 
@@ -2137,6 +2215,10 @@
         bootDebugPush(
           'getList: OK count=' + (Array.isArray(data) ? data.length : typeof data)
         );
+        // Reaching getList success means auth was good (or the local cache
+        // answered). Record the marker so the browser-tab fallback works
+        // for the same user later.
+        markAuthenticatedOnce();
         list = Array.isArray(data) ? data : [];
         renderDirectory();
         route();

--- a/tests/e2e/test_email_gate.py
+++ b/tests/e2e/test_email_gate.py
@@ -124,6 +124,58 @@ class TestEmailGate:
         finally:
             page.close()
 
+    def test_auth_status_503_falls_through_when_marker_set(self, context, base_url_fixture):
+        """A transient /api/auth/status 503 must NOT show the 'Authentication
+        check failed' panel when this origin has been authenticated before.
+        The offline-resilience fallback (phase-1) demotes the failure to a
+        quiet email gate with the build badge labelled 'server: unreachable'.
+        """
+        page = context.new_page()
+        # Simulate "has been authed here before" (marker persisted via
+        # localStorage), then 503 on auth-status.
+        page.add_init_script(
+            "window.localStorage.setItem('fellows_authenticated_once', '1');"
+        )
+        page.route(
+            AUTH_STATUS_PATH,
+            lambda r: r.fulfill(status=503, body="service unavailable"),
+        )
+        try:
+            page.goto(base_url_fixture + "/", wait_until="domcontentloaded")
+            page.wait_for_timeout(300)
+            # The error panel must NOT appear.
+            assert page.locator("#auth-error-panel").is_hidden(), (
+                "Auth-error panel surfaced despite marker being set — fallback failed."
+            )
+            # Email gate is the quiet fallback view.
+            expect(page.locator("#install-gate-private")).to_be_visible()
+            # Build badge reflects server unreachable.
+            server_line = page.locator("#build-badge-server")
+            expect(server_line).to_contain_text("unreachable")
+        finally:
+            page.close()
+
+    def test_auth_status_503_without_marker_still_shows_error_panel(self, context, base_url_fixture):
+        """First-time visitor hitting a 503 still sees the loud error panel.
+        The fallback is opt-in to "we have been here before" — a genuine
+        first-time failure should not silently degrade.
+        """
+        page = context.new_page()
+        # No marker — ensure clean storage.
+        page.add_init_script(
+            "window.localStorage.removeItem('fellows_authenticated_once');"
+        )
+        page.route(
+            AUTH_STATUS_PATH,
+            lambda r: r.fulfill(status=503, body="service unavailable"),
+        )
+        try:
+            page.goto(base_url_fixture + "/", wait_until="domcontentloaded")
+            page.wait_for_timeout(300)
+            expect(page.locator("#auth-error-panel")).to_be_visible()
+        finally:
+            page.close()
+
     def test_back_to_gate_link_posts_logout_and_navigates(self, context, base_url_fixture):
         page = context.new_page()
 


### PR DESCRIPTION
## Problem summary

Two scenarios from the operator's last session that should not have caused trouble on a local-first PWA:

1. **Intermittent internet → "Authentication check failed" panel.** \`/api/auth/status\` returned 503 (server blip). The client treated any non-2xx as fatal and showed a scary report-form-this-bug panel — even though the user has a valid HttpOnly session cookie and a fully-cached local app shell.
2. **Image prewarm stopped at 471/515** when connectivity flapped, and never resumed when it came back.

## Fix — Phase 1

### Persistent "authenticated before" marker

New \`localStorage['fellows_authenticated_once'] = '1'\` set:
- On every successful \`/api/auth/status\` with \`authenticated: true\`
- On every successful \`getList()\` in standalone mode

Preserved across \`clearAllAppData\` — the only key kept when everything else is wiped. Rationale: Clear App Cache is meant to fix a broken app, not to log users out of an install they were happily using.

### Auth-status graceful fallback

In \`startBrowserUx\`'s catch path, if the marker is set:
- Skip the \`showAuthFailure\` panel entirely
- Flip the build badge's server line to \`server: unreachable\` (low-drama label; non-technical users don't need to read this as "broken")
- Render the email gate quietly — user can still request a fresh link, or just reload later

First-time visitors (no marker) still see the loud error panel. The fallback is opt-in to "we've been here before."

### Prewarm resume on \`online\` event

\`window.addEventListener('online', maybeResumePrewarm)\` — refires the prewarm for any images that didn't land. Throttled to one attempt per 60s so mobile radios flapping don't hammer prod. Skips if the prior attempt finished cleanly.

### Badge bump

\`FELLOWS_UI_DIAG → diag-2026-04i-offline-fallback\` so you can confirm the new version is live at a glance after deploy.

## Tests

Two new e2e cases in \`tests/e2e/test_email_gate.py\`:

- \`test_auth_status_503_falls_through_when_marker_set\` — asserts the panel is hidden, email gate is visible, badge contains "unreachable"
- \`test_auth_status_503_without_marker_still_shows_error_panel\` — asserts first-time visitors still see the loud error (the fallback is opt-in)

108 tests green (up from 106).

## Not in this PR (tracked separately)

- **Phase 2**: hourly \`/build-meta.json\` poll with the existing \`#sw-update-banner\` + "Check for updates" button on About.
- **Phase 3**: \`docs/users_manual.md\` foundation for help system.
- **Deferred**: "browser-tab mode should show the directory directly when data is local." Nice-to-have per operator feedback but requires enabling OPFS in browser mode — a larger architectural change. Current fix addresses the scary-panel symptom without needing it.

## After merge

Deploy flow (unchanged):
\`\`\`bash
git pull
python build/build_pwa.py
./scripts/deploy_pwa.sh --ask-become-pass
\`\`\`

Build badge should flip to \`app: diag-2026-04i-offline-fallback\`. Next time the server has a blip, you'll see the quiet fallback (email gate + "server: unreachable" on the badge) instead of the scary auth-error panel.

🤖 Generated with [Claude Code](https://claude.com/claude-code)