### PR TITLE
fix: exclude Knack placeholder images + prewarm .png fallback

### DIFF
--- a/app/static/app.js
+++ b/app/static/app.js
@@ -63,7 +63,7 @@
   /** Bump on every meaningful UI / diagnostics change. Rendered in the
    *  always-visible build badge so a dev can tell at a glance which app.js
    *  is actually running vs what the server was deployed with. */
-  var FELLOWS_UI_DIAG = 'diag-2026-04i-offline-fallback';
+  var FELLOWS_UI_DIAG = 'diag-2026-04j-prewarm-png-fallback';
 
   // Persistent marker: "this origin has been authenticated successfully at
   // least once." Preserved across clearAllAppData. Used by startBrowserUx's
@@ -171,17 +171,40 @@
       if (!f) return null;
       // Same cache-busting suffix as <img src> in renderDetail — keeps the
       // prewarm and the on-demand render aligned so we hit one cache entry.
-      var url = '/images/' + encodeURIComponent(f.slug) + '.jpg?v=' + encodeURIComponent(FELLOWS_UI_DIAG);
-      return fetch(url, { cache: 'default', credentials: 'same-origin' })
+      var jpgUrl = '/images/' + encodeURIComponent(f.slug) + '.jpg?v=' + encodeURIComponent(FELLOWS_UI_DIAG);
+      var pngUrl = '/images/' + encodeURIComponent(f.slug) + '.png?v=' + encodeURIComponent(FELLOWS_UI_DIAG);
+      // Try .jpg first. If 404 / not-ok, fall back to .png — some fellows
+      // have only a .png on disk (they uploaded a PNG on Knack), and
+      // without this fallback the prewarm never caches them. Mirrors the
+      // same .jpg→.png fallback that renderDetail already does when the
+      // on-page <img> errors.
+      return fetch(jpgUrl, { cache: 'default', credentials: 'same-origin' })
         .then(function (r) {
           if (r && r.ok) {
             imagePrewarmState.loaded += 1;
-          } else {
-            imagePrewarmState.errors += 1;
+            return;
           }
+          return fetch(pngUrl, { cache: 'default', credentials: 'same-origin' })
+            .then(function (r2) {
+              if (r2 && r2.ok) {
+                imagePrewarmState.loaded += 1;
+              } else {
+                imagePrewarmState.errors += 1;
+              }
+            })
+            .catch(function () { imagePrewarmState.errors += 1; });
         })
         .catch(function () {
-          imagePrewarmState.errors += 1;
+          // Total network failure on .jpg — try .png anyway.
+          return fetch(pngUrl, { cache: 'default', credentials: 'same-origin' })
+            .then(function (r2) {
+              if (r2 && r2.ok) {
+                imagePrewarmState.loaded += 1;
+              } else {
+                imagePrewarmState.errors += 1;
+              }
+            })
+            .catch(function () { imagePrewarmState.errors += 1; });
         })
         .then(next);
     }

--- a/build/restore_from_knack_scrapefile.py
+++ b/build/restore_from_knack_scrapefile.py
@@ -339,6 +339,25 @@ def slugify(text: str) -> str:
     return re.sub(r"[^a-z0-9]+", "_", text.lower().strip()).strip("_") or ""
 
 
+# MD5 hashes of the grey-diamond Knack default avatar. Fellows who "have"
+# one of these on their profile never actually uploaded a photo — Knack put
+# it there as a default. Treat them as has_image=0 so the UI says
+# "Not Submitted" (accurate) rather than rendering a meaningless placeholder.
+# Source: build/filter_demo_data.py (where the hashes were first collected).
+PLACEHOLDER_IMAGE_HASHES: frozenset = frozenset({
+    "5aa43d100ed38aabebbd8393338e961d",
+    "d01a4e3bd727674a2e698c18b61a63bb",
+})
+
+
+def _md5_of_file(p: Path) -> str:
+    import hashlib
+    try:
+        return hashlib.md5(p.read_bytes()).hexdigest()
+    except OSError:
+        return ""
+
+
 def build_image_index() -> dict[str, Path]:
     d = IMAGES_DIR_SOURCE if IMAGES_DIR_SOURCE.is_dir() else (IMAGES_DIR_APP if IMAGES_DIR_APP.is_dir() else None)
     if not d:
@@ -346,6 +365,10 @@ def build_image_index() -> dict[str, Path]:
     idx: dict[str, Path] = {}
     for p in d.iterdir():
         if not p.is_file() or p.suffix.lower() not in (".jpg", ".jpeg", ".png"):
+            continue
+        # Skip known-placeholder images so the fellow gets has_image=0
+        # (and the UI correctly shows "Not Submitted").
+        if _md5_of_file(p) in PLACEHOLDER_IMAGE_HASHES:
             continue
         stem_alpha = re.sub(r"[^a-z0-9]", "", p.stem.lower())
         if stem_alpha and stem_alpha not in idx:


### PR DESCRIPTION
## Two fixes, already live on prod

Both changes deployed end-to-end during this session via ansible + \`BECOME_PASS_TMP\`.

### Placeholder-image detection

Seven fellows had Knack's grey-diamond default avatar on their profile instead of an actual photo. Rendering that placeholder misleads viewers — those fellows never uploaded anything.

\`build/filter_demo_data.py\` already had the MD5 hashes we needed. Lifted them into the ETL's \`build_image_index\`, which now skips files matching either known placeholder hash. Those fellows get \`has_image=0\` naturally, and the UI shows "Not Submitted" — accurate.

**Scope**: 7 fellows out of 515. No other duplicate MD5s found in the image set, so no hidden secondary placeholders to chase.

| Fellow                | Before | After |
|-----------------------|--------|-------|
| Alexey Rostapshov     | "Not Submitted" *(should be, but was showing placeholder)* | Not Submitted ✓ |
| Ankur Nandwani        | same | Not Submitted ✓ |
| Benjamin Ha           | same | Not Submitted ✓ |
| Jason Saw             | same | Not Submitted ✓ |
| Laura Patterson       | same | Not Submitted ✓ |
| Taaniko Nordstrom     | same | Not Submitted ✓ |
| (one more)            | same | Not Submitted ✓ |

### Prewarm `.png` fallback

Bug: the prewarm only fetched \`/images/<slug>.jpg\`. 45 fellows have a \`.png\` on disk (uploaded PNG to Knack), so their prewarm always 404'd — explaining the About-page counter stalling around 470/515 instead of climbing.

Fix: try \`.jpg\` first, fall back to \`.png\` on 404 — same pattern \`renderDetail\` already uses when the on-page \`<img>\` errors out.

Expected post-deploy counter ceiling: **508 / 508** (placeholder fellows don't contribute since their \`has_image\` is now 0).

### Badge bump

\`FELLOWS_UI_DIAG → diag-2026-04j-prewarm-png-fallback\`

## Live verification (ran now, post-deploy)

\`\`\`
prod: 515 fellows, 508 with_image=1 (expected 508)
  Alexey Rostapshov         has_image=0    ← placeholder, correct
  Jason Saw                 has_image=0    ← placeholder, correct
  Richard Bodo              has_image=1    ← real photo, unchanged
  Aaron Bird                has_image=1    ← real photo, unchanged
  Denise Chen               has_image=1    ← real photo, unchanged

Allowlist: 515 / 515 ✓ in sync
Smoke: /healthz 200, /manifest.webmanifest 200
\`\`\`

## What to expect in your PWA

After a hard reload:
- Build badge flips to \`app: diag-2026-04j-prewarm-png-fallback\`
- Alexey Rostapshov's detail page shows "Not Submitted" (instead of the grey diamond)
- About page's "photos cached locally" counter climbs toward **508 / 508** (not 515 / 515 — placeholder fellows don't contribute)

## Answer to the other observations

**"I also see a count of fellows at the top of the page, right below the search box, which I did not expect. Did we design that?"**

Yes — shipped in PR #21 ("has email filter + count"). Shows \`N fellows\` when no filter hides anyone, or \`N of M fellows\` when filter hides some. Will be included in the users manual (Phase 3 of the offline-resilience planning).

**"A hard reload does take me to the app, and not the email gate"**

Phase 1 (PR #44) working as designed. The offline-fallback marker is doing its job.

**"The app stopped loading photos at 472"**

That's this PR's fix. Post-deploy counter will reach 508.

🤖 Generated with [Claude Code](https://claude.com/claude-code)