### PR TITLE
feat(groups): PR 1 — schema + ATTACH probe + right-rail composer

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -2,6 +2,12 @@
 app/fellows.db
 app/fellows.db.backup.*
 
+# User-data DB (groups, tags, notes, settings). Per-user, never bundled.
+app/relationships.db
+app/relationships.db-journal
+app/relationships.db-wal
+app/relationships.db-shm
+
 # Python
 __pycache__/
 *.py[cod]

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -12,7 +12,7 @@ Read README.md for project setup, API docs, and test commands. Read docs/Archite
 
 ## Conventions
 
-- Keep the server as a single file (`app/server.py`).
+- Keep the server as a single file (`app/server.py`). Pure-logic helpers (e.g. `app/relationships.py`) may live alongside.
 - Frontend is a single IIFE in `app/static/app.js`. No modules, no classes.
 - `escapeHtml()` for all user data rendered into HTML.
 - Parameterized `?` placeholders for all SQL queries.
@@ -21,3 +21,7 @@ Read README.md for project setup, API docs, and test commands. Read docs/Archite
 - The DB file `app/fellows.db` is gitignored; rebuild from JSON source.
 - Always run relevant tests after changes.
 - For deploy- or infra-related work, put **manual QA steps for the maintainer** (smoke scripts, DNS/TLS checks, browser install flow) in the **PR description**, not only in commits or docs.
+
+## Two-DB architecture
+
+User-authored data (groups, per-fellow tags, per-fellow notes, settings) lives in `app/relationships.db`, a separate SQLite file from the imported contact data in `app/fellows.db`. Cross-DB joins use SQLite `ATTACH DATABASE` with `?mode=ro` on the fellows side — read-only-ness of contact tables is enforced at the SQLite level, not just the app layer. See `app/relationships.py` (Python) and the `RELATIONSHIPS_SCHEMA_SQL` mirror in `app/static/app.js` (PWA / OPFS). `relationships.db` is gitignored, per-user, and persists across app updates; `fellows.db` is regenerated from source on every build.

--- a/app/relationships.py
+++ b/app/relationships.py
@@ -1,0 +1,115 @@
+"""User-data store for the EHF Fellows app.
+
+Lives in ``app/relationships.db``, a separate SQLite file from
+``app/fellows.db``:
+
+- ``fellows.db`` holds imported Knack/EHF contact data — read-only at
+  runtime, replaced on every PWA update.
+- ``relationships.db`` holds user-authored data (groups, tags, notes,
+  settings) — read-write, persists across app updates.
+
+Tables here join to ``fellows`` via SQLite ``ATTACH DATABASE`` in
+read-only mode (see ``open_db``). The same architecture works in the
+PWA (sqlite3.wasm + OPFS) as it does on the dev server; the JS schema
+mirror lives in ``app/static/app.js`` near ``RELATIONSHIPS_SCHEMA_SQL``.
+"""
+
+from __future__ import annotations
+
+import sqlite3
+from pathlib import Path
+from urllib.parse import quote
+
+APP_DIR = Path(__file__).resolve().parent
+RELATIONSHIPS_DB_PATH = APP_DIR / "relationships.db"
+FELLOWS_DB_PATH = APP_DIR / "fellows.db"
+
+# Bump when the schema below changes. Stored in PRAGMA user_version on
+# every bootstrap so we can branch on it for future migrations.
+SCHEMA_VERSION = 1
+
+SCHEMA_SQL = """
+CREATE TABLE IF NOT EXISTS groups (
+    id INTEGER PRIMARY KEY,
+    name TEXT NOT NULL,
+    note TEXT NOT NULL DEFAULT '',
+    created_at TEXT NOT NULL,
+    updated_at TEXT NOT NULL
+);
+
+CREATE TABLE IF NOT EXISTS group_members (
+    group_id INTEGER NOT NULL REFERENCES groups(id) ON DELETE CASCADE,
+    fellow_record_id TEXT NOT NULL,
+    PRIMARY KEY (group_id, fellow_record_id)
+);
+
+CREATE INDEX IF NOT EXISTS idx_group_members_group
+    ON group_members(group_id);
+
+-- Reserved for a later PR (tag/note CRUD UI). Schema lives here from PR 1
+-- so cross-DB joins are designed in once.
+CREATE TABLE IF NOT EXISTS fellow_tags (
+    fellow_record_id TEXT NOT NULL,
+    tag TEXT NOT NULL,
+    created_at TEXT NOT NULL,
+    PRIMARY KEY (fellow_record_id, tag)
+);
+
+CREATE INDEX IF NOT EXISTS idx_fellow_tags_tag
+    ON fellow_tags(tag);
+
+CREATE TABLE IF NOT EXISTS fellow_notes (
+    fellow_record_id TEXT PRIMARY KEY,
+    body TEXT NOT NULL,
+    updated_at TEXT NOT NULL
+);
+
+-- Single key/value bag for user prefs (e.g. ``self_email`` override).
+CREATE TABLE IF NOT EXISTS settings (
+    key TEXT PRIMARY KEY,
+    value TEXT
+);
+"""
+
+
+def _path_to_sqlite_uri(p: Path, *, mode: str = "rwc") -> str:
+    """Build a ``file:``-style URI SQLite understands. URL-quotes path bytes."""
+    quoted = quote(str(p), safe="/:")
+    return f"file:{quoted}?mode={mode}"
+
+
+def bootstrap_schema(conn: sqlite3.Connection) -> None:
+    """Create tables/indexes if missing. Idempotent."""
+    conn.executescript(SCHEMA_SQL)
+    conn.execute(f"PRAGMA user_version = {SCHEMA_VERSION}")
+    conn.commit()
+
+
+def open_db(
+    *,
+    rel_db_path: Path | None = None,
+    fellows_db_path: Path | None = None,
+    attach_fellows: bool = True,
+) -> sqlite3.Connection:
+    """Open ``relationships.db`` (creating + bootstrapping if needed).
+
+    When ``attach_fellows`` is True, ``fellows.db`` is ATTACHed as ``f`` in
+    read-only mode (``?mode=ro``). Any accidental write to ``f.*`` raises
+    ``sqlite3.OperationalError`` — the read-only-ness of contact data is
+    enforced at the SQLite level, not just the app layer.
+    """
+    rel = rel_db_path or RELATIONSHIPS_DB_PATH
+    fel = fellows_db_path or FELLOWS_DB_PATH
+    rel.parent.mkdir(parents=True, exist_ok=True)
+    conn = sqlite3.connect(_path_to_sqlite_uri(rel, mode="rwc"), uri=True)
+    conn.row_factory = sqlite3.Row
+    conn.execute("PRAGMA foreign_keys = ON")
+    bootstrap_schema(conn)
+    if attach_fellows:
+        if not fel.is_file():
+            raise FileNotFoundError(f"fellows.db not found at {fel}")
+        conn.execute(
+            "ATTACH DATABASE ? AS f",
+            (_path_to_sqlite_uri(fel, mode="ro"),),
+        )
+    return conn

--- a/app/server.py
+++ b/app/server.py
@@ -242,6 +242,27 @@ class Handler(BaseHTTPRequestHandler):
         self.end_headers()
         self.wfile.write(b"Not Found")
 
+    def do_POST(self):
+        parsed = urllib.parse.urlparse(self.path)
+        path = parsed.path.rstrip("/") or "/"
+        # PR 1 stub: the create-group endpoint exists so the right-rail UI
+        # can POST and surface a clear "not yet implemented" message. PR 2
+        # replaces this with the real handler that writes to
+        # relationships.db. Tests pin the 501 contract.
+        if path == "/api/groups":
+            self.send_json(
+                {
+                    "error": "Not Implemented",
+                    "message": (
+                        "POST /api/groups lands in PR 2 of the groups feature. "
+                        "Your draft is preserved; reload the page to keep editing."
+                    ),
+                },
+                status=501,
+            )
+            return
+        self.send_error_404()
+
     def do_GET(self):
         parsed = urllib.parse.urlparse(self.path)
         path = parsed.path.rstrip("/") or "/"

--- a/app/static/app.js
+++ b/app/static/app.js
@@ -29,6 +29,36 @@
   var nlSearchStatusEl = document.getElementById('nl-search-status');
   var detailEl = document.getElementById('detail');
   var fullFellowsCache = null;
+  // Groups feature (PR 1): right-rail composer + +/✓ markers + draft store.
+  // The schema mirror for relationships.db (PWA / OPFS path) is summarised
+  // here for ctrl-F discoverability; the canonical DDL lives in
+  // app/relationships.py and is bootstrapped server-side. PR 2 wires the
+  // create-group POST + the OPFS open path.
+  var RELATIONSHIPS_TABLES = ['groups', 'group_members', 'fellow_tags', 'fellow_notes', 'settings'];
+  var groupRailEl = document.getElementById('group-rail');
+  var groupRailEyebrowEl = document.getElementById('group-rail-eyebrow');
+  var groupRailTitleEl = document.getElementById('group-rail-title');
+  var groupRailTitleIconEl = document.getElementById('group-rail-title-icon');
+  var groupRailHelperEl = document.getElementById('group-rail-helper');
+  var groupRailMembersEl = document.getElementById('group-rail-members');
+  var groupRailCreateEl = document.getElementById('group-rail-create');
+  var groupRailStatusEl = document.getElementById('group-rail-status');
+  var bulkSelectBarEl = document.getElementById('bulk-select-bar');
+  var bulkSelectInputEl = document.getElementById('bulk-select-input');
+  var bulkSelectTextEl = document.getElementById('bulk-select-text');
+  var GROUP_DRAFT_KEY = 'ehf.group_draft';
+  // Drafts persist to localStorage so they survive page reloads and app
+  // updates. They are NOT preserved across Clear App Cache (the red button
+  // calls localStorage.clear() and only preserves fellows_authenticated_once).
+  // That's acceptable: drafts are unsaved by definition. Saved groups go to
+  // relationships.db (PR 2+), which lives in OPFS and survives every reset.
+  // See docs/persistence_and_upgrades.md for the full state-survival matrix.
+  var groupDraft = {
+    members: new Set(),       // record_id values picked
+    memberNames: {},          // record_id -> display name (for chips)
+    title: '',
+    titleEdited: false
+  };
   var installLandingEl = document.getElementById('install-landing');
   var installGatePrivateEl = document.getElementById('install-gate-private');
   var unlockEmailFormEl = document.getElementById('unlock-email-form');
@@ -63,7 +93,7 @@
   /** Bump on every meaningful UI / diagnostics change. Rendered in the
    *  always-visible build badge so a dev can tell at a glance which app.js
    *  is actually running vs what the server was deployed with. */
-  var FELLOWS_UI_DIAG = 'diag-2026-04n-offline-only-mode';
+  var FELLOWS_UI_DIAG = 'diag-2026-04o-groups-pr1';
 
   // Persistent marker: "this origin has been authenticated successfully at
   // least once." Preserved across clearAllAppData. Used by startBrowserUx's
@@ -1615,10 +1645,28 @@
     var ul = document.createElement('ul');
     items.forEach(function (f) {
       var li = document.createElement('li');
+      li.className = 'dir-row';
+      var rid = f.record_id || '';
+      var on = !!(rid && groupDraft.members.has(rid));
+      var displayName = (f.name && String(f.name).trim()) ? f.name : 'Unknown';
+      var mark = document.createElement('button');
+      mark.type = 'button';
+      mark.className = 'dir-mark' + (on ? ' dir-mark--on' : '');
+      mark.dataset.recordId = rid;
+      mark.setAttribute('aria-pressed', on ? 'true' : 'false');
+      mark.title = on ? 'remove from group' : 'add to group';
+      mark.textContent = on ? '✓' : '+';
+      mark.addEventListener('click', function (ev) {
+        // Marker is inside the row but must NOT trigger row navigation.
+        ev.stopPropagation();
+        ev.preventDefault();
+        toggleDraftMember(rid, displayName);
+      });
       var a = document.createElement('a');
       a.href = '#/fellow/' + encodeURIComponent(f.slug || '');
-      var displayName = (f.name && String(f.name).trim()) ? f.name : 'Unknown';
+      a.className = 'dir-link';
       a.textContent = displayName;
+      li.appendChild(mark);
       li.appendChild(a);
       ul.appendChild(li);
     });
@@ -1630,6 +1678,7 @@
     if (!list.length) {
       directoryListEl.innerHTML = '<p class="placeholder">No fellows loaded.</p>';
       setFilterCount('');
+      updateBulkBar();
       return;
     }
     var filtered = applyHasEmailFilter(list);
@@ -1653,6 +1702,7 @@
     }
     showLoading(false);
     showApp(true);
+    updateBulkBar();
   }
 
   function setSearchStatus(msg) {
@@ -1706,11 +1756,20 @@
     }
     var name = fellow.name || fellow.slug || 'Unknown';
     var slug = fellow.slug || '';
+    var rid = fellow.record_id || '';
+    var inDraft = !!(rid && groupDraft.members.has(rid));
     var leftTop = '';
     var leftRest = '';
 
     var demo = [fellow.gender_pronouns, fellow.ethnicity].filter(Boolean).join(' | ');
-    leftTop += '<h2 class="detail-name">' + escapeHtml(name) + '</h2>';
+    leftTop += '<h2 class="detail-name">' + escapeHtml(name);
+    if (rid) {
+      leftTop += ' <a href="#" class="detail-add-to-group" data-record-id="' +
+        escapeHtml(rid) + '">' +
+        (inDraft ? 'remove from group' : 'add to group') +
+        '</a>';
+    }
+    leftTop += '</h2>';
     if (demo) leftTop += '<p class="detail-demographics">' + escapeHtml(demo) + '</p>';
     var hasImage = fellow.has_image === 1 || fellow.has_image === true;
     if (hasImage && slug) {
@@ -1809,6 +1868,16 @@
     detailEl.innerHTML = html;
     detailEl.scrollIntoView({ behavior: 'smooth', block: 'nearest' });
 
+    var addLink = detailEl.querySelector('.detail-add-to-group');
+    if (addLink) {
+      addLink.addEventListener('click', function (ev) {
+        ev.preventDefault();
+        var linkRid = addLink.dataset.recordId;
+        if (!linkRid) return;
+        toggleDraftMember(linkRid, fellow.name || fellow.slug || linkRid);
+      });
+    }
+
     var img = detailEl.querySelector('.profile-image');
     if (img) {
       var wrap = img.parentNode;
@@ -1858,6 +1927,246 @@
     div.textContent = s;
     return div.innerHTML;
   }
+
+  // ===== Groups feature (PR 1): draft state, rail rendering, marker sync ===
+
+  function loadGroupDraft() {
+    try {
+      var raw = localStorage.getItem(GROUP_DRAFT_KEY);
+      if (!raw) return;
+      var d = JSON.parse(raw);
+      if (Array.isArray(d.members)) {
+        groupDraft.members = new Set(d.members);
+      }
+      if (d.memberNames && typeof d.memberNames === 'object') {
+        groupDraft.memberNames = d.memberNames;
+      }
+      groupDraft.title = typeof d.title === 'string' ? d.title : '';
+      groupDraft.titleEdited = !!d.titleEdited;
+    } catch (e) {
+      // Corrupt draft; ignore — user can rebuild the selection.
+    }
+  }
+
+  function saveGroupDraft() {
+    try {
+      var snapshot = {
+        members: [],
+        memberNames: groupDraft.memberNames,
+        title: groupDraft.title,
+        titleEdited: groupDraft.titleEdited
+      };
+      groupDraft.members.forEach(function (rid) { snapshot.members.push(rid); });
+      localStorage.setItem(GROUP_DRAFT_KEY, JSON.stringify(snapshot));
+    } catch (e) {
+      // Quota or disabled storage — silent. The rail still works in-memory.
+    }
+  }
+
+  function deriveAutoTitle(query) {
+    var q = (query || '').trim();
+    if (!q) return '';
+    if (q.charAt(0) === '#') return q;
+    return q.charAt(0).toUpperCase() + q.slice(1);
+  }
+
+  function setRailStatus(msg, kind) {
+    if (!groupRailStatusEl) return;
+    groupRailStatusEl.textContent = msg || '';
+    groupRailStatusEl.classList.remove(
+      'group-rail-status--info',
+      'group-rail-status--warn'
+    );
+    if (kind) {
+      groupRailStatusEl.classList.add('group-rail-status--' + kind);
+    }
+  }
+
+  function renderRailHeader() {
+    if (!groupRailTitleEl || !groupRailHelperEl || !groupRailCreateEl) return;
+    var query = (searchInputEl && searchInputEl.value || '').trim();
+    var autoTitle = deriveAutoTitle(query);
+    var displayed = groupDraft.titleEdited ? groupDraft.title : autoTitle;
+    if (document.activeElement !== groupRailTitleEl) {
+      groupRailTitleEl.value = displayed;
+    }
+    if (groupDraft.titleEdited) {
+      groupRailTitleEl.classList.remove('group-rail-title--auto');
+    } else {
+      groupRailTitleEl.classList.add('group-rail-title--auto');
+    }
+    var n = groupDraft.members.size;
+    var fellows = n + ' fellow' + (n === 1 ? '' : 's');
+    var helper;
+    if (groupDraft.titleEdited) {
+      helper = fellows;
+    } else if (autoTitle) {
+      helper = 'auto-named — click to rename · ' + fellows;
+    } else {
+      helper = 'type a name, or search to auto-fill · ' + fellows;
+    }
+    groupRailHelperEl.textContent = helper;
+    groupRailCreateEl.disabled = n === 0;
+  }
+
+  function renderRailMembers() {
+    if (!groupRailMembersEl) return;
+    groupRailMembersEl.innerHTML = '';
+    groupDraft.members.forEach(function (rid) {
+      var li = document.createElement('li');
+      li.className = 'group-rail-member';
+      var name = document.createElement('span');
+      name.className = 'group-rail-member-name';
+      name.textContent = groupDraft.memberNames[rid] || rid;
+      var rm = document.createElement('button');
+      rm.type = 'button';
+      rm.className = 'group-rail-member-remove';
+      rm.title = 'remove';
+      rm.textContent = '×';
+      rm.addEventListener('click', function () {
+        toggleDraftMember(rid, name.textContent);
+      });
+      li.appendChild(name);
+      li.appendChild(rm);
+      groupRailMembersEl.appendChild(li);
+    });
+  }
+
+  function renderRail() {
+    renderRailHeader();
+    renderRailMembers();
+  }
+
+  function setMarkerEl(markEl, on) {
+    if (!markEl) return;
+    markEl.textContent = on ? '✓' : '+';
+    markEl.title = on ? 'remove from group' : 'add to group';
+    markEl.setAttribute('aria-pressed', on ? 'true' : 'false');
+    if (on) {
+      markEl.classList.add('dir-mark--on');
+    } else {
+      markEl.classList.remove('dir-mark--on');
+    }
+  }
+
+  function refreshAllMarkers() {
+    if (!directoryListEl) return;
+    var marks = directoryListEl.querySelectorAll('.dir-mark');
+    for (var i = 0; i < marks.length; i++) {
+      var m = marks[i];
+      var rid = m.dataset.recordId;
+      setMarkerEl(m, !!(rid && groupDraft.members.has(rid)));
+    }
+  }
+
+  function refreshDetailAddLink() {
+    if (!detailEl) return;
+    var link = detailEl.querySelector('.detail-add-to-group');
+    if (!link) return;
+    var rid = link.dataset.recordId;
+    var on = !!(rid && groupDraft.members.has(rid));
+    link.textContent = on ? 'remove from group' : 'add to group';
+  }
+
+  function toggleDraftMember(rid, name) {
+    if (!rid) return;
+    if (groupDraft.members.has(rid)) {
+      groupDraft.members.delete(rid);
+      delete groupDraft.memberNames[rid];
+    } else {
+      groupDraft.members.add(rid);
+      if (name) {
+        groupDraft.memberNames[rid] = name;
+      }
+    }
+    saveGroupDraft();
+    renderRail();
+    refreshAllMarkers();
+    refreshDetailAddLink();
+    updateBulkBar();
+  }
+
+  function updateBulkBar() {
+    if (!bulkSelectBarEl || !bulkSelectInputEl || !bulkSelectTextEl) return;
+    var query = (searchInputEl && searchInputEl.value || '').trim();
+    var filtered = !!query || hasEmailOnly;
+    if (!filtered || !displayedList || !displayedList.length) {
+      bulkSelectBarEl.classList.add('hidden');
+      return;
+    }
+    bulkSelectBarEl.classList.remove('hidden');
+    var allSelected = displayedList.every(function (f) {
+      return f.record_id && groupDraft.members.has(f.record_id);
+    });
+    bulkSelectInputEl.checked = allSelected;
+    bulkSelectTextEl.textContent =
+      (allSelected ? 'deselect' : 'select') + ' all ' + displayedList.length + ' results';
+  }
+
+  function bulkToggleVisible() {
+    if (!displayedList || !displayedList.length) return;
+    var allSelected = displayedList.every(function (f) {
+      return f.record_id && groupDraft.members.has(f.record_id);
+    });
+    displayedList.forEach(function (f) {
+      if (!f.record_id) return;
+      if (allSelected) {
+        groupDraft.members.delete(f.record_id);
+        delete groupDraft.memberNames[f.record_id];
+      } else {
+        groupDraft.members.add(f.record_id);
+        groupDraft.memberNames[f.record_id] = f.name || f.record_id;
+      }
+    });
+    saveGroupDraft();
+    renderRail();
+    refreshAllMarkers();
+    refreshDetailAddLink();
+    updateBulkBar();
+  }
+
+  function handleCreateGroupClick() {
+    if (!groupRailCreateEl) return;
+    if (groupDraft.members.size === 0) return;
+    var titleVal = groupDraft.titleEdited
+      ? groupDraft.title
+      : deriveAutoTitle((searchInputEl && searchInputEl.value) || '');
+    if (!titleVal || !titleVal.trim()) {
+      titleVal = 'Untitled group';
+    }
+    var ids = [];
+    groupDraft.members.forEach(function (rid) { ids.push(rid); });
+    setRailStatus('Saving…', 'info');
+    groupRailCreateEl.disabled = true;
+    fetch('/api/groups', {
+      method: 'POST',
+      headers: { 'Content-Type': 'application/json' },
+      credentials: 'same-origin',
+      body: JSON.stringify({
+        name: titleVal,
+        note: '',
+        fellow_record_ids: ids
+      })
+    })
+      .then(function (r) {
+        if (r.status === 501) {
+          return r.json().catch(function () { return null; }).then(function (data) {
+            var msg = (data && data.message) || 'Create group not yet wired up.';
+            setRailStatus(msg, 'warn');
+          });
+        }
+        // Reserved for PR 2 — happy path lands then.
+        setRailStatus('Unexpected response: ' + r.status, 'warn');
+      })
+      .catch(function () {
+        setRailStatus('Network error while saving.', 'warn');
+      })
+      .then(function () {
+        groupRailCreateEl.disabled = groupDraft.members.size === 0;
+      });
+  }
+
+  // ===== End groups feature ============================================
 
   function statsSection(title, items, color) {
     if (!items || !items.length) return '';
@@ -2040,10 +2349,19 @@
       renderDirectory();
       return;
     }
+    // #tag prefix → scope FTS5 to the search_tags column. The tokens are
+    // stored in fellows.search_tags as plain CSV-ish text and the FTS5
+    // virtual table indexes that column, so column-scoped MATCH works.
+    // Local-fallback search keeps the leading '#' and decodes it inside
+    // filterFellowsLocally.
+    var ftsQ = q;
+    if (q.charAt(0) === '#' && q.length > 1) {
+      ftsQ = 'search_tags:' + q.slice(1);
+    }
     if (directoryDataSource === 'sqlite' && dataProvider) {
       setSearchStatus('Searching…');
       dataProvider
-        .search(q)
+        .search(ftsQ)
         .then(function (results) {
           if (!Array.isArray(results)) {
             results = [];
@@ -2069,7 +2387,7 @@
       return;
     }
     setSearchStatus('Searching…');
-    var url = '/api/search?q=' + encodeURIComponent(q);
+    var url = '/api/search?q=' + encodeURIComponent(ftsQ);
     fetch(url)
       .then(function (r) {
         if (!r.ok) return [];
@@ -2122,6 +2440,7 @@
       msg += ' (' + total + ' before filter)';
     }
     setSearchStatus(msg);
+    updateBulkBar();
   }
 
   function runLocalSearch(q) {
@@ -2150,6 +2469,16 @@
   function filterFellowsLocally(fellows, q) {
     var query = (q || '').toLowerCase();
     if (!query) return fellows.slice();
+    // #tag prefix → match against the search_tags column only. Mirrors
+    // the FTS5 column-scoped path in runSearch so on/offline behaviour
+    // stays consistent.
+    if (query.charAt(0) === '#' && query.length > 1) {
+      var tag = query.slice(1);
+      return fellows.filter(function (f) {
+        var st = (f.search_tags == null ? '' : String(f.search_tags)).toLowerCase();
+        return st.indexOf(tag) !== -1;
+      });
+    }
     var tokens = query.split(/\s+/).filter(Boolean);
     return fellows.filter(function (f) {
       var parts = [
@@ -2354,6 +2683,10 @@
     if (loadingEl) {
       loadingEl.classList.remove('hidden');
     }
+    // Restore the in-progress group draft (members + auto-title state)
+    // before any rendering so the rail and markers come up consistent.
+    loadGroupDraft();
+    renderRail();
 
     if ('serviceWorker' in navigator) {
       navigator.serviceWorker.addEventListener('message', function (ev) {
@@ -2420,6 +2753,25 @@
         // marker so the URL-just-works path works on next visit.
         markAuthenticatedOnce();
         list = Array.isArray(data) ? data : [];
+        // Backfill display names for any draft members loaded before
+        // we had data (record_id was saved, name wasn't, or the saved
+        // name has since changed in fellows.db). Saves the rail from
+        // showing raw record_ids in chips.
+        var draftDirty = false;
+        list.forEach(function (f) {
+          if (
+            f.record_id &&
+            groupDraft.members.has(f.record_id) &&
+            groupDraft.memberNames[f.record_id] !== f.name
+          ) {
+            groupDraft.memberNames[f.record_id] = f.name || f.record_id;
+            draftDirty = true;
+          }
+        });
+        if (draftDirty) {
+          saveGroupDraft();
+          renderRail();
+        }
         renderDirectory();
         route();
         return dataProvider.getFull().catch(function (err) {
@@ -2486,6 +2838,9 @@
 
     if (searchInputEl) {
       searchInputEl.addEventListener('input', function () {
+        // Auto-following rail title is meant to feel instant; update it
+        // before the debounced search fires.
+        renderRailHeader();
         if (searchDebounceId) {
           clearTimeout(searchDebounceId);
         }
@@ -2507,6 +2862,24 @@
           renderDirectory();
         }
       });
+    }
+
+    if (groupRailTitleEl) {
+      groupRailTitleEl.addEventListener('input', function () {
+        // Once the user types in the title field, the auto-follow flip is
+        // permanent for this draft (even if they clear it back to empty).
+        groupDraft.title = groupRailTitleEl.value;
+        groupDraft.titleEdited = true;
+        groupRailTitleEl.classList.remove('group-rail-title--auto');
+        saveGroupDraft();
+        renderRailHeader();
+      });
+    }
+    if (groupRailCreateEl) {
+      groupRailCreateEl.addEventListener('click', handleCreateGroupClick);
+    }
+    if (bulkSelectInputEl) {
+      bulkSelectInputEl.addEventListener('change', bulkToggleVisible);
     }
 
     if (document.readyState === 'loading') {

--- a/app/static/index.html
+++ b/app/static/index.html
@@ -154,11 +154,36 @@
         <button id="nl-search-button" class="nl-search-button" type="button">Ask AI</button>
         <p id="nl-search-status" class="search-status" aria-live="polite"></p>
       </div>
+      <div id="bulk-select-bar" class="bulk-select-bar hidden">
+        <label class="bulk-select-label">
+          <input type="checkbox" id="bulk-select-input" />
+          <span id="bulk-select-text">select all results</span>
+        </label>
+      </div>
       <div id="directory-list"></div>
     </aside>
     <main id="detail" class="detail" aria-label="Fellow detail">
       <p class="placeholder">Select a fellow from the list.</p>
     </main>
+    <aside id="group-rail" class="group-rail" aria-label="Group composer">
+      <div class="group-rail-eyebrow" id="group-rail-eyebrow">add to a group</div>
+      <div class="group-rail-title-wrap">
+        <input
+          type="text"
+          id="group-rail-title"
+          class="group-rail-title group-rail-title--auto"
+          placeholder="name your group…"
+          autocomplete="off"
+          aria-label="Group name"
+        />
+        <span class="group-rail-title-icon" id="group-rail-title-icon" aria-hidden="true">✎</span>
+      </div>
+      <div class="group-rail-helper" id="group-rail-helper">type a name, or search to auto-fill · 0 fellows</div>
+      <ul class="group-rail-members" id="group-rail-members" aria-label="Selected fellows"></ul>
+      <button type="button" id="group-rail-create" class="group-rail-create" disabled>Create new group</button>
+      <div class="group-rail-footnote">saves immediately to your groups. You can rename and edit it later.</div>
+      <p id="group-rail-status" class="group-rail-status" aria-live="polite"></p>
+    </aside>
   </div>
   <script src="/vendor/sqlite3.js"></script>
   <script src="/app.js"></script>

--- a/app/static/styles.css
+++ b/app/static/styles.css
@@ -1028,3 +1028,273 @@ h1 {
   font-size: 0.9rem;
   color: #5a5a5a;
 }
+
+/* =========================================================================
+ * Groups feature — PR 1: right-rail composer, +/✓ markers, bulk-select bar
+ * Tokens taken from plans/group_feature/design_handoff_groups_feature/
+ * (lavender-soft #faf8fc, lavender-border #dcd6e8, pill #ede7f3/#3b2355,
+ * auto-title bg #fff7d6 / icon #a8923a / text #7a6326, purple #4a2c6a).
+ * ========================================================================= */
+
+/* The right rail joins the existing two-pane layout. Allow it to shrink to
+ * its 240px basis on desktop; stack below the detail on narrow viewports. */
+.group-rail {
+  flex: 0 0 240px;
+  display: flex;
+  flex-direction: column;
+  align-self: stretch;
+  max-height: 75vh;
+  background: #faf8fc;
+  border: 1px solid #dcd6e8;
+  padding: 0.55rem 0.6rem;
+  box-sizing: border-box;
+  font-size: 0.9rem;
+}
+
+.group-rail-eyebrow {
+  font-size: 0.75rem;
+  text-transform: uppercase;
+  letter-spacing: 0.04em;
+  color: #7a6f91;
+  margin-bottom: 0.25rem;
+}
+
+.group-rail-title-wrap {
+  position: relative;
+  margin-bottom: 0.25rem;
+}
+
+.group-rail-title {
+  box-sizing: border-box;
+  width: 100%;
+  padding: 0.3rem 0.45rem;
+  font-size: 0.95rem;
+  font-weight: 600;
+  font-family: inherit;
+  color: #222;
+  background: #fff;
+  border: 1px solid #dcd6e8;
+  border-radius: 2px;
+}
+
+.group-rail-title:focus {
+  outline: 2px solid #4a2c6a;
+  outline-offset: 1px;
+}
+
+/* Auto-following state: cream tint + ✎ glyph, padding-left to clear the icon. */
+.group-rail-title--auto {
+  padding-left: 1.5rem;
+  background: #fff7d6;
+  color: #7a6326;
+}
+
+.group-rail-title-icon {
+  position: absolute;
+  left: 7px;
+  top: 50%;
+  transform: translateY(-50%);
+  font-size: 0.9rem;
+  color: #a8923a;
+  pointer-events: none;
+}
+
+/* Hide the cream cue glyph once the user has typed their own title. */
+.group-rail-title:not(.group-rail-title--auto) + .group-rail-title-icon {
+  display: none;
+}
+
+.group-rail-helper {
+  font-size: 0.72rem;
+  color: #7a6f91;
+  margin-bottom: 0.4rem;
+}
+
+.group-rail-members {
+  list-style: none;
+  margin: 0 0 0.5rem 0;
+  padding: 0.2rem 0.4rem;
+  flex: 1 1 auto;
+  min-height: 4rem;
+  overflow-y: auto;
+  background: #fff;
+  border: 1px solid #dcd6e8;
+}
+
+.group-rail-members:empty::before {
+  content: 'tap + next to a name to add. Search again to add more.';
+  display: block;
+  padding: 0.4rem 0;
+  font-size: 0.78rem;
+  color: #888;
+}
+
+.group-rail-member {
+  display: flex;
+  align-items: center;
+  gap: 0.35rem;
+  padding: 1px 0;
+  font-size: 0.8rem;
+}
+
+.group-rail-member-name {
+  flex: 1;
+  overflow: hidden;
+  text-overflow: ellipsis;
+  white-space: nowrap;
+}
+
+.group-rail-member-remove {
+  background: transparent;
+  border: 0;
+  color: #999;
+  cursor: pointer;
+  font-family: ui-monospace, Menlo, monospace;
+  font-size: 0.78rem;
+  padding: 0 0.25rem;
+  line-height: 1;
+}
+
+.group-rail-member-remove:hover {
+  color: #7a1f1f;
+}
+
+.group-rail-create {
+  width: 100%;
+  padding: 0.35rem 0.7rem;
+  font: inherit;
+  font-weight: 600;
+  color: #fff;
+  background: #4a2c6a;
+  border: 1px solid #4a2c6a;
+  border-radius: 3px;
+  cursor: pointer;
+}
+
+.group-rail-create:hover:not(:disabled) {
+  background: #3b2355;
+}
+
+.group-rail-create:disabled {
+  opacity: 0.45;
+  cursor: not-allowed;
+}
+
+.group-rail-footnote {
+  font-size: 0.72rem;
+  color: #7a6f91;
+  margin-top: 0.35rem;
+  line-height: 1.4;
+}
+
+.group-rail-status {
+  margin: 0.4rem 0 0;
+  padding: 0.3rem 0.4rem;
+  font-size: 0.78rem;
+  min-height: 1.2em;
+  border-radius: 2px;
+  color: #444;
+}
+
+.group-rail-status--info {
+  background: #ede7f3;
+  color: #3b2355;
+}
+
+.group-rail-status--warn {
+  background: #fff3cd;
+  border: 1px solid #ffe69c;
+  color: #664d03;
+}
+
+/* +/✓ margin marker on each directory row. */
+.dir-row {
+  display: flex;
+  align-items: center;
+  gap: 4px;
+}
+
+.dir-mark {
+  flex: 0 0 18px;
+  width: 18px;
+  height: 18px;
+  padding: 0;
+  font-size: 0.95rem;
+  line-height: 1;
+  font-weight: 700;
+  background: transparent;
+  border: 0;
+  cursor: pointer;
+  color: #bbb;
+  text-align: center;
+  font-family: inherit;
+}
+
+.dir-mark:hover {
+  color: #4a2c6a;
+}
+
+.dir-mark--on {
+  color: #4a2c6a;
+}
+
+.dir-mark:focus {
+  outline: 2px solid #4a2c6a;
+  outline-offset: 1px;
+}
+
+#directory .dir-link {
+  display: inline-block;
+  padding: 0.25em 0;
+  flex: 1 1 auto;
+  min-width: 0;
+}
+
+/* Bulk select-all bar — only visible while filtered. */
+.bulk-select-bar {
+  margin: 0 0 0.4rem;
+  padding: 0.25rem 0.4rem;
+  background: #faf8fc;
+  border: 1px solid #dcd6e8;
+  border-radius: 2px;
+  font-size: 0.78rem;
+  color: #3b2355;
+}
+
+.bulk-select-bar.hidden {
+  display: none;
+}
+
+.bulk-select-label {
+  display: inline-flex;
+  align-items: center;
+  gap: 0.35rem;
+  cursor: pointer;
+  user-select: none;
+}
+
+/* "add to group" / "remove from group" link beside the detail-card name. */
+.detail-add-to-group {
+  display: inline-block;
+  margin-left: 0.5rem;
+  font-size: 0.85rem;
+  font-weight: 400;
+  color: #0066cc;
+  text-decoration: underline;
+  vertical-align: middle;
+  cursor: pointer;
+}
+
+.detail-add-to-group:hover {
+  color: #004499;
+}
+
+/* Mobile: stack the rail below the detail (existing 700px breakpoint
+ * already collapses the directory; keep the same stacking rhythm). */
+@media (max-width: 700px) {
+  .group-rail {
+    flex: none;
+    width: 100%;
+    max-height: none;
+  }
+}

--- a/app/static/sw.js
+++ b/app/static/sw.js
@@ -1,4 +1,4 @@
-const CACHE_VERSION = 'v8';
+const CACHE_VERSION = 'v9';
 const APP_SHELL_CACHE = `fellows-app-shell-${CACHE_VERSION}`;
 // Separate cache so shell-version bumps don't evict the ~34 MB of profile images.
 const IMAGES_CACHE = 'fellows-images-v1';

--- a/docs/Architecture.md
+++ b/docs/Architecture.md
@@ -32,6 +32,21 @@ The server opens a new SQLite connection per request (no connection pool — unn
 
 **HTTP API** (see README for the full list): besides fellows list/detail/search, `GET /api/stats` returns aggregate statistics for the About page: total fellow count, breakdowns by fellow type and cohort, per-region counts (splitting comma-separated `global_regions_currently_based_in`), and field completeness (non-empty column counts plus selected keys in `extra_json` via `json_extract`). Heavier than a simple row fetch; still fine at local scale.
 
+### Persistence and upgrades
+
+User-authored data (groups, tags, notes, settings) lives in
+`app/relationships.db`, a separate SQLite file from `fellows.db`.
+Cross-DB joins use SQLite `ATTACH DATABASE ... ?mode=ro`, which keeps
+contact data read-only at the SQLite level. `relationships.db` is
+durable across both app updates and Clear App Cache; `fellows.db` is
+re-imported on every boot.
+
+The full state-survival matrix (which storage layers survive which
+events, plus the standard upgrade flow) lives in
+[`docs/persistence_and_upgrades.md`](persistence_and_upgrades.md).
+Read that when adding a feature that touches storage, or when
+triaging a "why did my X disappear?" report.
+
 ## Two-Phase Load
 
 The frontend uses two sequential fetches to minimize time-to-interactive:

--- a/docs/persistence_and_upgrades.md
+++ b/docs/persistence_and_upgrades.md
@@ -1,0 +1,152 @@
+# Persistence and Upgrades
+
+The PWA stores user state across several layers, each with different
+survival semantics. This doc captures what survives what — so future
+features can land without surprising existing users, and so we have a
+shared mental model when triaging "why did my X disappear?" reports.
+
+## Storage layers
+
+| Layer | Holds | Replaced on app update | Cleared by **Clear App Cache** button |
+|---|---|---|---|
+| Cache API `fellows-app-shell-vN` | HTML, JS, CSS, SW, manifest, icons, sqlite3.wasm | Yes — every CACHE_VERSION bump | Yes |
+| Cache API `fellows-images-v1` | Profile photos | No (separate cache name) — re-fetched as needed | Yes |
+| IndexedDB `fellows-local-db` | Offline-fallback full fellow rows | Regenerated on every successful boot | Yes |
+| OPFS `fellows.db` | Imported Knack contact data | **Re-imported** every boot from `/fellows.db` | **No** (gap; see "Open questions") |
+| OPFS `relationships.db` (PR 2+) | Groups, group members, fellow_tags, fellow_notes, settings — all user-authored | **Never** — that's the whole point of this file | **No** |
+| localStorage `fellows_authenticated_once` | "this origin has authenticated at least once" marker | Untouched | **Preserved by name** in `clearAllAppData` |
+| localStorage `ehf_has_email_only` | Has-email filter pref | Untouched | Cleared |
+| localStorage `ehf.group_draft` (PR 1+) | In-progress group composer state | Untouched | Cleared (acceptable: drafts are unsaved) |
+| localStorage `fellows_self_email` (PR 5+) | User's "me" email for `mailto:?to=…` | Untouched | Cleared, but rehydrated from `relationships.settings` on next boot |
+| Cookie `fellows_session` (HttpOnly) | HMAC'd session, 7-day TTL, contains `token_issued_at` | Untouched (still valid until TTL) | Cleared (best effort — see `clearCookiesBestEffort`) |
+
+The key architectural decision behind PR 1: **`relationships.db` is a
+separate OPFS file from `fellows.db`** rather than a set of new tables
+inside `fellows.db`. That's because `fellows.db` is bundled with the
+build and re-imported on every boot, while OPFS files we don't
+explicitly touch are durable. Cross-DB joins use SQLite `ATTACH
+DATABASE 'fellows.db' AS f ?mode=ro`, which also enforces read-only
+access to contact data at the SQLite level (any stray write into `f.*`
+raises `OperationalError`).
+
+## Standard app update flow
+
+1. Operator runs `just ship`. Bundle goes out to the droplet.
+2. Existing user opens the installed PWA (or visits in a browser tab).
+3. SW polls `/build-meta.json` and notices the new build SHA.
+4. SW fetches new `sw.js` (which has bumped `CACHE_VERSION`); install
+   event runs and pre-caches the new shell.
+5. `app.js` shows the "New version available — Reload" banner.
+6. User clicks Reload. New SW activates. Old shell cache deleted.
+   Controlled tabs auto-navigate (see `sw.js`'s activate handler).
+7. Fresh `app.js` runs against fresh shell against fresh `fellows.db`.
+
+What survives the reload, end-to-end:
+- The session cookie (still valid until its 7-day TTL).
+- `fellows_authenticated_once` (the URL-just-works marker).
+- `relationships.db` (the user's groups, tags, notes, and settings).
+- The image cache.
+- All localStorage keys (drafts, filter prefs, etc.).
+
+What gets replaced (intentionally):
+- App shell HTML, JS, CSS, SW, manifest.
+- `fellows.db` in OPFS (re-imported from `/fellows.db`; this is how
+  new fellow data reaches the user).
+- IndexedDB cache (regenerated on next successful `getList`).
+
+## Per-user customization (or lack thereof)
+
+The deployed bundle is identical for everyone. There is no per-user
+packaging — the build does not generate a custom artifact per
+recipient.
+
+What looks "custom per user" is purely client-side state:
+
+- The user's email is captured into `localStorage[fellows_self_email]`
+  the first time they submit the magic-link gate (PR 5).
+- It is also written to the `relationships.settings` table so it
+  survives Clear App Cache. On boot, `app.js` mirrors the settings
+  value back into localStorage for fast read.
+- The Settings page (`#/settings`, PR 5) lets the user override —
+  useful when someone wants exports addressed to a different
+  mailbox than the one they sign in with.
+
+A user moving between browsers / devices re-enters their email at
+sign-in (the magic-link form already requires it). After verify, the
+gate handler stashes it client-side. No server-side per-user state
+beyond what the magic-link allowlist already requires.
+
+## Edge cases
+
+### A user upgrades to PR 5 with no `self_email` stashed
+
+On first PR 5 boot, `relationships.settings` has no `self_email`
+row. Surface a one-line nudge on the group-detail Export panel:
+"Set your email in Settings to enable 'email it to me'." Or
+auto-prompt on first export attempt. No data loss; just a one-time
+setup step. Users who installed before PR 5 will all hit this
+exactly once.
+
+### A user clicks Clear App Cache
+
+- localStorage clears (except `fellows_authenticated_once`).
+- IndexedDB clears.
+- All Cache API entries clear (shell + images).
+- Cookies clear.
+- Service worker registrations are unregistered.
+- **OPFS does not clear**, so `relationships.db` — and `fellows.db` —
+  both survive.
+- After reload: user re-prompted for a magic link (cookie gone), then
+  comes back into the directory with their groups intact. Their
+  `self_email` (PR 5) re-mirrors from `relationships.settings` on
+  boot, so the Settings page already shows it.
+- The in-progress group draft (`ehf.group_draft`) IS lost — drafts
+  are by definition unsaved.
+
+### A user installs on a brand-new device
+
+OPFS is empty, so `relationships.db` is created fresh. Their groups
+from the old device are NOT here — there is no cross-device sync.
+This is consistent with the project's "local-only PWA, no SaaS
+backend" stance. If sync becomes a requirement later, the relevant
+data is already isolated in `relationships.db` (separate from
+contact data, identifiable as user-authored), which makes
+export/import a tractable feature.
+
+### Browser-tab visit by an existing user
+
+`fellows_authenticated_once` is preserved across upgrades, so
+`shouldActAsApp()` returns true on browser-tab visits and the user
+boots directly into the directory — no install-landing detour. The
+"endless install loop" some devs see on `localhost` does **not**
+affect production users; it's gated on
+`authStatus.authEnabled === false`, which is a dev-only signal
+(prod always returns true).
+
+### A user with a stuck PWA on a stale shell
+
+The "New version available — Reload" banner is the canonical recovery
+path. If they ignore it, they keep running the old shell — fine.
+If they hit a bug that's already fixed in `main`, route them to
+either:
+1. Click the in-app **Reload** banner.
+2. Click **Clear App Cache & Reload** (red button, bottom right).
+   Their groups, settings, and auth marker survive; only the shell
+   is replaced.
+
+## Open questions / future work
+
+- **OPFS reset.** Clear App Cache does not touch OPFS. If a user ever
+  ends up with a corrupt OPFS-stored `fellows.db`, there's no UI path
+  to wipe just that file. If this surfaces, add a separate "wipe local
+  data and re-download" hook that deletes `fellows.db` from OPFS but
+  leaves `relationships.db` intact.
+- **PR 5 self-email migration.** When `fellows_self_email` is
+  introduced, decide: preserve it across `clearAllAppData` like
+  `fellows_authenticated_once`, or rely on the boot-time mirror from
+  `relationships.settings`. The latter is simpler (one less special
+  case in `clearAllAppData`) and the user-facing behavior is identical.
+- **Future cross-device sync.** Out of scope today, but the layering
+  here keeps the door open: `relationships.db` is a single
+  self-contained file with stable schemas, suitable for an
+  export/import flow or an opt-in sync against a future backend.

--- a/plans/group_feature/design_handoff_groups_feature/README.md
+++ b/plans/group_feature/design_handoff_groups_feature/README.md
@@ -1,0 +1,401 @@
+# Handoff: Fellows Groups feature
+
+A new feature for the EHF Fellows local-first directory: select arbitrary subsets of fellows into named **groups**, then contact the whole group or export the group as a portable visual directory (PDF / HTML).
+
+This document is the implementation spec. A developer who wasn't in the design conversation should be able to build the feature from this file alone.
+
+---
+
+## What's in this folder
+
+| File | What it is |
+|---|---|
+| `README.md` | This spec. Read first. |
+| `Selection wireframes.html` | The visual design canvas — open in a browser to see all artboards. The spec refers to artboards by number (① ② ③ ④ ④ᵇ ⑤ ⑥). |
+| `screen-browse.jsx` | Directory + right-rail composer + edit-mode banner. Reference for screens ① ② ③ ⑥. |
+| `screen-groups.jsx` | The `/groups/` index page. Reference for screen ⑤. |
+| `screen-group-detail.jsx` | The single-pane group detail page (action bar with Contact / Export / Edit). Reference for screens ④ and ④ᵇ. |
+| `screen-output.jsx` | The visual portrait directory (the in-app `view directory` view + the `Export → HTML` artifact). |
+| `prototype-shared.jsx` | Shared helpers (color tokens, fellow data, layout primitives) imported by all four `screen-*.jsx` files. Read this to understand the design tokens; do **not** carry it over verbatim. |
+
+The four `screen-*.jsx` files are **visual reference only** — translate their markup, class names, and behaviour into vanilla JS appended to `app/static/app.js`. The agent must not introduce React or a build step.
+
+## About the design files
+
+The files in this bundle are **design references created in HTML/JSX** — they are prototypes showing the intended look and behavior, not production code to copy directly. They were authored as a presentational design canvas (multiple artboards on one zoomable page) using inline React + Babel; that wrapper is for design review only.
+
+Your job is to **recreate these designs in the target codebase's existing environment**. The target codebase is the EHF Fellows local-first directory:
+
+- **Backend**: Python stdlib only (`http.server`, `sqlite3`, `json`, `pathlib`). No Flask, Django, Express. Single-file server: `app/server.py`.
+- **Frontend**: vanilla JS, no build tools, no npm, no bundlers, no transpilers. Single IIFE in `app/static/app.js`. No modules, no classes.
+- **Data**: SQLite (`app/fellows.db`) with FTS5 for search. ~500 fellows. Two-phase load (list-only first, full rows in background).
+- **Distribution**: this is a **local-only PWA**. Once installed it runs entirely offline; the only thing it ever asks the server for is an updated app build. There is no SaaS backend, no per-user account, no inbound traffic.
+
+Use these constraints faithfully — do not introduce React, a build step, or any new pip dependency. The HTML mocks use React purely as a design tool; **the real implementation must be vanilla JS** appended to `app/static/app.js`, with new HTML markup added to `app/static/index.html` and styles added to whatever CSS file the existing app uses.
+
+### Why every "send" is a `mailto:`
+
+The app has no server-side mail path and never will — this is a closed group that's being wound down, with no new members joining and no contact data being added or changed. Every "Contact the whole group" / "email it to me" affordance is a `mailto:` URL that hands off to the user's own mail client. **This is the intended design, not a workaround.** Don't introduce a server-side send route.
+
+### What's mutable vs read-only
+
+The fellows table (names, emails, phones, citizenship, free-text answers, photos) is **read-only**. The user authored none of it; they just consume it. The only things this feature lets the user create or change are **relationship data** — groups, group memberships, optional per-fellow tags, optional per-fellow private notes. Don't expose any UI that edits a fellow's contact info.
+
+See `CLAUDE.md` and `README.md` in the repo root for the full constraint list, including: `escapeHtml()` for all rendered user data, parameterised `?` SQL placeholders, no auth (local-only), port 8765 fixed.
+
+---
+
+## Fidelity
+
+**High-fidelity.** Colors, spacing, typography, button styles, and interaction states are intentional and match the existing app's visual language (system-ui, `#4a2c6a` purple section heads, plain blue underlined links, light-grey row labels). Recreate pixel-fidelity. Where this spec gives an exact value, use it.
+
+The one explicit *low-fidelity* element: portrait images in the visual directory output use a placeholder SVG silhouette. The real implementation should use `/images/<slug>.jpg|.png` from the existing image lookup endpoint.
+
+---
+
+## What's being built
+
+### User goal
+Enable a fellow to: search the directory → tap a `+` next to names to add them to an in-progress group → name the group → save it → later open the saved group to (a) email everyone, (b) export a PDF or HTML visual directory, or (c) edit the membership.
+
+### New surfaces
+1. **Right rail on the directory page** — "add to a group" composer, always visible.
+2. **`+` / `✓` margin marker** next to every fellow in the directory list.
+3. **"add to group" / "remove from group" link** on the open detail card.
+4. **Edit-mode banner** (yellow) — appears at the top of the directory when editing a saved group.
+5. **`/groups/` page** — list of saved groups (rename, delete, click name to open).
+6. **`/groups/<id>` page** — group detail with a single action bar (Contact / Export / Edit) and a members table.
+7. **Visual directory output** — generated HTML or PDF artifact written to disk on export.
+
+### New data
+Two new tables alongside the existing `fellows`:
+
+```sql
+CREATE TABLE groups (
+  id INTEGER PRIMARY KEY,
+  name TEXT NOT NULL,             -- display name; may start with '#' for tag-named groups
+  note TEXT NOT NULL DEFAULT '',  -- optional cream note shown on the detail page
+  created_at TEXT NOT NULL,       -- ISO date
+  updated_at TEXT NOT NULL
+);
+
+CREATE TABLE group_members (
+  group_id INTEGER NOT NULL REFERENCES groups(id) ON DELETE CASCADE,
+  fellow_record_id TEXT NOT NULL, -- matches fellows.record_id
+  PRIMARY KEY (group_id, fellow_record_id)
+);
+
+CREATE INDEX idx_group_members_group ON group_members(group_id);
+```
+
+In-progress (un-saved) drafts persist to `localStorage` only — the right rail is the draft. No "save draft" affordance.
+
+### New API endpoints
+Append to the existing routes in `app/server.py` (sketch — adapt to existing patterns):
+
+| Method | Path | Purpose |
+|---|---|---|
+| `GET` | `/api/groups` | list all groups: `[{id, name, count, note, created_at}, ...]` |
+| `POST` | `/api/groups` | create: body `{name, note, fellow_record_ids: [...]}` → returns the new group |
+| `GET` | `/api/groups/<id>` | full group: `{id, name, note, created_at, updated_at, members: [{record_id, name}, ...]}` |
+| `PATCH` | `/api/groups/<id>` | update: body may include `name`, `note`, `fellow_record_ids` (full replacement of membership) |
+| `DELETE` | `/api/groups/<id>` | delete |
+| `GET` | `/api/groups/<id>/export?format=pdf|html` | stream the export artifact |
+
+Use parameterised `?` placeholders. No auth.
+
+PATCH must accept a full `fellow_record_ids` list so the **cancel-edits revert** can post the entry-snapshot back. (See "Editing a group" below.)
+
+---
+
+## Design tokens
+
+These match the existing app. Reuse whatever CSS variables the current `app/static/` already defines; if none, hard-code these values exactly.
+
+### Colors
+| Token | Value | Where it's used |
+|---|---|---|
+| `--ink` | `#222` | Body text |
+| `--bg` | `#f5f5f8` | App background |
+| `--paper` | `#fff` | Cards, panels, modals |
+| `--muted` | `#555` | Secondary text |
+| `--border` | `#ccc` | Standard 1px borders, table cell borders |
+| `--row-label` | `#f0f0f0` | Background of `<td>` label cells in detail tables |
+| `--purple` | `#4a2c6a` | Primary buttons, section header backgrounds, active nav |
+| `--purple-dark` | `#3b2355` | Hover, sidebar emphasis text |
+| `--link` | `#0066cc` | All links (always underlined) |
+| `--link-hover` | `#004499` | Link hover |
+| `--warn-bg` | `#fff3cd` | Edit-mode banner background |
+| `--warn-border` | `#ffe69c` | Edit-mode banner border |
+| `--warn-text` | `#664d03` | Edit-mode banner text |
+| `--lavender-soft` | `#faf8fc` | Right-rail bg, action-bar bg, footer status bars |
+| `--lavender-border` | `#dcd6e8` | Right-rail border, action-bar border |
+| `--pill-bg` | `#ede7f3` | Tag pill background |
+| `--pill-text` | `#3b2355` | Tag pill text |
+| `--note-bg` | `#fffbe6` | Cream "my note" / group note callouts |
+| `--note-border` | `#e8d77a` | Cream note dashed border (1px dashed) |
+| `--auto-title-bg` | `#fff7d6` | Auto-following title field cue (group composer) |
+| `--auto-title-text` | `#7a6326` | Auto-following title field text |
+| `--auto-title-icon` | `#a8923a` | ✎ glyph in auto-following title field |
+| `--danger` | `#7a1f1f` | "delete" link color |
+
+### Spacing & sizing
+- Body font: `system-ui, -apple-system, BlinkMacSystemFont, "Segoe UI", Roboto, sans-serif`
+- Code/mono: `ui-monospace, Menlo, monospace`
+- Default font-size: `0.95rem` body, `0.88rem` table rows, `0.85rem` action bars, `0.78rem` meta/captions, `0.7rem` finest helper text
+- Border-radius: `2px` for inputs/panels, `3px` for buttons, `10px` for tag pills, `50%` for portraits
+- Default border: `1px solid var(--border)`
+- Section heads: `0.35em 0.5em` padding, `0.95rem` `font-weight: 600`, white on `--purple`
+- Buttons: `0.3rem 0.7rem` padding (`0.2rem 0.55rem` for `.small`)
+
+### Typography rules
+- All section titles use the purple `SectionHead` pattern (white text on `#4a2c6a`).
+- Links are blue `#0066cc` and **always** underlined (the existing app's convention).
+- Tag pills use the `--pill-*` palette and live at `0.72rem` font-size, 10px border-radius.
+
+---
+
+## Screens
+
+### 1. Directory + group composer (the main page)
+
+The existing directory page gains:
+- A **right rail** ("add to a group") — `flex: 0 0 240px`, `--lavender-soft` background, `--lavender-border` 1px border, `0.55rem 0.6rem` padding.
+- A **margin marker** next to every name in the sidebar list (`width: 16px`, centered, `font-weight: 700`):
+  - `+` in `#bbb` when the fellow is **not** in the group.
+  - `✓` in `var(--purple)` when in the group.
+  - Click toggles. The marker click must `stopPropagation` so it doesn't also trigger the row's "view fellow" navigation.
+- An **"add to group" / "remove from group"** plain-blue link on the open detail card, beside the fellow name.
+- A **"select all N results" bar** (lavender) above the sidebar list, **only visible when results are filtered** (search query present, or "has email only" checked). Hides when the unfiltered list of all 500 is showing — too easy to mis-click. Toggling adds/removes all currently-visible fellows.
+
+The right rail contains, top to bottom:
+
+1. Eyebrow label (uppercase, `0.78rem`, `#7a6f91`, letter-spacing `0.04em`):
+   - `add to a group` (compose mode)
+   - `editing group` (edit mode)
+2. **Title input** with a special "auto-following" state:
+   - **When auto-following** (user hasn't typed yet): background `--auto-title-bg` (cream), text in `--auto-title-text`, a `✎` glyph in `--auto-title-icon` positioned at the left inside the input (`position: absolute; left: 6px`), input padding-left increased to `1.45rem` to clear the glyph. The value mirrors the current search query — capitalised first letter, or the literal `#tag` if the query starts with `#`. Empty if no search.
+   - **When user-edited**: standard white background, no glyph, normal padding. The flip happens on the first `onChange` from the user; once flipped, the title no longer follows the search.
+   - The auto-follow → manual flip is one-way per session. There is no "reset to auto" button.
+3. Helper line beneath (`0.7rem`, `#7a6f91`):
+   - `auto-named — click to rename · N fellows` (auto-following with query)
+   - `type a name, or search to auto-fill · N fellows` (auto-following, empty query)
+   - `N fellows` (user-edited)
+4. **Member chip list** — each picked fellow gets a `0.78rem` row showing the name and a `×` to remove. Removals are **instant**; no undo. Rows ellipsis on overflow. Empty state: `tap + next to a name to add. Search again to add more.`
+5. **Primary button**, full width:
+   - `Create new group` (compose mode) — purple primary. Disabled when `picked.size === 0`.
+   - `Done editing` (edit mode).
+6. Helper line:
+   - `saves immediately to your groups. You can rename and edit it later.` (compose)
+   - `changes save automatically as you add or remove.` (edit)
+
+#### Edit-mode banner
+When the user opens a saved group via "Edit group", the directory loads with a yellow strip across the top:
+
+```
+✎ editing "<group name>" — search and tap + to add more, tap ✓ to remove.   cancel edits
+```
+
+`--warn-bg` background, `--warn-border` bottom border, `--warn-text` text, `0.4rem 0.75rem` padding. The "cancel edits" link is right-aligned and underlined; its `title` attribute reads `revert this group to the state it was in when you opened edit mode`.
+
+In edit mode, the directory **starts unrestricted** — no initial query, "has email only" *unchecked*, all 500 fellows visible. Members of the group are pre-loaded into the right rail with `✓` markers; the user filters/searches as normal to find more.
+
+The detail pane in edit mode shows the **same full fellow record** as the regular directory — name, status, email, tags, "How to Connect" table. No edit-specific simplification.
+
+---
+
+### 2. Groups index page (`/groups/`)
+
+A simple list of saved groups.
+
+- **Top heading**: "Groups" (h2, `1.2rem`).
+- **Empty state**: "No groups yet. Build one from the directory by selecting fellows and tapping Create new group."
+- **Table** (full-width, `0.88rem` rows):
+
+| Column | Content | Notes |
+|---|---|---|
+| Name | underlined blue link → `/groups/<id>` (group detail page) | Clicking the name navigates to detail. |
+| Members | integer count | |
+| Created | ISO date in mono | `0.78rem`, `#666` |
+| Note | first ~60 chars italicised, em-dash if empty | |
+| (actions) | `view directory` · `rename` · `delete` · `edit`, right-aligned | See below. |
+
+#### Row actions, in order:
+1. **`view directory`** — opens the visual portrait directory (the full-page artifact in `screen-output.jsx`). Same view that `Export → HTML` produces, rendered in-app instead of as a downloaded file.
+2. **`rename`** — inline rename. Replaces the name cell with an autofocus `<input>`; saves on blur via `PATCH /api/groups/<id>` with `{name: ...}`. Display name keeps the leading `#` for tag-named groups.
+3. **`delete`** — in `--danger` (`#7a1f1f`). Confirm via native `confirm()` before `DELETE /api/groups/<id>`. Deleting only removes the saved group; fellows themselves are unaffected.
+4. **`edit`** — opens the directory in edit mode (same as clicking "Edit group" on the detail page). Skips a stop on the detail page for users who already know what they want.
+
+- **Footer hint** (`0.78rem`, `#7a6f91`):
+  > Click a group's name to open its detail page — that's where you contact the whole group, export, or edit. Deleting only removes the saved group; the fellows themselves are unaffected.
+
+No "create" button on this page — groups are always created from the directory composer.
+
+---
+
+### 3. Group detail page (`/groups/<id>`)
+
+Single-pane, mobile-first. Whole page constrained to `max-width: 760px; margin: 0 auto`.
+
+Vertical stack:
+
+1. **Breadcrumb** (`0.8rem`, `--muted`):
+   `groups › <group name>`
+2. **Title row** — h2 group name, inline `rename` link, then meta (`N fellows · created <date>`).
+3. **Action bar** (`0.5rem 0.6rem` padding, `--lavender-soft` bg, `--lavender-border` border, flex wrap, gap `8px`). Three peer buttons in this order:
+   - **`✉ Contact the whole group`** — primary (purple). Wraps a `<a href="mailto:?cc=<emails>&subject=<group name>">`. **CC, not BCC** (these are within-group conversations). No expansion menu.
+   - **`⬇ Export a directory`** — default (white) button. Toggles the inline export panel below.
+   - **`✎ Edit group`** — default button. Navigates to the directory in edit mode.
+   - Right-aligned helper text (`0.72rem`, `#7a6f91`): `mailto: opens your client with everyone in CC`.
+4. **Inline export panel** — shown only when "Export a directory" is toggled on. White background, `--lavender-border`. Section head "Export a directory". Three checkboxes laid out flex-wrap with `0.6rem 1.2rem` gap:
+   - PDF directory · `<slug>.pdf` (default checked)
+   - HTML directory · `<slug>/` · view offline
+   - email it to me · your registered address (default checked)
+   - Bottom-right: `cancel` and `Export` buttons.
+   - Slug rule: `name.toLowerCase().replace(/^#/, "").replace(/[^a-z0-9]+/g, "-")`. So `Climate cohort` → `climate-cohort`, `#walking` → `walking`.
+5. **Note callout** (cream `--note-bg` with dashed `--note-border`, italic): the group's note text, with a small `edit` link.
+6. **Members card** — `SectionHead` "Members", then a borderless table where each row is a single cell containing an underlined blue name link. Footer strip (`--lavender-soft`): left "showing all N members", right "tap **Edit group** to add or remove".
+
+There is **no top-right button row, no right sidebar.** All three primary actions live in the single action bar. The page reads identically on mobile.
+
+#### Mailto details
+- `mailto:?cc=<comma-joined-emails>&subject=<group name URL-encoded>`
+- Body left empty (let the user write it).
+- For the visual-directory export, the same bar appears at the top of the exported page, also using `cc=`.
+
+---
+
+### 4. Visual directory output
+
+The artifact written to disk when the user runs Export. This is what gets opened in their browser or attached to an email.
+
+- **Layout**: simple page, max-width content area, off-white `#fafafa` background, system-ui type.
+- **Header**:
+  - h1 group name
+  - meta line (`0.85rem`, `#666`): `N fellows · created <date> · <note text if any>`
+- **Group action bar** (lavender, `#f0ecf5` bg, `#dcd6e8` border, `3px` radius): a single line — `✉ Contact the whole group` link (blue, underlined) using the same `mailto:?cc=` mechanic. Helper text: `opens your mail client with everyone in CC`.
+- **Portrait grid**: CSS grid, `repeat(auto-fill, minmax(120px, 1fr))`, gap `0.9rem`. Each cell:
+  - 1:1 circular portrait (`border-radius: 50%`, 1px `#ccc` border) using `/images/<slug>.jpg|.png`. Fallback: SVG silhouette placeholder (see `screen-output.jsx` for the inline SVG).
+  - Below the portrait: full name in `0.78rem`.
+  - Whole cell is a button — clicking opens the popup.
+- **Popup modal** (centred over a `rgba(30,25,50,0.45)` scrim):
+  - Card, `360px` wide, `1px solid #ccc`, `4px` radius, `1rem 1.1rem` padding.
+  - Top row: 80×80 circular portrait + name (`1.05rem` bold) + tiny caption "real photo from `fellows.db` images table".
+  - Close `×` top-right.
+  - Two-column table (`0.85rem`, label cells `#f0f0f0`):
+    - email (when present) — `mailto:` link
+    - phone — `tel:` link
+    - linkedin — external link
+  - Click outside the card or the `×` closes.
+
+The exported HTML must work **offline** and be **portable** — single folder, no external CDN, all images relative paths.
+
+---
+
+## Interactions & behavior
+
+### Composing a group (full walkthrough)
+
+1. User opens the directory. Right rail is empty: title field shows the auto-following cream + ✎ state with empty value, helper says `type a name, or search to auto-fill · 0 fellows`. Create button is disabled.
+2. User types `environment` in the search box. Sidebar filters. Title field auto-fills to `Environment` (cream + ✎). Bulk-select bar appears above the list.
+3. User clicks `+` next to Tilla Abbitt and Tina Jennen. Markers flip to `✓`. Right-rail member list grows to 2.
+4. User clicks the title field and types `Environment walking club`. Cream/✎ flips off; field is plain white now and stops following the search.
+5. User clears search, types `#walking`. Sidebar shows the 3 fellows tagged `walking`. Title is *not* affected (already user-edited). User clicks `+` next to Tim Derrick, Tim Moor, Trevor Squier.
+6. Right rail shows 5 fellows. User clicks `Create new group`. POST `/api/groups` with `{name: "Environment walking club", fellow_record_ids: [...]}`. Server returns `{id: 5, ...}`. Client navigates to `/groups/5`.
+
+### Editing a group later
+
+1. From `/groups/`, user clicks the group name → `/groups/5` (detail page) → clicks `✎ Edit group`. **Or** clicks `edit` directly from the row actions on the groups page. Both routes navigate to `/?edit=5`.
+2. **On entering edit mode, the client snapshots the current `fellow_record_ids` list** (and `name`, `note`) into in-memory state. Call this `editEntrySnapshot`. This is what "cancel edits" will restore.
+3. Directory loads unrestricted (no query, has-email *off*). Right rail loads in edit mode with the 5 existing members pre-checked. Yellow banner: `✎ editing "Environment walking club" — search and tap + to add more, tap ✓ to remove.   cancel edits`
+4. User searches, taps `+` to add, taps `✓` to remove. Each toggle PATCHes `/api/groups/5` with the new full `fellow_record_ids` list. Auto-saves; no explicit save button. The "Done editing" button at the bottom of the rail simply navigates back to `/groups/5`.
+5. **"cancel edits" link in the banner**:
+   - For a saved group: PATCH `/api/groups/5` with `editEntrySnapshot` (full revert of name/note/membership), clear the right-rail draft, navigate back to `/groups/5`. The group ends up exactly as it was when edit mode started.
+   - For a never-saved new group (the user navigated to edit mode without first saving — currently not possible by design, but guard anyway): clear the right-rail draft, navigate to the directory front page. Nothing was ever created.
+
+The honest tradeoff: between entering edit mode and clicking cancel, other parts of the UI (e.g. the visual directory in another tab) will see in-progress edits because they're auto-saved. For a single-user local-only PWA this is fine; the user is the only observer. Don't try to hide the edits from the user's other views.
+
+### Contacting a group
+- Click the primary `✉ Contact the whole group` button. Browser opens the user's default mail client with `mailto:?cc=<everyone>&subject=<group name>`. Empty body. **CC, not BCC** — these are intentional within-group conversations.
+- This is the **only** mechanism for sending mail. There is no server-side send.
+- Future feature (not in scope now): per-fellow default contact channel + override. Mentioned in design notes only.
+
+### Exporting a group
+- Click `⬇ Export a directory`. Inline panel expands.
+- User checks PDF, HTML, or both, plus optionally "email it to me".
+- Click `Export`. The PWA generates the artifact(s) client-side (or the server hands them back as a stream). Files land in the user's `Downloads/` folder.
+- "email it to me" opens a `mailto:?to=<self>&subject=<group name>&body=<reminder of where the file landed>`. There's no server-side mail send.
+- **PDF**: print-ready single document, alphabetical portrait grid, contact details listed inline.
+- **HTML**: a folder containing `index.html` + `images/`, served entirely via relative paths. Works offline. The HTML version is the exact mock in this bundle's `screen-output.jsx`. This is the same artifact the **`view directory`** row action renders in-app.
+
+### Bulk select
+- Only when filtered (search query OR has-email). Shows: `select all N results` / `deselect all N results`.
+- Toggles **only the currently visible** fellows — does not affect already-picked fellows outside the filter.
+
+### Removals
+- Instant. No confirmation, no undo. Both `×` in the right rail and `✓` toggle in the sidebar work the same way.
+
+### Group naming rules
+- Names may start with `#` (preserved verbatim — useful as a memory cue that the group came from a tag search).
+- Slugification (export filenames only): strip leading `#`, lowercase, replace non-alphanumerics with `-`.
+
+---
+
+## State management (vanilla JS sketch)
+
+Add to the existing IIFE in `app/static/app.js`:
+
+```js
+const groupDraft = {
+  members: new Set(),     // record_ids picked
+  title: "",              // current title value
+  titleEdited: false,     // has the user typed in the title field?
+  editingGroupId: null,   // null when composing new; an id when editing
+  editEntrySnapshot: null // {name, note, fellow_record_ids[]} captured on edit-mode entry
+};
+```
+
+Persist `groupDraft.{members, title, titleEdited}` to `localStorage` under `ehf.group_draft` on every change while composing a new group. Load on page boot. **Clear** on:
+- successful `Create new group` POST
+- successful "cancel edits" of a never-saved draft
+
+`editEntrySnapshot` lives in memory only — it's cleared when edit mode exits via "Done editing" or "cancel edits".
+
+Edit mode keys off `?edit=<id>` in the URL. On boot, if present:
+1. `GET /api/groups/<id>` to populate the rail.
+2. Capture `editEntrySnapshot = {name, note, fellow_record_ids: [...]}`.
+3. Show the yellow banner.
+4. Skip the localStorage draft restore for this session.
+
+Routing is hash- or query-based — match whatever the existing app uses. The existing app already routes `/`, `/about`, etc.; add `/groups`, `/groups/<id>`, `/groups/<id>/directory` (visual view), and `/?edit=<id>` in the same style.
+
+---
+
+## Assets
+
+- **Portrait images**: served by the existing `/images/<slug>.jpg|.png` endpoint. Fallback when missing: inline SVG silhouette (see `screen-output.jsx` line ~67 for the data URI).
+- **Glyphs used inline**: `+`, `✓`, `×`, `✎`, `✉`, `⬇`, `›`. All are Unicode — no icon font, no SVG sprite. This matches the existing app's plain aesthetic.
+
+---
+
+## Files in this bundle
+
+| File | What it is |
+|---|---|
+| `Selection wireframes.html` | The design canvas entry point. Open in a browser to see all artboards. |
+| `prototype-shared.jsx` | Mock data (40 fellow names, 4 saved groups), color tokens (`C.*`), and shared primitives: `SectionHead`, `Tag`, `Btn`, `AppFrame`, `initials()`. **The values in `C.*` are the source of truth for design tokens** — match them exactly. |
+| `screen-browse.jsx` | Directory + group composer (compose and edit modes). The most detailed reference. |
+| `screen-groups.jsx` | Groups index page (list, rename, delete). |
+| `screen-group-detail.jsx` | Group detail page (action bar, export panel, members table). |
+| `screen-output.jsx` | Visual directory export — what the generated HTML file looks like. |
+| `design-canvas.jsx` | Just the design-review wrapper (zoomable canvas with section labels). Ignore for implementation. |
+
+---
+
+## Out of scope (mentioned for context)
+
+- Per-fellow default contact channel + per-group override on "Contact the whole group". Will be added when fellows can tag a default channel on themselves.
+- Sharing a group with another fellow.
+- Importing/exporting groups as JSON.
+- Server-side mail send (currently `mailto:` opens the user's client).
+- Tag editing UX. Tags appear in the design as a future-proofing element (`#walking` search syntax, "your tags" row on the detail card with `+ add`); the actual tag-CRUD UI is a separate feature.

--- a/plans/group_feature/design_handoff_groups_feature/Selection wireframes.html
+++ b/plans/group_feature/design_handoff_groups_feature/Selection wireframes.html
@@ -1,0 +1,145 @@
+<!doctype html>
+<html lang="en">
+<head>
+<meta charset="utf-8" />
+<title>Group selection — hi-fi prototype</title>
+<meta name="viewport" content="width=device-width, initial-scale=1" />
+<style>
+  html, body { margin: 0; padding: 0; background: #ece8e0; height: 100%; }
+  body { font-family: system-ui, sans-serif; color: #222; }
+  * { box-sizing: border-box; }
+  code { font-family: ui-monospace, Menlo, monospace; font-size: 0.82em;
+    background: #f0ecf5; padding: 0 3px; border-radius: 2px; }
+</style>
+</head>
+<body>
+<div id="root"></div>
+
+<script src="https://unpkg.com/react@18.3.1/umd/react.development.js" integrity="sha384-hD6/rw4ppMLGNu3tX5cjIb+uRZ7UkRJ6BPkLpg4hAu/6onKUg4lLsHAs9EBPT82L" crossorigin="anonymous"></script>
+<script src="https://unpkg.com/react-dom@18.3.1/umd/react-dom.development.js" integrity="sha384-u6aeetuaXnQ38mYT8rp6sbXaQe3NL9t+IBXmnYxwkUI2Hw4bsp2Wvmx4yRQF1uAm" crossorigin="anonymous"></script>
+<script src="https://unpkg.com/@babel/standalone@7.29.0/babel.min.js" integrity="sha384-m08KidiNqLdpJqLq95G/LEi8Qvjl/xUYll3QILypMoQ65QorJ9Lvtp2RXYGBFj1y" crossorigin="anonymous"></script>
+
+<script type="text/babel" src="design-canvas.jsx"></script>
+<script type="text/babel" src="prototype-shared.jsx"></script>
+<script type="text/babel" src="screen-browse.jsx"></script>
+<script type="text/babel" src="screen-groups.jsx"></script>
+<script type="text/babel" src="screen-group-detail.jsx"></script>
+<script type="text/babel" src="screen-output.jsx"></script>
+
+<script type="text/babel" data-presets="react">
+function App() {
+  return (
+    <DesignCanvas
+      title="Group selection — hi-fi prototype"
+      subtitle='Walkthrough: build "Environment walking club" from scratch, then review and edit it.'
+      defaultZoom={0.55}
+    >
+      <DCSection
+        id="flow"
+        title='Building "Environment walking club" — temporal flow'
+        description='Search → add a couple → rename the auto-title → search again → add more → Create new group → open the saved group → edit it later.'
+      >
+        <DCArtboard id="s1" label='① search "environment", added Tilla & Tina — title auto-fills "Environment"' width={1280} height={760}>
+          <ScreenBrowse
+            mode="new"
+            initialQuery="environment"
+            initialPicked={["Tilla Abbitt", "Tina Jennen"]}
+            activeName="Tilla Abbitt"
+          />
+        </DCArtboard>
+
+        <DCArtboard id="s2" label='② user renames the title to "Environment walking club" (cream highlight is gone)' width={1280} height={760}>
+          <ScreenBrowse
+            mode="new"
+            initialQuery="environment"
+            initialPicked={["Tilla Abbitt", "Tina Jennen"]}
+            customTitle="Environment walking club"
+            activeName="Tilla Abbitt"
+          />
+        </DCArtboard>
+
+        <DCArtboard id="s3" label='③ second search: "#walking" — real results — adding Tim Derrick, Tim Moor, Trevor Squier' width={1280} height={760}>
+          <ScreenBrowse
+            mode="new"
+            initialQuery="#walking"
+            initialPicked={["Tilla Abbitt", "Tina Jennen", "Tim Derrick", "Tim Moor", "Trevor Squier"]}
+            customTitle="Environment walking club"
+            activeName="Tim Derrick"
+          />
+        </DCArtboard>
+
+        <DCArtboard id="s4a" label='④ click "Create new group" → group detail page — three peer actions, single-pane' width={1280} height={760}>
+          <ScreenGroupDetail name="Environment walking club" count={5} />
+        </DCArtboard>
+
+        <DCArtboard id="s4b" label='④ᵇ same page after clicking "Export a directory" — checkbox panel expands inline' width={1280} height={760}>
+          <ScreenGroupDetail name="Environment walking club" count={5} mode="export" />
+        </DCArtboard>
+
+        <DCArtboard id="s5" label='⑤ later — click "Edit group". Returns to directory unrestricted, yellow banner.' width={1280} height={760}>
+          <ScreenBrowse
+            mode="edit"
+            initialQuery=""
+            initialHasEmail={false}
+            customTitle="Environment walking club"
+            initialPicked={["Tilla Abbitt", "Tina Jennen", "Tim Derrick", "Tim Moor", "Trevor Squier"]}
+            activeName="Tilla Abbitt"
+          />
+        </DCArtboard>
+
+        <DCArtboard id="s6" label='⑥ groups page — saved groups list (click name = open)' width={1280} height={760}>
+          <ScreenGroups />
+        </DCArtboard>
+      </DCSection>
+
+      <DCSection
+        id="output"
+        title='What "View directory" produces'
+        description="Visual directory: alphabetical portrait grid + popup with email/phone/linkedin. 'Send email to all' link at the top opens your mail client with everyone in BCC."
+      >
+        <DCArtboard id="o1" label="visual directory output" width={1100} height={760}>
+          <ScreenOutputPreview />
+        </DCArtboard>
+      </DCSection>
+
+      <DCSection
+        id="notes"
+        title="Decisions baked in"
+        description="From your last round of feedback."
+      >
+        <DCArtboard id="n1" label="notes" width={1100} height={680}>
+          <div style={{ padding: "1.4rem 1.8rem", background: "#fff", height: "100%",
+            fontFamily: "system-ui, sans-serif", fontSize: "0.95rem", lineHeight: 1.55,
+            overflow: "auto" }}>
+            <h2 style={{ margin: 0, fontSize: "1.15rem" }}>Resolved this round</h2>
+            <ul>
+              <li><b>Local-only PWA, no server send.</b> <code>mailto:</code> is the canonical channel — there's no SaaS backend. Same logic for "email it to me" on export. Contact data is read-only by design; only relationship data (groups, tags, notes) is mutable.</li>
+              <li><b>Groups page row actions</b>, in order: <b>view directory</b> · <b>rename</b> · <b>delete</b> · <b>edit</b>. Clicking the group <i>name</i> still opens the detail page (members + Contact / Export / Edit action bar).</li>
+              <li><b>Cancel-edits semantics</b> — banner button is <b>cancel edits</b>. Auto-save stays. On entering edit mode, snapshot the group's current membership; <b>cancel edits</b> reverts the group (DB + rail) to that snapshot. For a never-saved new group, <b>cancel edits</b> clears the right-rail draft and navigates back to the directory front page; nothing is created.</li>
+              <li><b>Group detail is single-pane</b> — one lavender action bar, three peer buttons: <b>✉ Contact the whole group</b> (primary, <code>mailto:?cc=</code>) · <b>⬇ Export a directory</b> · <b>✎ Edit group</b>. Reads identically on mobile.</li>
+              <li><b>BCC → CC</b> for group mails (intentional within-group conversations).</li>
+              <li><b>"View directory" button removed</b> from the detail page — top-left "EHF Fellows" is the canonical home affordance, and "view directory" is now a row action on the groups page.</li>
+              <li><b>Edit mode</b> starts unrestricted (no query, no <i>has email only</i>) and shows the full fellow record in the detail pane.</li>
+              <li><b>Title field cue:</b> soft cream + ✎ while auto-following the search; flips to plain white on first user keystroke.</li>
+              <li><b>Removals are instant</b>; keep <code>#</code> in saved tag-group names; export slugifies (<code>#walking</code> → <code>walking.pdf</code>).</li>
+            </ul>
+
+            <h2 style={{ margin: "1rem 0 0.3rem", fontSize: "1.1rem" }}>What I'd build first</h2>
+            <ol>
+              <li>Schema: <code>groups(id, name, note, created_at, updated_at)</code> + <code>group_members(group_id, fellow_record_id)</code>. Two extra tables, no migration to existing fellows.</li>
+              <li>Right rail in directory + <code>+/✓</code> margin marker. Persist the in-progress draft to localStorage only.</li>
+              <li>Groups page (list + rename + delete) and group detail page (with the email-all bar).</li>
+              <li>Edit mode wiring (open with all members in the rail, yellow banner, auto-save on change).</li>
+              <li><i>Then</i> the visual directory + export.</li>
+            </ol>
+          </div>
+        </DCArtboard>
+      </DCSection>
+    </DesignCanvas>
+  );
+}
+
+ReactDOM.createRoot(document.getElementById("root")).render(<App />);
+</script>
+</body>
+</html>

--- a/plans/group_feature/design_handoff_groups_feature/design-canvas.jsx
+++ b/plans/group_feature/design_handoff_groups_feature/design-canvas.jsx
@@ -1,0 +1,622 @@
+
+// DesignCanvas.jsx — Figma-ish design canvas wrapper
+// Warm gray grid bg + Sections + Artboards + PostIt notes.
+// Artboards are reorderable (grip-drag), labels/titles are inline-editable,
+// and any artboard can be opened in a fullscreen focus overlay (←/→/Esc).
+// State persists to a .design-canvas.state.json sidecar via the host
+// bridge. No assets, no deps.
+//
+// Usage:
+//   <DesignCanvas>
+//     <DCSection id="onboarding" title="Onboarding" subtitle="First-run variants">
+//       <DCArtboard id="a" label="A · Dusk" width={260} height={480}>…</DCArtboard>
+//       <DCArtboard id="b" label="B · Minimal" width={260} height={480}>…</DCArtboard>
+//     </DCSection>
+//   </DesignCanvas>
+
+const DC = {
+  bg: '#f0eee9',
+  grid: 'rgba(0,0,0,0.06)',
+  label: 'rgba(60,50,40,0.7)',
+  title: 'rgba(40,30,20,0.85)',
+  subtitle: 'rgba(60,50,40,0.6)',
+  postitBg: '#fef4a8',
+  postitText: '#5a4a2a',
+  font: '-apple-system, BlinkMacSystemFont, "Segoe UI", system-ui, sans-serif',
+};
+
+// One-time CSS injection (classes are dc-prefixed so they don't collide with
+// the hosted design's own styles).
+if (typeof document !== 'undefined' && !document.getElementById('dc-styles')) {
+  const s = document.createElement('style');
+  s.id = 'dc-styles';
+  s.textContent = [
+    '.dc-editable{cursor:text;outline:none;white-space:nowrap;border-radius:3px;padding:0 2px;margin:0 -2px}',
+    '.dc-editable:focus{background:#fff;box-shadow:0 0 0 1.5px #c96442}',
+    '[data-dc-slot]{transition:transform .18s cubic-bezier(.2,.7,.3,1)}',
+    '[data-dc-slot].dc-dragging{transition:none;z-index:10;pointer-events:none}',
+    '[data-dc-slot].dc-dragging .dc-card{box-shadow:0 12px 40px rgba(0,0,0,.25),0 0 0 2px #c96442;transform:scale(1.02)}',
+    '.dc-card{transition:box-shadow .15s,transform .15s}',
+    '.dc-card *{scrollbar-width:none}',
+    '.dc-card *::-webkit-scrollbar{display:none}',
+    '.dc-labelrow{display:flex;align-items:center;gap:4px;height:24px}',
+    '.dc-grip{cursor:grab;display:flex;align-items:center;padding:5px 4px;border-radius:4px;transition:background .12s}',
+    '.dc-grip:hover{background:rgba(0,0,0,.08)}',
+    '.dc-grip:active{cursor:grabbing}',
+    '.dc-labeltext{cursor:pointer;border-radius:4px;padding:3px 6px;display:flex;align-items:center;transition:background .12s}',
+    '.dc-labeltext:hover{background:rgba(0,0,0,.05)}',
+    '.dc-expand{position:absolute;bottom:100%;right:0;margin-bottom:5px;z-index:2;opacity:0;transition:opacity .12s,background .12s;',
+    '  width:22px;height:22px;border-radius:5px;border:none;cursor:pointer;padding:0;',
+    '  background:transparent;color:rgba(60,50,40,.7);display:flex;align-items:center;justify-content:center}',
+    '.dc-expand:hover{background:rgba(0,0,0,.06);color:#2a251f}',
+    '[data-dc-slot]:hover .dc-expand{opacity:1}',
+  ].join('\n');
+  document.head.appendChild(s);
+}
+
+const DCCtx = React.createContext(null);
+
+// ─────────────────────────────────────────────────────────────
+// DesignCanvas — stateful wrapper around the pan/zoom viewport.
+// Owns runtime state (per-section order, renamed titles/labels, focused
+// artboard). Order/titles/labels persist to a .design-canvas.state.json
+// sidecar next to the HTML. Reads go via plain fetch() so the saved
+// arrangement is visible anywhere the HTML + sidecar are served together
+// (omelette preview, direct link, downloaded zip). Writes go through the
+// host's window.omelette bridge — editing requires the omelette runtime.
+// Focus is ephemeral.
+// ─────────────────────────────────────────────────────────────
+const DC_STATE_FILE = '.design-canvas.state.json';
+
+function DesignCanvas({ children, minScale, maxScale, style }) {
+  const [state, setState] = React.useState({ sections: {}, focus: null });
+  // Hold rendering until the sidecar read settles so the saved order/titles
+  // appear on first paint (no source-order flash). didRead gates writes until
+  // the read settles so the empty initial state can't clobber a slow read;
+  // skipNextWrite suppresses the one echo-write that would otherwise follow
+  // hydration.
+  const [ready, setReady] = React.useState(false);
+  const didRead = React.useRef(false);
+  const skipNextWrite = React.useRef(false);
+
+  React.useEffect(() => {
+    let off = false;
+    fetch('./' + DC_STATE_FILE)
+      .then((r) => (r.ok ? r.json() : null))
+      .then((saved) => {
+        if (off || !saved || !saved.sections) return;
+        skipNextWrite.current = true;
+        setState((s) => ({ ...s, sections: saved.sections }));
+      })
+      .catch(() => {})
+      .finally(() => { didRead.current = true; if (!off) setReady(true); });
+    const t = setTimeout(() => { if (!off) setReady(true); }, 150);
+    return () => { off = true; clearTimeout(t); };
+  }, []);
+
+  React.useEffect(() => {
+    if (!didRead.current) return;
+    if (skipNextWrite.current) { skipNextWrite.current = false; return; }
+    const t = setTimeout(() => {
+      window.omelette?.writeFile(DC_STATE_FILE, JSON.stringify({ sections: state.sections })).catch(() => {});
+    }, 250);
+    return () => clearTimeout(t);
+  }, [state.sections]);
+
+  // Build registries synchronously from children so FocusOverlay can read
+  // them in the same render. Only direct DCSection > DCArtboard children are
+  // walked — wrapping them in other elements opts out of focus/reorder.
+  const registry = {};     // slotId -> { sectionId, artboard }
+  const sectionMeta = {};  // sectionId -> { title, subtitle, slotIds[] }
+  const sectionOrder = [];
+  React.Children.forEach(children, (sec) => {
+    if (!sec || sec.type !== DCSection) return;
+    const sid = sec.props.id ?? sec.props.title;
+    if (!sid) return;
+    sectionOrder.push(sid);
+    const persisted = state.sections[sid] || {};
+    const srcIds = [];
+    React.Children.forEach(sec.props.children, (ab) => {
+      if (!ab || ab.type !== DCArtboard) return;
+      const aid = ab.props.id ?? ab.props.label;
+      if (!aid) return;
+      registry[`${sid}/${aid}`] = { sectionId: sid, artboard: ab };
+      srcIds.push(aid);
+    });
+    const kept = (persisted.order || []).filter((k) => srcIds.includes(k));
+    sectionMeta[sid] = {
+      title: persisted.title ?? sec.props.title,
+      subtitle: sec.props.subtitle,
+      slotIds: [...kept, ...srcIds.filter((k) => !kept.includes(k))],
+    };
+  });
+
+  const api = React.useMemo(() => ({
+    state,
+    section: (id) => state.sections[id] || {},
+    patchSection: (id, p) => setState((s) => ({
+      ...s,
+      sections: { ...s.sections, [id]: { ...s.sections[id], ...(typeof p === 'function' ? p(s.sections[id] || {}) : p) } },
+    })),
+    setFocus: (slotId) => setState((s) => ({ ...s, focus: slotId })),
+  }), [state]);
+
+  // Esc exits focus; any outside pointerdown commits an in-progress rename.
+  React.useEffect(() => {
+    const onKey = (e) => { if (e.key === 'Escape') api.setFocus(null); };
+    const onPd = (e) => {
+      const ae = document.activeElement;
+      if (ae && ae.isContentEditable && !ae.contains(e.target)) ae.blur();
+    };
+    document.addEventListener('keydown', onKey);
+    document.addEventListener('pointerdown', onPd, true);
+    return () => {
+      document.removeEventListener('keydown', onKey);
+      document.removeEventListener('pointerdown', onPd, true);
+    };
+  }, [api]);
+
+  return (
+    <DCCtx.Provider value={api}>
+      <DCViewport minScale={minScale} maxScale={maxScale} style={style}>{ready && children}</DCViewport>
+      {state.focus && registry[state.focus] && (
+        <DCFocusOverlay entry={registry[state.focus]} sectionMeta={sectionMeta} sectionOrder={sectionOrder} />
+      )}
+    </DCCtx.Provider>
+  );
+}
+
+// ─────────────────────────────────────────────────────────────
+// DCViewport — transform-based pan/zoom (internal)
+//
+// Input mapping (Figma-style):
+//   • trackpad pinch  → zoom   (ctrlKey wheel; Safari gesture* events)
+//   • trackpad scroll → pan    (two-finger)
+//   • mouse wheel     → zoom   (notched; distinguished from trackpad scroll)
+//   • middle-drag / primary-drag-on-bg → pan
+//
+// Transform state lives in a ref and is written straight to the DOM
+// (translate3d + will-change) so wheel ticks don't go through React —
+// keeps pans at 60fps on dense canvases.
+// ─────────────────────────────────────────────────────────────
+function DCViewport({ children, minScale = 0.1, maxScale = 8, style = {} }) {
+  const vpRef = React.useRef(null);
+  const worldRef = React.useRef(null);
+  const tf = React.useRef({ x: 0, y: 0, scale: 1 });
+
+  const apply = React.useCallback(() => {
+    const { x, y, scale } = tf.current;
+    const el = worldRef.current;
+    if (el) el.style.transform = `translate3d(${x}px, ${y}px, 0) scale(${scale})`;
+  }, []);
+
+  React.useEffect(() => {
+    const vp = vpRef.current;
+    if (!vp) return;
+
+    const zoomAt = (cx, cy, factor) => {
+      const r = vp.getBoundingClientRect();
+      const px = cx - r.left, py = cy - r.top;
+      const t = tf.current;
+      const next = Math.min(maxScale, Math.max(minScale, t.scale * factor));
+      const k = next / t.scale;
+      // keep the world point under the cursor fixed
+      t.x = px - (px - t.x) * k;
+      t.y = py - (py - t.y) * k;
+      t.scale = next;
+      apply();
+    };
+
+    // Mouse-wheel vs trackpad-scroll heuristic. A physical wheel sends
+    // line-mode deltas (Firefox) or large integer pixel deltas with no X
+    // component (Chrome/Safari, typically multiples of 100/120). Trackpad
+    // two-finger scroll sends small/fractional pixel deltas, often with
+    // non-zero deltaX. ctrlKey is set by the browser for trackpad pinch.
+    const isMouseWheel = (e) =>
+      e.deltaMode !== 0 ||
+      (e.deltaX === 0 && Number.isInteger(e.deltaY) && Math.abs(e.deltaY) >= 40);
+
+    const onWheel = (e) => {
+      e.preventDefault();
+      if (isGesturing) return; // Safari: gesture* owns the pinch — discard concurrent wheels
+      if (e.ctrlKey) {
+        // trackpad pinch (or explicit ctrl+wheel)
+        zoomAt(e.clientX, e.clientY, Math.exp(-e.deltaY * 0.01));
+      } else if (isMouseWheel(e)) {
+        // notched mouse wheel — fixed-ratio step per click
+        zoomAt(e.clientX, e.clientY, Math.exp(-Math.sign(e.deltaY) * 0.18));
+      } else {
+        // trackpad two-finger scroll — pan
+        tf.current.x -= e.deltaX;
+        tf.current.y -= e.deltaY;
+        apply();
+      }
+    };
+
+    // Safari sends native gesture* events for trackpad pinch with a smooth
+    // e.scale; preferring these over the ctrl+wheel fallback gives a much
+    // better feel there. No-ops on other browsers. Safari also fires
+    // ctrlKey wheel events during the same pinch — isGesturing makes
+    // onWheel drop those entirely so they neither zoom nor pan.
+    let gsBase = 1;
+    let isGesturing = false;
+    const onGestureStart = (e) => { e.preventDefault(); isGesturing = true; gsBase = tf.current.scale; };
+    const onGestureChange = (e) => {
+      e.preventDefault();
+      zoomAt(e.clientX, e.clientY, (gsBase * e.scale) / tf.current.scale);
+    };
+    const onGestureEnd = (e) => { e.preventDefault(); isGesturing = false; };
+
+    // Drag-pan: middle button anywhere, or primary button on canvas
+    // background (anything that isn't an artboard or an inline editor).
+    let drag = null;
+    const onPointerDown = (e) => {
+      const onBg = !e.target.closest('[data-dc-slot], .dc-editable');
+      if (!(e.button === 1 || (e.button === 0 && onBg))) return;
+      e.preventDefault();
+      vp.setPointerCapture(e.pointerId);
+      drag = { id: e.pointerId, lx: e.clientX, ly: e.clientY };
+      vp.style.cursor = 'grabbing';
+    };
+    const onPointerMove = (e) => {
+      if (!drag || e.pointerId !== drag.id) return;
+      tf.current.x += e.clientX - drag.lx;
+      tf.current.y += e.clientY - drag.ly;
+      drag.lx = e.clientX; drag.ly = e.clientY;
+      apply();
+    };
+    const onPointerUp = (e) => {
+      if (!drag || e.pointerId !== drag.id) return;
+      vp.releasePointerCapture(e.pointerId);
+      drag = null;
+      vp.style.cursor = '';
+    };
+
+    vp.addEventListener('wheel', onWheel, { passive: false });
+    vp.addEventListener('gesturestart', onGestureStart, { passive: false });
+    vp.addEventListener('gesturechange', onGestureChange, { passive: false });
+    vp.addEventListener('gestureend', onGestureEnd, { passive: false });
+    vp.addEventListener('pointerdown', onPointerDown);
+    vp.addEventListener('pointermove', onPointerMove);
+    vp.addEventListener('pointerup', onPointerUp);
+    vp.addEventListener('pointercancel', onPointerUp);
+    return () => {
+      vp.removeEventListener('wheel', onWheel);
+      vp.removeEventListener('gesturestart', onGestureStart);
+      vp.removeEventListener('gesturechange', onGestureChange);
+      vp.removeEventListener('gestureend', onGestureEnd);
+      vp.removeEventListener('pointerdown', onPointerDown);
+      vp.removeEventListener('pointermove', onPointerMove);
+      vp.removeEventListener('pointerup', onPointerUp);
+      vp.removeEventListener('pointercancel', onPointerUp);
+    };
+  }, [apply, minScale, maxScale]);
+
+  const gridSvg = `url("data:image/svg+xml,%3Csvg width='120' height='120' xmlns='http://www.w3.org/2000/svg'%3E%3Cpath d='M120 0H0v120' fill='none' stroke='${encodeURIComponent(DC.grid)}' stroke-width='1'/%3E%3C/svg%3E")`;
+  return (
+    <div
+      ref={vpRef}
+      className="design-canvas"
+      style={{
+        height: '100vh', width: '100vw',
+        background: DC.bg,
+        overflow: 'hidden',
+        overscrollBehavior: 'none',
+        touchAction: 'none',
+        position: 'relative',
+        fontFamily: DC.font,
+        boxSizing: 'border-box',
+        ...style,
+      }}
+    >
+      <div
+        ref={worldRef}
+        style={{
+          position: 'absolute', top: 0, left: 0,
+          transformOrigin: '0 0',
+          willChange: 'transform',
+          width: 'max-content', minWidth: '100%',
+          minHeight: '100%',
+          padding: '60px 0 80px',
+        }}
+      >
+        <div style={{ position: 'absolute', inset: -6000, backgroundImage: gridSvg, backgroundSize: '120px 120px', pointerEvents: 'none', zIndex: -1 }} />
+        {children}
+      </div>
+    </div>
+  );
+}
+
+// ─────────────────────────────────────────────────────────────
+// DCSection — editable title + h-row of artboards in persisted order
+// ─────────────────────────────────────────────────────────────
+function DCSection({ id, title, subtitle, children, gap = 48 }) {
+  const ctx = React.useContext(DCCtx);
+  const sid = id ?? title;
+  const all = React.Children.toArray(children);
+  const artboards = all.filter((c) => c && c.type === DCArtboard);
+  const rest = all.filter((c) => !(c && c.type === DCArtboard));
+  const srcOrder = artboards.map((a) => a.props.id ?? a.props.label);
+  const sec = (ctx && sid && ctx.section(sid)) || {};
+
+  const order = React.useMemo(() => {
+    const kept = (sec.order || []).filter((k) => srcOrder.includes(k));
+    return [...kept, ...srcOrder.filter((k) => !kept.includes(k))];
+  }, [sec.order, srcOrder.join('|')]);
+
+  const byId = Object.fromEntries(artboards.map((a) => [a.props.id ?? a.props.label, a]));
+
+  return (
+    <div data-dc-section={sid} style={{ marginBottom: 80, position: 'relative' }}>
+      <div style={{ padding: '0 60px 56px' }}>
+        <DCEditable tag="div" value={sec.title ?? title}
+          onChange={(v) => ctx && sid && ctx.patchSection(sid, { title: v })}
+          style={{ fontSize: 28, fontWeight: 600, color: DC.title, letterSpacing: -0.4, marginBottom: 6, display: 'inline-block' }} />
+        {subtitle && <div style={{ fontSize: 16, color: DC.subtitle }}>{subtitle}</div>}
+      </div>
+      <div style={{ display: 'flex', gap, padding: '0 60px', alignItems: 'flex-start', width: 'max-content' }}>
+        {order.map((k) => (
+          <DCArtboardFrame key={k} sectionId={sid} artboard={byId[k]} order={order}
+            label={(sec.labels || {})[k] ?? byId[k].props.label}
+            onRename={(v) => ctx && ctx.patchSection(sid, (x) => ({ labels: { ...x.labels, [k]: v } }))}
+            onReorder={(next) => ctx && ctx.patchSection(sid, { order: next })}
+            onFocus={() => ctx && ctx.setFocus(`${sid}/${k}`)} />
+        ))}
+      </div>
+      {rest}
+    </div>
+  );
+}
+
+// DCArtboard — marker; rendered by DCArtboardFrame via DCSection.
+function DCArtboard() { return null; }
+
+function DCArtboardFrame({ sectionId, artboard, label, order, onRename, onReorder, onFocus }) {
+  const { id: rawId, label: rawLabel, width = 260, height = 480, children, style = {} } = artboard.props;
+  const id = rawId ?? rawLabel;
+  const ref = React.useRef(null);
+
+  // Live drag-reorder: dragged card sticks to cursor; siblings slide into
+  // their would-be slots in real time via transforms. DOM order only
+  // changes on drop.
+  const onGripDown = (e) => {
+    e.preventDefault(); e.stopPropagation();
+    const me = ref.current;
+    // translateX is applied in local (pre-scale) space but pointer deltas and
+    // getBoundingClientRect().left are screen-space — divide by the viewport's
+    // current scale so the dragged card tracks the cursor at any zoom level.
+    const scale = me.getBoundingClientRect().width / me.offsetWidth || 1;
+    const peers = Array.from(document.querySelectorAll(`[data-dc-section="${sectionId}"] [data-dc-slot]`));
+    const homes = peers.map((el) => ({ el, id: el.dataset.dcSlot, x: el.getBoundingClientRect().left }));
+    const slotXs = homes.map((h) => h.x);
+    const startIdx = order.indexOf(id);
+    const startX = e.clientX;
+    let liveOrder = order.slice();
+    me.classList.add('dc-dragging');
+
+    const layout = () => {
+      for (const h of homes) {
+        if (h.id === id) continue;
+        const slot = liveOrder.indexOf(h.id);
+        h.el.style.transform = `translateX(${(slotXs[slot] - h.x) / scale}px)`;
+      }
+    };
+
+    const move = (ev) => {
+      const dx = ev.clientX - startX;
+      me.style.transform = `translateX(${dx / scale}px)`;
+      const cur = homes[startIdx].x + dx;
+      let nearest = 0, best = Infinity;
+      for (let i = 0; i < slotXs.length; i++) {
+        const d = Math.abs(slotXs[i] - cur);
+        if (d < best) { best = d; nearest = i; }
+      }
+      if (liveOrder.indexOf(id) !== nearest) {
+        liveOrder = order.filter((k) => k !== id);
+        liveOrder.splice(nearest, 0, id);
+        layout();
+      }
+    };
+
+    const up = () => {
+      document.removeEventListener('pointermove', move);
+      document.removeEventListener('pointerup', up);
+      const finalSlot = liveOrder.indexOf(id);
+      me.classList.remove('dc-dragging');
+      me.style.transform = `translateX(${(slotXs[finalSlot] - homes[startIdx].x) / scale}px)`;
+      // After the settle transition, kill transitions + clear transforms +
+      // commit the reorder in the same frame so there's no visual snap-back.
+      setTimeout(() => {
+        for (const h of homes) { h.el.style.transition = 'none'; h.el.style.transform = ''; }
+        if (liveOrder.join('|') !== order.join('|')) onReorder(liveOrder);
+        requestAnimationFrame(() => requestAnimationFrame(() => {
+          for (const h of homes) h.el.style.transition = '';
+        }));
+      }, 180);
+    };
+    document.addEventListener('pointermove', move);
+    document.addEventListener('pointerup', up);
+  };
+
+  return (
+    <div ref={ref} data-dc-slot={id} style={{ position: 'relative', flexShrink: 0 }}>
+      <div className="dc-labelrow" style={{ position: 'absolute', bottom: '100%', left: -4, marginBottom: 4, color: DC.label }}>
+        <div className="dc-grip" onPointerDown={onGripDown} title="Drag to reorder">
+          <svg width="9" height="13" viewBox="0 0 9 13" fill="currentColor"><circle cx="2" cy="2" r="1.1"/><circle cx="7" cy="2" r="1.1"/><circle cx="2" cy="6.5" r="1.1"/><circle cx="7" cy="6.5" r="1.1"/><circle cx="2" cy="11" r="1.1"/><circle cx="7" cy="11" r="1.1"/></svg>
+        </div>
+        <div className="dc-labeltext" onClick={onFocus} title="Click to focus">
+          <DCEditable value={label} onChange={onRename} onClick={(e) => e.stopPropagation()}
+            style={{ fontSize: 15, fontWeight: 500, color: DC.label, lineHeight: 1 }} />
+        </div>
+      </div>
+      <button className="dc-expand" onClick={onFocus} onPointerDown={(e) => e.stopPropagation()} title="Focus">
+        <svg width="12" height="12" viewBox="0 0 12 12" fill="none" stroke="currentColor" strokeWidth="1.6" strokeLinecap="round"><path d="M7 1h4v4M5 11H1V7M11 1L7.5 4.5M1 11l3.5-3.5"/></svg>
+      </button>
+      <div className="dc-card"
+        style={{ borderRadius: 2, boxShadow: '0 1px 3px rgba(0,0,0,.08),0 4px 16px rgba(0,0,0,.06)', overflow: 'hidden', width, height, background: '#fff', ...style }}>
+        {children || <div style={{ height: '100%', display: 'flex', alignItems: 'center', justifyContent: 'center', color: '#bbb', fontSize: 13, fontFamily: DC.font }}>{id}</div>}
+      </div>
+    </div>
+  );
+}
+
+// Inline rename — commits on blur or Enter.
+function DCEditable({ value, onChange, style, tag = 'span', onClick }) {
+  const T = tag;
+  return (
+    <T className="dc-editable" contentEditable suppressContentEditableWarning
+      onClick={onClick}
+      onPointerDown={(e) => e.stopPropagation()}
+      onBlur={(e) => onChange && onChange(e.currentTarget.textContent)}
+      onKeyDown={(e) => { if (e.key === 'Enter') { e.preventDefault(); e.currentTarget.blur(); } }}
+      style={style}>{value}</T>
+  );
+}
+
+// ─────────────────────────────────────────────────────────────
+// Focus mode — overlay one artboard; ←/→ within section, ↑/↓ across
+// sections, Esc or backdrop click to exit.
+// ─────────────────────────────────────────────────────────────
+function DCFocusOverlay({ entry, sectionMeta, sectionOrder }) {
+  const ctx = React.useContext(DCCtx);
+  const { sectionId, artboard } = entry;
+  const sec = ctx.section(sectionId);
+  const meta = sectionMeta[sectionId];
+  const peers = meta.slotIds;
+  const aid = artboard.props.id ?? artboard.props.label;
+  const idx = peers.indexOf(aid);
+  const secIdx = sectionOrder.indexOf(sectionId);
+
+  const go = (d) => { const n = peers[(idx + d + peers.length) % peers.length]; if (n) ctx.setFocus(`${sectionId}/${n}`); };
+  const goSection = (d) => {
+    const ns = sectionOrder[(secIdx + d + sectionOrder.length) % sectionOrder.length];
+    const first = sectionMeta[ns] && sectionMeta[ns].slotIds[0];
+    if (first) ctx.setFocus(`${ns}/${first}`);
+  };
+
+  React.useEffect(() => {
+    const k = (e) => {
+      if (e.key === 'ArrowLeft') { e.preventDefault(); go(-1); }
+      if (e.key === 'ArrowRight') { e.preventDefault(); go(1); }
+      if (e.key === 'ArrowUp') { e.preventDefault(); goSection(-1); }
+      if (e.key === 'ArrowDown') { e.preventDefault(); goSection(1); }
+    };
+    document.addEventListener('keydown', k);
+    return () => document.removeEventListener('keydown', k);
+  });
+
+  const { width = 260, height = 480, children } = artboard.props;
+  const [vp, setVp] = React.useState({ w: window.innerWidth, h: window.innerHeight });
+  React.useEffect(() => { const r = () => setVp({ w: window.innerWidth, h: window.innerHeight }); window.addEventListener('resize', r); return () => window.removeEventListener('resize', r); }, []);
+  const scale = Math.max(0.1, Math.min((vp.w - 200) / width, (vp.h - 260) / height, 2));
+
+  const [ddOpen, setDd] = React.useState(false);
+  const Arrow = ({ dir, onClick }) => (
+    <button onClick={(e) => { e.stopPropagation(); onClick(); }}
+      style={{ position: 'absolute', top: '50%', [dir]: 28, transform: 'translateY(-50%)',
+        border: 'none', background: 'rgba(255,255,255,.08)', color: 'rgba(255,255,255,.9)',
+        width: 44, height: 44, borderRadius: 22, fontSize: 18, cursor: 'pointer',
+        display: 'flex', alignItems: 'center', justifyContent: 'center', transition: 'background .15s' }}
+      onMouseEnter={(e) => (e.currentTarget.style.background = 'rgba(255,255,255,.18)')}
+      onMouseLeave={(e) => (e.currentTarget.style.background = 'rgba(255,255,255,.08)')}>
+      <svg width="18" height="18" viewBox="0 0 18 18" fill="none" stroke="currentColor" strokeWidth="2" strokeLinecap="round">
+        <path d={dir === 'left' ? 'M11 3L5 9l6 6' : 'M7 3l6 6-6 6'} /></svg>
+    </button>
+  );
+
+  // Portal to body so position:fixed is the real viewport regardless of any
+  // transform on DesignCanvas's ancestors (including the canvas zoom itself).
+  return ReactDOM.createPortal(
+    <div onClick={() => ctx.setFocus(null)}
+      onWheel={(e) => e.preventDefault()}
+      style={{ position: 'fixed', inset: 0, zIndex: 100, background: 'rgba(24,20,16,.6)', backdropFilter: 'blur(14px)',
+        fontFamily: DC.font, color: '#fff' }}>
+
+      {/* top bar: section dropdown (left) · close (right) */}
+      <div onClick={(e) => e.stopPropagation()}
+        style={{ position: 'absolute', top: 0, left: 0, right: 0, height: 72, display: 'flex', alignItems: 'flex-start', padding: '16px 20px 0', gap: 16 }}>
+        <div style={{ position: 'relative' }}>
+          <button onClick={() => setDd((o) => !o)}
+            style={{ border: 'none', background: 'transparent', color: '#fff', cursor: 'pointer', padding: '6px 8px',
+              borderRadius: 6, textAlign: 'left', fontFamily: 'inherit' }}>
+            <span style={{ display: 'flex', alignItems: 'center', gap: 8 }}>
+              <span style={{ fontSize: 18, fontWeight: 600, letterSpacing: -0.3 }}>{meta.title}</span>
+              <svg width="11" height="11" viewBox="0 0 11 11" fill="none" stroke="currentColor" strokeWidth="1.8" strokeLinecap="round" style={{ opacity: .7 }}><path d="M2 4l3.5 3.5L9 4"/></svg>
+            </span>
+            {meta.subtitle && <span style={{ display: 'block', fontSize: 13, opacity: .6, fontWeight: 400, marginTop: 2 }}>{meta.subtitle}</span>}
+          </button>
+          {ddOpen && (
+            <div style={{ position: 'absolute', top: '100%', left: 0, marginTop: 4, background: '#2a251f', borderRadius: 8,
+              boxShadow: '0 8px 32px rgba(0,0,0,.4)', padding: 4, minWidth: 200, zIndex: 10 }}>
+              {sectionOrder.map((sid) => (
+                <button key={sid} onClick={() => { setDd(false); const f = sectionMeta[sid].slotIds[0]; if (f) ctx.setFocus(`${sid}/${f}`); }}
+                  style={{ display: 'block', width: '100%', textAlign: 'left', border: 'none', cursor: 'pointer',
+                    background: sid === sectionId ? 'rgba(255,255,255,.1)' : 'transparent', color: '#fff',
+                    padding: '8px 12px', borderRadius: 5, fontSize: 14, fontWeight: sid === sectionId ? 600 : 400, fontFamily: 'inherit' }}>
+                  {sectionMeta[sid].title}
+                </button>
+              ))}
+            </div>
+          )}
+        </div>
+        <div style={{ flex: 1 }} />
+        <button onClick={() => ctx.setFocus(null)}
+          onMouseEnter={(e) => (e.currentTarget.style.background = 'rgba(255,255,255,.12)')}
+          onMouseLeave={(e) => (e.currentTarget.style.background = 'transparent')}
+          style={{ border: 'none', background: 'transparent', color: 'rgba(255,255,255,.7)', width: 32, height: 32,
+            borderRadius: 16, fontSize: 20, cursor: 'pointer', lineHeight: 1, transition: 'background .12s' }}>×</button>
+      </div>
+
+      {/* card centered, label + index below — only the card itself stops
+          propagation so any backdrop click (including the margins around
+          the card) exits focus */}
+      <div
+        style={{ position: 'absolute', top: 64, bottom: 56, left: 100, right: 100, display: 'flex', flexDirection: 'column', alignItems: 'center', justifyContent: 'center', gap: 16 }}>
+        <div onClick={(e) => e.stopPropagation()} style={{ width: width * scale, height: height * scale, position: 'relative' }}>
+          <div style={{ width, height, transform: `scale(${scale})`, transformOrigin: 'top left', background: '#fff', borderRadius: 2, overflow: 'hidden',
+            boxShadow: '0 20px 80px rgba(0,0,0,.4)' }}>
+            {children || <div style={{ height: '100%', display: 'flex', alignItems: 'center', justifyContent: 'center', color: '#bbb' }}>{aid}</div>}
+          </div>
+        </div>
+        <div onClick={(e) => e.stopPropagation()} style={{ fontSize: 14, fontWeight: 500, opacity: .85, textAlign: 'center' }}>
+          {(sec.labels || {})[aid] ?? artboard.props.label}
+          <span style={{ opacity: .5, marginLeft: 10, fontVariantNumeric: 'tabular-nums' }}>{idx + 1} / {peers.length}</span>
+        </div>
+      </div>
+
+      <Arrow dir="left" onClick={() => go(-1)} />
+      <Arrow dir="right" onClick={() => go(1)} />
+
+      {/* dots */}
+      <div onClick={(e) => e.stopPropagation()}
+        style={{ position: 'absolute', bottom: 20, left: '50%', transform: 'translateX(-50%)', display: 'flex', gap: 8 }}>
+        {peers.map((p, i) => (
+          <button key={p} onClick={() => ctx.setFocus(`${sectionId}/${p}`)}
+            style={{ border: 'none', padding: 0, cursor: 'pointer', width: 6, height: 6, borderRadius: 3,
+              background: i === idx ? '#fff' : 'rgba(255,255,255,.3)' }} />
+        ))}
+      </div>
+    </div>,
+    document.body,
+  );
+}
+
+// ─────────────────────────────────────────────────────────────
+// Post-it — absolute-positioned sticky note
+// ─────────────────────────────────────────────────────────────
+function DCPostIt({ children, top, left, right, bottom, rotate = -2, width = 180 }) {
+  return (
+    <div style={{
+      position: 'absolute', top, left, right, bottom, width,
+      background: DC.postitBg, padding: '14px 16px',
+      fontFamily: '"Comic Sans MS", "Marker Felt", "Segoe Print", cursive',
+      fontSize: 14, lineHeight: 1.4, color: DC.postitText,
+      boxShadow: '0 2px 8px rgba(0,0,0,0.12), 0 1px 2px rgba(0,0,0,0.08)',
+      transform: `rotate(${rotate}deg)`,
+      zIndex: 5,
+    }}>{children}</div>
+  );
+}
+
+Object.assign(window, { DesignCanvas, DCSection, DCArtboard, DCPostIt });
+

--- a/plans/group_feature/design_handoff_groups_feature/prototype-shared.jsx
+++ b/plans/group_feature/design_handoff_groups_feature/prototype-shared.jsx
@@ -1,0 +1,161 @@
+// Shared data + small primitives matched to the existing app's visual language:
+// system-ui, purple #4a2c6a section heads, plain blue underlined links,
+// table-row label/value pattern, light grey #f0f0f0 row labels, modest density.
+
+const FELLOWS = [
+  { name: "Tatyana Mikayilova", tags: ["environment", "policy"], email: true },
+  { name: "Tejas Viswanath", tags: ["fintech"], email: true },
+  { name: "Teresa Tepania-Ashton", tags: ["indigenous", "policy"], email: true },
+  { name: "Teruhide Sato", tags: ["investment", "fintech"], email: true },
+  { name: "Tesh Randall", tags: ["food", "environment"], email: true },
+  { name: "Tessa Vincent", tags: ["arts"], email: false },
+  { name: "Thabiso Mashaba", tags: ["education", "africa"], email: true },
+  { name: "Thea La Grou", tags: ["arts", "media"], email: true },
+  { name: "Thiago Canellas", tags: ["fintech"], email: true },
+  { name: "Thomas Staggs", tags: ["media"], email: false },
+  { name: "Tilla Abbitt", tags: ["food", "environment"], email: true },
+  { name: "Tillie Walton", tags: ["adventure", "environment"], email: true },
+  { name: "Tim Chang", tags: ["investment", "wellbeing"], email: true },
+  { name: "Tim Derrick", tags: ["pickleball", "wellbeing"], email: true },
+  { name: "Tim Ferriss", tags: ["wellbeing", "media"], email: true },
+  { name: "Tim Hawkey", tags: ["health", "design"], email: true },
+  { name: "Tim Moor", tags: ["pickleball"], email: true },
+  { name: "Tim Pare", tags: ["environment"], email: true },
+  { name: "Timothy Allan", tags: ["design"], email: true },
+  { name: "Tina Jennen", tags: ["energy", "environment"], email: true },
+  { name: "Tjiu Liang Chua", tags: ["fintech"], email: false },
+  { name: "Todd Porter", tags: ["design"], email: true },
+  { name: "Tony Lai", tags: ["legal", "policy"], email: true },
+  { name: "Topaz Adizes", tags: ["arts", "media"], email: true },
+  { name: "Tory Patterson", tags: ["investment"], email: true },
+  { name: "Tracy Chou", tags: ["tech", "policy"], email: true },
+  { name: "Trevor Squier", tags: ["pickleball"], email: true },
+  { name: "Tristan Harris", tags: ["tech", "policy"], email: true },
+  { name: "Trushar Khetia", tags: ["africa", "investment"], email: true },
+  { name: "Udit Shah", tags: ["food"], email: true },
+  { name: "Uri Lopatin", tags: ["health"], email: true },
+  { name: "Usman Iftikhar", tags: ["education"], email: true },
+  { name: "Vanessa Coleman", tags: ["policy"], email: true },
+  { name: "Vanessa Paranjothy", tags: ["food"], email: true },
+  { name: "Venetia Pristavec", tags: ["design"], email: true },
+  { name: "Veronica H-Stevenson", tags: ["education"], email: false },
+  { name: "Vicky Robertson", tags: ["environment"], email: true },
+  { name: "Victor Zonana", tags: ["health", "policy"], email: true },
+  { name: "Vienna Nordstrom", tags: ["arts"], email: true },
+  { name: "Vishal Chaddha", tags: ["fintech"], email: true },
+];
+
+const SAVED_GROUPS = [
+  { id: "g_001", name: "Climate cohort", count: 14, created: "2026-04-12", note: "for the Wellington roundtable" },
+  { id: "g_002", name: "Pickleball lunch crew", count: 4, created: "2026-04-18", note: "" },
+  { id: "g_003", name: "Tāmaki design folks", count: 9, created: "2026-04-20", note: "intro book for Aroha" },
+  { id: "g_004", name: "Fintech intros — Thiago", count: 6, created: "2026-04-23", note: "" },
+];
+
+function initials(name) {
+  const parts = name.split(/[\s-]+/).filter(Boolean);
+  return ((parts[0]?.[0] || "") + (parts[1]?.[0] || "")).toUpperCase();
+}
+
+// Match the app's swatches
+const C = {
+  bg: "#f5f5f8",
+  paper: "#fff",
+  ink: "#222",
+  muted: "#555",
+  border: "#ccc",
+  rowLabel: "#f0f0f0",
+  purple: "#4a2c6a",
+  purpleDark: "#3b2355",
+  link: "#0066cc",
+  linkHover: "#004499",
+  warnBg: "#fff3cd",
+  warnBorder: "#ffe69c",
+  warnText: "#664d03",
+  lightLavender: "#faf8fc",
+  lavenderBorder: "#dcd6e8",
+  pillBg: "#ede7f3",
+  pillText: "#3b2355",
+};
+
+// One-line section header in the app's purple style
+function SectionHead({ children, secondary, style }) {
+  return (
+    <div style={{
+      padding: "0.35em 0.5em",
+      background: secondary ? "#e8e8e8" : C.purple,
+      color: secondary ? "#333" : "#fff",
+      fontSize: "0.95rem",
+      fontWeight: 600,
+      ...style
+    }}>{children}</div>
+  );
+}
+
+// Tag pill, low-key
+function Tag({ children, onClick, removable }) {
+  return (
+    <span style={{
+      display: "inline-flex", alignItems: "center", gap: 4,
+      padding: "1px 7px", marginRight: 4,
+      fontSize: "0.72rem", fontWeight: 500,
+      background: C.pillBg, color: C.pillText,
+      border: `1px solid ${C.lavenderBorder}`, borderRadius: 10,
+      cursor: onClick ? "pointer" : "default"
+    }} onClick={onClick}>
+      {children}{removable && <span style={{ opacity: 0.6 }}>×</span>}
+    </span>
+  );
+}
+
+// Plain app-style button
+function Btn({ children, onClick, primary, danger, small, disabled, style }) {
+  const base = {
+    padding: small ? "0.2rem 0.55rem" : "0.3rem 0.7rem",
+    fontSize: small ? "0.78rem" : "0.85rem",
+    borderRadius: 3, cursor: disabled ? "not-allowed" : "pointer",
+    fontFamily: "inherit", lineHeight: 1.3,
+    opacity: disabled ? 0.5 : 1,
+  };
+  let scheme;
+  if (primary) scheme = { background: C.purple, color: "#fff", border: `1px solid ${C.purple}` };
+  else if (danger) scheme = { background: "#fff", color: "#7a1f1f", border: "1px solid #c9a3a3" };
+  else scheme = { background: "#fff", color: "#333", border: `1px solid ${C.border}` };
+  return <button onClick={disabled ? undefined : onClick} style={{ ...base, ...scheme, ...style }}>{children}</button>;
+}
+
+// Small framing for each artboard so they all read as the same app
+function AppFrame({ children, page = "directory", title = "Confidential — Fellows Local-Only Directory" }) {
+  return (
+    <div style={{
+      width: "100%", height: "100%", background: C.bg, color: C.ink,
+      fontFamily: 'system-ui, -apple-system, BlinkMacSystemFont, "Segoe UI", Roboto, sans-serif',
+      fontSize: "0.95rem", display: "flex", flexDirection: "column",
+      overflow: "hidden"
+    }}>
+      {/* Top bar */}
+      <div style={{
+        padding: "0.55rem 0.75rem", borderBottom: `1px solid ${C.border}`,
+        background: "#fff", display: "flex", alignItems: "center", gap: "1rem", flexShrink: 0
+      }}>
+        <div style={{ fontSize: "0.95rem", fontWeight: 600 }}>EHF Fellows</div>
+        <nav style={{ display: "flex", gap: "0.9rem", fontSize: "0.85rem" }}>
+          <a href="#" style={{ color: page === "directory" ? C.purple : C.link,
+            fontWeight: page === "directory" ? 600 : 400,
+            textDecoration: page === "directory" ? "none" : "underline" }}>directory</a>
+          <a href="#" style={{ color: page === "groups" ? C.purple : C.link,
+            fontWeight: page === "groups" ? 600 : 400,
+            textDecoration: page === "groups" ? "none" : "underline" }}>groups</a>
+          <a href="#" style={{ color: C.link, textDecoration: "underline" }}>about</a>
+        </nav>
+        <div style={{ marginLeft: "auto", fontSize: "0.7rem", color: "#7a6f91",
+          fontFamily: "ui-monospace, Menlo, monospace" }}>{title}</div>
+      </div>
+      <div style={{ flex: 1, minHeight: 0, overflow: "hidden" }}>{children}</div>
+    </div>
+  );
+}
+
+Object.assign(window, {
+  FELLOWS, SAVED_GROUPS, initials, C, SectionHead, Tag, Btn, AppFrame
+});

--- a/plans/group_feature/design_handoff_groups_feature/screen-browse.jsx
+++ b/plans/group_feature/design_handoff_groups_feature/screen-browse.jsx
@@ -1,0 +1,279 @@
+// Screen: BROWSE + ADD-TO-GROUP
+// The right rail is "add to a group" with an auto-generated, editable title
+// (search query / #tag) and a single "Create new group" button.
+// mode="new"  — composing a fresh group
+// mode="edit" — editing a saved group (yellow banner, "Done editing")
+
+function ScreenBrowse({
+  mode = "new",
+  initialQuery = "",
+  initialPicked,
+  customTitle,         // explicitly typed title (we treat as user-edited)
+  initialHasEmail,
+  activeName,          // override the open detail card
+}) {
+  const [picked, setPicked] = React.useState(new Set(initialPicked || []));
+  const [query, setQuery] = React.useState(initialQuery);
+  const [hasEmail, setHasEmail] = React.useState(
+    initialHasEmail !== undefined ? initialHasEmail : false
+  );
+  const [active, setActive] = React.useState(activeName || initialPicked?.[0] || null);
+
+  // Auto-generated group title that follows the search,
+  // unless the user has typed their own (we seed titleEdited true if customTitle given).
+  const autoTitle = React.useMemo(() => {
+    if (!query) return "";
+    if (query.startsWith("#")) return query;
+    return query.replace(/^./, c => c.toUpperCase());
+  }, [query]);
+  const [titleEdited, setTitleEdited] = React.useState(!!customTitle);
+  const [title, setTitle] = React.useState(customTitle || autoTitle);
+  React.useEffect(() => {
+    if (!titleEdited) setTitle(autoTitle);
+  }, [autoTitle, titleEdited]);
+
+  const visible = FELLOWS.filter(f => {
+    if (hasEmail && !f.email) return false;
+    if (!query) return true;
+    const q = query.toLowerCase();
+    if (q.startsWith("#")) {
+      const tag = q.slice(1);
+      return f.tags.some(t => t.includes(tag));
+    }
+    return f.name.toLowerCase().includes(q)
+        || f.tags.some(t => t.includes(q));
+  });
+
+  const allVisibleSelected = visible.length > 0 && visible.every(f => picked.has(f.name));
+  const activeFellow = FELLOWS.find(f => f.name === active);
+
+  const toggle = (name) => setPicked(prev => {
+    const n = new Set(prev);
+    if (n.has(name)) n.delete(name); else n.add(name);
+    return n;
+  });
+
+  const toggleAllVisible = () => setPicked(prev => {
+    const n = new Set(prev);
+    if (allVisibleSelected) visible.forEach(f => n.delete(f.name));
+    else visible.forEach(f => n.add(f.name));
+    return n;
+  });
+
+  const isEdit = mode === "edit";
+  const titleAutoFollowing = !titleEdited;
+
+  return (
+    <AppFrame page="directory">
+      {/* Edit-mode banner */}
+      {isEdit && (
+        <div style={{
+          padding: "0.4rem 0.75rem",
+          background: "#fff3cd", borderBottom: "1px solid #ffe69c",
+          fontSize: "0.85rem", color: "#664d03",
+          display: "flex", gap: "0.6rem", alignItems: "center"
+        }}>
+          <span>✎ <b>editing</b> "{title}" — search and tap <b>+</b> to add more, tap <b>✓</b> to remove.</span>
+          <a href="#" title="revert this group to the state it was in when you opened edit mode"
+             style={{ marginLeft: "auto", color: "#664d03", textDecoration: "underline" }}>cancel edits</a>
+        </div>
+      )}
+
+      <div style={{ display: "flex", height: "100%", padding: "0.6rem", gap: "0.75rem", boxSizing: "border-box" }}>
+        {/* Sidebar / directory list */}
+        <div style={{ flex: "0 0 250px", display: "flex", flexDirection: "column",
+          minHeight: 0, fontSize: "0.9rem" }}>
+          <label style={{ fontSize: "0.85rem", fontWeight: 600, marginBottom: "0.25rem" }}>Search</label>
+          <input
+            value={query}
+            onChange={(e) => setQuery(e.target.value)}
+            placeholder="name, tag, or #tag"
+            style={{
+              padding: "0.25rem 0.5rem", fontSize: "0.9rem",
+              border: `1px solid #bbb`, borderRadius: 2, marginBottom: 4
+            }}
+          />
+          <div style={{ fontSize: "0.7rem", color: "#7a6f91", marginBottom: 4 }}>
+            tip: <code>#walking</code> searches by tag
+          </div>
+          <div style={{
+            display: "flex", justifyContent: "space-between",
+            fontSize: "0.78rem", color: "#555", margin: "0.2rem 0 0.4rem"
+          }}>
+            <label style={{ display: "inline-flex", gap: 4, alignItems: "center", cursor: "pointer" }}>
+              <input type="checkbox" checked={hasEmail} onChange={(e) => setHasEmail(e.target.checked)} />
+              has email only
+            </label>
+            <span>{visible.length} of {FELLOWS.length}</span>
+          </div>
+
+          {/* Bulk-select bar (only show when filtered) */}
+          {(query || hasEmail) && visible.length > 0 && (
+            <div style={{
+              display: "flex", alignItems: "center", gap: 6,
+              padding: "4px 6px", margin: "0 0 2px",
+              background: C.lightLavender, border: `1px solid ${C.lavenderBorder}`,
+              borderRadius: 2, fontSize: "0.78rem"
+            }}>
+              <input type="checkbox" checked={allVisibleSelected} onChange={toggleAllVisible}
+                style={{ margin: 0 }} />
+              <span style={{ color: "#3b2355", fontWeight: 500 }}>
+                {allVisibleSelected ? "deselect" : "select"} all {visible.length} results
+              </span>
+            </div>
+          )}
+
+          {/* List */}
+          <div style={{ flex: 1, overflow: "auto", paddingRight: 4 }}>
+            <ul style={{ listStyle: "none", padding: 0, margin: 0 }}>
+              {visible.map(f => {
+                const on = picked.has(f.name);
+                const isActive = active === f.name;
+                return (
+                  <li key={f.name}
+                    onClick={() => setActive(f.name)}
+                    style={{
+                      display: "flex", alignItems: "center", gap: 4,
+                      padding: "2px 4px",
+                      background: isActive ? "#e8e0f0" : "transparent",
+                      cursor: "pointer"
+                    }}>
+                    <span
+                      onClick={(e) => { e.stopPropagation(); toggle(f.name); }}
+                      title={on ? "remove from group" : "add to group"}
+                      style={{
+                        width: 16, textAlign: "center",
+                        fontSize: 14, lineHeight: 1, fontWeight: 700,
+                        color: on ? C.purple : "#bbb",
+                        userSelect: "none"
+                      }}>{on ? "✓" : "+"}</span>
+                    <a href="#" onClick={(e) => e.preventDefault()}
+                      style={{ color: C.link, textDecoration: "underline", fontSize: "0.88rem" }}>
+                      {f.name}
+                    </a>
+                  </li>
+                );
+              })}
+            </ul>
+          </div>
+        </div>
+
+        {/* Detail pane */}
+        <div style={{
+          flex: 1, minWidth: 0, padding: "0.75rem 0.9rem",
+          border: `1px solid ${C.border}`, background: "#fff",
+          overflow: "auto", display: "flex", flexDirection: "column", gap: "0.6rem"
+        }}>
+          {activeFellow ? (
+            <>
+              <div style={{ display: "flex", alignItems: "baseline", gap: "0.6rem",
+                paddingBottom: "0.4rem", borderBottom: `1px solid ${C.border}` }}>
+                <div style={{ fontSize: "1rem", fontWeight: 600 }}>{activeFellow.name}</div>
+                <a href="#" onClick={(e) => { e.preventDefault(); toggle(activeFellow.name); }}
+                  style={{ fontSize: "0.8rem", color: C.link, textDecoration: "underline" }}>
+                  {picked.has(activeFellow.name) ? "remove from group" : "add to group"}
+                </a>
+                <div style={{ marginLeft: "auto", fontSize: "0.72rem", color: "#7a6f91" }}>
+                  your tags: {activeFellow.tags.map(t => <Tag key={t}>{t}</Tag>)}
+                  <span style={{ marginLeft: 4, color: "#aaa" }}>+ add</span>
+                </div>
+              </div>
+              <SectionHead>How to Connect</SectionHead>
+              <table style={{ width: "100%", borderCollapse: "separate", borderSpacing: "0 0.4em", fontSize: "0.85rem" }}>
+                <tbody>
+                  <tr><td style={{ background: C.rowLabel, padding: "0.3em 0.5em", fontWeight: 600, width: "32%" }}>Status</td>
+                    <td style={{ padding: "0.3em 0.5em" }}>Active Fellow</td></tr>
+                  <tr><td style={{ background: C.rowLabel, padding: "0.3em 0.5em", fontWeight: 600 }}>Email</td>
+                    <td style={{ padding: "0.3em 0.5em" }}>
+                      <a href="#" onClick={(e) => e.preventDefault()} style={{ color: C.link }}>
+                        {activeFellow.name.split(" ")[0].toLowerCase()}@example.com
+                      </a>
+                    </td></tr>
+                </tbody>
+              </table>
+            </>
+          ) : (
+            <div style={{ color: "#888", fontSize: "0.85rem", padding: "1rem 0", textAlign: "center" }}>
+              Select a fellow on the left to view their details.
+            </div>
+          )}
+        </div>
+
+        {/* Right rail — "add to a group" */}
+        <div style={{
+          flex: "0 0 240px", display: "flex", flexDirection: "column",
+          minHeight: 0,
+          border: `1px solid ${C.lavenderBorder}`, background: C.lightLavender,
+          padding: "0.55rem 0.6rem"
+        }}>
+          <div style={{ fontSize: "0.78rem", color: "#7a6f91", textTransform: "uppercase",
+            letterSpacing: "0.04em", marginBottom: 3 }}>
+            {isEdit ? "editing group" : "add to a group"}
+          </div>
+
+          {/* Title field — soft tinted bg + ✎ icon when auto-following; solid white when user-edited */}
+          <div style={{ position: "relative", marginBottom: 2 }}>
+            <input
+              value={title}
+              onChange={(e) => { setTitle(e.target.value); setTitleEdited(true); }}
+              placeholder="name your group…"
+              style={{
+                fontSize: "0.95rem", fontWeight: 600,
+                padding: "0.25rem 0.4rem 0.25rem " + (titleAutoFollowing && !isEdit ? "1.45rem" : "0.4rem"),
+                border: `1px solid ${C.lavenderBorder}`,
+                borderRadius: 2,
+                background: titleAutoFollowing && !isEdit ? "#fff7d6" : "#fff",
+                boxSizing: "border-box", width: "100%",
+                fontStyle: titleAutoFollowing && !isEdit && !title ? "italic" : "normal",
+                color: titleAutoFollowing && !isEdit && title ? "#7a6326" : C.ink,
+              }}
+            />
+            {titleAutoFollowing && !isEdit && (
+              <span style={{
+                position: "absolute", left: 6, top: "50%", transform: "translateY(-50%)",
+                fontSize: "0.85rem", color: "#a8923a", pointerEvents: "none"
+              }}>✎</span>
+            )}
+          </div>
+          <div style={{ fontSize: "0.7rem", color: "#7a6f91", marginBottom: 6 }}>
+            {titleAutoFollowing && !isEdit && query
+              ? <>auto-named — click to rename · {picked.size} fellows</>
+              : titleAutoFollowing && !isEdit
+                ? <>type a name, or search to auto-fill · {picked.size} fellows</>
+                : <>{picked.size} fellows</>}
+          </div>
+          <div style={{ flex: 1, overflow: "auto", marginBottom: 6,
+            border: `1px solid ${C.lavenderBorder}`, background: "#fff", padding: "0.25rem 0.4rem" }}>
+            {[...picked].length === 0 && (
+              <div style={{ fontSize: "0.78rem", color: "#888", padding: "0.4rem 0" }}>
+                tap <b style={{ color: C.purple }}>+</b> next to a name to add. Search again to add more.
+              </div>
+            )}
+            {[...picked].map(n => (
+              <div key={n} style={{
+                display: "flex", alignItems: "center", gap: 4,
+                padding: "1px 0", fontSize: "0.78rem"
+              }}>
+                <span style={{ flex: 1, overflow: "hidden", textOverflow: "ellipsis", whiteSpace: "nowrap" }}>
+                  {n}
+                </span>
+                <span onClick={() => toggle(n)} title="remove"
+                  style={{ color: "#999", cursor: "pointer", fontFamily: "ui-monospace, monospace", fontSize: 11 }}>×</span>
+              </div>
+            ))}
+          </div>
+          <Btn primary style={{ width: "100%" }} disabled={!isEdit && picked.size === 0}>
+            {isEdit ? "Done editing" : "Create new group"}
+          </Btn>
+          <div style={{ fontSize: "0.7rem", color: "#7a6f91", marginTop: 4, lineHeight: 1.4 }}>
+            {isEdit
+              ? "changes save automatically as you add or remove."
+              : "saves immediately to your groups. You can rename and edit it later."}
+          </div>
+        </div>
+      </div>
+    </AppFrame>
+  );
+}
+
+window.ScreenBrowse = ScreenBrowse;

--- a/plans/group_feature/design_handoff_groups_feature/screen-group-detail.jsx
+++ b/plans/group_feature/design_handoff_groups_feature/screen-group-detail.jsx
@@ -1,0 +1,144 @@
+// Screen: GROUP DETAIL — what you see when you click a group's name.
+// Single-pane, mobile-friendly: title row, then one action bar with three
+// peer buttons (Contact / Export / Edit), then note, then members.
+// "Contact the whole group" is a plain mailto:?cc= — no expansion.
+// "Export a directory" expands a checkbox panel inline.
+// "Edit group" returns to the directory in editing mode.
+
+function ScreenGroupDetail({ name = "Climate cohort", count = 14, mode = "default" }) {
+  const members = [
+    "Tatyana Mikayilova", "Tesh Randall", "Tilla Abbitt", "Tillie Walton",
+    "Tim Derrick", "Tim Ferriss", "Tim Pare", "Tina Jennen", "Tony Lai",
+    "Tracy Chou", "Trevor Squier", "Tristan Harris", "Vanessa Coleman",
+    "Vicky Robertson"
+  ].slice(0, count);
+  const [showExport, setShowExport] = React.useState(mode === "export");
+
+  const slug = name.toLowerCase().replace(/^#/, "").replace(/[^a-z0-9]+/g, "-");
+  const cc = members.map(n => `${n.split(" ")[0].toLowerCase()}@example.com`).join(",");
+
+  return (
+    <AppFrame page="groups">
+      <div style={{ padding: "0.8rem 1rem", display: "flex", flexDirection: "column",
+        height: "100%", boxSizing: "border-box", gap: "0.7rem", maxWidth: 760, margin: "0 auto", width: "100%" }}>
+
+        {/* Breadcrumb */}
+        <div style={{ fontSize: "0.8rem", color: C.muted }}>
+          <a href="#" style={{ color: C.link, textDecoration: "underline" }}>groups</a>
+          {" › "}<span>{name}</span>
+        </div>
+
+        {/* Title row */}
+        <div style={{ display: "flex", alignItems: "baseline", gap: "0.7rem", flexWrap: "wrap" }}>
+          <h2 style={{ margin: 0, fontSize: "1.25rem" }}>{name}</h2>
+          <a href="#" style={{ fontSize: "0.78rem", color: C.link, textDecoration: "underline" }}>rename</a>
+          <span style={{ fontSize: "0.85rem", color: C.muted }}>
+            {members.length} fellows · created Apr 12, 2026
+          </span>
+        </div>
+
+        {/* Single action bar — three peer buttons */}
+        <div style={{
+          display: "flex", flexWrap: "wrap", gap: 8,
+          padding: "0.5rem 0.6rem",
+          background: C.lightLavender, border: `1px solid ${C.lavenderBorder}`,
+        }}>
+          <Btn primary>
+            <a href={`mailto:?cc=${cc}&subject=${encodeURIComponent(name)}`}
+               style={{ color: "inherit", textDecoration: "none" }}>
+              ✉ Contact the whole group
+            </a>
+          </Btn>
+          <Btn onClick={() => setShowExport(!showExport)}>
+            ⬇ Export a directory
+          </Btn>
+          <Btn>
+            ✎ Edit group
+          </Btn>
+          <span style={{ marginLeft: "auto", fontSize: "0.72rem", color: "#7a6f91", alignSelf: "center" }}>
+            mailto: opens your client with everyone in CC
+          </span>
+        </div>
+
+        {/* Inline export panel — appears beneath the action bar when toggled */}
+        {showExport && (
+          <div style={{
+            background: "#fff", border: `1px solid ${C.lavenderBorder}`,
+            fontSize: "0.85rem"
+          }}>
+            <SectionHead>Export a directory</SectionHead>
+            <div style={{ padding: "0.55rem 0.7rem", display: "flex", flexWrap: "wrap", gap: "0.6rem 1.2rem" }}>
+              <label style={{ display: "flex", alignItems: "flex-start", gap: 6, cursor: "pointer" }}>
+                <input type="checkbox" defaultChecked style={{ marginTop: 3 }} />
+                <div>
+                  <div>PDF directory</div>
+                  <div style={{ fontSize: "0.7rem", color: "#7a6f91" }}><code>{slug}.pdf</code></div>
+                </div>
+              </label>
+              <label style={{ display: "flex", alignItems: "flex-start", gap: 6, cursor: "pointer" }}>
+                <input type="checkbox" style={{ marginTop: 3 }} />
+                <div>
+                  <div>HTML directory</div>
+                  <div style={{ fontSize: "0.7rem", color: "#7a6f91" }}><code>{slug}/</code> · view offline</div>
+                </div>
+              </label>
+              <label style={{ display: "flex", alignItems: "flex-start", gap: 6, cursor: "pointer" }}>
+                <input type="checkbox" defaultChecked style={{ marginTop: 3 }} />
+                <div>
+                  <div>email it to me</div>
+                  <div style={{ fontSize: "0.7rem", color: "#7a6f91" }}>your registered address</div>
+                </div>
+              </label>
+            </div>
+            <div style={{ display: "flex", justifyContent: "flex-end", gap: 6,
+              padding: "0 0.7rem 0.6rem" }}>
+              <Btn small onClick={() => setShowExport(false)}>cancel</Btn>
+              <Btn small primary>Export</Btn>
+            </div>
+          </div>
+        )}
+
+        {/* Note */}
+        <div style={{
+          padding: "0.4em 0.6em", background: "#fffbe6",
+          border: "1px dashed #e8d77a", fontSize: "0.85rem",
+          color: "#444", fontStyle: "italic"
+        }}>
+          for the Wellington roundtable
+          <a href="#" style={{ marginLeft: 8, fontStyle: "normal",
+            color: C.link, textDecoration: "underline", fontSize: "0.78rem" }}>edit</a>
+        </div>
+
+        {/* Members table */}
+        <div style={{ flex: 1, minWidth: 0, display: "flex", flexDirection: "column",
+          border: `1px solid ${C.border}`, background: "#fff" }}>
+          <SectionHead>Members</SectionHead>
+          <div style={{ flex: 1, overflow: "auto" }}>
+            <table style={{ width: "100%", borderCollapse: "collapse", fontSize: "0.88rem" }}>
+              <tbody>
+                {members.map(n => (
+                  <tr key={n} style={{ borderBottom: `1px solid #efefef` }}>
+                    <td style={{ padding: "0.35em 0.7em" }}>
+                      <a href="#" onClick={(e) => e.preventDefault()}
+                         style={{ color: C.link, textDecoration: "underline" }}>{n}</a>
+                    </td>
+                  </tr>
+                ))}
+              </tbody>
+            </table>
+          </div>
+          <div style={{
+            padding: "0.4em 0.6em", borderTop: `1px solid ${C.border}`,
+            background: C.lightLavender, fontSize: "0.78rem", color: "#3b2355",
+            display: "flex", justifyContent: "space-between"
+          }}>
+            <span>showing all {members.length} members</span>
+            <span style={{ color: "#7a6f91" }}>tap <b>Edit group</b> to add or remove</span>
+          </div>
+        </div>
+      </div>
+    </AppFrame>
+  );
+}
+
+window.ScreenGroupDetail = ScreenGroupDetail;

--- a/plans/group_feature/design_handoff_groups_feature/screen-groups.jsx
+++ b/plans/group_feature/design_handoff_groups_feature/screen-groups.jsx
@@ -1,0 +1,92 @@
+// Screen 3: GROUPS PAGE — permalinked, like /about
+// Lists saved groups. Inline rename, reload-into-cart, duplicate, delete, re-create.
+
+function ScreenGroups() {
+  const [groups, setGroups] = React.useState(SAVED_GROUPS);
+  const [editingId, setEditingId] = React.useState(null);
+
+  return (
+    <AppFrame page="groups">
+      <div style={{ padding: "0.7rem 0.9rem", display: "flex", flexDirection: "column",
+        height: "100%", boxSizing: "border-box", gap: "0.6rem" }}>
+        <div style={{ display: "flex", alignItems: "baseline", gap: "0.9rem" }}>
+          <h2 style={{ margin: 0, fontSize: "1.15rem" }}>Groups</h2>
+          <div style={{ fontSize: "0.85rem", color: C.muted }}>
+            {groups.length} saved · stored in <code>fellows.db</code>
+          </div>
+          <div style={{ marginLeft: "auto" }}>
+            <Btn primary>+ start a new group</Btn>
+          </div>
+        </div>
+
+        <div style={{ border: `1px solid ${C.border}`, background: "#fff", flex: 1,
+          minHeight: 0, overflow: "auto" }}>
+          <table style={{ width: "100%", borderCollapse: "collapse", fontSize: "0.88rem" }}>
+            <thead>
+              <tr style={{ background: C.rowLabel, fontSize: "0.78rem", color: "#555" }}>
+                <th style={{ textAlign: "left", padding: "0.4em 0.7em", fontWeight: 600 }}>Name</th>
+                <th style={{ textAlign: "left", padding: "0.4em 0.7em", fontWeight: 600, width: "85px" }}>Members</th>
+                <th style={{ textAlign: "left", padding: "0.4em 0.7em", fontWeight: 600, width: "120px" }}>Created</th>
+                <th style={{ textAlign: "left", padding: "0.4em 0.7em", fontWeight: 600 }}>Note</th>
+                <th style={{ width: "320px", padding: "0.4em 0.7em" }}></th>
+              </tr>
+            </thead>
+            <tbody>
+              {groups.map(g => (
+                <tr key={g.id} style={{ borderBottom: `1px solid #efefef` }}>
+                  <td style={{ padding: "0.4em 0.7em" }}>
+                    {editingId === g.id ? (
+                      <input
+                        autoFocus defaultValue={g.name}
+                        onBlur={(e) => {
+                          setGroups(prev => prev.map(x => x.id === g.id ? { ...x, name: e.target.value } : x));
+                          setEditingId(null);
+                        }}
+                        style={{ padding: "0.2rem 0.4rem", fontSize: "0.88rem",
+                          border: "1px solid #bbb", borderRadius: 2 }}
+                      />
+                    ) : (
+                      <a href="#" onClick={(e) => e.preventDefault()}
+                         title="open this group"
+                         style={{ color: C.link, textDecoration: "underline", fontWeight: 500 }}>
+                        {g.name}
+                      </a>
+                    )}
+                  </td>
+                  <td style={{ padding: "0.4em 0.7em", color: "#444" }}>{g.count}</td>
+                  <td style={{ padding: "0.4em 0.7em", color: "#666",
+                    fontFamily: "ui-monospace, monospace", fontSize: "0.78rem" }}>{g.created}</td>
+                  <td style={{ padding: "0.4em 0.7em", color: "#666", fontStyle: g.note ? "italic" : "normal" }}>
+                    {g.note || <span style={{ color: "#bbb" }}>—</span>}
+                  </td>
+                  <td style={{ padding: "0.4em 0.7em", textAlign: "right", whiteSpace: "nowrap" }}>
+                    <a href="#" onClick={(e) => e.preventDefault()}
+                       title="open the visual portrait directory"
+                       style={{ color: C.link, textDecoration: "underline", marginRight: 10, fontSize: "0.8rem" }}>view directory</a>
+                    <a href="#" onClick={(e) => { e.preventDefault(); setEditingId(g.id); }}
+                       style={{ color: C.link, textDecoration: "underline", marginRight: 10, fontSize: "0.8rem" }}>rename</a>
+                    <a href="#" onClick={(e) => {
+                      e.preventDefault();
+                      setGroups(prev => prev.filter(x => x.id !== g.id));
+                    }}
+                       style={{ color: "#7a1f1f", textDecoration: "underline", marginRight: 10, fontSize: "0.8rem" }}>delete</a>
+                    <a href="#" onClick={(e) => e.preventDefault()}
+                       title="add or remove members from this group"
+                       style={{ color: C.link, textDecoration: "underline", fontSize: "0.8rem" }}>edit</a>
+                  </td>
+                </tr>
+              ))}
+            </tbody>
+          </table>
+        </div>
+
+        <div style={{ fontSize: "0.78rem", color: "#7a6f91", lineHeight: 1.5 }}>
+          Click a group's name to open its detail page — that's where you edit, view, and export it.
+          Deleting only removes the saved group; the fellows themselves are unaffected.
+        </div>
+      </div>
+    </AppFrame>
+  );
+}
+
+window.ScreenGroups = ScreenGroups;

--- a/plans/group_feature/design_handoff_groups_feature/screen-output.jsx
+++ b/plans/group_feature/design_handoff_groups_feature/screen-output.jsx
@@ -1,0 +1,141 @@
+// Screen 4: OUTPUT PREVIEW — what `create` produces.
+// A self-contained HTML directory: alphabetical portrait grid with a popup
+// showing name + contact info on click. This artboard mocks the *exported*
+// page so you can see what gets written to disk.
+
+function ScreenOutputPreview() {
+  const members = [
+    "Tatyana Mikayilova", "Tesh Randall", "Tilla Abbitt", "Tillie Walton",
+    "Tim Derrick", "Tim Ferriss", "Tim Pare", "Tina Jennen", "Tony Lai",
+    "Tracy Chou", "Trevor Squier", "Tristan Harris", "Vanessa Coleman",
+    "Vicky Robertson"
+  ].sort();
+  const [openName, setOpenName] = React.useState("Tony Lai");
+  const open = members.find(n => n === openName);
+  const f = open ? FELLOWS.find(ff => ff.name === open) : null;
+
+  return (
+    <div style={{
+      width: "100%", height: "100%",
+      background: "#fafafa", color: "#222",
+      fontFamily: 'system-ui, -apple-system, "Segoe UI", Roboto, sans-serif',
+      display: "flex", flexDirection: "column", overflow: "hidden", position: "relative"
+    }}>
+      {/* Browser-style chrome to make it clear this is the EXPORTED file */}
+      <div style={{
+        background: "#e8e4ef", padding: "0.4rem 0.7rem", fontSize: "0.78rem",
+        color: "#3b2355", borderBottom: "1px solid #c9c2d4",
+        display: "flex", gap: 8, alignItems: "center"
+      }}>
+        <span style={{ fontFamily: "ui-monospace, monospace" }}>
+          file:///environment-pickleball-folks/index.html
+        </span>
+        <span style={{ marginLeft: "auto", fontStyle: "italic" }}>
+          ↑ this is the exported portable directory (offline, sharable)
+        </span>
+      </div>
+
+      <div style={{ padding: "1.2rem 1.6rem", flex: 1, overflow: "auto" }}>
+        <h1 style={{ margin: "0 0 0.2rem", fontSize: "1.4rem" }}>Environment + pickleball folks</h1>
+        <div style={{ fontSize: "0.85rem", color: "#666", marginBottom: "0.5rem" }}>
+          {members.length} fellows · created Apr 28, 2026 · for Wairarapa weekend
+        </div>
+
+        {/* Group action bar */}
+        <div style={{
+          display: "flex", alignItems: "center", gap: "0.75rem",
+          padding: "0.5rem 0.7rem", marginBottom: "1rem",
+          background: "#f0ecf5", border: "1px solid #dcd6e8", borderRadius: 3,
+          fontSize: "0.85rem"
+        }}>
+          <a href={`mailto:?cc=${members.map(n => `${n.split(" ")[0].toLowerCase()}@example.com`).join(",")}&subject=${encodeURIComponent("Environment + pickleball folks")}`}
+            style={{ color: C.link, textDecoration: "underline", fontWeight: 500 }}>
+            ✉ Contact the whole group
+          </a>
+          <span style={{ color: "#7a6f91", fontSize: "0.78rem" }}>
+            opens your mail client with everyone in CC
+          </span>
+        </div>
+
+        <div style={{
+          display: "grid",
+          gridTemplateColumns: "repeat(auto-fill, minmax(120px, 1fr))",
+          gap: "0.9rem"
+        }}>
+          {members.map(n => (
+            <button key={n} onClick={() => setOpenName(n)}
+              style={{
+                background: "transparent", border: "none", padding: 0,
+                cursor: "pointer", textAlign: "center", fontFamily: "inherit"
+              }}>
+              <div style={{
+                width: "100%", aspectRatio: "1 / 1", borderRadius: "50%",
+                backgroundImage: `url("data:image/svg+xml;utf8,<svg xmlns='http://www.w3.org/2000/svg' viewBox='0 0 80 80'><rect width='80' height='80' fill='%23d9cfc1'/><circle cx='40' cy='32' r='14' fill='%23a89682'/><path d='M14 76c4-16 18-22 26-22s22 6 26 22z' fill='%23a89682'/></svg>")`,
+                backgroundSize: "cover", backgroundPosition: "center",
+                border: "1px solid #ccc"
+              }} title={`portrait of ${n}`} />
+              <div style={{ fontSize: "0.78rem", marginTop: 4, lineHeight: 1.2 }}>{n}</div>
+            </button>
+          ))}
+        </div>
+      </div>
+
+      {/* Popup */}
+      {open && (
+        <div onClick={() => setOpenName(null)}
+          style={{
+            position: "absolute", inset: 0,
+            background: "rgba(30, 25, 50, 0.45)",
+            display: "flex", alignItems: "center", justifyContent: "center",
+            zIndex: 10
+          }}>
+          <div onClick={(e) => e.stopPropagation()}
+            style={{
+              background: "#fff", border: "1px solid #ccc", borderRadius: 4,
+              padding: "1rem 1.1rem", width: 360, boxShadow: "0 6px 24px rgba(0,0,0,0.18)",
+              position: "relative"
+            }}>
+            <button onClick={() => setOpenName(null)} aria-label="close"
+              style={{
+                position: "absolute", top: 6, right: 8,
+                background: "transparent", border: "none", fontSize: 18,
+                cursor: "pointer", color: "#888"
+              }}>×</button>
+            <div style={{ display: "flex", gap: 14, alignItems: "center", marginBottom: 10 }}>
+              <div style={{
+                width: 80, height: 80, borderRadius: "50%",
+                backgroundImage: `url("data:image/svg+xml;utf8,<svg xmlns='http://www.w3.org/2000/svg' viewBox='0 0 80 80'><rect width='80' height='80' fill='%23d9cfc1'/><circle cx='40' cy='32' r='14' fill='%23a89682'/><path d='M14 76c4-16 18-22 26-22s22 6 26 22z' fill='%23a89682'/></svg>")`,
+                backgroundSize: "cover", backgroundPosition: "center",
+                border: "1px solid #ccc",
+                display: "flex", alignItems: "flex-end", justifyContent: "center",
+                fontSize: "0.6rem", fontWeight: 600, color: "#fff",
+                textShadow: "0 1px 1px rgba(0,0,0,0.4)", paddingBottom: 2
+              }}>{initials(open)}</div>
+              <div>
+                <div style={{ fontSize: "1.05rem", fontWeight: 600 }}>{open}</div>
+                <div style={{ fontSize: "0.78rem", color: "#666" }}>real photo from <code>fellows.db</code> images table</div>
+              </div>
+            </div>
+            <table style={{ width: "100%", borderCollapse: "separate", borderSpacing: "0 0.3em", fontSize: "0.85rem" }}>
+              <tbody>
+                {f?.email && (
+                  <tr><td style={{ background: "#f0f0f0", padding: "0.3em 0.5em", fontWeight: 600, width: "32%" }}>email</td>
+                    <td style={{ padding: "0.3em 0.5em" }}>
+                      <a href={`mailto:${open.split(" ")[0].toLowerCase()}@example.com`}>
+                        {open.split(" ")[0].toLowerCase()}@example.com
+                      </a></td></tr>
+                )}
+                <tr><td style={{ background: "#f0f0f0", padding: "0.3em 0.5em", fontWeight: 600, width: "32%" }}>phone</td>
+                  <td style={{ padding: "0.3em 0.5em" }}><a href="#" onClick={(e) => e.preventDefault()}>+64 21 555 0142</a></td></tr>
+                <tr><td style={{ background: "#f0f0f0", padding: "0.3em 0.5em", fontWeight: 600 }}>linkedin</td>
+                  <td style={{ padding: "0.3em 0.5em" }}><a href="#" onClick={(e) => e.preventDefault()}>linkedin.com/in/{open.split(" ")[0].toLowerCase()}</a></td></tr>
+              </tbody>
+            </table>
+          </div>
+        </div>
+      )}
+    </div>
+  );
+}
+
+window.ScreenOutputPreview = ScreenOutputPreview;

--- a/tests/e2e/test_groups_compose.py
+++ b/tests/e2e/test_groups_compose.py
@@ -1,0 +1,200 @@
+"""E2E for the PR 1 right-rail group composer.
+
+Pins the user-visible contract:
+- Right rail is present on the directory page.
+- +/✓ markers next to every fellow toggle draft membership; click does
+  not navigate the row.
+- Picked fellows appear as chips in the rail; create button enables.
+- Title field auto-follows the search until the user types, then flips
+  to white permanently.
+- localStorage persists the draft across reload.
+- #tag search routes to the search_tags column (real data: #climate).
+- Create button POSTs and surfaces the dev-server 501 stub message
+  ("PR 2 wires this up").
+- Bulk-select bar shows only when filtered and toggles all visible
+  fellows in the draft.
+"""
+from __future__ import annotations
+
+import re
+
+from playwright.sync_api import expect
+
+
+def _wait_for_directory(page):
+    page.locator("#loading").wait_for(state="hidden", timeout=10000)
+    page.locator("#directory").wait_for(state="visible", timeout=5000)
+
+
+def _aaron_row(page):
+    """Return the directory row container for Aaron Bird."""
+    link = page.locator("#directory a.dir-link", has_text="Aaron Bird").first
+    expect(link).to_be_visible()
+    # Row container is the parent <li class="dir-row">.
+    return link.locator("xpath=..")
+
+
+class TestGroupComposer:
+    def test_right_rail_is_visible(self, standalone_page, base_url_fixture):
+        page = standalone_page
+        page.goto(base_url_fixture + "/", wait_until="domcontentloaded")
+        _wait_for_directory(page)
+        rail = page.locator("#group-rail")
+        expect(rail).to_be_visible()
+        expect(page.locator("#group-rail-eyebrow")).to_have_text("add to a group")
+        expect(page.locator("#group-rail-create")).to_be_disabled()
+
+    def test_marker_toggles_glyph_and_adds_chip(self, standalone_page, base_url_fixture):
+        page = standalone_page
+        page.goto(base_url_fixture + "/", wait_until="domcontentloaded")
+        _wait_for_directory(page)
+        row = _aaron_row(page)
+        mark = row.locator(".dir-mark")
+        expect(mark).to_have_text("+")
+        expect(mark).to_have_attribute("aria-pressed", "false")
+        mark.click()
+        expect(mark).to_have_text("✓")
+        expect(mark).to_have_attribute("aria-pressed", "true")
+        expect(mark).to_have_class(re.compile(r"\bdir-mark--on\b"))
+        chip = page.locator("#group-rail-members .group-rail-member-name").first
+        expect(chip).to_have_text("Aaron Bird")
+        expect(page.locator("#group-rail-create")).to_be_enabled()
+
+    def test_marker_click_does_not_navigate_row(self, standalone_page, base_url_fixture):
+        """The +/✓ click is intercepted via stopPropagation; URL hash stays put."""
+        page = standalone_page
+        page.goto(base_url_fixture + "/", wait_until="domcontentloaded")
+        _wait_for_directory(page)
+        starting_url = page.url
+        _aaron_row(page).locator(".dir-mark").click()
+        expect(page.locator("#group-rail-members .group-rail-member-name").first).to_be_visible()
+        # No navigation happened.
+        assert page.url == starting_url, f"Expected URL unchanged, got {page.url}"
+
+    def test_chip_remove_button_round_trips(self, standalone_page, base_url_fixture):
+        page = standalone_page
+        page.goto(base_url_fixture + "/", wait_until="domcontentloaded")
+        _wait_for_directory(page)
+        row = _aaron_row(page)
+        mark = row.locator(".dir-mark")
+        mark.click()
+        expect(mark).to_have_text("✓")
+        # Chip × removes; marker flips back.
+        page.locator("#group-rail-members .group-rail-member-remove").first.click()
+        expect(mark).to_have_text("+")
+        expect(page.locator("#group-rail-create")).to_be_disabled()
+
+    def test_title_auto_follows_search_then_flips_on_user_type(
+        self, standalone_page, base_url_fixture
+    ):
+        page = standalone_page
+        page.goto(base_url_fixture + "/", wait_until="domcontentloaded")
+        _wait_for_directory(page)
+        title = page.locator("#group-rail-title")
+        expect(title).to_have_class(re.compile(r"\bgroup-rail-title--auto\b"))
+        expect(title).to_have_value("")
+        # Typing in the search box updates the rail title immediately
+        # (no debounce on the title path; title is for visual feedback,
+        # the actual search runs after 250ms).
+        page.locator("#search-input").fill("climate")
+        expect(title).to_have_value("Climate")
+        # Typing in the title field flips off the auto-follow class for good.
+        title.fill("My climate group")
+        expect(title).not_to_have_class(re.compile(r"\bgroup-rail-title--auto\b"))
+        # Subsequent search-box edits no longer rewrite the title.
+        page.locator("#search-input").fill("")
+        page.locator("#search-input").fill("anything")
+        expect(title).to_have_value("My climate group")
+
+    def test_draft_persists_across_reload(self, standalone_page, base_url_fixture):
+        page = standalone_page
+        page.goto(base_url_fixture + "/", wait_until="domcontentloaded")
+        _wait_for_directory(page)
+        _aaron_row(page).locator(".dir-mark").click()
+        expect(page.locator("#group-rail-members .group-rail-member-name").first).to_have_text(
+            "Aaron Bird"
+        )
+        page.reload(wait_until="domcontentloaded")
+        _wait_for_directory(page)
+        # Marker comes up already on; chip restored from localStorage.
+        expect(_aaron_row(page).locator(".dir-mark")).to_have_text("✓")
+        expect(page.locator("#group-rail-members .group-rail-member-name").first).to_have_text(
+            "Aaron Bird"
+        )
+
+    def test_hash_tag_search_filters_to_climate_fellows(
+        self, standalone_page, base_url_fixture
+    ):
+        """#climate routes through search_tags (FTS5 column-scoped) and
+        returns only fellows whose tags include 'climate'. We assert a
+        known climate fellow appears (Aliza Napartivaumnuay, Andy Sack,
+        Barry Neal — chosen because their search_tags column reliably
+        contains 'climate' in the canonical 2026-04-08 dataset)."""
+        page = standalone_page
+        page.goto(base_url_fixture + "/", wait_until="domcontentloaded")
+        _wait_for_directory(page)
+        # Disable the has-email filter so we don't accidentally suppress
+        # anyone in the small expected set.
+        page.locator("#has-email-filter").uncheck()
+        page.locator("#search-input").fill("#climate")
+        # Search debounces 250ms, then renders.
+        page.wait_for_timeout(700)
+        link = page.locator("#directory a.dir-link", has_text="Andy Sack").first
+        expect(link).to_be_visible()
+
+    def test_create_button_posts_and_surfaces_501_message(
+        self, standalone_page, base_url_fixture
+    ):
+        page = standalone_page
+        page.goto(base_url_fixture + "/", wait_until="domcontentloaded")
+        _wait_for_directory(page)
+        _aaron_row(page).locator(".dir-mark").click()
+        page.locator("#group-rail-title").fill("Smoke group")
+        page.locator("#group-rail-create").click()
+        # Server returns 501 with the PR 2 explainer; rail surfaces the
+        # message and stays usable.
+        status = page.locator("#group-rail-status")
+        expect(status).to_contain_text("PR 2", timeout=3000)
+        # Draft is NOT cleared on stub failure; create button reflects
+        # current selection (still 1).
+        expect(page.locator("#group-rail-members .group-rail-member-name").first).to_have_text(
+            "Aaron Bird"
+        )
+
+    def test_bulk_select_bar_visibility_tracks_filtered_state(
+        self, standalone_page, base_url_fixture
+    ):
+        """Per the design spec: the bar shows when results are filtered
+        (search query OR has-email checked) and hides when the unfiltered
+        list is showing — "too easy to mis-click" otherwise."""
+        page = standalone_page
+        page.goto(base_url_fixture + "/", wait_until="domcontentloaded")
+        _wait_for_directory(page)
+        bar = page.locator("#bulk-select-bar")
+        # has-email is on by default → bar is visible from boot.
+        expect(page.locator("#has-email-filter")).to_be_checked()
+        expect(bar).to_be_visible()
+        # Unchecking has-email with no query → bar hides (truly unfiltered).
+        page.locator("#has-email-filter").uncheck()
+        page.wait_for_timeout(200)
+        expect(bar).to_be_hidden()
+        # Typing a query → bar appears again.
+        page.locator("#search-input").fill("Aaron")
+        page.wait_for_timeout(700)
+        expect(bar).to_be_visible()
+
+    def test_bulk_select_toggles_all_visible_into_draft(
+        self, standalone_page, base_url_fixture
+    ):
+        page = standalone_page
+        page.goto(base_url_fixture + "/", wait_until="domcontentloaded")
+        _wait_for_directory(page)
+        page.locator("#search-input").fill("Aaron")
+        page.wait_for_timeout(700)
+        before = page.locator("#group-rail-members .group-rail-member-name").count()
+        page.locator("#bulk-select-input").check()
+        page.wait_for_timeout(200)
+        after = page.locator("#group-rail-members .group-rail-member-name").count()
+        assert after >= before + 1, (
+            f"Expected bulk-select to add at least 1 chip; before={before} after={after}"
+        )

--- a/tests/test_api.py
+++ b/tests/test_api.py
@@ -28,6 +28,23 @@ def get(path, query=None):
     return r.status, ctype, raw.decode("utf-8")
 
 
+def post(path, body=None, content_type="application/json"):
+    conn = HTTPConnection("127.0.0.1", PORT, timeout=5)
+    if body is None:
+        payload = b""
+    elif isinstance(body, (bytes, bytearray)):
+        payload = bytes(body)
+    else:
+        payload = json.dumps(body).encode("utf-8")
+    headers = {"Content-Type": content_type, "Content-Length": str(len(payload))}
+    conn.request("POST", path, body=payload, headers=headers)
+    r = conn.getresponse()
+    raw = r.read()
+    conn.close()
+    ctype = r.getheader("Content-Type") or ""
+    return r.status, ctype, raw.decode("utf-8")
+
+
 @pytest.mark.usefixtures("app_server")
 class TestAPI:
     """API endpoint tests. Server started by session-scoped app_server fixture."""
@@ -157,3 +174,17 @@ class TestAPI:
         assert "octet-stream" in ctype
         assert raw[:15] == b"SQLite format 3"
         assert len(raw) > 512
+
+    def test_post_groups_returns_501_until_pr2(self):
+        """The right-rail UI POSTs to /api/groups; PR 1 ships only the stub.
+        The contract: 501 + JSON body with `error` and `message`. PR 2
+        replaces this handler with the real create-group implementation."""
+        status, ctype, body = post(
+            "/api/groups",
+            {"name": "smoke", "note": "", "fellow_record_ids": []},
+        )
+        assert status == 501
+        assert "application/json" in ctype
+        data = json.loads(body)
+        assert data.get("error") == "Not Implemented"
+        assert "PR 2" in (data.get("message") or "")

--- a/tests/test_relationships.py
+++ b/tests/test_relationships.py
@@ -1,0 +1,185 @@
+"""Schema bootstrap + ATTACH probe for app/relationships.py.
+
+Architecture pinned by these tests:
+- relationships.db is created on first open and is idempotent.
+- fellows.db ATTACHes as `f` in read-only mode (?mode=ro), so a stray
+  INSERT into f.fellows raises OperationalError at the SQLite level.
+- Cross-DB JOIN (group_members → f.fellows) works in stdlib sqlite3.
+"""
+from __future__ import annotations
+
+import os
+import sqlite3
+import sys
+from pathlib import Path
+
+import pytest
+
+REPO_ROOT = os.path.dirname(os.path.dirname(os.path.abspath(__file__)))
+if REPO_ROOT not in sys.path:
+    sys.path.insert(0, REPO_ROOT)
+
+from app import relationships
+from app.relationships import (
+    SCHEMA_VERSION,
+    bootstrap_schema,
+    open_db,
+)
+
+FELLOWS_DB_PATH = Path(REPO_ROOT) / "app" / "fellows.db"
+
+
+@pytest.fixture
+def rel_path(tmp_path: Path) -> Path:
+    """Per-test relationships.db path under tmp_path."""
+    return tmp_path / "relationships.db"
+
+
+def test_bootstrap_creates_file_and_tables(rel_path: Path):
+    assert not rel_path.exists()
+    conn = open_db(rel_db_path=rel_path, attach_fellows=False)
+    try:
+        assert rel_path.exists()
+        tables = {
+            r[0]
+            for r in conn.execute(
+                "SELECT name FROM sqlite_master WHERE type='table'"
+            ).fetchall()
+        }
+        assert {"groups", "group_members", "fellow_tags", "fellow_notes", "settings"} <= tables
+    finally:
+        conn.close()
+
+
+def test_bootstrap_is_idempotent(rel_path: Path):
+    conn = open_db(rel_db_path=rel_path, attach_fellows=False)
+    conn.close()
+    # Second open must not raise; tables already exist.
+    conn = open_db(rel_db_path=rel_path, attach_fellows=False)
+    try:
+        version = conn.execute("PRAGMA user_version").fetchone()[0]
+        assert version == SCHEMA_VERSION
+    finally:
+        conn.close()
+
+
+def test_groups_columns(rel_path: Path):
+    conn = open_db(rel_db_path=rel_path, attach_fellows=False)
+    try:
+        cols = {r[1] for r in conn.execute("PRAGMA table_info(groups)").fetchall()}
+        assert cols == {"id", "name", "note", "created_at", "updated_at"}
+        cols = {r[1] for r in conn.execute("PRAGMA table_info(group_members)").fetchall()}
+        assert cols == {"group_id", "fellow_record_id"}
+    finally:
+        conn.close()
+
+
+def test_foreign_keys_cascade_on_group_delete(rel_path: Path):
+    conn = open_db(rel_db_path=rel_path, attach_fellows=False)
+    try:
+        conn.execute(
+            "INSERT INTO groups(id, name, created_at, updated_at)"
+            " VALUES (1, 'g', '2026-04-28', '2026-04-28')"
+        )
+        conn.execute(
+            "INSERT INTO group_members(group_id, fellow_record_id) VALUES (1, 'r1')"
+        )
+        conn.commit()
+        conn.execute("DELETE FROM groups WHERE id = 1")
+        conn.commit()
+        n = conn.execute("SELECT COUNT(*) FROM group_members").fetchone()[0]
+        assert n == 0
+    finally:
+        conn.close()
+
+
+@pytest.mark.skipif(
+    not FELLOWS_DB_PATH.is_file(),
+    reason="app/fellows.db not built; run `just db-rebuild`",
+)
+def test_attach_fellows_readonly_allows_select(rel_path: Path):
+    conn = open_db(rel_db_path=rel_path, attach_fellows=True)
+    try:
+        n = conn.execute("SELECT COUNT(*) FROM f.fellows").fetchone()[0]
+        assert n >= 1
+        # Sanity: we can also see schema names from the attached db
+        names = {r[0] for r in conn.execute("PRAGMA database_list").fetchall()[:0]}
+        assert names == set()  # database_list returns (seq,name,file) tuples
+    finally:
+        conn.close()
+
+
+@pytest.mark.skipif(
+    not FELLOWS_DB_PATH.is_file(),
+    reason="app/fellows.db not built; run `just db-rebuild`",
+)
+def test_attach_fellows_readonly_denies_write(rel_path: Path):
+    conn = open_db(rel_db_path=rel_path, attach_fellows=True)
+    try:
+        with pytest.raises(sqlite3.OperationalError):
+            conn.execute("UPDATE f.fellows SET name = 'X' WHERE 1 = 0")
+    finally:
+        conn.close()
+
+
+@pytest.mark.skipif(
+    not FELLOWS_DB_PATH.is_file(),
+    reason="app/fellows.db not built; run `just db-rebuild`",
+)
+def test_cross_db_join_resolves_member_names(rel_path: Path):
+    conn = open_db(rel_db_path=rel_path, attach_fellows=True)
+    try:
+        # Pick two real fellows by record_id from the read-only attach.
+        rows = conn.execute(
+            "SELECT record_id, name FROM f.fellows ORDER BY name LIMIT 2"
+        ).fetchall()
+        assert len(rows) == 2
+        rid_a, name_a = rows[0]["record_id"], rows[0]["name"]
+        rid_b, name_b = rows[1]["record_id"], rows[1]["name"]
+
+        conn.execute(
+            "INSERT INTO groups(name, created_at, updated_at)"
+            " VALUES ('test', '2026-04-28', '2026-04-28')"
+        )
+        gid = conn.execute("SELECT last_insert_rowid()").fetchone()[0]
+        conn.executemany(
+            "INSERT INTO group_members(group_id, fellow_record_id) VALUES (?, ?)",
+            [(gid, rid_a), (gid, rid_b)],
+        )
+        conn.commit()
+
+        joined = conn.execute(
+            """
+            SELECT f.fellows.name AS name
+            FROM group_members
+            JOIN f.fellows ON f.fellows.record_id = group_members.fellow_record_id
+            WHERE group_members.group_id = ?
+            ORDER BY f.fellows.name
+            """,
+            (gid,),
+        ).fetchall()
+        names = [r["name"] for r in joined]
+        assert names == sorted([name_a, name_b])
+    finally:
+        conn.close()
+
+
+def test_settings_round_trip(rel_path: Path):
+    conn = open_db(rel_db_path=rel_path, attach_fellows=False)
+    try:
+        conn.execute(
+            "INSERT INTO settings(key, value) VALUES ('self_email', 'me@example.com')"
+        )
+        conn.commit()
+        v = conn.execute(
+            "SELECT value FROM settings WHERE key = 'self_email'"
+        ).fetchone()[0]
+        assert v == "me@example.com"
+    finally:
+        conn.close()
+
+
+def test_constants_match_repo_layout():
+    """Path constants in the module point inside the app/ dir of this repo."""
+    assert relationships.RELATIONSHIPS_DB_PATH.parent.name == "app"
+    assert relationships.FELLOWS_DB_PATH.parent.name == "app"


### PR DESCRIPTION
## Summary

PR 1 of 5 for the groups feature. Lays the architectural foundation
and ships the directory-side composer; saved-group persistence, the
`/groups` index, edit mode, and export land in PRs 2–5.

- **Schema (`app/relationships.py`).** New SQLite file at
  `app/relationships.db` (gitignored, per-user, durable across both
  app updates and Clear App Cache). Tables: `groups`, `group_members`,
  + reserved `fellow_tags`, `fellow_notes`, `settings`. `open_db()`
  ATTACHes `fellows.db` as `f` in read-only mode (`?mode=ro`); any
  stray write to `f.*` raises `OperationalError` at the SQLite layer.
- **Server (`app/server.py`).** Adds `do_POST`. `/api/groups` returns
  `501` with a JSON body pointing at PR 2; the rail surfaces the
  message cleanly without losing the draft.
- **Frontend (`app/static/{index.html,styles.css,app.js}`).** Right
  rail with auto-following cream/✎ title, member chips, primary
  Create button, status line. `+`/`✓` margin marker on every
  directory row (click toggles draft, `stopPropagation` so it
  doesn't navigate). "add to group" / "remove from group" link on
  the detail card. Bulk select-all bar above the list, visible only
  when filtered. `#tag` search routes through `fellows.search_tags`
  (FTS5 column-scoped on sqlite/api paths; substring on the local
  fallback). Draft persists to `localStorage[ehf.group_draft]`.
- **Service worker.** `CACHE_VERSION` bumped `v8` → `v9` so existing
  users get the standard "New version available — Reload" banner on
  next deploy.
- **Docs.** New `docs/persistence_and_upgrades.md` — full
  state-survival matrix + upgrade flow + edge cases. Linked from
  `docs/Architecture.md`. `CLAUDE.md` gets a short two-DB note.
  `plans/group_feature/` adds the design handoff bundle (visual
  reference, not production code; see its README).

## Test plan

- [x] `pytest tests/test_relationships.py -v` — 9 tests pin
      idempotent schema bootstrap, FK cascade on group delete,
      `ATTACH ?mode=ro` allows SELECT, `ATTACH ?mode=ro` denies
      writes, cross-DB JOIN resolves member names, settings
      round-trip, path constants.
- [x] `pytest tests/test_api.py -v` — new `test_post_groups_returns_501_until_pr2` plus all existing API tests pass.
- [x] `pytest tests/e2e/test_groups_compose.py -v` — 10 e2e tests
      pin: rail visibility, marker glyph + `aria-pressed`,
      no-navigate-on-mark, chip round-trip, title auto-follow +
      permanent flip on user-type, localStorage persistence across
      reload, `#climate` search, 501 surfaced cleanly, bulk-select
      bar visibility tracks filter state, bulk-toggle adds visible
      rows to draft.
- [x] `pytest tests/ --ignore=tests/test_prod_stats.py -q` — **136
      passed.** (`tests/test_prod_stats.py` has 10 pre-existing
      failures on `main` from the recent `prod-stats-long` merge —
      unrelated to this PR.)

## Manual QA for the maintainer

- [ ] `just serve` and visit `http://localhost:8765/`. If the page
      shows a stale install landing, paste this once in DevTools to
      flush the old `v8` shell:
      ```js
      localStorage.setItem('fellows_authenticated_once', '1');
      caches.keys().then(ks => Promise.all(ks.map(k => caches.delete(k))))
        .then(() => navigator.serviceWorker.getRegistrations())
        .then(rs => Promise.all(rs.map(r => r.unregister())))
        .then(() => location.reload());
      ```
- [ ] Build badge reads `app: diag-2026-04o-groups-pr1`.
- [ ] Pick a few fellows with `+` → chips fill the rail, marker
      flips to `✓`.
- [ ] Reload the page → markers and chips restore from localStorage.
- [ ] Type `#climate` → only climate-tagged fellows visible.
- [ ] Click `Create new group` → status line shows the PR 2 message;
      draft is preserved.
- [ ] Bulk-select bar visible from boot (has-email default on);
      uncheck has-email with no query → bar hides.
- [ ] No deploy this PR — wait until PR 2 ships the server-side
      handler so production users don't hit a broken Create button.

🤖 Generated with [Claude Code](https://claude.com/claude-code)