### PR TITLE
fix(pwa): clarify visible-count text and drop false-positive install warning

### DIFF
--- a/app/static/app.js
+++ b/app/static/app.js
@@ -63,7 +63,7 @@
   /** Bump on every meaningful UI / diagnostics change. Rendered in the
    *  always-visible build badge so a dev can tell at a glance which app.js
    *  is actually running vs what the server was deployed with. */
-  var FELLOWS_UI_DIAG = 'diag-2026-04i-offline-fallback';
+  var FELLOWS_UI_DIAG = 'diag-2026-04k-visible-count-text';
 
   // Persistent marker: "this origin has been authenticated successfully at
   // least once." Preserved across clearAllAppData. Used by startBrowserUx's
@@ -1184,17 +1184,14 @@
       if (installButtonEl) installButtonEl.classList.add('hidden');
     });
 
-    // Unsupported-browser detection: if after ~3s no beforeinstallprompt has
-    // fired AND we're not iOS Safari (which uses Share → Add to Home Screen),
-    // swap the install button for the "your browser doesn't support install"
-    // hint. The timer is long enough to avoid a flash on browsers that fire
-    // late, short enough that a dev doesn't think the page is broken.
-    setTimeout(function () {
-      if (deferredInstallPrompt) return;
-      if (isIosSafari()) return;
-      if (installUnsupportedHintEl) installUnsupportedHintEl.classList.remove('hidden');
-      if (installButtonEl) installButtonEl.classList.add('hidden');
-    }, 3000);
+    // Note: no proactive "unsupported browser" detection timer.
+    //   An earlier version flipped the install landing to an "unsupported"
+    //   warning after 3s if `beforeinstallprompt` hadn't fired. That's a
+    //   false positive on Chrome/Edge when the PWA is already installed on
+    //   the device — Chrome won't re-fire the event in that case (the
+    //   address bar shows "Open in app" instead). We now rely on the
+    //   click-handler fallback below, which shows the hint only if the
+    //   user actually clicks Install and the prompt isn't available.
 
     if (installButtonEl && !installButtonEl._wired) {
       installButtonEl._wired = true;
@@ -1507,10 +1504,13 @@
       renderDirectoryList(filtered);
       displayedList = filtered;
     }
+    // This UI element is defined as "count of fellows visible in the current
+    // view." In directory mode it reflects the `has email` filter; in search
+    // mode it reflects the search + filter together (see renderSearchResults).
     setFilterCount(
       filtered.length === list.length
-        ? list.length + ' fellows'
-        : filtered.length + ' of ' + list.length + ' fellows'
+        ? list.length + ' fellows visible'
+        : filtered.length + ' of ' + list.length + ' fellows visible'
     );
     if (loadingPanelEl) {
       loadingPanelEl.classList.add('hidden');
@@ -1933,7 +1933,12 @@
     var total = results.length;
     var filtered = applyHasEmailFilter(results);
     displayedList = filtered;
-    setFilterCount('');
+    // Keep the visible-count indicator in sync with what's actually shown,
+    // including during search. The denominator stays at list.length (total
+    // fellows in the current data set) so "5 of 515 fellows visible" is
+    // unambiguous even when both a search AND the has-email filter apply.
+    var total_in_data = (list && list.length) || total;
+    setFilterCount(filtered.length + ' of ' + total_in_data + ' fellows visible');
     if (!filtered.length) {
       if (!total) {
         directoryListEl.innerHTML = '<p class="placeholder">No fellows match that search.</p>';


### PR DESCRIPTION
## Summary
- Count indicator now says \`N fellows visible\` / \`N of M fellows visible\` and stays synced during search (previously blanked out when a search was active).
- Remove the 3s \"your browser doesn't support install\" timer. Chrome suppresses \`beforeinstallprompt\` when the PWA is already installed on the device, producing a false positive. The click-handler fallback still covers genuinely unsupported browsers.
- Diag bumped to \`diag-2026-04k-visible-count-text\`.

## Why
Bug 1: The count indicator was empty during search. If you searched and got 5 hits out of 515, nothing in the UI told you that.
Bug 2: Users reported a \"your browser doesn't support install\" warning on Chrome a few seconds after landing, even though their PWA was already installed. That matched the 3s timer exactly — Chrome's behavior is to suppress the install prompt once a PWA is installed, so the timer fired a false positive.

## Test plan
- [x] Unit tests: \`tests/test_database.py\`, \`tests/test_api.py\` — 24/24 pass
- [x] E2E: \`tests/e2e/test_directory.py\`, \`tests/e2e/test_install_landing.py\`, \`tests/e2e/test_email_gate.py\` — all pass
- [ ] Maintainer QA on prod after deploy:
  - Visit app in a browser tab → install landing visible, no \"unsupported\" warning appears after 3s.
  - Install PWA → open it → filter \"has email\" toggle → count reads \`N fellows visible\` / \`N of M fellows visible\`.
  - Search in directory → count updates to \`X of M fellows visible\`.
  - Try an unsupported browser (or Safari macOS) → click Install → hint appears via click-handler fallback.

🤖 Generated with [Claude Code](https://claude.com/claude-code)