### PR TITLE
feat(groups): PR 2 — full /api/groups CRUD + index page + detail page

### DIFF
--- a/app/relationships.py
+++ b/app/relationships.py
@@ -16,13 +16,24 @@ mirror lives in ``app/static/app.js`` near ``RELATIONSHIPS_SCHEMA_SQL``.
 
 from __future__ import annotations
 
+import os
 import sqlite3
 from pathlib import Path
 from urllib.parse import quote
 
 APP_DIR = Path(__file__).resolve().parent
+# Default location. Tests override via FELLOWS_RELATIONSHIPS_DB_PATH so they
+# don't pollute the dev DB; the env var is resolved per-call (see open_db).
 RELATIONSHIPS_DB_PATH = APP_DIR / "relationships.db"
 FELLOWS_DB_PATH = APP_DIR / "fellows.db"
+
+
+def resolve_relationships_db_path() -> Path:
+    """Return the relationships.db path, honouring FELLOWS_RELATIONSHIPS_DB_PATH."""
+    env = os.environ.get("FELLOWS_RELATIONSHIPS_DB_PATH")
+    if env:
+        return Path(env)
+    return RELATIONSHIPS_DB_PATH
 
 # Bump when the schema below changes. Stored in PRAGMA user_version on
 # every bootstrap so we can branch on it for future migrations.
@@ -85,6 +96,160 @@ def bootstrap_schema(conn: sqlite3.Connection) -> None:
     conn.commit()
 
 
+def _now_iso() -> str:
+    """ISO-8601 timestamp with seconds precision (UTC)."""
+    import datetime
+
+    return datetime.datetime.utcnow().isoformat(timespec="seconds") + "Z"
+
+
+def list_groups(conn: sqlite3.Connection) -> list[dict]:
+    """All groups + member counts, newest-touched first."""
+    cur = conn.execute(
+        """
+        SELECT g.id, g.name, g.note, g.created_at, g.updated_at,
+               COUNT(gm.fellow_record_id) AS count
+        FROM groups g
+        LEFT JOIN group_members gm ON gm.group_id = g.id
+        GROUP BY g.id
+        ORDER BY g.updated_at DESC, g.id DESC
+        """
+    )
+    return [dict(r) for r in cur.fetchall()]
+
+
+def get_group(
+    conn: sqlite3.Connection,
+    group_id: int,
+    *,
+    attached: bool = True,
+) -> dict | None:
+    """One group with its members, or None if not found.
+
+    ``attached``: when True, JOIN against ATTACHed ``f.fellows`` so each
+    member carries the fellow's display name. When False (PWA path,
+    where we skip ATTACH on OPFS), members come back with ``record_id``
+    only and the caller resolves names client-side from the in-memory
+    fellows cache.
+    """
+    row = conn.execute(
+        "SELECT * FROM groups WHERE id = ?", (group_id,)
+    ).fetchone()
+    if row is None:
+        return None
+    out = dict(row)
+    if attached:
+        members = conn.execute(
+            """
+            SELECT gm.fellow_record_id AS record_id, fl.name AS name
+            FROM group_members gm
+            LEFT JOIN f.fellows fl ON fl.record_id = gm.fellow_record_id
+            WHERE gm.group_id = ?
+            ORDER BY COALESCE(fl.name, gm.fellow_record_id) ASC
+            """,
+            (group_id,),
+        ).fetchall()
+    else:
+        members = conn.execute(
+            """
+            SELECT fellow_record_id AS record_id
+            FROM group_members
+            WHERE group_id = ?
+            ORDER BY fellow_record_id ASC
+            """,
+            (group_id,),
+        ).fetchall()
+    out["members"] = [dict(m) for m in members]
+    return out
+
+
+def _dedupe_record_ids(ids):
+    """Strip empty / whitespace-only / duplicate record_ids, preserving order."""
+    seen = set()
+    out = []
+    for rid in ids or ():
+        if not isinstance(rid, str):
+            continue
+        s = rid.strip()
+        if not s or s in seen:
+            continue
+        seen.add(s)
+        out.append(s)
+    return out
+
+
+def create_group(
+    conn: sqlite3.Connection,
+    *,
+    name: str,
+    note: str = "",
+    fellow_record_ids=None,
+) -> int:
+    """Insert a group and link its members in one transaction. Returns the new id."""
+    now = _now_iso()
+    cur = conn.execute(
+        "INSERT INTO groups(name, note, created_at, updated_at) VALUES (?, ?, ?, ?)",
+        (name, note, now, now),
+    )
+    group_id = cur.lastrowid
+    rows = [(group_id, rid) for rid in _dedupe_record_ids(fellow_record_ids)]
+    if rows:
+        conn.executemany(
+            "INSERT INTO group_members(group_id, fellow_record_id) VALUES (?, ?)",
+            rows,
+        )
+    conn.commit()
+    return group_id
+
+
+def update_group(
+    conn: sqlite3.Connection,
+    group_id: int,
+    *,
+    name=None,
+    note=None,
+    fellow_record_ids=None,
+) -> bool:
+    """Patch a group. Each field is optional. ``fellow_record_ids``, when
+    provided, is a full replacement of group_members for this group.
+    Returns True if the group existed (and was patched), False if not found.
+    """
+    exists = conn.execute(
+        "SELECT 1 FROM groups WHERE id = ?", (group_id,)
+    ).fetchone()
+    if not exists:
+        return False
+    sets = ["updated_at = ?"]
+    params = [_now_iso()]
+    if name is not None:
+        sets.append("name = ?")
+        params.append(name)
+    if note is not None:
+        sets.append("note = ?")
+        params.append(note)
+    params.append(group_id)
+    conn.execute(f"UPDATE groups SET {', '.join(sets)} WHERE id = ?", params)
+    if fellow_record_ids is not None:
+        conn.execute(
+            "DELETE FROM group_members WHERE group_id = ?", (group_id,)
+        )
+        rows = [(group_id, rid) for rid in _dedupe_record_ids(fellow_record_ids)]
+        if rows:
+            conn.executemany(
+                "INSERT INTO group_members(group_id, fellow_record_id) VALUES (?, ?)",
+                rows,
+            )
+    conn.commit()
+    return True
+
+
+def delete_group(conn: sqlite3.Connection, group_id: int) -> bool:
+    """Delete a group (FK cascades to group_members). Returns True if a row was removed."""
+    cur = conn.execute("DELETE FROM groups WHERE id = ?", (group_id,))
+    conn.commit()
+    return cur.rowcount > 0
+
+
 def open_db(
     *,
     rel_db_path: Path | None = None,
@@ -98,7 +263,7 @@ def open_db(
     ``sqlite3.OperationalError`` — the read-only-ness of contact data is
     enforced at the SQLite level, not just the app layer.
     """
-    rel = rel_db_path or RELATIONSHIPS_DB_PATH
+    rel = rel_db_path or resolve_relationships_db_path()
     fel = fellows_db_path or FELLOWS_DB_PATH
     rel.parent.mkdir(parents=True, exist_ok=True)
     conn = sqlite3.connect(_path_to_sqlite_uri(rel, mode="rwc"), uri=True)

--- a/app/server.py
+++ b/app/server.py
@@ -1,7 +1,8 @@
 #!/usr/bin/env python3
 """
 EHF Fellows local directory server.
-Serves static files, /api/fellows, /api/search, and /images/<slug>.<ext>.
+Serves static files, /api/fellows, /api/search, /api/groups, and
+/images/<slug>.<ext>.
 
 Run from repo root: python app/server.py
 Then open http://localhost:8765/
@@ -10,12 +11,20 @@ Then open http://localhost:8765/
 import json
 import re
 import sqlite3
+import sys
 import urllib.parse
 from pathlib import Path
 from http.server import HTTPServer, BaseHTTPRequestHandler
 
 APP_DIR = Path(__file__).resolve().parent
 REPO_ROOT = APP_DIR.parent
+# Allow running this as a script (`python app/server.py`) AND as a package
+# member (`from app.server import ...` from tests). The script-mode launcher
+# only puts ``app/`` on sys.path, so we add the repo root explicitly.
+if str(REPO_ROOT) not in sys.path:
+    sys.path.insert(0, str(REPO_ROOT))
+
+from app import relationships  # noqa: E402  (after sys.path manipulation)
 DB_PATH = APP_DIR / "fellows.db"
 STATIC_DIR = APP_DIR / "static"
 IMAGES_DIR = APP_DIR / "fellow_profile_images_by_name"
@@ -242,24 +251,148 @@ class Handler(BaseHTTPRequestHandler):
         self.end_headers()
         self.wfile.write(b"Not Found")
 
+    # --- Helpers for /api/groups CRUD --------------------------------------
+
+    def _read_json_body(self, max_bytes=64 * 1024):
+        """Parse a JSON request body. Returns the parsed value or None on error."""
+        try:
+            length = int(self.headers.get("Content-Length", "0"))
+        except (TypeError, ValueError):
+            length = 0
+        if length <= 0 or length > max_bytes:
+            return None
+        try:
+            raw = self.rfile.read(length)
+        except OSError:
+            return None
+        try:
+            return json.loads(raw.decode("utf-8"))
+        except (json.JSONDecodeError, UnicodeDecodeError):
+            return None
+
+    def _send_json_error(self, status, message):
+        self.send_json({"error": message}, status=status)
+
+    @staticmethod
+    def _validate_group_payload(body, *, require_name=True):
+        """Light validation. Returns (clean_dict, error_str)."""
+        if not isinstance(body, dict):
+            return None, "body must be a JSON object"
+        out = {}
+        if "name" in body:
+            name = body["name"]
+            if not isinstance(name, str):
+                return None, "name must be a string"
+            name = name.strip()
+            if not name or len(name) > 200:
+                return None, "name must be 1-200 characters"
+            out["name"] = name
+        elif require_name:
+            return None, "name is required"
+        if "note" in body:
+            note = body["note"]
+            if not isinstance(note, str):
+                return None, "note must be a string"
+            if len(note) > 4000:
+                return None, "note must be at most 4000 characters"
+            out["note"] = note
+        if "fellow_record_ids" in body:
+            ids = body["fellow_record_ids"]
+            if not isinstance(ids, list):
+                return None, "fellow_record_ids must be a list"
+            for rid in ids:
+                if not isinstance(rid, str) or not rid.strip():
+                    return None, "fellow_record_ids must be non-empty strings"
+            out["fellow_record_ids"] = [rid.strip() for rid in ids]
+        return out, None
+
+    def _open_relationships_db(self):
+        """Open relationships.db with fellows.db ATTACHed read-only."""
+        try:
+            return relationships.open_db()
+        except FileNotFoundError:
+            return None
+
+    # --- Method dispatch ---------------------------------------------------
+
     def do_POST(self):
         parsed = urllib.parse.urlparse(self.path)
         path = parsed.path.rstrip("/") or "/"
-        # PR 1 stub: the create-group endpoint exists so the right-rail UI
-        # can POST and surface a clear "not yet implemented" message. PR 2
-        # replaces this with the real handler that writes to
-        # relationships.db. Tests pin the 501 contract.
         if path == "/api/groups":
-            self.send_json(
-                {
-                    "error": "Not Implemented",
-                    "message": (
-                        "POST /api/groups lands in PR 2 of the groups feature. "
-                        "Your draft is preserved; reload the page to keep editing."
-                    ),
-                },
-                status=501,
-            )
+            body = self._read_json_body()
+            if body is None:
+                return self._send_json_error(400, "invalid JSON body")
+            clean, err = self._validate_group_payload(body, require_name=True)
+            if err:
+                return self._send_json_error(400, err)
+            conn = self._open_relationships_db()
+            if conn is None:
+                return self._send_json_error(503, "relationships db unavailable")
+            try:
+                gid = relationships.create_group(
+                    conn,
+                    name=clean["name"],
+                    note=clean.get("note", ""),
+                    fellow_record_ids=clean.get("fellow_record_ids"),
+                )
+                full = relationships.get_group(conn, gid, attached=True)
+            finally:
+                conn.close()
+            return self.send_json(full, status=201)
+        self.send_error_404()
+
+    def do_PATCH(self):
+        parsed = urllib.parse.urlparse(self.path)
+        path = parsed.path.rstrip("/") or "/"
+        if path.startswith("/api/groups/"):
+            try:
+                gid = int(path[len("/api/groups/"):].strip("/"))
+            except ValueError:
+                return self.send_error_404()
+            body = self._read_json_body()
+            if body is None:
+                return self._send_json_error(400, "invalid JSON body")
+            clean, err = self._validate_group_payload(body, require_name=False)
+            if err:
+                return self._send_json_error(400, err)
+            conn = self._open_relationships_db()
+            if conn is None:
+                return self._send_json_error(503, "relationships db unavailable")
+            try:
+                ok = relationships.update_group(
+                    conn,
+                    gid,
+                    name=clean.get("name"),
+                    note=clean.get("note"),
+                    fellow_record_ids=clean.get("fellow_record_ids"),
+                )
+                if not ok:
+                    return self.send_error_404()
+                full = relationships.get_group(conn, gid, attached=True)
+            finally:
+                conn.close()
+            return self.send_json(full)
+        self.send_error_404()
+
+    def do_DELETE(self):
+        parsed = urllib.parse.urlparse(self.path)
+        path = parsed.path.rstrip("/") or "/"
+        if path.startswith("/api/groups/"):
+            try:
+                gid = int(path[len("/api/groups/"):].strip("/"))
+            except ValueError:
+                return self.send_error_404()
+            conn = self._open_relationships_db()
+            if conn is None:
+                return self._send_json_error(503, "relationships db unavailable")
+            try:
+                ok = relationships.delete_group(conn, gid)
+            finally:
+                conn.close()
+            if not ok:
+                return self.send_error_404()
+            self.send_response(204)
+            self.end_headers()
             return
         self.send_error_404()
 
@@ -313,6 +446,41 @@ class Handler(BaseHTTPRequestHandler):
                 self.send_json(fellows)
             finally:
                 conn.close()
+            return
+
+        # API: groups list
+        if path == "/api/groups":
+            conn = self._open_relationships_db()
+            if conn is None:
+                # No fellows.db on disk yet → empty list, not an error
+                self.send_json([])
+                return
+            try:
+                groups = relationships.list_groups(conn)
+            finally:
+                conn.close()
+            self.send_json(groups)
+            return
+
+        # API: one group by id
+        if path.startswith("/api/groups/"):
+            try:
+                gid = int(path[len("/api/groups/"):].strip("/"))
+            except ValueError:
+                self.send_error_404()
+                return
+            conn = self._open_relationships_db()
+            if conn is None:
+                self.send_error_404()
+                return
+            try:
+                group = relationships.get_group(conn, gid, attached=True)
+            finally:
+                conn.close()
+            if group is None:
+                self.send_error_404()
+                return
+            self.send_json(group)
             return
 
         # API: auth status stub — dev server has no auth, but the PWA client

--- a/app/static/app.js
+++ b/app/static/app.js
@@ -29,12 +29,41 @@
   var nlSearchStatusEl = document.getElementById('nl-search-status');
   var detailEl = document.getElementById('detail');
   var fullFellowsCache = null;
-  // Groups feature (PR 1): right-rail composer + +/✓ markers + draft store.
-  // The schema mirror for relationships.db (PWA / OPFS path) is summarised
-  // here for ctrl-F discoverability; the canonical DDL lives in
-  // app/relationships.py and is bootstrapped server-side. PR 2 wires the
-  // create-group POST + the OPFS open path.
-  var RELATIONSHIPS_TABLES = ['groups', 'group_members', 'fellow_tags', 'fellow_notes', 'settings'];
+  // Groups feature: relationships.db schema mirror. The canonical DDL is in
+  // app/relationships.py; this string must stay in sync. Bootstrap is
+  // idempotent (CREATE TABLE IF NOT EXISTS), so running it on every PWA
+  // boot is cheap. The OPFS-stored DB persists across app updates; the
+  // schema only adds, never destructively migrates.
+  var RELATIONSHIPS_SCHEMA_SQL =
+    'CREATE TABLE IF NOT EXISTS groups (' +
+    '  id INTEGER PRIMARY KEY,' +
+    '  name TEXT NOT NULL,' +
+    '  note TEXT NOT NULL DEFAULT \'\',' +
+    '  created_at TEXT NOT NULL,' +
+    '  updated_at TEXT NOT NULL' +
+    ');' +
+    'CREATE TABLE IF NOT EXISTS group_members (' +
+    '  group_id INTEGER NOT NULL REFERENCES groups(id) ON DELETE CASCADE,' +
+    '  fellow_record_id TEXT NOT NULL,' +
+    '  PRIMARY KEY (group_id, fellow_record_id)' +
+    ');' +
+    'CREATE INDEX IF NOT EXISTS idx_group_members_group ON group_members(group_id);' +
+    'CREATE TABLE IF NOT EXISTS fellow_tags (' +
+    '  fellow_record_id TEXT NOT NULL,' +
+    '  tag TEXT NOT NULL,' +
+    '  created_at TEXT NOT NULL,' +
+    '  PRIMARY KEY (fellow_record_id, tag)' +
+    ');' +
+    'CREATE INDEX IF NOT EXISTS idx_fellow_tags_tag ON fellow_tags(tag);' +
+    'CREATE TABLE IF NOT EXISTS fellow_notes (' +
+    '  fellow_record_id TEXT PRIMARY KEY,' +
+    '  body TEXT NOT NULL,' +
+    '  updated_at TEXT NOT NULL' +
+    ');' +
+    'CREATE TABLE IF NOT EXISTS settings (' +
+    '  key TEXT PRIMARY KEY,' +
+    '  value TEXT' +
+    ');';
   var groupRailEl = document.getElementById('group-rail');
   var groupRailEyebrowEl = document.getElementById('group-rail-eyebrow');
   var groupRailTitleEl = document.getElementById('group-rail-title');
@@ -93,7 +122,7 @@
   /** Bump on every meaningful UI / diagnostics change. Rendered in the
    *  always-visible build badge so a dev can tell at a glance which app.js
    *  is actually running vs what the server was deployed with. */
-  var FELLOWS_UI_DIAG = 'diag-2026-04o-groups-pr1';
+  var FELLOWS_UI_DIAG = 'diag-2026-04p-groups-pr2';
 
   // Persistent marker: "this origin has been authenticated successfully at
   // least once." Preserved across clearAllAppData. Used by startBrowserUx's
@@ -451,6 +480,45 @@
     return rows.length ? rows[0] : null;
   }
 
+  /** Run a non-SELECT statement (INSERT/UPDATE/DELETE). Used by the groups
+   *  data layer; the fellows side is read-only and uses dbSelect* only. */
+  function dbRun(db, sql, bind) {
+    var st = db.prepare(sql);
+    try {
+      if (bind !== undefined && bind !== null) {
+        st.bind(bind);
+      }
+      st.step();
+    } finally {
+      st.finalize();
+    }
+  }
+
+  function bootstrapRelationshipsSchema(relDb) {
+    // exec accepts multi-statement scripts; idempotent thanks to IF NOT EXISTS.
+    relDb.exec(RELATIONSHIPS_SCHEMA_SQL);
+    relDb.exec('PRAGMA user_version = 1');
+  }
+
+  function nowIsoSecond() {
+    return new Date().toISOString().replace(/\.\d+Z$/, 'Z');
+  }
+
+  function dedupeRecordIds(ids) {
+    var seen = {};
+    var out = [];
+    if (!ids) return out;
+    for (var i = 0; i < ids.length; i++) {
+      var rid = ids[i];
+      if (typeof rid !== 'string') continue;
+      var s = rid.replace(/^\s+|\s+$/g, '');
+      if (!s || seen[s]) continue;
+      seen[s] = 1;
+      out.push(s);
+    }
+    return out;
+  }
+
   function buildStatsFromDb(db) {
     var total = dbSelectOne(db, 'SELECT COUNT(*) AS c FROM fellows', null);
     var totalN = total ? total.c : 0;
@@ -556,7 +624,39 @@
     };
   }
 
-  function createSqliteDataProvider(db) {
+  function createSqliteDataProvider(db, relDb) {
+    function attachMemberNames(rows) {
+      // OPFS path skips ATTACH between SAH-pool databases; instead we
+      // resolve fellow names from the in-memory cache populated by
+      // getList/getFull on boot. Rows arrive as [{record_id}], leave as
+      // [{record_id, name}].
+      return rows.map(function (m) {
+        var rid = m.record_id;
+        var fellow = fellowsBySlug.get(rid);
+        return { record_id: rid, name: fellow ? fellow.name : rid };
+      });
+    }
+
+    function readGroupWithMembers(gid) {
+      var row = dbSelectOne(relDb, 'SELECT * FROM groups WHERE id = ?', [gid]);
+      if (!row) return null;
+      var members = dbSelectAll(
+        relDb,
+        'SELECT fellow_record_id AS record_id FROM group_members WHERE group_id = ?',
+        [gid]
+      );
+      // Sort members by resolved name (or record_id fallback) so the order
+      // matches the dev API's COALESCE(fl.name, gm.fellow_record_id).
+      var withNames = attachMemberNames(members);
+      withNames.sort(function (a, b) {
+        var an = (a.name || '').toLowerCase();
+        var bn = (b.name || '').toLowerCase();
+        return an < bn ? -1 : (an > bn ? 1 : 0);
+      });
+      row.members = withNames;
+      return row;
+    }
+
     return {
       kind: 'sqlite',
       getList: function () {
@@ -606,6 +706,104 @@
       },
       getStats: function () {
         return Promise.resolve(buildStatsFromDb(db));
+      },
+
+      // ===== Groups =================================================
+      // Mirrors the /api/groups REST shape. relDb is the OPFS-stored
+      // relationships.db opened by initOpfsDataProvider.
+      listGroups: function () {
+        if (!relDb) return Promise.reject(new Error('relationships db not open'));
+        var rows = dbSelectAll(
+          relDb,
+          'SELECT g.id, g.name, g.note, g.created_at, g.updated_at, ' +
+            'COUNT(gm.fellow_record_id) AS count ' +
+            'FROM groups g ' +
+            'LEFT JOIN group_members gm ON gm.group_id = g.id ' +
+            'GROUP BY g.id ' +
+            'ORDER BY g.updated_at DESC, g.id DESC',
+          null
+        );
+        return Promise.resolve(rows);
+      },
+      getGroup: function (id) {
+        if (!relDb) return Promise.reject(new Error('relationships db not open'));
+        return Promise.resolve(readGroupWithMembers(id));
+      },
+      createGroup: function (data) {
+        if (!relDb) return Promise.reject(new Error('relationships db not open'));
+        var name = data && data.name;
+        var note = (data && typeof data.note === 'string') ? data.note : '';
+        var ids = dedupeRecordIds(data && data.fellow_record_ids);
+        var now = nowIsoSecond();
+        relDb.exec('BEGIN');
+        try {
+          dbRun(
+            relDb,
+            'INSERT INTO groups(name, note, created_at, updated_at) VALUES (?, ?, ?, ?)',
+            [name, note, now, now]
+          );
+          var idRow = dbSelectOne(relDb, 'SELECT last_insert_rowid() AS id', null);
+          var gid = idRow && idRow.id;
+          for (var i = 0; i < ids.length; i++) {
+            dbRun(
+              relDb,
+              'INSERT INTO group_members(group_id, fellow_record_id) VALUES (?, ?)',
+              [gid, ids[i]]
+            );
+          }
+          relDb.exec('COMMIT');
+          return Promise.resolve(readGroupWithMembers(gid));
+        } catch (e) {
+          try { relDb.exec('ROLLBACK'); } catch (e2) {}
+          return Promise.reject(e);
+        }
+      },
+      updateGroup: function (id, patch) {
+        if (!relDb) return Promise.reject(new Error('relationships db not open'));
+        var existing = dbSelectOne(relDb, 'SELECT 1 AS x FROM groups WHERE id = ?', [id]);
+        if (!existing) return Promise.resolve(null);
+        var sets = ['updated_at = ?'];
+        var params = [nowIsoSecond()];
+        if (patch && typeof patch.name === 'string') {
+          sets.push('name = ?');
+          params.push(patch.name);
+        }
+        if (patch && typeof patch.note === 'string') {
+          sets.push('note = ?');
+          params.push(patch.note);
+        }
+        params.push(id);
+        relDb.exec('BEGIN');
+        try {
+          dbRun(
+            relDb,
+            'UPDATE groups SET ' + sets.join(', ') + ' WHERE id = ?',
+            params
+          );
+          if (patch && Array.isArray(patch.fellow_record_ids)) {
+            dbRun(relDb, 'DELETE FROM group_members WHERE group_id = ?', [id]);
+            var ids = dedupeRecordIds(patch.fellow_record_ids);
+            for (var i = 0; i < ids.length; i++) {
+              dbRun(
+                relDb,
+                'INSERT INTO group_members(group_id, fellow_record_id) VALUES (?, ?)',
+                [id, ids[i]]
+              );
+            }
+          }
+          relDb.exec('COMMIT');
+          return Promise.resolve(readGroupWithMembers(id));
+        } catch (e) {
+          try { relDb.exec('ROLLBACK'); } catch (e2) {}
+          return Promise.reject(e);
+        }
+      },
+      deleteGroup: function (id) {
+        if (!relDb) return Promise.reject(new Error('relationships db not open'));
+        var existing = dbSelectOne(relDb, 'SELECT 1 AS x FROM groups WHERE id = ?', [id]);
+        if (!existing) return Promise.resolve(false);
+        dbRun(relDb, 'DELETE FROM groups WHERE id = ?', [id]);
+        return Promise.resolve(true);
       }
     };
   }
@@ -620,6 +818,13 @@
   }
 
   function createApiDataProvider() {
+    function jsonOr(url, opts, expectedShapeOnEmpty) {
+      return fetch(url, opts || {}).then(function (r) {
+        if (r.status === 204) return expectedShapeOnEmpty;
+        if (!r.ok) throw apiError(url, r.status);
+        return r.json();
+      });
+    }
     return {
       kind: 'api',
       getList: function () {
@@ -647,6 +852,55 @@
       getStats: function () {
         return fetch('/api/stats').then(function (r) {
           return r.ok ? r.json() : null;
+        });
+      },
+
+      // ===== Groups (HTTP fallback) =================================
+      // Same JSON shape as the SQLite path. Resolves member names via
+      // ATTACHed f.fellows on the dev server. In production (deploy/
+      // server.py), these endpoints don't exist yet — the SQLite path
+      // is the canonical production implementation.
+      listGroups: function () {
+        return jsonOr('/api/groups', null, []);
+      },
+      getGroup: function (id) {
+        return fetch('/api/groups/' + encodeURIComponent(id)).then(function (r) {
+          if (r.status === 404) return null;
+          if (!r.ok) throw apiError('/api/groups/' + id, r.status);
+          return r.json();
+        });
+      },
+      createGroup: function (data) {
+        return fetch('/api/groups', {
+          method: 'POST',
+          headers: { 'Content-Type': 'application/json' },
+          credentials: 'same-origin',
+          body: JSON.stringify(data || {})
+        }).then(function (r) {
+          if (!r.ok) throw apiError('/api/groups', r.status);
+          return r.json();
+        });
+      },
+      updateGroup: function (id, patch) {
+        return fetch('/api/groups/' + encodeURIComponent(id), {
+          method: 'PATCH',
+          headers: { 'Content-Type': 'application/json' },
+          credentials: 'same-origin',
+          body: JSON.stringify(patch || {})
+        }).then(function (r) {
+          if (r.status === 404) return null;
+          if (!r.ok) throw apiError('/api/groups/' + id, r.status);
+          return r.json();
+        });
+      },
+      deleteGroup: function (id) {
+        return fetch('/api/groups/' + encodeURIComponent(id), {
+          method: 'DELETE',
+          credentials: 'same-origin'
+        }).then(function (r) {
+          if (r.status === 204) return true;
+          if (r.status === 404) return false;
+          throw apiError('/api/groups/' + id, r.status);
         });
       }
     };
@@ -1134,9 +1388,25 @@
         }).then(function (bytes) {
           bootDebugPush('fellows.db download: OK bytes=' + (bytes && bytes.byteLength));
           setSetupStatus('Preparing offline database…');
+          // fellows.db: re-imported from server every boot (replaces any
+          // previous OPFS copy, picking up new fellow data on update).
           poolUtil.importDb('fellows.db', bytes);
           var db = new poolUtil.OpfsSAHPoolDb('fellows.db');
-          return createSqliteDataProvider(db);
+          // relationships.db: created on first use; never replaced by
+          // updates. SAH-pool VFS handles file-not-existing by creating it.
+          // Schema bootstrap is idempotent (CREATE IF NOT EXISTS).
+          var relDb;
+          try {
+            relDb = new poolUtil.OpfsSAHPoolDb('relationships.db');
+            bootstrapRelationshipsSchema(relDb);
+            bootDebugPush('relationships.db: open + schema OK');
+          } catch (relErr) {
+            bootDebugPush(
+              'relationships.db: open failed (' + (relErr && relErr.message || relErr) + ')'
+            );
+            relDb = null;
+          }
+          return createSqliteDataProvider(db, relDb);
         });
       });
   }
@@ -2125,9 +2395,25 @@
     updateBulkBar();
   }
 
+  function clearDraftAfterSave() {
+    groupDraft.members = new Set();
+    groupDraft.memberNames = {};
+    groupDraft.title = '';
+    groupDraft.titleEdited = false;
+    saveGroupDraft();
+    renderRail();
+    refreshAllMarkers();
+    refreshDetailAddLink();
+    updateBulkBar();
+  }
+
   function handleCreateGroupClick() {
     if (!groupRailCreateEl) return;
     if (groupDraft.members.size === 0) return;
+    if (!dataProvider || typeof dataProvider.createGroup !== 'function') {
+      setRailStatus('Groups not available right now.', 'warn');
+      return;
+    }
     var titleVal = groupDraft.titleEdited
       ? groupDraft.title
       : deriveAutoTitle((searchInputEl && searchInputEl.value) || '');
@@ -2138,30 +2424,28 @@
     groupDraft.members.forEach(function (rid) { ids.push(rid); });
     setRailStatus('Saving…', 'info');
     groupRailCreateEl.disabled = true;
-    fetch('/api/groups', {
-      method: 'POST',
-      headers: { 'Content-Type': 'application/json' },
-      credentials: 'same-origin',
-      body: JSON.stringify({
-        name: titleVal,
-        note: '',
-        fellow_record_ids: ids
-      })
+    dataProvider.createGroup({
+      name: titleVal,
+      note: '',
+      fellow_record_ids: ids
     })
-      .then(function (r) {
-        if (r.status === 501) {
-          return r.json().catch(function () { return null; }).then(function (data) {
-            var msg = (data && data.message) || 'Create group not yet wired up.';
-            setRailStatus(msg, 'warn');
-          });
+      .then(function (group) {
+        if (!group || group.id == null) {
+          setRailStatus('Save returned no group; please retry.', 'warn');
+          groupRailCreateEl.disabled = groupDraft.members.size === 0;
+          return;
         }
-        // Reserved for PR 2 — happy path lands then.
-        setRailStatus('Unexpected response: ' + r.status, 'warn');
+        clearDraftAfterSave();
+        setRailStatus('Group saved.', 'info');
+        // Navigate to the new group's detail page. route() runs on
+        // hashchange and renders renderGroupDetailPage.
+        window.location.hash = '#/groups/' + encodeURIComponent(String(group.id));
       })
-      .catch(function () {
-        setRailStatus('Network error while saving.', 'warn');
-      })
-      .then(function () {
+      .catch(function (err) {
+        setRailStatus(
+          'Could not save: ' + (err && err.message ? err.message : 'unknown error'),
+          'warn'
+        );
         groupRailCreateEl.disabled = groupDraft.members.size === 0;
       });
   }
@@ -2301,9 +2585,245 @@
     var hash = window.location.hash || '';
     if (hash === '#/about') {
       renderAboutPage();
-    } else {
-      updateDetailFromHash();
+      return;
     }
+    if (hash === '#/groups') {
+      renderGroupsPage();
+      return;
+    }
+    var groupMatch = hash.match(/^#\/groups\/(\d+)$/);
+    if (groupMatch) {
+      renderGroupDetailPage(parseInt(groupMatch[1], 10));
+      return;
+    }
+    updateDetailFromHash();
+  }
+
+  // ===== Groups index + detail (PR 2) =====================================
+
+  function renderGroupsPage() {
+    if (!detailEl) return;
+    var html =
+      '<div class="groups-page">' +
+        '<h2 class="groups-title">Groups</h2>' +
+        '<p class="groups-meta" id="groups-meta">Loading groups…</p>' +
+        '<div id="groups-list-wrap"></div>' +
+        '<p class="groups-footer-hint">' +
+          'Click a group’s name to open its detail page — that’s ' +
+          'where you’ll contact the whole group, export, or edit. ' +
+          'Deleting only removes the saved group; the fellows themselves are unaffected.' +
+        '</p>' +
+      '</div>';
+    detailEl.innerHTML = html;
+    detailEl.scrollIntoView({ behavior: 'smooth', block: 'nearest' });
+    if (!dataProvider || typeof dataProvider.listGroups !== 'function') {
+      var w0 = document.getElementById('groups-list-wrap');
+      if (w0) w0.innerHTML = '<p class="placeholder">Groups not available in this mode.</p>';
+      return;
+    }
+    dataProvider.listGroups()
+      .then(function (groups) { renderGroupsList(groups || []); })
+      .catch(function () {
+        var wrap = document.getElementById('groups-list-wrap');
+        if (wrap) wrap.innerHTML = '<p class="placeholder">Could not load groups.</p>';
+      });
+  }
+
+  function renderGroupsList(groups) {
+    var wrap = document.getElementById('groups-list-wrap');
+    var meta = document.getElementById('groups-meta');
+    if (!wrap || !meta) return;
+    if (!groups.length) {
+      meta.textContent = '';
+      wrap.innerHTML =
+        '<p class="groups-empty">No groups yet. Build one from the directory by selecting fellows and tapping <b>Create new group</b>.</p>';
+      return;
+    }
+    meta.textContent =
+      groups.length + (groups.length === 1 ? ' saved group' : ' saved groups');
+    var rowsHtml = groups.map(function (g) {
+      var gidStr = String(g.id);
+      var date = (g.created_at || '').slice(0, 10);
+      var note = g.note || '';
+      var noteHtml = note
+        ? '<span class="groups-note">' + escapeHtml(note) + '</span>'
+        : '<span class="groups-note groups-note--empty">—</span>';
+      return (
+        '<tr data-group-id="' + escapeHtml(gidStr) + '">' +
+          '<td class="groups-cell-name">' +
+            '<a class="groups-name-link" href="#/groups/' + escapeHtml(gidStr) + '">' +
+              escapeHtml(g.name || '(untitled)') +
+            '</a>' +
+          '</td>' +
+          '<td class="groups-cell-num">' + escapeHtml(String(g.count || 0)) + '</td>' +
+          '<td class="groups-cell-date">' + escapeHtml(date) + '</td>' +
+          '<td>' + noteHtml + '</td>' +
+          '<td class="groups-cell-actions">' +
+            '<a href="#" class="groups-action groups-action-rename" data-group-id="' + escapeHtml(gidStr) + '">rename</a>' +
+            '<a href="#" class="groups-action groups-action-delete" data-group-id="' + escapeHtml(gidStr) + '">delete</a>' +
+          '</td>' +
+        '</tr>'
+      );
+    }).join('');
+    wrap.innerHTML =
+      '<table class="groups-table">' +
+        '<thead><tr>' +
+          '<th>Name</th>' +
+          '<th class="groups-th-num">Members</th>' +
+          '<th>Created</th>' +
+          '<th>Note</th>' +
+          '<th class="groups-th-actions"></th>' +
+        '</tr></thead>' +
+        '<tbody>' + rowsHtml + '</tbody>' +
+      '</table>';
+    wireGroupsTableActions(wrap);
+  }
+
+  function wireGroupsTableActions(wrap) {
+    var renameLinks = wrap.querySelectorAll('.groups-action-rename');
+    for (var i = 0; i < renameLinks.length; i++) {
+      renameLinks[i].addEventListener('click', function (ev) {
+        ev.preventDefault();
+        startInlineRename(wrap, this.dataset.groupId);
+      });
+    }
+    var deleteLinks = wrap.querySelectorAll('.groups-action-delete');
+    for (var j = 0; j < deleteLinks.length; j++) {
+      deleteLinks[j].addEventListener('click', function (ev) {
+        ev.preventDefault();
+        confirmAndDeleteGroup(wrap, this.dataset.groupId);
+      });
+    }
+  }
+
+  function startInlineRename(wrap, gidStr) {
+    var row = wrap.querySelector('tr[data-group-id="' + gidStr + '"]');
+    if (!row) return;
+    var nameCell = row.querySelector('.groups-cell-name');
+    var nameLink = nameCell.querySelector('.groups-name-link');
+    if (!nameCell || !nameLink) return;
+    var current = nameLink.textContent;
+    var input = document.createElement('input');
+    input.type = 'text';
+    input.value = current;
+    input.className = 'groups-rename-input';
+    input.maxLength = 200;
+    nameCell.innerHTML = '';
+    nameCell.appendChild(input);
+    input.focus();
+    input.select();
+    var done = false;
+    function commit(save) {
+      if (done) return;
+      done = true;
+      var next = (input.value || '').replace(/^\s+|\s+$/g, '');
+      if (!save || !next || next === current) {
+        restoreNameLink(nameCell, gidStr, current);
+        return;
+      }
+      nameCell.innerHTML = '<span class="groups-saving">saving…</span>';
+      dataProvider.updateGroup(parseInt(gidStr, 10), { name: next })
+        .then(function (updated) {
+          restoreNameLink(nameCell, gidStr, (updated && updated.name) || next);
+        })
+        .catch(function () {
+          restoreNameLink(nameCell, gidStr, current);
+        });
+    }
+    input.addEventListener('blur', function () { commit(true); });
+    input.addEventListener('keydown', function (ev) {
+      if (ev.key === 'Enter') { ev.preventDefault(); commit(true); }
+      else if (ev.key === 'Escape') { ev.preventDefault(); commit(false); }
+    });
+  }
+
+  function restoreNameLink(nameCell, gidStr, name) {
+    nameCell.innerHTML = '';
+    var a = document.createElement('a');
+    a.className = 'groups-name-link';
+    a.href = '#/groups/' + encodeURIComponent(gidStr);
+    a.textContent = name;
+    nameCell.appendChild(a);
+  }
+
+  function confirmAndDeleteGroup(wrap, gidStr) {
+    var row = wrap.querySelector('tr[data-group-id="' + gidStr + '"]');
+    var name = row ? row.querySelector('.groups-name-link').textContent : '(untitled)';
+    var ok = window.confirm(
+      'Delete the group "' + name + '"? ' +
+      'This removes only the group, not the fellows themselves.'
+    );
+    if (!ok) return;
+    dataProvider.deleteGroup(parseInt(gidStr, 10)).then(function (deleted) {
+      if (!deleted) return;
+      if (row && row.parentNode) row.parentNode.removeChild(row);
+      if (!wrap.querySelector('tbody tr')) {
+        var meta = document.getElementById('groups-meta');
+        if (meta) meta.textContent = '';
+        wrap.innerHTML =
+          '<p class="groups-empty">No groups yet. Build one from the directory by selecting fellows and tapping <b>Create new group</b>.</p>';
+      } else {
+        // Update the saved-count line.
+        var remaining = wrap.querySelectorAll('tbody tr').length;
+        var meta2 = document.getElementById('groups-meta');
+        if (meta2) {
+          meta2.textContent = remaining + (remaining === 1 ? ' saved group' : ' saved groups');
+        }
+      }
+    });
+  }
+
+  function renderGroupDetailPage(groupId) {
+    if (!detailEl) return;
+    detailEl.innerHTML = '<p class="placeholder">Loading group…</p>';
+    detailEl.scrollIntoView({ behavior: 'smooth', block: 'nearest' });
+    if (!dataProvider || typeof dataProvider.getGroup !== 'function') {
+      detailEl.innerHTML = '<p class="placeholder">Could not load group.</p>';
+      return;
+    }
+    dataProvider.getGroup(groupId).then(function (group) {
+      if (!group) {
+        detailEl.innerHTML =
+          '<p class="placeholder">Group not found. <a href="#/groups">Back to groups</a>.</p>';
+        return;
+      }
+      var name = group.name || '(untitled)';
+      var members = group.members || [];
+      var memberCount = members.length;
+      var memberWord = memberCount === 1 ? ' fellow' : ' fellows';
+      var html = '<div class="group-detail-page">' +
+        '<p class="group-detail-breadcrumb">' +
+          '<a href="#/groups">groups</a> › ' + escapeHtml(name) +
+        '</p>' +
+        '<h2 class="group-detail-title">' + escapeHtml(name) + '</h2>' +
+        '<p class="group-detail-meta">' +
+          escapeHtml(String(memberCount)) + memberWord +
+          ' · created ' + escapeHtml((group.created_at || '').slice(0, 10)) +
+        '</p>';
+      if (group.note) {
+        html += '<p class="group-detail-note">' + escapeHtml(group.note) + '</p>';
+      }
+      if (memberCount) {
+        html +=
+          '<table class="group-detail-members">' +
+            '<thead><tr><th>Member</th></tr></thead><tbody>';
+        members.forEach(function (m) {
+          var rid = m.record_id || '';
+          var fellow = fellowsBySlug.get(rid);
+          var slug = fellow && fellow.slug ? fellow.slug : '';
+          var href = slug ? '#/fellow/' + encodeURIComponent(slug) : '#';
+          html += '<tr><td><a href="' + escapeHtml(href) + '">' +
+            escapeHtml(m.name || rid) + '</a></td></tr>';
+        });
+        html += '</tbody></table>';
+      } else {
+        html += '<p class="placeholder">No members yet.</p>';
+      }
+      html += '</div>';
+      detailEl.innerHTML = html;
+    }).catch(function () {
+      detailEl.innerHTML = '<p class="placeholder">Could not load group.</p>';
+    });
   }
 
   function getSlugFromHash() {

--- a/app/static/index.html
+++ b/app/static/index.html
@@ -117,6 +117,7 @@
       <p id="search-status" class="search-status" aria-live="polite"></p>
     </div>
     <nav class="site-nav">
+      <a href="#/groups" class="site-nav-link" id="nav-groups-link">Groups</a>
       <a href="#/about" class="site-nav-link">About</a>
     </nav>
   </header>

--- a/app/static/styles.css
+++ b/app/static/styles.css
@@ -1298,3 +1298,198 @@ h1 {
     max-height: none;
   }
 }
+
+/* =========================================================================
+ * Groups feature — PR 2: groups index + minimal detail page
+ * ========================================================================= */
+
+.groups-page {
+  max-width: 60rem;
+}
+
+.groups-title {
+  margin: 0 0 0.25rem 0;
+  font-size: 1.2rem;
+}
+
+.groups-meta {
+  margin: 0 0 0.75rem 0;
+  font-size: 0.85rem;
+  color: #555;
+}
+
+.groups-empty {
+  padding: 0.6rem 0.75rem;
+  font-size: 0.9rem;
+  color: #444;
+  background: #faf8fc;
+  border: 1px solid #dcd6e8;
+  border-radius: 2px;
+}
+
+.groups-footer-hint {
+  margin-top: 0.6rem;
+  font-size: 0.78rem;
+  color: #7a6f91;
+  line-height: 1.5;
+}
+
+.groups-table {
+  width: 100%;
+  border-collapse: collapse;
+  font-size: 0.88rem;
+  background: #fff;
+  border: 1px solid #ccc;
+}
+
+.groups-table thead tr {
+  background: #f0f0f0;
+  font-size: 0.78rem;
+  color: #555;
+}
+
+.groups-table th {
+  text-align: left;
+  padding: 0.4em 0.7em;
+  font-weight: 600;
+}
+
+.groups-th-num { width: 90px; }
+.groups-th-actions { width: 200px; }
+
+.groups-table tbody tr {
+  border-bottom: 1px solid #efefef;
+}
+
+.groups-table td {
+  padding: 0.4em 0.7em;
+  vertical-align: middle;
+}
+
+.groups-cell-num {
+  color: #444;
+}
+
+.groups-cell-date {
+  color: #666;
+  font-family: ui-monospace, Menlo, monospace;
+  font-size: 0.78rem;
+}
+
+.groups-name-link {
+  color: #0066cc;
+  text-decoration: underline;
+  font-weight: 500;
+}
+
+.groups-note {
+  color: #666;
+  font-style: italic;
+  font-size: 0.85rem;
+}
+
+.groups-note--empty {
+  color: #bbb;
+  font-style: normal;
+}
+
+.groups-cell-actions {
+  text-align: right;
+  white-space: nowrap;
+}
+
+.groups-action {
+  color: #0066cc;
+  text-decoration: underline;
+  font-size: 0.8rem;
+  margin-left: 12px;
+}
+
+.groups-action-delete {
+  color: #7a1f1f;
+}
+
+.groups-rename-input {
+  padding: 0.2rem 0.4rem;
+  font-size: 0.88rem;
+  font-family: inherit;
+  border: 1px solid #4a2c6a;
+  border-radius: 2px;
+  width: 95%;
+}
+
+.groups-saving {
+  font-style: italic;
+  color: #7a6f91;
+  font-size: 0.85rem;
+}
+
+/* Group detail page */
+.group-detail-page {
+  max-width: 760px;
+}
+
+.group-detail-breadcrumb {
+  margin: 0 0 0.4rem 0;
+  font-size: 0.8rem;
+  color: #555;
+}
+
+.group-detail-breadcrumb a {
+  color: #0066cc;
+  text-decoration: underline;
+}
+
+.group-detail-title {
+  margin: 0 0 0.25rem 0;
+  font-size: 1.25rem;
+}
+
+.group-detail-meta {
+  margin: 0 0 0.75rem 0;
+  font-size: 0.85rem;
+  color: #555;
+}
+
+.group-detail-note {
+  margin: 0 0 0.75rem 0;
+  padding: 0.4em 0.6em;
+  font-size: 0.85rem;
+  color: #444;
+  font-style: italic;
+  background: #fffbe6;
+  border: 1px dashed #e8d77a;
+}
+
+.group-detail-members {
+  width: 100%;
+  border-collapse: collapse;
+  font-size: 0.9rem;
+  background: #fff;
+  border: 1px solid #ccc;
+}
+
+.group-detail-members thead {
+  background: #4a2c6a;
+  color: #fff;
+}
+
+.group-detail-members th {
+  text-align: left;
+  padding: 0.35em 0.7em;
+  font-weight: 600;
+  font-size: 0.95rem;
+}
+
+.group-detail-members tbody tr {
+  border-bottom: 1px solid #efefef;
+}
+
+.group-detail-members td {
+  padding: 0.35em 0.7em;
+}
+
+.group-detail-members a {
+  color: #0066cc;
+  text-decoration: underline;
+}

--- a/app/static/sw.js
+++ b/app/static/sw.js
@@ -1,4 +1,4 @@
-const CACHE_VERSION = 'v9';
+const CACHE_VERSION = 'v10';
 const APP_SHELL_CACHE = `fellows-app-shell-${CACHE_VERSION}`;
 // Separate cache so shell-version bumps don't evict the ~34 MB of profile images.
 const IMAGES_CACHE = 'fellows-images-v1';

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -67,16 +67,22 @@ def _wait_for_server(port, max_attempts=15):
 
 
 @pytest.fixture(scope="session")
-def app_server():
+def app_server(tmp_path_factory):
     """Start the app server on port 8765 once per test session (for M2 and e2e).
 
     If ``E2E_BASE_URL`` is set (e.g. ``https://fellows.globaldonut.com``), skips starting
     a local server so ``tests/e2e/`` can run against that origin. Use only when running
     ``pytest tests/e2e/``; unset for ``tests/test_api.py`` and full-suite runs.
+
+    Sets ``FELLOWS_RELATIONSHIPS_DB_PATH`` to a session-scoped temp file so the
+    test session never reads or writes the dev ``app/relationships.db``.
+    Resolved at call time inside ``app.relationships.open_db``.
     """
     if os.environ.get("E2E_BASE_URL"):
         yield
         return
+    rel_dir = tmp_path_factory.mktemp("relationships")
+    os.environ["FELLOWS_RELATIONSHIPS_DB_PATH"] = str(rel_dir / "relationships.db")
     global _server
     from app.server import PORT, HTTPServer, Handler, DB_PATH
     if not os.path.isfile(DB_PATH):

--- a/tests/e2e/test_groups_compose.py
+++ b/tests/e2e/test_groups_compose.py
@@ -142,25 +142,6 @@ class TestGroupComposer:
         link = page.locator("#directory a.dir-link", has_text="Andy Sack").first
         expect(link).to_be_visible()
 
-    def test_create_button_posts_and_surfaces_501_message(
-        self, standalone_page, base_url_fixture
-    ):
-        page = standalone_page
-        page.goto(base_url_fixture + "/", wait_until="domcontentloaded")
-        _wait_for_directory(page)
-        _aaron_row(page).locator(".dir-mark").click()
-        page.locator("#group-rail-title").fill("Smoke group")
-        page.locator("#group-rail-create").click()
-        # Server returns 501 with the PR 2 explainer; rail surfaces the
-        # message and stays usable.
-        status = page.locator("#group-rail-status")
-        expect(status).to_contain_text("PR 2", timeout=3000)
-        # Draft is NOT cleared on stub failure; create button reflects
-        # current selection (still 1).
-        expect(page.locator("#group-rail-members .group-rail-member-name").first).to_have_text(
-            "Aaron Bird"
-        )
-
     def test_bulk_select_bar_visibility_tracks_filtered_state(
         self, standalone_page, base_url_fixture
     ):

--- a/tests/e2e/test_groups_index.py
+++ b/tests/e2e/test_groups_index.py
@@ -1,0 +1,184 @@
+"""E2E for the PR 2 groups index, detail page, and create-flow navigation.
+
+Pins:
+- Create from the rail navigates to #/groups/<id> and renders the detail.
+- The /groups page lists saved groups with name, member count, created date.
+- Empty state appears when there are no groups.
+- Inline rename persists across reload.
+- Delete with confirm() removes the row; cancel keeps it.
+- Top-nav "Groups" link is wired.
+
+Each test wipes the relationships DB via the API before running, so they're
+order-independent within the session-scoped dev server.
+"""
+from __future__ import annotations
+
+import json
+from http.client import HTTPConnection
+from urllib.parse import urlparse
+
+import pytest
+from playwright.sync_api import expect
+
+
+def _wait_for_directory(page):
+    page.locator("#loading").wait_for(state="hidden", timeout=10000)
+    page.locator("#directory").wait_for(state="visible", timeout=5000)
+
+
+def _wipe_groups(base_url):
+    """Delete all groups via the dev API. Idempotent."""
+    parsed = urlparse(base_url)
+    host, port = parsed.hostname, parsed.port
+    conn = HTTPConnection(host, port, timeout=5)
+    conn.request("GET", "/api/groups")
+    r = conn.getresponse()
+    body = r.read()
+    conn.close()
+    if r.status != 200:
+        return
+    try:
+        groups = json.loads(body)
+    except ValueError:
+        return
+    for g in groups:
+        c2 = HTTPConnection(host, port, timeout=5)
+        c2.request("DELETE", f"/api/groups/{g['id']}")
+        c2.getresponse().read()
+        c2.close()
+
+
+def _aaron_row(page):
+    link = page.locator("#directory a.dir-link", has_text="Aaron Bird").first
+    expect(link).to_be_visible()
+    return link.locator("xpath=..")
+
+
+@pytest.fixture(autouse=True)
+def _reset_relationships_db(base_url_fixture):
+    _wipe_groups(base_url_fixture)
+    yield
+
+
+class TestGroupsIndex:
+    def test_top_nav_groups_link_exists(self, standalone_page, base_url_fixture):
+        page = standalone_page
+        page.goto(base_url_fixture + "/", wait_until="domcontentloaded")
+        _wait_for_directory(page)
+        nav_link = page.locator("#nav-groups-link")
+        expect(nav_link).to_be_visible()
+        expect(nav_link).to_have_attribute("href", "#/groups")
+
+    def test_groups_page_empty_state(self, standalone_page, base_url_fixture):
+        page = standalone_page
+        page.goto(base_url_fixture + "/#/groups", wait_until="domcontentloaded")
+        _wait_for_directory(page)
+        empty = page.locator(".groups-empty")
+        expect(empty).to_be_visible(timeout=5000)
+        expect(empty).to_contain_text("No groups yet")
+
+    def test_create_from_rail_navigates_to_detail_page(
+        self, standalone_page, base_url_fixture
+    ):
+        page = standalone_page
+        page.goto(base_url_fixture + "/", wait_until="domcontentloaded")
+        _wait_for_directory(page)
+        _aaron_row(page).locator(".dir-mark").click()
+        page.locator("#group-rail-title").fill("Smoke group")
+        page.locator("#group-rail-create").click()
+        # Hash changes to #/groups/<n>; detail page renders.
+        page.wait_for_url(lambda u: "#/groups/" in u, timeout=5000)
+        title = page.locator(".group-detail-title")
+        expect(title).to_have_text("Smoke group", timeout=3000)
+        # Member count + name resolved via cross-DB JOIN on the dev server.
+        expect(page.locator(".group-detail-meta")).to_contain_text("1 fellow")
+        member_link = page.locator(".group-detail-members a")
+        expect(member_link).to_have_text("Aaron Bird")
+        # Draft is cleared after save.
+        expect(page.locator("#group-rail-create")).to_be_disabled()
+        expect(page.locator("#group-rail-members .group-rail-member-name")).to_have_count(0)
+
+    def test_groups_index_lists_created_group(self, standalone_page, base_url_fixture):
+        page = standalone_page
+        page.goto(base_url_fixture + "/", wait_until="domcontentloaded")
+        _wait_for_directory(page)
+        _aaron_row(page).locator(".dir-mark").click()
+        page.locator("#group-rail-title").fill("Listed group")
+        page.locator("#group-rail-create").click()
+        page.wait_for_url(lambda u: "#/groups/" in u, timeout=5000)
+        # Now navigate to the index.
+        page.locator("#nav-groups-link").click()
+        page.wait_for_url(lambda u: u.endswith("#/groups"), timeout=3000)
+        row = page.locator(".groups-table tbody tr")
+        expect(row).to_have_count(1)
+        expect(page.locator(".groups-name-link")).to_have_text("Listed group")
+        expect(page.locator(".groups-cell-num")).to_have_text("1")
+
+    def test_inline_rename_persists_across_reload(
+        self, standalone_page, base_url_fixture
+    ):
+        page = standalone_page
+        page.goto(base_url_fixture + "/", wait_until="domcontentloaded")
+        _wait_for_directory(page)
+        _aaron_row(page).locator(".dir-mark").click()
+        page.locator("#group-rail-title").fill("old name")
+        page.locator("#group-rail-create").click()
+        page.wait_for_url(lambda u: "#/groups/" in u, timeout=5000)
+        page.locator("#nav-groups-link").click()
+        # Click rename; input appears.
+        page.locator(".groups-action-rename").click()
+        rename = page.locator(".groups-rename-input")
+        expect(rename).to_be_visible()
+        rename.fill("new name")
+        rename.press("Enter")
+        # Wait for the saving... → resolved name link.
+        expect(page.locator(".groups-name-link")).to_have_text("new name", timeout=3000)
+        # Reload — name persists.
+        page.reload(wait_until="domcontentloaded")
+        _wait_for_directory(page)
+        expect(page.locator(".groups-name-link")).to_have_text("new name")
+
+    def test_delete_with_confirm_removes_row_and_shows_empty_state(
+        self, standalone_page, base_url_fixture
+    ):
+        page = standalone_page
+        page.on("dialog", lambda d: d.accept())
+        page.goto(base_url_fixture + "/", wait_until="domcontentloaded")
+        _wait_for_directory(page)
+        _aaron_row(page).locator(".dir-mark").click()
+        page.locator("#group-rail-title").fill("doomed")
+        page.locator("#group-rail-create").click()
+        page.wait_for_url(lambda u: "#/groups/" in u, timeout=5000)
+        page.locator("#nav-groups-link").click()
+        page.locator(".groups-action-delete").click()
+        # Empty state replaces the table.
+        expect(page.locator(".groups-empty")).to_be_visible(timeout=3000)
+        expect(page.locator(".groups-table")).to_have_count(0)
+
+    def test_delete_cancel_keeps_row(self, standalone_page, base_url_fixture):
+        page = standalone_page
+        page.on("dialog", lambda d: d.dismiss())
+        page.goto(base_url_fixture + "/", wait_until="domcontentloaded")
+        _wait_for_directory(page)
+        _aaron_row(page).locator(".dir-mark").click()
+        page.locator("#group-rail-title").fill("survivor")
+        page.locator("#group-rail-create").click()
+        page.wait_for_url(lambda u: "#/groups/" in u, timeout=5000)
+        page.locator("#nav-groups-link").click()
+        page.locator(".groups-action-delete").click()
+        # Row stays.
+        expect(page.locator(".groups-name-link")).to_have_text("survivor")
+
+    def test_detail_member_link_navigates_to_fellow(
+        self, standalone_page, base_url_fixture
+    ):
+        page = standalone_page
+        page.goto(base_url_fixture + "/", wait_until="domcontentloaded")
+        _wait_for_directory(page)
+        _aaron_row(page).locator(".dir-mark").click()
+        page.locator("#group-rail-title").fill("nav test")
+        page.locator("#group-rail-create").click()
+        page.wait_for_url(lambda u: "#/groups/" in u, timeout=5000)
+        page.locator(".group-detail-members a", has_text="Aaron Bird").click()
+        page.wait_for_url(lambda u: "#/fellow/aaron_bird" in u, timeout=3000)
+        expect(page.locator(".detail-name")).to_contain_text("Aaron Bird")

--- a/tests/test_api.py
+++ b/tests/test_api.py
@@ -29,6 +29,18 @@ def get(path, query=None):
 
 
 def post(path, body=None, content_type="application/json"):
+    return _send("POST", path, body, content_type)
+
+
+def patch(path, body=None, content_type="application/json"):
+    return _send("PATCH", path, body, content_type)
+
+
+def delete(path):
+    return _send("DELETE", path, None, "application/json")
+
+
+def _send(method, path, body, content_type):
     conn = HTTPConnection("127.0.0.1", PORT, timeout=5)
     if body is None:
         payload = b""
@@ -37,12 +49,12 @@ def post(path, body=None, content_type="application/json"):
     else:
         payload = json.dumps(body).encode("utf-8")
     headers = {"Content-Type": content_type, "Content-Length": str(len(payload))}
-    conn.request("POST", path, body=payload, headers=headers)
+    conn.request(method, path, body=payload, headers=headers)
     r = conn.getresponse()
     raw = r.read()
     conn.close()
     ctype = r.getheader("Content-Type") or ""
-    return r.status, ctype, raw.decode("utf-8")
+    return r.status, ctype, raw.decode("utf-8") if raw else ""
 
 
 @pytest.mark.usefixtures("app_server")
@@ -175,16 +187,149 @@ class TestAPI:
         assert raw[:15] == b"SQLite format 3"
         assert len(raw) > 512
 
-    def test_post_groups_returns_501_until_pr2(self):
-        """The right-rail UI POSTs to /api/groups; PR 1 ships only the stub.
-        The contract: 501 + JSON body with `error` and `message`. PR 2
-        replaces this handler with the real create-group implementation."""
-        status, ctype, body = post(
-            "/api/groups",
-            {"name": "smoke", "note": "", "fellow_record_ids": []},
-        )
-        assert status == 501
+@pytest.mark.usefixtures("app_server")
+class TestGroupsCRUD:
+    """Full /api/groups round-trip against the dev server.
+
+    Each test wipes the relationships DB before running so they're order-
+    independent. ``app_server`` already isolates the DB to a tmp file via
+    ``FELLOWS_RELATIONSHIPS_DB_PATH`` (see conftest.py).
+    """
+
+    @pytest.fixture(autouse=True)
+    def _reset_groups_db(self):
+        path = os.environ.get("FELLOWS_RELATIONSHIPS_DB_PATH")
+        if path and os.path.exists(path):
+            os.unlink(path)
+        yield
+
+    @staticmethod
+    def _real_record_ids(n=2):
+        """Pick real record_ids from the dev /api/fellows so cross-DB JOIN
+        produces names. Using fixed slugs would be brittle if the dataset
+        shifts."""
+        _, _, body = get("/api/fellows")
+        rows = json.loads(body)
+        assert len(rows) >= n
+        return [(r["record_id"], r["name"]) for r in rows[:n]]
+
+    def test_list_empty_initially(self):
+        status, ctype, body = get("/api/groups")
+        assert status == 200
         assert "application/json" in ctype
-        data = json.loads(body)
-        assert data.get("error") == "Not Implemented"
-        assert "PR 2" in (data.get("message") or "")
+        assert json.loads(body) == []
+
+    def test_create_returns_201_with_full_record(self):
+        ids = self._real_record_ids(2)
+        status, _, body = post(
+            "/api/groups",
+            {
+                "name": "Climate cohort",
+                "note": "for the Wellington roundtable",
+                "fellow_record_ids": [r[0] for r in ids],
+            },
+        )
+        assert status == 201
+        g = json.loads(body)
+        assert isinstance(g["id"], int)
+        assert g["name"] == "Climate cohort"
+        assert g["note"] == "for the Wellington roundtable"
+        assert g["created_at"] and g["updated_at"]
+        assert len(g["members"]) == 2
+        # Members come back with names resolved via ATTACHed f.fellows.
+        names = sorted(m["name"] for m in g["members"])
+        assert names == sorted(r[1] for r in ids)
+
+    def test_create_then_list_shows_one(self):
+        ids = self._real_record_ids(1)
+        post("/api/groups", {"name": "g1", "fellow_record_ids": [ids[0][0]]})
+        status, _, body = get("/api/groups")
+        assert status == 200
+        groups = json.loads(body)
+        assert len(groups) == 1
+        assert groups[0]["name"] == "g1"
+        assert groups[0]["count"] == 1
+
+    def test_get_by_id_returns_members_and_404_when_missing(self):
+        ids = self._real_record_ids(1)
+        _, _, body = post("/api/groups", {"name": "x", "fellow_record_ids": [ids[0][0]]})
+        gid = json.loads(body)["id"]
+        status, _, gbody = get(f"/api/groups/{gid}")
+        assert status == 200
+        g = json.loads(gbody)
+        assert g["id"] == gid
+        assert len(g["members"]) == 1
+        # Bogus id → 404
+        status404, _, _ = get(f"/api/groups/{gid + 999}")
+        assert status404 == 404
+
+    def test_patch_renames_and_replaces_members(self):
+        ids3 = self._real_record_ids(3)
+        _, _, body = post(
+            "/api/groups",
+            {"name": "old name", "fellow_record_ids": [r[0] for r in ids3[:2]]},
+        )
+        gid = json.loads(body)["id"]
+        status, _, body2 = patch(
+            f"/api/groups/{gid}",
+            {
+                "name": "new name",
+                "note": "noted",
+                "fellow_record_ids": [ids3[2][0]],
+            },
+        )
+        assert status == 200
+        g = json.loads(body2)
+        assert g["name"] == "new name"
+        assert g["note"] == "noted"
+        assert [m["record_id"] for m in g["members"]] == [ids3[2][0]]
+        # updated_at must move forward; created_at must NOT change.
+        assert g["updated_at"] >= g["created_at"]
+
+    def test_patch_partial_only_touches_provided_fields(self):
+        ids = self._real_record_ids(1)
+        _, _, body = post("/api/groups", {"name": "keepme", "fellow_record_ids": [ids[0][0]]})
+        gid = json.loads(body)["id"]
+        # Patch only the note — name and members unchanged.
+        status, _, body2 = patch(f"/api/groups/{gid}", {"note": "just a note"})
+        assert status == 200
+        g = json.loads(body2)
+        assert g["name"] == "keepme"
+        assert g["note"] == "just a note"
+        assert len(g["members"]) == 1
+
+    def test_patch_404_for_missing_group(self):
+        status, _, _ = patch("/api/groups/9999", {"name": "x"})
+        assert status == 404
+
+    def test_delete_returns_204_then_404(self):
+        _, _, body = post("/api/groups", {"name": "doomed"})
+        gid = json.loads(body)["id"]
+        status, _, _ = delete(f"/api/groups/{gid}")
+        assert status == 204
+        status2, _, _ = delete(f"/api/groups/{gid}")
+        assert status2 == 404
+        # List is empty again.
+        _, _, lbody = get("/api/groups")
+        assert json.loads(lbody) == []
+
+    def test_post_validation_rejects_empty_name(self):
+        status, _, body = post("/api/groups", {"name": "  "})
+        assert status == 400
+        assert "name" in (json.loads(body).get("error") or "").lower()
+
+    def test_post_validation_rejects_non_list_members(self):
+        status, _, body = post(
+            "/api/groups", {"name": "x", "fellow_record_ids": "not-a-list"}
+        )
+        assert status == 400
+        assert "list" in (json.loads(body).get("error") or "").lower()
+
+    def test_create_dedupes_member_ids(self):
+        ids = self._real_record_ids(1)
+        _, _, body = post(
+            "/api/groups",
+            {"name": "x", "fellow_record_ids": [ids[0][0], ids[0][0], ids[0][0]]},
+        )
+        g = json.loads(body)
+        assert len(g["members"]) == 1


### PR DESCRIPTION
## Summary

PR 2 of 5 for the groups feature. Persistence, the groups index, the
minimal detail page, inline rename, delete, and the real create-flow
that navigates to the new group's detail page. PR 3 will layer the
action bar (Contact / Export / Edit) onto the detail page.

- **Backend (`app/relationships.py` + `app/server.py`).** Full CRUD
  for `/api/groups`. `POST` returns `201` with the new group; `GET`
  returns lists or one group with members joined via ATTACHed
  `f.fellows`; `PATCH` does partial updates (any subset of `name` /
  `note` / `fellow_record_ids`); `DELETE` returns `204` then `404`.
  Validation rejects empty names, non-string ids, oversized notes.
  `FELLOWS_RELATIONSHIPS_DB_PATH` env var lets tests isolate from the
  dev DB.
- **PWA OPFS (`app/static/app.js`).** `initOpfsDataProvider` opens
  `relationships.db` in the SAH pool alongside `fellows.db`. Schema
  bootstrap is idempotent. ATTACH between SAH-pool DBs is skipped —
  member names resolve from the in-memory `fellowsBySlug` cache, so
  the JSON shape from the SQLite path matches the dev API.
- **Both data providers** (`createSqliteDataProvider(db, relDb)` and
  `createApiDataProvider()`) expose `listGroups` / `getGroup` /
  `createGroup` / `updateGroup` / `deleteGroup`. The UI is provider-
  agnostic.
- **Frontend.** New routes `#/groups` and `#/groups/<id>`. Top-nav
  "Groups" link added. Inline rename (autofocus input, save on blur
  or Enter, Escape cancels). Native `confirm()` delete; row removed
  in place; empty state restored when the last row goes. Cream note
  callout and member-link navigation on the detail page.
- **Create-flow rewire.** `handleCreateGroupClick` now uses
  `dataProvider.createGroup`, clears the draft on success, and
  navigates to `#/groups/<new_id>`.
- **Service worker.** `CACHE_VERSION` bumped `v9` → `v10` so existing
  users get the new shell on next deploy via the standard banner.

## Test plan

- [x] `pytest tests/test_relationships.py tests/test_api.py -v` —
      9 schema/ATTACH tests + 11 new `TestGroupsCRUD` tests (create
      `201` + full record, list-empty, list-after-create, get-by-id,
      get-404, patch-rename + replace-members, partial-patch,
      patch-404, delete-`204`-then-`404`, validation rejects empty
      name + non-list members, dedupe).
- [x] `pytest tests/e2e/test_groups_compose.py tests/e2e/test_groups_index.py -v`
      — 18 e2e tests across the rail composer (10) and the new index /
      detail / rename / delete flow (8).
- [x] `pytest tests/ --ignore=tests/test_prod_stats.py -q` — **153
      passed.** (`tests/test_prod_stats.py` failures pre-date this
      branch and are tracked separately.)

## Manual QA for the maintainer

- [ ] `just serve`. Build badge reads `app: diag-2026-04p-groups-pr2`.
      If you're stuck on the v9 shell, the same DevTools snippet from
      PR 1 will flush it.
- [ ] On the directory page, pick a few fellows with `+`, type a
      group name in the rail, click **Create new group**. The URL
      should change to `#/groups/<n>`, the detail page renders with
      the breadcrumb / title / member count / member list, and the
      rail empties.
- [ ] Click the **Groups** link in the top nav. The new group should
      appear in the table with name, member count, today's date.
- [ ] Click `rename` on the row → input appears autofocused. Type a
      new name, hit Enter. The displayed name updates. Reload the
      page — the new name persists.
- [ ] Click `delete` on the row, confirm the dialog. Row goes away;
      empty state appears once the last row is gone.
- [ ] Repeat with **Cancel** on the confirm dialog — row stays.
- [ ] Click a member name in the detail page → navigates to the
      fellow detail (`#/fellow/<slug>`).
- [ ] Reload while on `#/groups/<id>` — the page renders correctly
      from a cold boot (validates the OPFS-stored `relationships.db`
      survives reloads).

## Deployment note

Same caveat as PR 1: do **not** deploy this PR alone to production.
`deploy/server.py` doesn't have these routes; production users in
browser-tab mode would see "Could not load groups." A later PR will
either (a) add the routes to `deploy/server.py` for the browser-tab
path, or (b) drop the `shouldTryOpfsProvider` standalone-only gate
so browser-tab visits also use OPFS. For now, dev-mode users on
`localhost` see the full feature working end-to-end.

🤖 Generated with [Claude Code](https://claude.com/claude-code)