### PR TITLE
feat(pwa): hourly update check + user guide (offline resilience ph.2/3)

### DIFF
--- a/app/static/app.js
+++ b/app/static/app.js
@@ -63,7 +63,7 @@
   /** Bump on every meaningful UI / diagnostics change. Rendered in the
    *  always-visible build badge so a dev can tell at a glance which app.js
    *  is actually running vs what the server was deployed with. */
-  var FELLOWS_UI_DIAG = 'diag-2026-04k-visible-count-text';
+  var FELLOWS_UI_DIAG = 'diag-2026-04l-update-check';
 
   // Persistent marker: "this origin has been authenticated successfully at
   // least once." Preserved across clearAllAppData. Used by startBrowserUx's
@@ -112,6 +112,17 @@
 
   initBuildBadge();
 
+  // Boot snapshot of /build-meta.json. The hourly update check and the
+  // About-page "Check for updates" button both compare against this snapshot
+  // to decide whether the server has shipped a newer build since this page
+  // was loaded. Populated asynchronously; consumers guard on .git_sha.
+  var bootBuildMeta = { git_sha: null, built_at: null, capturedAt: null };
+  var updateCheckState = {
+    lastAttemptAt: null,
+    lastResult: null,
+    lastLatestMeta: null
+  };
+
   // Populate the server-side label independently of the auth flow so a dev
   // reading the badge still gets a signal when /api/auth/status is failing.
   function primeServerBadgeFromBuildMeta() {
@@ -119,12 +130,80 @@
       fetch('/build-meta.json', { cache: 'no-cache', credentials: 'same-origin' })
         .then(function (r) { return r.ok ? r.json() : null; })
         .then(function (meta) {
-          if (meta) setBuildBadgeServer(meta.git_sha, meta.built_at);
+          if (meta) {
+            setBuildBadgeServer(meta.git_sha, meta.built_at);
+            if (!bootBuildMeta.git_sha) {
+              bootBuildMeta = {
+                git_sha: meta.git_sha || null,
+                built_at: meta.built_at || null,
+                capturedAt: new Date().toISOString()
+              };
+            }
+          }
         })
         .catch(function () {});
     } catch (e) {}
   }
   primeServerBadgeFromBuildMeta();
+
+  // Fetch /build-meta.json and compare to the boot snapshot. If the server
+  // has shipped a newer build (different git_sha), surface the existing
+  // sw-update-banner so the user can reload into the new version.
+  //
+  // Returns a Promise resolving to { status, latest?, error? } where status
+  // is one of:
+  //   'update-available' — server build differs from boot snapshot
+  //   'up-to-date'       — server build matches boot snapshot
+  //   'no-boot-snapshot' — never captured a boot snapshot (offline at boot)
+  //   'error'            — fetch failed or response was not ok
+  function checkForServerUpdate() {
+    updateCheckState.lastAttemptAt = new Date().toISOString();
+    return fetch('/build-meta.json', { cache: 'no-store', credentials: 'same-origin' })
+      .then(function (r) {
+        if (!r.ok) throw new Error('HTTP ' + r.status);
+        return r.json();
+      })
+      .then(function (meta) {
+        updateCheckState.lastLatestMeta = meta || null;
+        if (!bootBuildMeta.git_sha) {
+          // First successful fetch: adopt it as the boot snapshot so subsequent
+          // polls have something to compare against.
+          bootBuildMeta = {
+            git_sha: (meta && meta.git_sha) || null,
+            built_at: (meta && meta.built_at) || null,
+            capturedAt: new Date().toISOString()
+          };
+          updateCheckState.lastResult = 'no-boot-snapshot';
+          return { status: 'no-boot-snapshot', latest: meta };
+        }
+        var latestSha = meta && meta.git_sha;
+        if (latestSha && latestSha !== bootBuildMeta.git_sha) {
+          showSwUpdateBanner('server-meta-drift');
+          updateCheckState.lastResult = 'update-available';
+          return { status: 'update-available', latest: meta };
+        }
+        updateCheckState.lastResult = 'up-to-date';
+        return { status: 'up-to-date', latest: meta };
+      })
+      .catch(function (err) {
+        updateCheckState.lastResult = 'error';
+        return { status: 'error', error: err && err.message ? err.message : String(err) };
+      });
+  }
+
+  // Hourly background check. Runs only once the document is visible and only
+  // in standalone PWA mode — a browser-mode visit is transient and doesn't
+  // need a poll. Exposed via window for e2e testing.
+  var UPDATE_CHECK_INTERVAL_MS = 60 * 60 * 1000; // 1 hour
+  var updateCheckIntervalHandle = null;
+  function startUpdateCheckPoll() {
+    if (updateCheckIntervalHandle) return;
+    if (!isStandaloneDisplayMode()) return;
+    updateCheckIntervalHandle = setInterval(function () {
+      if (document.hidden) return;
+      checkForServerUpdate();
+    }, UPDATE_CHECK_INTERVAL_MS);
+  }
 
   function logSwLifecycle(event, detail) {
     swLifecycleLog.push({
@@ -1780,6 +1859,11 @@
     aboutHtml += 'There is no API, login, or web app, so this can only be shared intentionally. ';
     aboutHtml += 'For support, request to join the github repository or just ask on one of the fellows channels.</p>';
     aboutHtml += '<p class="about-support">Having trouble with the app? Contact the EHF Communications Working Group.</p>';
+    aboutHtml += '<p class="about-users-manual"><a href="https://github.com/richbodo/fellows_local_db/blob/main/docs/users_manual.md" target="_blank" rel="noopener">User Guide</a> \u2014 how to install, update, and clear app data.</p>';
+    aboutHtml += '<p class="about-update-check">';
+    aboutHtml += '<button type="button" id="about-check-updates" class="about-check-updates-btn">Check for updates</button>';
+    aboutHtml += '<span id="about-update-status" class="about-update-status" role="status" aria-live="polite"></span>';
+    aboutHtml += '</p>';
     aboutHtml += '<p class="about-repo"><a href="https://github.com/richbodo/fellows_local_db" target="_blank" rel="noopener">';
     aboutHtml += '<svg class="github-icon" viewBox="0 0 16 16" width="20" height="20" aria-hidden="true"><path fill="currentColor" d="M8 0C3.58 0 0 3.58 0 8c0 3.54 2.29 6.53 5.47 7.59.4.07.55-.17.55-.38 0-.19-.01-.82-.01-1.49-2.01.37-2.53-.49-2.69-.94-.09-.23-.48-.94-.82-1.13-.28-.15-.68-.52-.01-.53.63-.01 1.08.58 1.23.82.72 1.21 1.87.87 2.33.66.07-.52.28-.87.51-1.07-1.78-.2-3.64-.89-3.64-3.95 0-.87.31-1.59.82-2.15-.08-.2-.36-1.02.08-2.12 0 0 .67-.21 2.2.82.64-.18 1.32-.27 2-.27.68 0 1.36.09 2 .27 1.53-1.04 2.2-.82 2.2-.82.44 1.1.16 1.92.08 2.12.51.56.82 1.27.82 2.15 0 3.07-1.87 3.75-3.65 3.95.29.25.54.73.54 1.48 0 1.07-.01 1.93-.01 2.2 0 .21.15.46.55.38A8.013 8.013 0 0016 8c0-4.42-3.58-8-8-8z"/></svg>';
     aboutHtml += ' richbodo/fellows_local_db</a></p>';
@@ -1791,6 +1875,31 @@
     aboutHtml += '<div class="stats-grid" id="stats-grid"></div>';
     aboutHtml += '</div>';
     detailEl.innerHTML = aboutHtml;
+
+    // Wire the "Check for updates" button. Shares the same checker used by
+    // the hourly poll so the user-visible status stays consistent with what
+    // triggers the sw-update-banner.
+    (function wireUpdateCheckButton() {
+      var btn = document.getElementById('about-check-updates');
+      var statusEl = document.getElementById('about-update-status');
+      if (!btn || !statusEl) return;
+      btn.addEventListener('click', function () {
+        btn.disabled = true;
+        statusEl.textContent = 'Checking\u2026';
+        checkForServerUpdate().then(function (res) {
+          btn.disabled = false;
+          if (res.status === 'update-available') {
+            statusEl.textContent = 'New version available \u2014 reload to apply.';
+          } else if (res.status === 'up-to-date') {
+            statusEl.textContent = 'You\u2019re on the latest version.';
+          } else if (res.status === 'no-boot-snapshot') {
+            statusEl.textContent = 'Version recorded \u2014 future checks will compare against this build.';
+          } else {
+            statusEl.textContent = 'Unable to reach the server right now. Try again later.';
+          }
+        });
+      });
+    })();
 
     // Render the "N / M" cached-photo counter using the existing helper.
     // Snapshotted at page-render time; refreshes on next About visit.
@@ -2271,6 +2380,9 @@
             prewarmProfileImages(full).catch(function () {});
           }, 0);
         }
+        // Start the hourly server-build-drift check. Idempotent; only
+        // arms the interval when running as an installed PWA.
+        startUpdateCheckPoll();
       })
       .catch(function (err) {
         showBootFailure(err);

--- a/app/static/styles.css
+++ b/app/static/styles.css
@@ -991,3 +991,40 @@ h1 {
   font-size: 0.95rem;
   color: #4a2c6a;
 }
+
+.about-users-manual {
+  margin-top: 0.75rem;
+  font-size: 0.95rem;
+}
+
+.about-update-check {
+  margin-top: 0.75rem;
+  display: flex;
+  align-items: center;
+  gap: 0.75rem;
+  flex-wrap: wrap;
+}
+
+.about-check-updates-btn {
+  background: #fff;
+  border: 1px solid #4a2c6a;
+  color: #4a2c6a;
+  border-radius: 4px;
+  padding: 0.4rem 0.8rem;
+  font: inherit;
+  cursor: pointer;
+}
+
+.about-check-updates-btn:hover:not(:disabled) {
+  background: #f4eef9;
+}
+
+.about-check-updates-btn:disabled {
+  opacity: 0.6;
+  cursor: default;
+}
+
+.about-update-status {
+  font-size: 0.9rem;
+  color: #5a5a5a;
+}

--- a/docs/users_manual.md
+++ b/docs/users_manual.md
@@ -1,0 +1,113 @@
+# EHF Fellows Directory — User Guide
+
+A short, practical guide for fellows using the installed app. For a deeper
+technical tour, see [`Architecture.md`](Architecture.md).
+
+---
+
+## What this app is
+
+A private, installable directory of Edmund Hillary Fellowship fellow
+profiles. Once installed, the app runs locally on your device — the fellow
+data lives in a local database inside your browser's app storage, so you
+can browse the directory even when you're offline.
+
+The app is only distributed to EHF fellows, by emailed magic link. Please
+keep the data confidential and do not share the link or screenshots
+outside the fellowship.
+
+---
+
+## Installing the app
+
+1. Click the install link in your email. You'll land on a page titled
+   **"Install EHF Fellows Directory."**
+2. Click **Install app**.
+   - On **desktop Chrome / Edge**: a small install prompt appears near the
+     address bar — confirm it. The app opens in its own window.
+   - On **Android Chrome**: the prompt offers **Add to Home screen**. Accept
+     it; the app shows up as an icon in your launcher.
+   - On **iOS Safari**: tap the **Share** button, then **Add to Home
+     Screen**. (iOS doesn't support the one-click install prompt.)
+3. Open the installed app. The first launch downloads fellow data in the
+   background — you should see photos filling in over a minute or so on a
+   normal connection.
+
+If you see a message saying your browser doesn't support install, try
+Chrome or Edge on desktop, or Safari on iOS.
+
+---
+
+## Using the directory
+
+- **Search** by name, tagline, or any keyword. Results update as you type.
+- **Has email** filter (top of the directory) is on by default — it hides
+  fellows the app can't reach by email. Turn it off to see everyone.
+- **Profile photos** are cached on your device after the first load, so
+  scrolling is fast and works offline.
+- The visible-count text (e.g. **"142 of 515 fellows visible"**) shows how
+  many fellows match your current search + filter.
+
+---
+
+## Updates
+
+The app checks for new versions automatically:
+
+- **On every launch**, the service worker compares against the server.
+- **Once an hour** while the app is open, a background check confirms
+  you're still on the latest build.
+- You can also force a check from the **About** page → **Check for
+  updates**.
+
+When an update is available, a banner appears across the top of the app:
+**"New version available — Reload."** Click Reload to apply it.
+
+---
+
+## Clearing app data
+
+If the app gets into a weird state (corrupt cache, stuck banner, stale
+data), you can reset it:
+
+1. Go to the **About** page.
+2. Scroll to **Diagnostics** → **Clear app cache**.
+3. Confirm. The app wipes its local storage and reloads.
+
+**Heads-up:** clearing the cache logs you out of the app on that device.
+You'll need the original install link (or a fresh one) to re-enter. The
+app preserves a small "you've been here before" marker so a future
+server outage won't strand you at the loud error panel — that marker is
+also cleared.
+
+---
+
+## Offline behaviour
+
+- Once installed and first-loaded, the directory works fully offline.
+- Photos that finished caching are available offline; photos that never
+  downloaded show a placeholder until you're back online and the prewarm
+  catches up.
+- If the server is temporarily unreachable (flaky connection, deploy
+  blip), the build badge at the top of the app flips to **"server:
+  unreachable."** This is informational — the app keeps working.
+
+---
+
+## Getting help
+
+- **General questions**: ask on one of the fellows channels, or contact
+  the EHF Communications Working Group.
+- **Bug reports / feature requests**: open an issue on the GitHub repo
+  (link on the About page). You'll need to be added to the repo first —
+  ask Rich.
+- **Install link expired or lost**: request a fresh one from the
+  operator.
+
+---
+
+## Privacy
+
+The app ships a dump of fellow contact info and free-text responses. It
+is explicitly **not** hosted as a public service — distribution is by
+individual invitation. Keep screenshots and data within the fellowship.

--- a/tests/e2e/test_update_check.py
+++ b/tests/e2e/test_update_check.py
@@ -1,0 +1,117 @@
+"""E2E tests: About-page "Check for updates" button + server-drift banner.
+
+Exercises the Phase-2 update check: a boot snapshot of ``/build-meta.json``
+is compared against the latest value each time the user clicks the button
+(and, in production, once an hour). When the server git_sha has changed,
+the shared ``#sw-update-banner`` is surfaced so the user can reload.
+"""
+import json
+
+import pytest
+from playwright.sync_api import expect
+
+from conftest import _STANDALONE_DISPLAY_INIT
+
+
+BUILD_META_PATH = "**/build-meta.json"
+
+
+def _route_build_meta(context, git_sha, built_at="2026-04-20T00:00:00Z"):
+    # NB: use context.route (not page.route) — page.route only fires for the
+    # first matching request in our Playwright version; the boot fetch and the
+    # button-click fetch both need to be mocked.
+    body = json.dumps({"git_sha": git_sha, "built_at": built_at})
+
+    def _fulfill(route):
+        route.fulfill(
+            status=200,
+            content_type="application/json",
+            body=body,
+            headers={"Cache-Control": "no-cache"},
+        )
+
+    context.route(BUILD_META_PATH, _fulfill)
+
+
+def _make_standalone_page(context):
+    page = context.new_page()
+    page.add_init_script(_STANDALONE_DISPLAY_INIT)
+    return page
+
+
+class TestAboutUpdateCheck:
+    """About-page "Check for updates" flow."""
+
+    def test_up_to_date_shows_reassuring_status(self, context, base_url_fixture):
+        page = _make_standalone_page(context)
+        try:
+            _route_build_meta(context, git_sha="abc123")
+            page.goto(base_url_fixture + "/#/about", wait_until="domcontentloaded")
+            # Let the boot fetch land and populate bootBuildMeta.
+            page.wait_for_timeout(300)
+
+            btn = page.locator("#about-check-updates")
+            expect(btn).to_be_visible()
+            btn.click()
+            status = page.locator("#about-update-status")
+            expect(status).to_contain_text("latest version", timeout=5000)
+            expect(page.locator("#sw-update-banner")).to_be_hidden()
+        finally:
+            context.unroute(BUILD_META_PATH)
+            page.close()
+
+    def test_server_drift_surfaces_banner_and_status(self, context, base_url_fixture):
+        page = _make_standalone_page(context)
+        try:
+            _route_build_meta(context, git_sha="abc123")
+            page.goto(base_url_fixture + "/#/about", wait_until="domcontentloaded")
+            page.wait_for_timeout(300)
+
+            # A newer build is now live — re-arm the mock with a different sha.
+            context.unroute(BUILD_META_PATH)
+            _route_build_meta(context, git_sha="xyz999")
+
+            page.locator("#about-check-updates").click()
+            status = page.locator("#about-update-status")
+            expect(status).to_contain_text("New version available", timeout=5000)
+            expect(page.locator("#sw-update-banner")).to_be_visible()
+        finally:
+            context.unroute(BUILD_META_PATH)
+            page.close()
+
+    def test_fetch_error_shows_unreachable_status(self, context, base_url_fixture):
+        page = _make_standalone_page(context)
+        try:
+            _route_build_meta(context, git_sha="abc123")
+            page.goto(base_url_fixture + "/#/about", wait_until="domcontentloaded")
+            page.wait_for_timeout(300)
+
+            # Simulate server outage on the manual check.
+            context.unroute(BUILD_META_PATH)
+            context.route(
+                BUILD_META_PATH,
+                lambda r: r.fulfill(status=503, body="service unavailable"),
+            )
+
+            page.locator("#about-check-updates").click()
+            status = page.locator("#about-update-status")
+            expect(status).to_contain_text("Unable to reach", timeout=5000)
+            expect(page.locator("#sw-update-banner")).to_be_hidden()
+        finally:
+            context.unroute(BUILD_META_PATH)
+            page.close()
+
+    def test_users_manual_link_on_about_page(self, context, base_url_fixture):
+        page = _make_standalone_page(context)
+        try:
+            _route_build_meta(context, git_sha="abc123")
+            page.goto(base_url_fixture + "/#/about", wait_until="domcontentloaded")
+            link = page.get_by_role("link", name="User Guide")
+            expect(link).to_be_visible()
+            expect(link).to_have_attribute(
+                "href",
+                "https://github.com/richbodo/fellows_local_db/blob/main/docs/users_manual.md",
+            )
+        finally:
+            context.unroute(BUILD_META_PATH)
+            page.close()


### PR DESCRIPTION
## Summary

Completes the offline-resilience series (follow-up to #44).

**Phase 2 — server-build drift detection**
- Capture \`/build-meta.json\` at boot as the \"current version\" snapshot.
- New \`checkForServerUpdate()\` re-fetches and compares \`git_sha\`; on drift it surfaces the existing \`#sw-update-banner\` so the user can reload.
- Hourly \`setInterval\` poll in standalone mode; skipped while tab hidden.
- \"Check for updates\" button on the About page for on-demand checks, with inline status (\"latest version\" / \"new version available\" / \"unable to reach\"). Button shares the same checker as the poll.

**Phase 3 — user-facing guide**
- New \`docs/users_manual.md\`: install, usage, updates, clear-cache, offline behavior, support, privacy.
- Link on the About page (\"User Guide\").

## Why
Per follow-up plan in PR #44. The SW \`updatefound\` event handles the fast path; the hourly poll covers users who leave the app open for days (and gives the operator a user-initiated \"is there a new version?\" answer on About).

## Tests
- 4 new e2e cases in \`tests/e2e/test_update_check.py\` (up-to-date, drift, fetch-error, users-manual link).
- Full suite: 112/112 pass (up from 108).

Diag bumped to \`diag-2026-04l-update-check\`.

## Test plan (maintainer QA on prod after deploy)
- [ ] Visit About page → see \"User Guide\" link + \"Check for updates\" button.
- [ ] Click \"Check for updates\" → status reads \"You're on the latest version.\"
- [ ] Bump any commit on main and redeploy; in the still-open PWA, click the button again → status reads \"New version available — reload to apply\" AND the \`#sw-update-banner\` appears.
- [ ] Click Reload on the banner → app reloads into the new build.
- [ ] Leave the PWA open for 1+ hour, ship a new deploy, verify the banner appears without any user action (hourly poll).
- [ ] Click through the User Guide link → opens \`docs/users_manual.md\` on GitHub in a new tab.

🤖 Generated with [Claude Code](https://claude.com/claude-code)