### PR TITLE
feat(ops): prod-stats dashboard + pre-public cleanup

### DIFF
--- a/README.md
+++ b/README.md
@@ -53,37 +53,51 @@ See `[docs/Architecture.md](docs/Architecture.md)` for system design, data flow,
 
 `requirements-dev.txt` only covers dev/test tools (pytest, Playwright). The app runtime itself does not need them.
 
-> A `just`-based shortcut layer over the scripts below lives at `justfile` (see [`docs/justfile.md`](docs/justfile.md)). `just setup`, `just serve`, `just test`, `just deploy`, etc. — no new deps; the long forms here still work.
+> Commands below use the project's `just` command runner. See [`docs/justfile.md`](docs/justfile.md) for the full recipe list and what each one wraps. The long-form scripts still work — `just` is a shortcut, not a replacement.
 
 ### First-Time Setup (Developers)
 
 From repo root:
 
 ```bash
+just setup
+```
+
+That creates `.venv`, installs dev deps + Playwright Chromium + Ansible collections, and builds `app/fellows.db` from the canonical Knack dump.
+
+Under the hood (run these directly if you don't have `just`):
+
+```bash
 python3 -m venv .venv
 source .venv/bin/activate          # Windows: .venv\Scripts\activate
 pip install -r requirements-dev.txt
 playwright install chromium
-python build/import_json_to_sqlite.py
+ansible-galaxy collection install -r ansible/collections/requirements.yml -p ansible/collections
+python build/restore_from_knack_scrapefile.py
 ```
 
-Use `python` from the activated `.venv` when running tests so `pytest` and Playwright are on PATH. `scripts/ensure_port_8765_free.sh` expects `.venv/bin/pytest`.
+Use `python` from the activated `.venv` when running tests so `pytest` and Playwright are on PATH. `scripts/ensure_port_8765_free.sh` expects `.venv/bin/pytest`. Run `just doctor` any time to sanity-check venv / DB / Playwright / collections / port 8765.
 
 ## Run Locally
 
 ### Server
 
 ```bash
-python app/server.py
+just serve              # background + auto-opens browser (default)
+just serve-fg           # foreground, watch request logs live
+just stop               # stop background server
+just status             # is it running?
+just restart            # stop + start
+just reset              # stop, canonical DB rebuild (with auto-backup), start
 ```
 
-Then open `http://localhost:8765/`.
+Then open `http://localhost:8765/` (the `just serve` recipe already does this).
 
-Launcher option:
+Lower-level equivalents — useful for one-off debugging or understanding the plumbing:
 
 ```bash
-chmod +x run.sh
-./run.sh
+python app/server.py    # raw foreground server
+./run.sh                # the shell launcher just serve wraps (backgrounds with a PID file)
 ```
 
 ### API Endpoints
@@ -103,33 +117,32 @@ The UI requests `/api/fellows` first (instant list), then fetches `/api/fellows?
 
 ## Testing
 
-Prereqs: `.venv` active, `requirements-dev.txt` installed, Playwright Chromium installed, and `app/fellows.db` present.
-
-Recommended:
+Prereqs: `.venv` active, `requirements-dev.txt` installed, Playwright Chromium installed, and `app/fellows.db` present. `just doctor` verifies all five in one shot.
 
 ```bash
-chmod +x scripts/ensure_port_8765_free.sh
-./scripts/ensure_port_8765_free.sh tests/ -v
+just test               # full suite (port 8765 auto-freed first)
+just test-fast          # DB + API only, skips Playwright (~10x faster)
+just test-db            # just tests/test_database.py
+just test-api           # just tests/test_api.py
+just test-e2e           # just Playwright e2e
+just test-e2e email     # e2e filtered by pytest -k email
+just port               # free port 8765 without running tests
 ```
 
-Free port only:
+To forward pytest flags through `just test`, separate with `--`:
 
 ```bash
-./scripts/ensure_port_8765_free.sh
+just test -- tests/e2e/ -v -k email_gate
 ```
 
-Direct pytest:
+Under the hood — what each recipe does:
 
 ```bash
-pytest tests/ -v
-```
-
-By category:
-
-```bash
-pytest tests/test_database.py -v
-pytest tests/test_api.py -v
-pytest tests/e2e/ -v
+./scripts/ensure_port_8765_free.sh           # frees port 8765
+./scripts/ensure_port_8765_free.sh tests/ -v # frees port, runs pytest
+pytest tests/test_database.py -v             # no server needed
+pytest tests/test_api.py -v                  # fixture spawns the server
+pytest tests/e2e/ -v                         # Playwright e2e
 ```
 
 ## Build And Data Pipeline

--- a/README.md
+++ b/README.md
@@ -1,6 +1,8 @@
 # EHF Fellows Local Directory
 
-Local web app to browse Edmund Hillary Fellowship fellow profiles and run experiments. Data and assets are local-first (SQLite + static files), served by Python stdlib.
+Local web app to quickly browse Edmund Hillary Fellowship fellow profiles and run experiments. 
+
+Data and assets are local-first (SQLite + static files), served by Python stdlib.
 
 ## Table of Contents
 
@@ -24,7 +26,7 @@ Local web app to browse Edmund Hillary Fellowship fellow profiles and run experi
 
 ## Data Note
 
-The app runs against a dump of fellows data (contact emails, mobile numbers, citizenship, location, free-text responses) plus profile photos. **This data is never committed.** The `final_fellows_set/` directory is gitignored; obtain the JSON and image directory out-of-band from the maintainer and drop them in locally:
+The app runs against a dump of fellows data (contact emails, mobile numbers, citizenship, location, free-text responses) plus profile photos. **This data is never committed.**  If we need to write this from scratch and get all the data again: you will have obtain the JSON and image directory out-of-band from the old directory and drop them in locally:
 
 ```
 final_fellows_set/
@@ -32,22 +34,26 @@ final_fellows_set/
   fellow_profile_images_by_name/*.{jpg,png}
 ```
 
-Treat the contents as confidential regardless of demo status. Do not paste excerpts into issues, PRs, commit messages, or third-party tools.
+The github tree is clean of PII.  Still, treat the contents of your app as confidential - you will be given all the info that you are entiled to by the fellows directory system. Do not paste excerpts of fellows data into issues, PRs, commit messages, or third-party tools.
 
 ## Architecture
 
-See [`docs/Architecture.md`](docs/Architecture.md) for system design, data flow, and schema.
+See `[docs/Architecture.md](docs/Architecture.md)` for system design, data flow, and schema.
 
 ## Setup
 
 ### What To Install
 
-| Goal | Install |
-|------|---------|
-| **Run the app only** | **Python 3.8+** and built **`app/fellows.db`**. No pip deps beyond stdlib. |
-| **Run full test suite** (DB + API + Playwright e2e) | Python 3.8+, **`app/fellows.db`**, **`.venv`**, `pip install -r requirements-dev.txt`, and `playwright install chromium`. |
+
+| Goal                                                | Install                                                                                                                   |
+| --------------------------------------------------- | ------------------------------------------------------------------------------------------------------------------------- |
+| **Run the app only**                                | **Python 3.8+** and built `**app/fellows.db`**. No pip deps beyond stdlib.                                                |
+| **Run full test suite** (DB + API + Playwright e2e) | Python 3.8+, `**app/fellows.db`**, `**.venv`**, `pip install -r requirements-dev.txt`, and `playwright install chromium`. |
+
 
 `requirements-dev.txt` only covers dev/test tools (pytest, Playwright). The app runtime itself does not need them.
+
+> A `just`-based shortcut layer over the scripts below lives at `justfile` (see [`docs/justfile.md`](docs/justfile.md)). `just setup`, `just serve`, `just test`, `just deploy`, etc. — no new deps; the long forms here still work.
 
 ### First-Time Setup (Developers)
 
@@ -155,7 +161,7 @@ python build/build_pwa.py
 
 ## Production / DevOps
 
-Production runs one Ubuntu droplet behind Caddy TLS. The unix architecture (service account, operator sudo model, systemd hardening, filesystem layout) and routine ops (build + deploy, smoke, bootstrap) are in [`docs/DevOps.md`](docs/DevOps.md). Mechanical Ansible details (tags, galaxy install, logs, troubleshooting) are in [`ansible/README.md`](ansible/README.md). Magic-link auth operator steps (Postmark, env file, journald event schema) are in [`docs/email_system_management.md`](docs/email_system_management.md).
+Production runs one Ubuntu droplet behind Caddy TLS. The unix architecture (service account, operator sudo model, systemd hardening, filesystem layout) and routine ops (build + deploy, smoke, bootstrap) are in `[docs/DevOps.md](docs/DevOps.md)`. Mechanical Ansible details (tags, galaxy install, logs, troubleshooting) are in `[ansible/README.md](ansible/README.md)`. Magic-link auth operator steps (Postmark, env file, journald event schema) are in `[docs/email_system_management.md](docs/email_system_management.md)`.
 
 Most common command, from the repo root:
 
@@ -168,41 +174,7 @@ Most common command, from the repo root:
 - **Port 8765:** Prefer `./scripts/ensure_port_8765_free.sh` before manual testing when the port is occupied. Equivalent one-liner: `lsof -ti:8765 | xargs kill -9`.
 - **Automation hygiene:** test runs should not leave long-lived servers running. If the port is stuck, run the script above or re-run pytest (which also attempts cleanup in fixtures).
 - **Virtualenv scope:** use `.venv` for dev/test tooling on your workstation; production server runtime uses system Python.
-- **Debugging a stuck PWA / service worker:** when a bug reproduces on your own browser but not on a clean Playwright profile, see [`docs/debugging.md`](docs/debugging.md) for the chrome-devtools-mcp setup that attaches Claude Code to your running Chrome.
-
-## Before Making This Repo Public
-
-**The `final_fellows_set/` data was in git history from the initial commit through this branch point.** Gitignoring it now prevents future commits from leaking PII, but existing history still contains 515+ contact emails, mobile numbers, ethnicity, free-text responses, and 268 profile photos. Any fork or clone made before a history scrub retains that data.
-
-**Do this exactly once, immediately before flipping the repo to public:**
-
-1. **Scrub history:**
-   ```bash
-   # Install if needed: brew install git-filter-repo
-   git filter-repo --path final_fellows_set/ --invert-paths --force
-   ```
-   This rewrites every commit on every branch. All commit SHAs change.
-
-2. **Force-push every branch:**
-   ```bash
-   git push --force-with-lease origin --all
-   git push --force-with-lease origin --tags
-   ```
-   All open PRs, in-flight branches, and clones will break — coordinate before running.
-
-3. **Also scrub** (run `grep -r` before publishing):
-   - Any historical `deploy/dist/` snapshots that might have slipped in (it's gitignored, but double-check).
-   - `ansible/group_vars/fellows.yml` if it ever contained secrets (currently clean — only non-secret config).
-   - Commit messages, author emails, and PR descriptions: GitHub retains these separately from git; audit via `gh pr list --state all` and redact or close anything sensitive.
-
-4. **Rotate any credentials that ever touched the repo**, even if they were only in deleted files:
-   - Postmark server token.
-   - `FELLOWS_SESSION_SECRET` on the droplet.
-   - Any SSH keys whose public parts were committed.
-
-5. **Verify** with `git log --all --full-history -- final_fellows_set/` returning empty, and `git count-objects -v` showing a smaller repo.
-
-6. **Republish the `allowed_emails.json` allowlist** after scrub by re-running `python build/build_pwa.py` and redeploying — the hash file is regenerated from the source JSON so scrubbing history doesn't affect what production serves.
+- **Debugging a stuck PWA / service worker:** when a bug reproduces on your own browser but not on a clean Playwright profile, see `[docs/debugging.md](docs/debugging.md)` for the chrome-devtools-mcp setup that attaches Claude Code to your running Chrome.
 
 ## Project Layout
 
@@ -234,3 +206,4 @@ tests/
   test_magic_link_auth.py
   e2e/
 ```
+

--- a/README.md
+++ b/README.md
@@ -150,13 +150,23 @@ pytest tests/e2e/ -v                         # Playwright e2e
 ### JSON To SQLite + FTS5
 
 ```bash
-python build/import_json_to_sqlite.py
-python build/import_json_to_sqlite.py /path/to/other.json
+just db-rebuild         # canonical Knack rebuild, auto-backup first, prints row counts
+just db-stats           # row / email / image counts
+just db-verify          # bytewise-diff vs app/fellows.db.backup.2026-04-08
+just db-open            # open app/fellows.db in sqlite3
 ```
 
-Writes `app/fellows.db` and backs up existing DB to `app/fellows.db.backup.YYYY-MM-DD`.
+See [`docs/data_provenance.md`](docs/data_provenance.md) for the full data pipeline and why the canonical Knack rebuild is the right choice over the legacy demo importer.
 
-Verify:
+Under the hood (the ETL scripts the recipes call):
+
+```bash
+python build/restore_from_knack_scrapefile.py                # canonical, what just db-rebuild runs
+python build/restore_from_knack_scrapefile.py /path/to/other.json
+python build/import_json_to_sqlite.py                        # legacy demo importer — see data_provenance.md
+```
+
+Raw SQL probes (for FTS5 experimentation beyond `just db-stats`):
 
 ```bash
 sqlite3 app/fellows.db "SELECT COUNT(*) FROM fellows;"
@@ -167,24 +177,33 @@ sqlite3 app/fellows.db "SELECT name FROM fellows_fts WHERE fellows_fts MATCH 'Aa
 ### PWA Static Bundle
 
 ```bash
-python build/build_pwa.py
+just build              # assemble deploy/dist/
+just build-meta         # print the build-meta.json (timestamp + git sha) of the last build
 ```
 
-`build/build_pwa.py` assembles `deploy/dist/` from `app/static/`, adds `fellows.db`, images, and writes `allowed_emails.json` (SHA-256 hashes of normalized `contact_email` values from the DB).
+Under the hood: `python build/build_pwa.py` assembles `deploy/dist/` from `app/static/`, adds `fellows.db`, images, and writes `allowed_emails.json` (SHA-256 hashes of normalized `contact_email` values from the DB).
 
 ## Production / DevOps
 
 Production runs one Ubuntu droplet behind Caddy TLS. The unix architecture (service account, operator sudo model, systemd hardening, filesystem layout) and routine ops (build + deploy, smoke, bootstrap) are in `[docs/DevOps.md](docs/DevOps.md)`. Mechanical Ansible details (tags, galaxy install, logs, troubleshooting) are in `[ansible/README.md](ansible/README.md)`. Magic-link auth operator steps (Postmark, env file, journald event schema) are in `[docs/email_system_management.md](docs/email_system_management.md)`.
 
-Most common command, from the repo root:
+Most common commands, from the repo root:
 
 ```bash
-./scripts/deploy_pwa.sh --ask-become-pass
+just deploy             # test-agnostic deploy: build + ansible + HTTPS smoke
+just ship               # test-fast → deploy (the full build-test-deploy-test sequence)
+just ship-fast          # deploy-fast → smoke (reuse existing deploy/dist/, skip tests)
+just drift              # prod X-Fellows-Build vs local HEAD + origin/main
+just smoke              # HTTPS smoke check against prod
+just prod-status        # systemctl status fellows-pwa caddy
+just prod-logs          # journalctl -u fellows-pwa -f (over SSH)
 ```
+
+Under the hood: `./scripts/deploy_pwa.sh --ask-become-pass` runs the `ansible/deploy_pwa.yml` playbook (build → rsync → restart → HTTPS smoke).
 
 ## Local Dev Notes
 
-- **Port 8765:** Prefer `./scripts/ensure_port_8765_free.sh` before manual testing when the port is occupied. Equivalent one-liner: `lsof -ti:8765 | xargs kill -9`.
+- **Port 8765:** Prefer `just port` (or `./scripts/ensure_port_8765_free.sh`) before manual testing when the port is occupied. Equivalent one-liner: `lsof -ti:8765 | xargs kill -9`. Every `just test*` recipe frees the port automatically.
 - **Automation hygiene:** test runs should not leave long-lived servers running. If the port is stuck, run the script above or re-run pytest (which also attempts cleanup in fixtures).
 - **Virtualenv scope:** use `.venv` for dev/test tooling on your workstation; production server runtime uses system Python.
 - **Debugging a stuck PWA / service worker:** when a bug reproduces on your own browser but not on a clean Playwright profile, see `[docs/debugging.md](docs/debugging.md)` for the chrome-devtools-mcp setup that attaches Claude Code to your running Chrome.

--- a/ansible/roles/common/tasks/main.yml
+++ b/ansible/roles/common/tasks/main.yml
@@ -41,6 +41,16 @@
     groups: "{{ service_user }}"
     append: true
 
+# Read-only access to journald without sudo. The systemd-journal group is the
+# intended primitive for ops read access (cannot write, cannot escalate) and
+# is narrower than per-command NOPASSWD sudoers. Enables `just prod-stats` and
+# plain `journalctl -u fellows-pwa` from a non-sudo SSH session.
+- name: Ensure operator ({{ operator_user }}) is a member of systemd-journal group
+  ansible.builtin.user:
+    name: "{{ operator_user }}"
+    groups: systemd-journal
+    append: true
+
 # Supplementary group membership only takes effect at next login. Force a
 # fresh SSH session so subsequent tasks (and later rsync) see the new group.
 - name: Reset SSH connection so new group membership takes effect

--- a/ansible/roles/fellows_app/tasks/main.yml
+++ b/ansible/roles/fellows_app/tasks/main.yml
@@ -88,6 +88,24 @@
     mode: "0644"
   notify: Restart fellows app
 
+# Operator-facing read-only helpers live under {{ app_root }}/bin. The app
+# service itself never invokes these, so no restart notify.
+- name: Ensure operator-helpers bin directory exists
+  ansible.builtin.file:
+    path: "{{ app_root }}/bin"
+    state: directory
+    owner: "{{ service_user }}"
+    group: "{{ service_user }}"
+    mode: "2775"
+
+- name: Install prod_stats helper
+  ansible.builtin.copy:
+    src: "{{ playbook_dir }}/../scripts/prod_stats.py"
+    dest: "{{ app_root }}/bin/prod_stats"
+    owner: "{{ service_user }}"
+    group: "{{ service_user }}"
+    mode: "0755"
+
 # Preflight: confirm the operator (ansible_user, not root) can actually write
 # into every dist subdirectory before rsync tries. If normalization above
 # didn't take — filesystem ACLs, mount options, something unexpected — we

--- a/app/server.py
+++ b/app/server.py
@@ -211,7 +211,7 @@ def find_image(slug: str) -> Path | None:
         if p.is_file():
             return p
     # Fallback: compare alphanumeric-only to handle mismatched underscores/hyphens
-    # e.g. slug "shannon_o_leary_joy" matches file "shannon_oleary_joy.jpg"
+    # e.g. slug "a_b_c_d" matches file "abcd.jpg"
     base_alpha = re.sub(r"[^a-z0-9]", "", base.lower())
     if not base_alpha:
         return None

--- a/docs/DevOps.md
+++ b/docs/DevOps.md
@@ -109,15 +109,18 @@ Adhoc commands that don't need root require `ANSIBLE_BECOME=false` (because beco
 From the repo root:
 
 ```bash
-# Rebuild the static bundle and push to the droplet (most common flow).
-./scripts/deploy_pwa.sh --ask-become-pass
+just deploy             # most common: build + push + restart + HTTPS smoke
+just ship               # test-fast → deploy (safest daily push)
+just ship-fast          # deploy-fast + smoke (reuse existing deploy/dist/)
+just deploy-check       # Ansible --check mode: what would change, no writes
+```
 
-# Equivalent manual form:
+Under the hood these call `./scripts/deploy_pwa.sh --ask-become-pass`, which runs the `ansible/deploy_pwa.yml` playbook. Equivalent manual form:
+
+```bash
 python build/build_pwa.py
 ansible-playbook ansible/site.yml --tags deploy --ask-become-pass
 ```
-
-> `just deploy`, `just ship`, `just smoke`, `just prod-logs`, `just prod-status`, `just drift` wrap these and the ops below — see [`justfile.md`](justfile.md).
 
 The deploy path touches:
 1. `/opt/fellows/deploy/` — `server.py`, `sqlite_api_support.py`, `magic_link_auth.py` (via `ansible.builtin.copy`, become: true).
@@ -128,8 +131,17 @@ The deploy path touches:
 Post-deploy smoke:
 
 ```bash
-./scripts/smoke_prod.sh       # /healthz, /manifest.webmanifest
-./scripts/check_deploy_env.sh # DNS + TLS
+just smoke              # /healthz, /manifest.webmanifest, /api/debug/diagnostics
+just check-env          # DNS + TLS + healthz
+just prod-status        # systemctl status fellows-pwa caddy (over SSH)
+just drift              # prod X-Fellows-Build vs local HEAD + origin/main
+```
+
+Lower-level equivalents (what each recipe runs):
+
+```bash
+./scripts/smoke_prod.sh
+./scripts/check_deploy_env.sh
 ssh -p 52221 rsb@fellows.globaldonut.com 'systemctl status fellows-pwa caddy --no-pager'
 ```
 
@@ -139,6 +151,13 @@ ssh -p 52221 rsb@fellows.globaldonut.com 'systemctl status fellows-pwa caddy --n
 # 1. Provision Droplet, assign Reserved IP (170.64.243.67), create DNS A record.
 # 2. Ensure your SSH key is in /home/rsb/.ssh/authorized_keys on the droplet.
 # 3. From the repo root:
+just ansible-collections    # one-time per workstation
+just bootstrap              # ansible site.yml --tags bootstrap --ask-become-pass
+```
+
+Under the hood:
+
+```bash
 ansible-galaxy collection install -r ansible/collections/requirements.yml -p ansible/collections
 ansible-playbook ansible/site.yml --tags bootstrap --ask-become-pass
 ```
@@ -150,17 +169,18 @@ The first run creates the `fellows` system user, adds `rsb` to the `fellows` gro
 After bootstrap, install Postmark + session secrets once:
 
 ```bash
-./scripts/configure_email_auth_env.sh
+just prod-configure-env
 ```
 
-The script prompts for `FELLOWS_MAIL_FROM`, `FELLOWS_PUBLIC_ORIGIN`, `FELLOWS_POSTMARK_TOKEN`, `FELLOWS_SESSION_SECRET`, then SSHes to the droplet and creates `/etc/fellows/fellows-pwa.env` (`root:fellows 0640`) and the systemd drop-in. Re-run only when a secret rotates.
+That wraps `./scripts/configure_email_auth_env.sh`, which prompts for `FELLOWS_MAIL_FROM`, `FELLOWS_PUBLIC_ORIGIN`, `FELLOWS_POSTMARK_TOKEN`, `FELLOWS_SESSION_SECRET`, then SSHes to the droplet and creates `/etc/fellows/fellows-pwa.env` (`root:fellows 0640`) and the systemd drop-in. Re-run only when a secret rotates.
 
 ## Debugging
 
-- **Service**: `journalctl -u fellows-pwa -f` streams structured JSON (`event=auth_status`, `event=send_unlock_email`, `event=build_meta`).
-- **Bundle drift**: the browser has a Diagnostics panel (`?diag=1`) that shows `X-Fellows-Build`, auth state, and Cache API contents. Pair with `journalctl` to confirm client and server are on the same build.
+- **Service**: `just prod-logs` (`journalctl -u fellows-pwa -f`) streams structured JSON (`event=auth_status`, `event=send_unlock_email`, `event=build_meta`). Pass a different unit with `just prod-logs caddy`.
+- **Bundle drift**: `just drift` shows prod's `X-Fellows-Build` alongside local `HEAD` and `origin/main`. The browser's Diagnostics panel (`?diag=1`) shows the same header plus auth state and Cache API contents. Pair with `just prod-logs` to confirm client and server are on the same build.
+- **Send-flow failures**: `just email-debug` mines recent `event=send_unlock_email` entries from journald and optionally resolves Postmark `MessageID`s.
 - **Deploy failures**: `ansible-playbook … -vvv` for SSH/module detail. Log path is `ansible/ansible.log` relative to the repo root.
-- **Permissions on `/opt/fellows`**: if rsync fails with "Permission denied," confirm the operator is in the `fellows` group (`id rsb` should list it) and that a fresh SSH session picked it up (logout/login or the Ansible `reset_connection` step).
+- **Permissions on `/opt/fellows`**: `just prod-diag-perms` (a read-only audit) reports group membership, mode bits, setgid inheritance, and runs rsync write probes. If rsync fails with "Permission denied," confirm the operator is in the `fellows` group (`id rsb` should list it) and that a fresh SSH session picked it up (logout/login or the Ansible `reset_connection` step).
 
 ## What we explicitly did not build
 

--- a/docs/data_provenance.md
+++ b/docs/data_provenance.md
@@ -22,17 +22,19 @@ data in the repo derives from that extraction.
 ## How to rebuild `app/fellows.db` from source
 
 ```bash
-python build/restore_from_knack_scrapefile.py
+just db-rebuild
 ```
 
-> `just db-rebuild` wraps this and auto-snapshots via `scripts/backup_fellows_data.sh` first — see [`justfile.md`](justfile.md).
+This snapshots the current state via `scripts/backup_fellows_data.sh` first (so a botched rebuild is always recoverable), then runs the canonical ETL, then prints row / email / image counts for a sanity check.
 
-Defaults to `final_fellows_set/knack_api_detail_dump.json` as input. Pass a
-different path if you ever run the scrape again:
+Under the hood — the raw ETL script, if you want to pass a different input file or see exactly what runs:
 
 ```bash
+python build/restore_from_knack_scrapefile.py
 python build/restore_from_knack_scrapefile.py /path/to/newer_detail_dump.json
 ```
+
+Defaults to `final_fellows_set/knack_api_detail_dump.json` as input. Pass a different path if you ever run the scrape again.
 
 The script:
 1. Reads the detail dump (dict keyed by `record_id`).
@@ -44,10 +46,10 @@ The script:
 To verify bytewise equivalence against the reference backup:
 
 ```bash
-python build/diff_fellows_db.py app/fellows.db app/fellows.db.backup.2026-04-08
+just db-verify
 ```
 
-Expected: `✓ bytewise match on all columns`.
+Under the hood: `python build/diff_fellows_db.py app/fellows.db app/fellows.db.backup.2026-04-08`. Expected: `✓ bytewise match on all columns`. Use `just db-diff OTHER` to compare against any other DB file.
 
 ## Column-by-column provenance
 
@@ -109,16 +111,27 @@ you change the mapping, update this table too.
 
 ## Backup workflow
 
-`scripts/backup_fellows_data.sh` snapshots the current state — DB + all
-source JSONs + image dir + manifest — into `backup/fellows_data_<ts>_<sha>.zip`.
+```bash
+just data-backup        # snapshot DB + source JSONs + images into backup/*.zip
+just data-restore       # restore from --latest (interactive y/N after manifest)
+just data-restore-dry   # print manifest + file list, don't touch anything
+```
 
-Run it:
-- Before any rebuild (`restore_from_knack_scrapefile.py`)
-- Before any manual SQL on `app/fellows.db`
-- Before any new scrape
+Under the hood: `scripts/backup_fellows_data.sh` snapshots the current state — DB + all source JSONs + image dir + manifest — into `backup/fellows_data_<ts>_<sha>.zip`. `just db-rebuild` and `just db-rebuild-demo` call it automatically.
 
-Restore from a snapshot with `scripts/restore_fellows_data.sh <zip>` (or
-`--latest`). See [`backup/README.md`](../backup/README.md) for details.
+Run a backup:
+- Before any rebuild (`just db-rebuild` does it for you; do it yourself before raw `restore_from_knack_scrapefile.py`).
+- Before any manual SQL on `app/fellows.db`.
+- Before any new scrape.
+
+Restore lower-level (same script `just data-restore` wraps):
+
+```bash
+./scripts/restore_fellows_data.sh <zip>
+./scripts/restore_fellows_data.sh --latest
+```
+
+See [`backup/README.md`](../backup/README.md) for details.
 
 ## Rollback / recovery
 
@@ -126,7 +139,8 @@ Three recovery paths, in order of safety:
 
 1. **From a recent local snapshot**. Fastest:
    ```bash
-   ./scripts/restore_fellows_data.sh --latest
+   just data-restore
+   # under the hood: ./scripts/restore_fellows_data.sh --latest
    ```
 2. **From the reference backup DB**. If snapshots are gone or corrupted,
    the Apr 8 backup DB is the fixed point in time:
@@ -135,14 +149,15 @@ Three recovery paths, in order of safety:
    ```
    Note: this DB predates the `has_image` column (added in PR #19). The
    ETL adds it on rebuild; if you restore the backup directly, re-run
-   `python build/restore_from_knack_scrapefile.py` afterwards to get the
-   modern schema + image-index backfill.
+   `just db-rebuild` (or `python build/restore_from_knack_scrapefile.py`)
+   afterwards to get the modern schema + image-index backfill.
 3. **From raw Knack dumps**. The full rebuild:
    ```bash
-   python build/restore_from_knack_scrapefile.py
+   just db-rebuild
+   # under the hood: python build/restore_from_knack_scrapefile.py
    ```
    Produces the same DB as the Apr 8 backup, bytewise (verify with
-   `diff_fellows_db.py`).
+   `just db-verify`).
 
 ## Why `build/filter_demo_data.py` and the `.bak` JSON are DANGEROUS
 

--- a/docs/debugging.md
+++ b/docs/debugging.md
@@ -53,11 +53,11 @@ If you're reproducing a bug on a **fresh** visitor (first-time install, behavior
 When local code and production behavior diverge, check that the droplet is on current `main`:
 
 ```bash
-curl -sSI https://fellows.globaldonut.com/api/auth/status | grep -i x-fellows-build
+just drift              # prod X-Fellows-Build vs local HEAD + origin/main, side-by-side
+just deploy             # rebuild bundle and push if prod is behind
+just ship-fast          # if deploy/dist/ is already current, just re-push + smoke
 ```
 
-Compare with `git log --format='%ci %h' -1 origin/main`. Production has shipped with stale `deploy/dist/` before; if the build timestamp trails main, run `./scripts/deploy_pwa.sh --ask-become-pass`.
-
-> `just drift` prints both sides side-by-side in one shot; `just deploy` and `just ship-fast` push new builds — see [`justfile.md`](justfile.md).
+Under the hood: `just drift` runs `curl -sSI https://fellows.globaldonut.com/api/auth/status | grep -i x-fellows-build` and compares against `git log -1 origin/main` / `HEAD`. Production has shipped with stale `deploy/dist/` before; if the build timestamp trails main, run `just deploy` (or `./scripts/deploy_pwa.sh --ask-become-pass`).
 
 Other production debug entry points (service logs, Postmark send flow, Diagnostics panel) live in [`docs/email_system_management.md`](email_system_management.md) and [`docs/DevOps.md`](DevOps.md).

--- a/docs/email_system_management.md
+++ b/docs/email_system_management.md
@@ -2,7 +2,7 @@
 
 The production email system is a magic-link gate on `deploy/server.py`: users submit an email to `POST /api/send-unlock`, the server checks a SHA-256 hash against `deploy/dist/allowed_emails.json`, issues a short-lived token (30 minutes — see [`email_gate.md`](email_gate.md)), and sends a Postmark email with a `/#/unlock/<token>` link. When that token is posted to `POST /api/verify-token`, the server sets a signed session cookie and the browser can access protected directory assets (`/fellows.db`, `/images/*`, directory `/api/*`). The system is stateless at deploy-time except for in-memory tokens/rate buckets, so restarts invalidate outstanding tokens by design.
 
-> Command shortcuts: `just prod-configure-env`, `just prod-env`, `just prod-repair-env`, `just email-debug` wrap the scripts below — see [`justfile.md`](justfile.md).
+> Commands below use `just` recipes where available. See [`justfile.md`](justfile.md) for the full menu; every recipe falls through to the underlying script shown in each step.
 
 ## Production Setup
 
@@ -19,23 +19,28 @@ Environment variables used in this section:
 1. **[Machine: local dev machine] Build fresh bundle with allowlist**
    ```bash
    cd /path/to/fellows_local_db
-   python build/build_pwa.py
+   just build
+   # under the hood: python build/build_pwa.py
    ```
    Confirm `deploy/dist/allowed_emails.json` exists.
 
 2. **[Machine: local dev machine] Install/update Ansible collection (once per machine)**
    ```bash
-   ansible-galaxy collection install -r ansible/collections/requirements.yml -p ansible/collections
+   just ansible-collections
+   # under the hood: ansible-galaxy collection install -r ansible/collections/requirements.yml -p ansible/collections
    ```
 
 3. **[Machine: local dev machine] Deploy application files**
    ```bash
-   ansible-playbook ansible/site.yml --tags deploy --ask-become-pass
+   just deploy
+   # under the hood: ./scripts/deploy_pwa.sh --ask-become-pass → ansible/deploy_pwa.yml
    ```
+   `just deploy` does build + rsync + restart + HTTPS smoke in one go. If `deploy/dist/` is already fresh from step 1 and you don't want to rebuild, use `just deploy-fast`.
 
 4. **[Machine: local dev machine] Run interactive auth-env setup script (replaces old steps 4-6)**
    ```bash
-   ./scripts/configure_email_auth_env.sh
+   just prod-configure-env
+   # under the hood: ./scripts/configure_email_auth_env.sh
    ```
    This script prompts for the required env vars, then SSHes to the app server to:
    - write `/etc/fellows/fellows-pwa.env` with correct ownership/mode,
@@ -45,6 +50,11 @@ Environment variables used in this section:
    Keep your SSH key and sudo access for the app server available on the machine where you run the script.
 
 5. **[Machine: local dev machine, or any client machine] Smoke test auth APIs**
+   - Overall HTTPS smoke (healthz / manifest / diagnostics):
+     ```bash
+     just smoke
+     # under the hood: ./scripts/smoke_prod.sh
+     ```
    - `GET /api/auth/status` can be opened directly in a browser:
      - `https://fellows.globaldonut.com/api/auth/status`
    - Or via curl:
@@ -68,7 +78,8 @@ Environment variables used in this section:
 
 6. **[Machine: local dev machine] Optional one-command deploy path**
    ```bash
-   ./scripts/deploy_pwa.sh --ask-become-pass
+   just deploy
+   # under the hood: ./scripts/deploy_pwa.sh --ask-become-pass
    ```
    Then repeat steps 4-5 if env changes were made.
 
@@ -105,7 +116,8 @@ sudo systemctl restart fellows-pwa
 Then from your laptop:
 
 ```bash
-scripts/show_server_env.sh          # confirms the change landed (values shown raw — copy/paste-ready)
+just prod-env           # confirms the change landed (values shown raw — copy/paste-ready)
+# under the hood: scripts/show_server_env.sh
 ```
 
 ### D. Smoke-test the new sender
@@ -113,11 +125,16 @@ scripts/show_server_env.sh          # confirms the change landed (values shown r
 1. Open `https://fellows.globaldonut.com/?gate=1` in a fresh incognito window (forces the email gate even if you already have a session cookie).
 2. Submit a known-allowlisted address.
 3. Check the inbox — the `From:` header should read `admin@fellows.globaldonut.com`. If you click Reply, your MUA should pre-fill `FELLOWS_REPLY_TO`.
-4. From your laptop: `scripts/debug_email_delivery.py --sudo --since '10 minutes ago'` should show a `result=sent` event with a Postmark MessageID.
+4. From your laptop:
+   ```bash
+   just email-debug '10 minutes ago'
+   # under the hood: scripts/debug_email_delivery.py --since '10 minutes ago'
+   ```
+   Should show a `result=sent` event with a Postmark MessageID. Pass an email as a second argument to filter: `just email-debug '10 minutes ago' you@example.com`.
 
 ## Email Debugging In Production (Postmark + Server Logs)
 
-**Deploy / PWA drift:** After deploy, use the in-app **Diagnostics** panel (`?diag=1` or the Diagnostics button) to compare `/api/auth/status`, `/api/debug/diagnostics`, and `/build-meta.json` with response headers `X-Fellows-Build`. On the app server, `journalctl -u fellows-pwa -f` shows `event=auth_status` JSON for each auth status request and `event=build_meta` at process start.
+**Deploy / PWA drift:** `just drift` prints prod's `X-Fellows-Build` alongside local `HEAD` and `origin/main`. After deploy, use the in-app **Diagnostics** panel (`?diag=1` or the Diagnostics button) to compare `/api/auth/status`, `/api/debug/diagnostics`, and `/build-meta.json` with response headers `X-Fellows-Build`. On the app server, `just prod-logs` (which runs `journalctl -u fellows-pwa -f`) shows `event=auth_status` JSON for each auth status request and `event=build_meta` at process start.
 
 Postmark debugging reference: [Postmark support and debugging docs](https://postmarkapp.com/support).
 
@@ -142,10 +159,12 @@ Recommended debug workflow:
      -H 'content-type: application/json' \
      -d '{"email":"you@example.com"}'
    ```
-2. **[Machine: app server]** Check logs for send diagnostics:
+2. **[Machine: local dev machine]** Check logs for send diagnostics:
    ```bash
-   journalctl -u fellows-pwa -n 50 --no-pager
+   just email-debug '2 hours ago' you@example.com
+   # under the hood: scripts/debug_email_delivery.py --since '2 hours ago' --email you@example.com
    ```
+   Or tail live from the app server with `just prod-logs` (streams `journalctl -u fellows-pwa -f` over SSH). To read the last 50 lines only, SSH directly and run `journalctl -u fellows-pwa -n 50 --no-pager`.
 3. If `result=sent`, use `MessageID` in Postmark dashboard/API to inspect final delivery events.
 4. If `result=http_error`, fix credentials/domain/sender policy indicated by status/body.
 5. If no log entry appears, verify auth is enabled (`/api/auth/status`) and that requests reach this host (Caddy/systemd logs).

--- a/docs/justfile.md
+++ b/docs/justfile.md
@@ -141,6 +141,13 @@ Export them or inline: `FELLOWS_BASE_URL=https://staging.example.com just smoke`
   `HEAD` and `origin/main`. One glance tells you whether prod is current.
 - **`prod-logs [UNIT]`** — SSH + `journalctl -u UNIT -f`. Default unit
   `fellows-pwa`; try `just prod-logs caddy` for the reverse proxy.
+- **`prod-stats [SINCE]`** — summary of page views, magic-link send/verify
+  counts, 5xx errors, and disk usage over the window (default `24 hours
+  ago`). Runs `/opt/fellows/bin/prod_stats` on the droplet via SSH; reads
+  journald directly (no sudo needed — the operator is in the
+  `systemd-journal` group). Examples: `just prod-stats`,
+  `just prod-stats '7 days ago'`. Source: `scripts/prod_stats.py`, deployed
+  by the `fellows_app` Ansible role.
 - **`prod-status`** — SSH + `systemctl status fellows-pwa caddy --no-pager`.
 - **`prod-env`** — dump remote `/etc/fellows/fellows-pwa.env` (prompts for
   sudo password — values shown raw for paste-ready rotation). Wraps

--- a/justfile
+++ b/justfile
@@ -309,6 +309,11 @@ drift:
 prod-logs unit="fellows-pwa":
     ssh -p {{ssh_port}} {{ssh_user}}@{{host}} "journalctl -u {{unit}} -f"
 
+# Production stats summary (page views, magic links, disk) for SINCE.
+[group('prod')]
+prod-stats since="24 hours ago":
+    ssh -p {{ssh_port}} {{ssh_user}}@{{host}} "/opt/fellows/bin/prod_stats --since '{{since}}'"
+
 # systemctl status fellows-pwa caddy.
 [group('prod')]
 prod-status:

--- a/scripts/prod_stats.py
+++ b/scripts/prod_stats.py
@@ -1,0 +1,195 @@
+#!/usr/bin/env python3
+"""Production stats summary for fellows-pwa.
+
+Reads journald for the fellows-pwa unit, tallies requests and structured
+events over a time window, adds disk usage, prints to stdout. Stdlib only
+so it runs on the droplet without a venv.
+
+Usage:
+    prod_stats [--since "24 hours ago"] [--unit fellows-pwa] [--json]
+"""
+
+from __future__ import annotations
+
+import argparse
+import json
+import re
+import shutil
+import subprocess
+import sys
+from collections import Counter
+
+
+# Matches the request-line fragment BaseHTTPRequestHandler writes into every
+# access-log line, e.g. '"GET /api/fellows?full=1 HTTP/1.1" 200 -'. The path
+# group includes the query string, which is exactly what we want when
+# distinguishing /api/fellows from /api/fellows/<slug>.
+ACCESS_RE = re.compile(
+    r'"(?P<method>[A-Z]+) (?P<path>\S+) HTTP/\d\.\d" (?P<status>\d{3})'
+)
+
+
+def journal_messages(unit: str, since: str) -> list:
+    """Return MESSAGE strings from journalctl for (unit, since).
+
+    Returns [] on any journalctl failure, after printing a hint on stderr.
+    """
+    try:
+        proc = subprocess.run(
+            ["journalctl", "-u", unit, "--since", since, "-o", "json", "--no-pager"],
+            capture_output=True,
+            text=True,
+        )
+    except FileNotFoundError:
+        print("journalctl not found (not a systemd host?)", file=sys.stderr)
+        return []
+    if proc.returncode != 0:
+        print(f"journalctl failed (exit {proc.returncode}): {proc.stderr.strip()}",
+              file=sys.stderr)
+        return []
+    messages = []
+    for line in proc.stdout.splitlines():
+        try:
+            entry = json.loads(line)
+        except json.JSONDecodeError:
+            continue
+        msg = entry.get("MESSAGE")
+        if isinstance(msg, str):
+            messages.append(msg)
+    return messages
+
+
+def tally(messages) -> dict:
+    """Count request categories and structured events from MESSAGE strings."""
+    shell_loads = 0
+    api_fellows = 0
+    db_downloads = 0
+    verify_ok = 0
+    verify_fail = 0
+    errors_5xx: Counter = Counter()
+    links_sent = 0
+    links_send_failed: Counter = Counter()
+
+    for m in messages:
+        # Structured JSON events (emitted on stderr from deploy/server.py).
+        if m.startswith("{") and "send_unlock_email" in m:
+            try:
+                evt = json.loads(m)
+            except json.JSONDecodeError:
+                evt = None
+            if isinstance(evt, dict) and evt.get("event") == "send_unlock_email":
+                result = evt.get("result")
+                if result == "sent":
+                    links_sent += 1
+                elif isinstance(result, str):
+                    links_send_failed[result] += 1
+                continue
+
+        # HTTP access log lines.
+        match = ACCESS_RE.search(m)
+        if not match:
+            continue
+        method = match.group("method")
+        path = match.group("path")
+        status = int(match.group("status"))
+
+        path_no_query = path.split("?", 1)[0]
+
+        if method == "GET" and path_no_query in ("/", "/index.html"):
+            shell_loads += 1
+        if method == "GET" and path_no_query.startswith("/api/fellows"):
+            api_fellows += 1
+        if method == "GET" and path_no_query == "/fellows.db":
+            db_downloads += 1
+        if method == "POST" and path_no_query == "/api/verify-token":
+            if status == 200:
+                verify_ok += 1
+            else:
+                verify_fail += 1
+        if status >= 500:
+            errors_5xx[f"{status} {method} {path_no_query}"] += 1
+
+    return {
+        "shell_loads": shell_loads,
+        "api_fellows": api_fellows,
+        "db_downloads": db_downloads,
+        "magic_links_sent": links_sent,
+        "magic_links_send_failed": dict(links_send_failed),
+        "magic_links_verified": verify_ok,
+        "magic_links_verify_failed": verify_fail,
+        "errors_5xx": dict(errors_5xx),
+    }
+
+
+def disk_usage(path: str = "/") -> dict:
+    total, used, free = shutil.disk_usage(path)
+    pct_used = round(100 * used / total, 1) if total else 0.0
+    return {
+        "path": path,
+        "total_gib": round(total / 2 ** 30, 1),
+        "used_gib": round(used / 2 ** 30, 1),
+        "free_gib": round(free / 2 ** 30, 1),
+        "pct_used": pct_used,
+    }
+
+
+def print_human(stats: dict, disk: dict, since: str, unit: str) -> None:
+    print(f"== {unit} — since {since} ==")
+    print(f"  App-shell loads:         {stats['shell_loads']}")
+    print(f"  Directory API hits:      {stats['api_fellows']}")
+    print(f"  DB downloads:            {stats['db_downloads']}")
+    print(f"  Magic links sent:        {stats['magic_links_sent']}")
+    for result, count in sorted(stats["magic_links_send_failed"].items()):
+        print(f"    └─ send {result:12s} {count}")
+    print(f"  Magic links verified:    {stats['magic_links_verified']}")
+    if stats["magic_links_verify_failed"]:
+        print(f"  Magic links rejected:    {stats['magic_links_verify_failed']}")
+    total_5xx = sum(stats["errors_5xx"].values())
+    print(f"  5xx errors:              {total_5xx}")
+    for line, count in sorted(stats["errors_5xx"].items(), key=lambda kv: -kv[1])[:5]:
+        print(f"    └─ {line}: {count}")
+    print(
+        f"  Disk ({disk['path']}):  "
+        f"{disk['used_gib']:.1f} / {disk['total_gib']:.1f} GiB used "
+        f"({disk['pct_used']:.1f}%, {disk['free_gib']:.1f} GiB free)"
+    )
+
+
+def main(argv=None) -> int:
+    parser = argparse.ArgumentParser(description=__doc__)
+    parser.add_argument(
+        "--since", default="24 hours ago",
+        help="Time window passed to journalctl --since (default: '24 hours ago')",
+    )
+    parser.add_argument(
+        "--unit", default="fellows-pwa",
+        help="Systemd unit to read (default: fellows-pwa)",
+    )
+    parser.add_argument(
+        "--json", dest="as_json", action="store_true",
+        help="Emit machine-readable JSON instead of human text",
+    )
+    parser.add_argument(
+        "--disk-path", default="/",
+        help="Path for disk usage (default: /)",
+    )
+    args = parser.parse_args(argv)
+
+    messages = journal_messages(args.unit, args.since)
+    stats = tally(messages)
+    disk = disk_usage(args.disk_path)
+
+    if args.as_json:
+        print(json.dumps({
+            "unit": args.unit,
+            "since": args.since,
+            "requests": stats,
+            "disk": disk,
+        }, sort_keys=True))
+    else:
+        print_human(stats, disk, args.since, args.unit)
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/tests/test_prod_stats.py
+++ b/tests/test_prod_stats.py
@@ -1,0 +1,160 @@
+"""Unit tests for scripts/prod_stats.py.
+
+The script is stdlib-only and lives under scripts/ (not a package), so we
+load it by path. Tests exercise the pure functions (tally, disk_usage,
+print_human) against fixture MESSAGE strings — no real journalctl or SSH.
+"""
+import importlib.util
+import io
+import json
+import os
+import sys
+
+REPO_ROOT = os.path.dirname(os.path.dirname(os.path.abspath(__file__)))
+SCRIPT_PATH = os.path.join(REPO_ROOT, "scripts", "prod_stats.py")
+
+_spec = importlib.util.spec_from_file_location("prod_stats", SCRIPT_PATH)
+prod_stats = importlib.util.module_from_spec(_spec)
+_spec.loader.exec_module(prod_stats)
+
+
+# ---- fixture: representative journald MESSAGE strings --------------------
+
+FIXTURE_MESSAGES = [
+    # App-shell loads
+    '127.0.0.1 - - [23/Apr/2026 10:15:32] "GET / HTTP/1.1" 200 -',
+    '127.0.0.1 - - [23/Apr/2026 10:15:33] "GET /index.html HTTP/1.1" 200 -',
+    '127.0.0.1 - - [23/Apr/2026 10:16:01] "GET / HTTP/1.1" 304 -',
+    # Directory API (count both list and detail)
+    '127.0.0.1 - - [23/Apr/2026 10:15:34] "GET /api/fellows HTTP/1.1" 200 -',
+    '127.0.0.1 - - [23/Apr/2026 10:15:35] "GET /api/fellows?full=1 HTTP/1.1" 200 -',
+    '127.0.0.1 - - [23/Apr/2026 10:16:00] "GET /api/fellows/jane-doe HTTP/1.1" 200 -',
+    # DB downloads
+    '127.0.0.1 - - [23/Apr/2026 10:15:36] "GET /fellows.db HTTP/1.1" 200 -',
+    # Magic-link verify: one success, one 401
+    '127.0.0.1 - - [23/Apr/2026 10:17:00] "POST /api/verify-token HTTP/1.1" 200 -',
+    '127.0.0.1 - - [23/Apr/2026 10:17:05] "POST /api/verify-token HTTP/1.1" 401 -',
+    # 5xx error (should bucket under errors_5xx)
+    '127.0.0.1 - - [23/Apr/2026 10:18:00] "GET /api/stats HTTP/1.1" 500 -',
+    # Send-unlock structured events: two sent, one http_error
+    json.dumps({"event": "send_unlock_email", "result": "sent",
+                "email_hash_prefix": "deadbeef1234", "token_prefix": "aaaaaaaaaaaa",
+                "postmark": {"MessageID": "m1"}}),
+    json.dumps({"event": "send_unlock_email", "result": "sent",
+                "email_hash_prefix": "cafebabe5678", "token_prefix": "bbbbbbbbbbbb",
+                "postmark": {"MessageID": "m2"}}),
+    json.dumps({"event": "send_unlock_email", "result": "http_error",
+                "email_hash_prefix": "feedface9abc", "token_prefix": "cccccccccccc",
+                "status": 422}),
+    # Noise that must not bump any counter
+    "Rate limit: send-unlock for hash prefix deadbeef1234",
+    '{"event": "build_meta", "build": {"built_at": "2026-04-23T09:00Z"}}',
+    "",
+    "not-a-log-line at all",
+]
+
+
+# ---- tally() -------------------------------------------------------------
+
+def test_tally_counts_shell_loads():
+    stats = prod_stats.tally(FIXTURE_MESSAGES)
+    assert stats["shell_loads"] == 3
+
+
+def test_tally_counts_directory_api():
+    stats = prod_stats.tally(FIXTURE_MESSAGES)
+    # list + ?full=1 + detail
+    assert stats["api_fellows"] == 3
+
+
+def test_tally_counts_db_downloads():
+    stats = prod_stats.tally(FIXTURE_MESSAGES)
+    assert stats["db_downloads"] == 1
+
+
+def test_tally_counts_magic_link_verifications():
+    stats = prod_stats.tally(FIXTURE_MESSAGES)
+    assert stats["magic_links_verified"] == 1
+    assert stats["magic_links_verify_failed"] == 1
+
+
+def test_tally_counts_magic_links_sent_and_failures():
+    stats = prod_stats.tally(FIXTURE_MESSAGES)
+    assert stats["magic_links_sent"] == 2
+    assert stats["magic_links_send_failed"] == {"http_error": 1}
+
+
+def test_tally_bucket_5xx_by_route():
+    stats = prod_stats.tally(FIXTURE_MESSAGES)
+    assert stats["errors_5xx"] == {"500 GET /api/stats": 1}
+
+
+def test_tally_ignores_build_meta_and_rate_limit_lines():
+    # Inputs that look structured but aren't send_unlock_email must not count.
+    msgs = [
+        '{"event": "build_meta", "build": {"built_at": "x"}}',
+        "Rate limit: send-unlock for hash prefix deadbeef1234",
+    ]
+    stats = prod_stats.tally(msgs)
+    assert stats["magic_links_sent"] == 0
+    assert stats["shell_loads"] == 0
+
+
+def test_tally_empty_input_returns_zeros():
+    stats = prod_stats.tally([])
+    assert stats["shell_loads"] == 0
+    assert stats["magic_links_sent"] == 0
+    assert stats["errors_5xx"] == {}
+    assert stats["magic_links_send_failed"] == {}
+
+
+def test_tally_distinguishes_api_fellows_from_api_stats():
+    # /api/stats must not be counted as /api/fellows.
+    msgs = [
+        '127.0.0.1 - - [x] "GET /api/stats HTTP/1.1" 200 -',
+        '127.0.0.1 - - [x] "GET /api/fellows HTTP/1.1" 200 -',
+    ]
+    stats = prod_stats.tally(msgs)
+    assert stats["api_fellows"] == 1
+
+
+# ---- disk_usage() --------------------------------------------------------
+
+def test_disk_usage_shape():
+    disk = prod_stats.disk_usage("/")
+    assert set(disk.keys()) == {"path", "total_gib", "used_gib", "free_gib", "pct_used"}
+    assert disk["path"] == "/"
+    assert disk["total_gib"] > 0
+    assert 0.0 <= disk["pct_used"] <= 100.0
+
+
+# ---- print_human() -------------------------------------------------------
+
+def test_print_human_includes_expected_sections(capsys):
+    stats = prod_stats.tally(FIXTURE_MESSAGES)
+    disk = {"path": "/", "total_gib": 25.0, "used_gib": 10.0,
+            "free_gib": 15.0, "pct_used": 40.0}
+    prod_stats.print_human(stats, disk, "24 hours ago", "fellows-pwa")
+    out = capsys.readouterr().out
+    assert "fellows-pwa" in out
+    assert "App-shell loads:" in out
+    assert "Magic links sent:" in out
+    assert "Disk (/)" in out
+    assert "40.0%" in out
+
+
+# ---- main() + --json -----------------------------------------------------
+
+def test_main_json_output_parses(monkeypatch, capsys):
+    # Short-circuit journal_messages so the test doesn't shell out to journalctl.
+    monkeypatch.setattr(prod_stats, "journal_messages", lambda unit, since: FIXTURE_MESSAGES)
+    rc = prod_stats.main(["--json", "--since", "1 hour ago"])
+    assert rc == 0
+    payload = json.loads(capsys.readouterr().out)
+    assert payload["unit"] == "fellows-pwa"
+    assert payload["since"] == "1 hour ago"
+    assert payload["requests"]["shell_loads"] == 3
+    assert payload["requests"]["magic_links_sent"] == 2
+    assert set(payload["disk"].keys()) == {
+        "path", "total_gib", "used_gib", "free_gib", "pct_used",
+    }


### PR DESCRIPTION
## Summary

Final pre-public PR. Two independent changes:

**1. `just prod-stats [SINCE]` — one-liner production telemetry.** SSHes to the droplet and prints a summary: app-shell loads, directory API hits, DB downloads, magic links sent / send-failures / verified / rejected, 5xx errors by route, disk usage. Parsing runs on the droplet (`/opt/fellows/bin/prod_stats`) against `journalctl -u fellows-pwa -o json` + `shutil.disk_usage('/')` — stdlib only, matches the no-pip-deps-for-runtime posture. `--json` flag for future tooling.

**2. Pre-public housekeeping.** README polish; the "Before Making This Repo Public" history-scrub checklist is removed now that it's being enacted rather than documented-for-later. `app/server.py:214` — example slug swapped from a real fellow's name to `a_b_c_d`/`abcd.jpg` (same fuzzy-match behavior, zero PII in source).

## Design notes

- **Access model:** adds the operator to the `systemd-journal` group in the `common` role. That's the intended Linux primitive for read-only journal access — narrower than per-command NOPASSWD sudoers, and scales to future ops reads (`journalctl -u caddy`, etc.) without touching sudoers.
- **Parse on the box, not on the laptop.** Ships the computed summary over SSH instead of piping journal JSON through awk on the laptop. Also means `--json` is a stable interface for whatever comes next (local dashboard, alerting).
- **Five-number discipline.** Counts are deliberately narrow: shell loads, API hits, DB downloads, magic links (sent + verified), 5xx. A sixth gets added when there's a real reason, not speculation.
- **Privacy:** `send_unlock_email` events carry hashed email prefixes (per `docs/email_system_management.md`); this PR doesn't change that. The reverse-map-to-real-email question is deferred — counts work without it.

## Test plan

- [x] `pytest tests/test_prod_stats.py` — 12/12 pass (pure-function coverage of `tally()`, `disk_usage()`, `print_human()`, `main(--json)` with monkeypatched `journal_messages`; fixture inputs cover access log lines + structured events + noise).
- [x] `pytest tests/test_database.py tests/test_magic_link_auth.py tests/test_deploy_sqlite_api.py tests/test_debug_email_delivery.py` — 81/81 pass.
- [x] `./scripts/ensure_port_8765_free.sh tests/test_api.py` — 12/12 pass.
- [x] `ansible-playbook ansible/site.yml --syntax-check` — clean.
- [x] `just --list` shows the new `prod-stats` recipe under `[prod]`.
- [ ] **Maintainer QA on the droplet after deploy:**
  - `just deploy` (picks up the new common-role group task + fellows_app copy task). Log out / in of the SSH session once after deploy so the new group membership takes effect.
  - `ssh -p 52221 rsb@fellows.globaldonut.com id | grep systemd-journal` — confirms the group membership.
  - `ssh -p 52221 rsb@fellows.globaldonut.com ls -la /opt/fellows/bin/prod_stats` — confirms the script landed as `fellows:fellows 0755`.
  - `just prod-stats` — should print a summary with no sudo prompt. Windows further back: `just prod-stats '7 days ago'`.
  - `just prod-stats '30 minutes ago'` with a fresh `GET https://fellows.globaldonut.com/` in the middle — shell-loads count should tick up.

🤖 Generated with [Claude Code](https://claude.com/claude-code)