### PR TITLE
feat(pwa): URL acts as the app for returning users + user-guide launch docs

### DIFF
--- a/app/static/app.js
+++ b/app/static/app.js
@@ -63,7 +63,7 @@
   /** Bump on every meaningful UI / diagnostics change. Rendered in the
    *  always-visible build badge so a dev can tell at a glance which app.js
    *  is actually running vs what the server was deployed with. */
-  var FELLOWS_UI_DIAG = 'diag-2026-04l-update-check';
+  var FELLOWS_UI_DIAG = 'diag-2026-04m-url-is-app';
 
   // Persistent marker: "this origin has been authenticated successfully at
   // least once." Preserved across clearAllAppData. Used by startBrowserUx's
@@ -1113,6 +1113,20 @@
       return true;
     }
     return window.matchMedia && window.matchMedia('(display-mode: standalone)').matches;
+  }
+
+  // Treat the current visit as "the app is running" (not "the install
+  // landing") when the page is open as an installed PWA *or* when this
+  // browser profile has already authenticated against this origin before.
+  // The second case covers: user installed once, then later visits the
+  // URL in a regular browser tab. Without this, every tab visit would
+  // force them through the install landing even though the app is ready.
+  // `?gate=1` still bypasses both branches so a dev can always reach the
+  // email gate explicitly.
+  function shouldActAsApp() {
+    if (isStandaloneDisplayMode()) return true;
+    if (parseGateOverride().force) return false;
+    return hasAuthenticatedOnce();
   }
 
   function setInstallStatus(msg) {
@@ -2311,7 +2325,7 @@
   initClearCacheButton();
   initDiagnosticsPanel();
 
-  if (isStandaloneDisplayMode()) {
+  function bootDirectoryAsApp() {
     bootDebugLines.length = 0;
     if (siteHeaderEl) siteHeaderEl.classList.remove('hidden');
     if (loadingPanelEl) {
@@ -2337,8 +2351,7 @@
       });
     }
 
-    tryUnlockFromHash()
-      .then(function () { return pickDataProvider(); })
+    pickDataProvider()
       .then(function (provider) {
         dataProvider = provider;
         bootDebugPush('provider ready kind=' + provider.kind);
@@ -2385,6 +2398,20 @@
         startUpdateCheckPoll();
       })
       .catch(function (err) {
+        // Browser-tab-acting-as-app path: if the API refuses us (session
+        // expired, etc.), don't show the scary boot-failure panel — hand
+        // off to startBrowserUx, which will show the email gate. A user
+        // who has the app installed can always relaunch the standalone
+        // copy from their desktop/home icon, which uses cached data.
+        if (!isStandaloneDisplayMode() && hasAuthenticatedOnce()) {
+          bootDebugPush('as-app boot failed; handing off to startBrowserUx: ' +
+            (err && err.message ? err.message : String(err)));
+          if (siteHeaderEl) siteHeaderEl.classList.add('hidden');
+          if (loadingPanelEl) loadingPanelEl.classList.add('hidden');
+          if (loadingEl) loadingEl.classList.add('hidden');
+          startBrowserUx();
+          return;
+        }
         showBootFailure(err);
       });
 
@@ -2435,11 +2462,15 @@
     window.addEventListener('online', updateConnectionBanner);
     window.addEventListener('offline', updateConnectionBanner);
     updateConnectionBanner();
-  } else {
-    tryUnlockFromHash().then(function () {
-      startBrowserUx();
-    });
   }
+
+  tryUnlockFromHash().then(function () {
+    if (shouldActAsApp()) {
+      bootDirectoryAsApp();
+    } else {
+      startBrowserUx();
+    }
+  });
 
   registerServiceWorker();
 })();

--- a/docs/email_gate.md
+++ b/docs/email_gate.md
@@ -28,7 +28,8 @@ Operator procedures (Postmark, env file, Postmark response interpretation) stay 
 7. **Dev escape hatch is always reachable.** Two layers:
    - A **"Back to email gate"** control on the install landing, which `POST`s `/api/logout` (clears the cookie server-side) then navigates to `/?gate=1`.
    - A **hardcoded URL override** `/?gate=1` that forces the gate UI regardless of cookie state. Works even when JS-driven logout fails.
-8. **Unsupported browsers are told so.** If `beforeinstallprompt` doesn't fire within ~3 seconds and the user isn't on iOS Safari (which installs via Share → Add to Home Screen), the install landing swaps to a panel asking them to use Chrome, Edge, Safari, or another browser that supports PWA install. No in-browser fallback to the directory — this is a PWA, not SaaS.
+8. **Unsupported browsers are told so — on click, not eagerly.** If a user clicks "Install app" and `beforeinstallprompt` never fired (and they're not on iOS Safari), the install landing swaps in a panel asking them to use Chrome, Edge, Safari, or another browser that supports PWA install. No auto-timer: Chrome suppresses `beforeinstallprompt` when the PWA is already installed on the device, and an eager timer would false-positive on those users.
+9. **URL-just-works for returning visitors.** A browser-tab visit with `fellows_authenticated_once` set *acts as the app* (directory via API) instead of forcing the install landing. The installed standalone PWA remains the preferred launcher; this is a graceful fallback for users who type/bookmark the URL. `?gate=1` still wins in every case.
 
 ## Browser-mode decision tree
 
@@ -37,29 +38,49 @@ Evaluated on every page render (after auth-status fetch). Order matters — firs
 ```
 1. URL hash == "#/unlock/<token>"?
      POST /api/verify-token {token}
-       → 200 ok        : cookie{token_issued_at=now} set by server; strip hash; fall through to #3
+       → 200 ok        : cookie{token_issued_at=now} set by server; strip hash; fall through to #2
        → 401 expired   : location.replace("/?gate=1&reason=expired")
        → 401 invalid   : location.replace("/?gate=1&reason=invalid")
        → network err   : location.replace("/?gate=1&reason=invalid")
 
-2. ?gate=1 in URL?
+2. localStorage[fellows_authenticated_once] == "1"  AND  ?gate=1 NOT in URL?
+     → ACT AS APP (directory via API, same code path as standalone PWA)
+       - This is "URL-just-works": a returning user who already installed the
+         PWA once sees the directory in a regular browser tab instead of
+         being pushed through the install landing again. The installed
+         standalone copy remains the preferred launcher; this path is a
+         graceful fallback when they type/bookmark the URL.
+       - If the API refuses (session expired, 5xx), fall through to
+         startBrowserUx (item #3+) so the email gate can appear.
+
+3. ?gate=1 in URL?
      → EMAIL GATE
        ?reason=expired → banner "That link expired. Enter your email to get a new one."
        ?reason=invalid → banner "That link isn't valid. Enter your email to get a new one."
        otherwise       → no banner
 
-3. authStatus.authEnabled == false  (local dev passthrough)
+4. authStatus.authEnabled == false  (local dev passthrough)
      → INSTALL LANDING (dev has no real gate; this preserves the developer UX)
 
-4. authStatus.authenticated && authStatus.installRecentlyAllowed
+5. authStatus.authenticated && authStatus.installRecentlyAllowed
      → INSTALL LANDING
        - Install button wired to beforeinstallprompt
-       - After 3s with no prompt and not iOS Safari: swap to unsupported-browser panel
+       - Unsupported-browser hint only shows on click when prompt isn't
+         available (no 3s auto-timer — see PR #47).
        - "Back to email gate" link: POST /api/logout then navigate /?gate=1
 
-5. default
+6. default
      → EMAIL GATE (no banner)
 ```
+
+### `fellows_authenticated_once` marker
+
+Set in two places:
+
+- `startBrowserUx` when `/api/auth/status` returns `authenticated: true` — the browser has a valid session, so even if the install window has closed we know this origin has been cleared before.
+- Successful `getList()` in app-mode boot (standalone PWA, or browser-tab-acting-as-app) — proves the API accepted our session.
+
+Preserved across `clearAllAppData` (the only localStorage key that survives Clear App Cache). Rationale: "Clear App Cache" exists to fix a broken app, not to log users out of an install they were happily using.
 
 ## PWA-mode decision tree
 

--- a/docs/users_manual.md
+++ b/docs/users_manual.md
@@ -38,6 +38,50 @@ Chrome or Edge on desktop, or Safari on iOS.
 
 ---
 
+## Where does the installed app live?
+
+A PWA install drops an icon on your device so you can launch the app like
+any other app — you don't need to type the URL or open a browser to use
+it day-to-day.
+
+- **macOS (Chrome / Edge)**: the app appears in your **Applications** folder
+  and in Spotlight (Cmd-Space, type "EHF"). Also listed under Chrome's
+  **Apps** at [chrome://apps](chrome://apps).
+- **Windows (Chrome / Edge)**: look in the **Start menu** under "EHF Fellows
+  Directory". Edge also offers to add a taskbar shortcut during install.
+- **Linux (Chrome / Edge)**: appears in the application launcher (GNOME
+  Activities, KDE Kickoff) and under `~/.local/share/applications/`.
+- **Android (Chrome)**: added to the **home screen** (unless you declined)
+  and always available in the app drawer.
+- **iOS (Safari)**: added to the **home screen**. iOS has no app drawer.
+
+Clicking/tapping the icon opens the app in its own window — no browser
+chrome, runs offline from cached data.
+
+---
+
+## Two ways to launch
+
+You have two doors to the same app. Pick whichever is easier:
+
+1. **The installed app icon** (preferred). Opens in its own window, runs
+   cleanly offline, and doesn't need a browser to be running. This is the
+   "real" app; treat it like any other desktop / mobile app.
+
+2. **The URL — https://fellows.globaldonut.com — in any browser tab**. If
+   you've already installed the app on this browser profile, the URL opens
+   the directory directly (same data, same UI, inside a regular tab). This
+   is handy when:
+   - You want to open the app on a device where the icon isn't obvious.
+   - You clicked a link from a chat or email.
+   - You bookmarked the URL.
+
+The *first* visit from a browser profile always starts at the install
+landing. Once you've installed and used the app once, later URL visits
+skip the install landing and go straight to the directory.
+
+---
+
 ## Using the directory
 
 - **Search** by name, tagline, or any keyword. Results update as you type.
@@ -74,11 +118,12 @@ data), you can reset it:
 2. Scroll to **Diagnostics** → **Clear app cache**.
 3. Confirm. The app wipes its local storage and reloads.
 
-**Heads-up:** clearing the cache logs you out of the app on that device.
-You'll need the original install link (or a fresh one) to re-enter. The
-app preserves a small "you've been here before" marker so a future
-server outage won't strand you at the loud error panel — that marker is
-also cleared.
+**Heads-up:** clearing the cache also re-downloads the fellow data and
+photos on the next launch. The session cookie is cleared, so if the
+server asks for auth again you'll need your install link (or a fresh
+one). The app preserves a small "you've been here before" marker so the
+URL still opens the directory directly and a future server outage won't
+strand you at the error panel.
 
 ---
 

--- a/tests/e2e/test_email_gate.py
+++ b/tests/e2e/test_email_gate.py
@@ -124,17 +124,60 @@ class TestEmailGate:
         finally:
             page.close()
 
-    def test_auth_status_503_falls_through_when_marker_set(self, context, base_url_fixture):
-        """A transient /api/auth/status 503 must NOT show the 'Authentication
-        check failed' panel when this origin has been authenticated before.
-        The offline-resilience fallback (phase-1) demotes the failure to a
-        quiet email gate with the build badge labelled 'server: unreachable'.
+    def test_marker_set_boots_directory_directly(self, context, base_url_fixture):
+        """Browser-tab visits with the marker set skip the install landing and
+        boot the directory via the API — "URL-just-works" (docs/email_gate.md).
+        The marker is the signal that this browser has used the app before,
+        so we act as the app rather than forcing install-landing again.
         """
         page = context.new_page()
-        # Simulate "has been authed here before" (marker persisted via
-        # localStorage), then 503 on auth-status.
         page.add_init_script(
             "window.localStorage.setItem('fellows_authenticated_once', '1');"
+        )
+        try:
+            page.goto(base_url_fixture + "/", wait_until="domcontentloaded")
+            page.locator("#loading").wait_for(state="hidden", timeout=10000)
+            # Directory visible, install landing and email gate both hidden.
+            expect(page.locator("#directory")).to_be_visible()
+            expect(page.locator("#install-landing")).to_be_hidden()
+            expect(page.locator("#install-gate-private")).to_be_hidden()
+        finally:
+            page.close()
+
+    def test_marker_set_with_gate_override_still_shows_gate(self, context, base_url_fixture):
+        """?gate=1 always wins, even when the marker is set. Gives the user
+        (or a dev) an explicit escape back to the email gate for a fresh
+        session — e.g., when handing the app off to another fellow on a
+        shared device.
+        """
+        page = context.new_page()
+        page.add_init_script(
+            "window.localStorage.setItem('fellows_authenticated_once', '1');"
+        )
+        try:
+            _mock_auth_status(page, authEnabled=True, authenticated=False)
+            page.goto(base_url_fixture + "/?gate=1", wait_until="domcontentloaded")
+            expect(page.locator("#install-gate-private")).to_be_visible()
+            expect(page.locator("#directory")).to_be_hidden()
+        finally:
+            page.close()
+
+    def test_marker_set_api_unreachable_falls_back_to_gate(self, context, base_url_fixture):
+        """With marker set but the API is completely unreachable, the as-app
+        boot fails and we hand off to startBrowserUx — which, finding auth
+        status also down, shows the quiet email-gate fallback. No scary
+        auth-error panel.
+        """
+        page = context.new_page()
+        page.add_init_script(
+            "window.localStorage.setItem('fellows_authenticated_once', '1');"
+        )
+        # Nuke both endpoints: the as-app boot path AND the gate/install
+        # fallback rely on different endpoints; both must fail for this test
+        # to exercise the "everything 5xx with marker" safety net.
+        page.route(
+            "**/api/fellows*",
+            lambda r: r.fulfill(status=503, body="service unavailable"),
         )
         page.route(
             AUTH_STATUS_PATH,
@@ -142,14 +185,13 @@ class TestEmailGate:
         )
         try:
             page.goto(base_url_fixture + "/", wait_until="domcontentloaded")
-            page.wait_for_timeout(300)
-            # The error panel must NOT appear.
+            page.wait_for_timeout(500)
+            # No scary error panel.
             assert page.locator("#auth-error-panel").is_hidden(), (
-                "Auth-error panel surfaced despite marker being set — fallback failed."
+                "Auth-error panel surfaced despite marker being set."
             )
             # Email gate is the quiet fallback view.
             expect(page.locator("#install-gate-private")).to_be_visible()
-            # Build badge reflects server unreachable.
             server_line = page.locator("#build-badge-server")
             expect(server_line).to_contain_text("unreachable")
         finally:


### PR DESCRIPTION
## Summary

Fixes the \"why does visiting the URL send me to Install again?\" surprise. Browser-tab visits with \`fellows_authenticated_once\` now skip the install landing and boot the directory via the API — same code path as the standalone PWA, just inside a regular tab.

The installed standalone icon is still the preferred launcher. The URL-in-tab path is a graceful fallback for users who type / bookmark / click a link to the URL.

## Changes

**app/static/app.js**
- New \`shouldActAsApp()\` helper: true if standalone OR (marker set AND no \`?gate=1\`). Used at the main boot branch instead of \`isStandaloneDisplayMode()\`.
- Extract the standalone boot body into \`bootDirectoryAsApp()\` so browser-tab-acting-as-app and standalone share it.
- Safety net: if the as-app boot fails (API 5xx / 401 / network), hand off to \`startBrowserUx()\` so the email gate can appear quietly — no scary boot-failure panel.
- \`?gate=1\` still wins in every case.
- Diag bumped to \`diag-2026-04m-url-is-app\`.

**docs/email_gate.md**
- New step #2 in the browser-mode decision tree: \"marker set, no ?gate=1 → ACT AS APP.\"
- New \"fellows_authenticated_once marker\" section documenting where it's set and why it survives Clear App Cache.
- Invariant #8 rewritten to reflect the click-handler-only unsupported-browser detection (the 3s timer was removed in PR #47).
- New invariant #9 for URL-just-works.

**docs/users_manual.md**
- New \"Where does the installed app live?\" section with per-OS launcher locations (macOS Applications / Spotlight, Windows Start menu, Linux launcher, Android home screen, iOS home screen).
- New \"Two ways to launch\" section explaining icon vs URL.
- Small tweak to \"Clearing App Data\": note the marker survives, so the URL still works as a launcher after a cache clear.

**tests/e2e/test_email_gate.py**
- Replaced \`test_auth_status_503_falls_through_when_marker_set\` with:
  - \`test_marker_set_boots_directory_directly\` — new URL-just-works path.
  - \`test_marker_set_api_unreachable_falls_back_to_gate\` — safety net test.
  - \`test_marker_set_with_gate_override_still_shows_gate\` — ?gate=1 override.

## Tests
114/114 pass (up from 112).

## Test plan (maintainer QA on prod after deploy)
- [ ] First visit from a fresh browser profile (e.g. incognito) → install landing appears, as before.
- [ ] Install the PWA → icon appears per OS (desktop / home screen / launcher).
- [ ] Close everything, visit the URL in a regular tab → directory loads (not the install landing).
- [ ] Open the installed app from the icon → directory loads, works offline.
- [ ] Visit \`?gate=1\` → always reaches the email gate.
- [ ] Clear App Cache via About → reload → URL still lands you on the directory (marker survives).

## Not in this PR

- PR #50: treat 401s as offline-only-mode rather than forcing email gate. Separate change.

🤖 Generated with [Claude Code](https://claude.com/claude-code)