### PR TITLE
feat(groups): PR 3 — group detail action bar + Contact + Export panel + note edit

### DIFF
--- a/app/static/app.js
+++ b/app/static/app.js
@@ -122,7 +122,7 @@
   /** Bump on every meaningful UI / diagnostics change. Rendered in the
    *  always-visible build badge so a dev can tell at a glance which app.js
    *  is actually running vs what the server was deployed with. */
-  var FELLOWS_UI_DIAG = 'diag-2026-04p-groups-pr2';
+  var FELLOWS_UI_DIAG = 'diag-2026-04q-groups-pr3';
 
   // Persistent marker: "this origin has been authenticated successfully at
   // least once." Preserved across clearAllAppData. Used by startBrowserUx's
@@ -2198,6 +2198,27 @@
     return div.innerHTML;
   }
 
+  // Transient bottom-of-page toast. role="status" so screen readers announce it
+  // without yanking focus. Singleton element re-used across calls.
+  var toastEl = null;
+  var toastTimer = null;
+  function showToast(msg, ttlMs) {
+    if (!toastEl) {
+      toastEl = document.createElement('div');
+      toastEl.className = 'app-toast';
+      toastEl.id = 'app-toast';
+      toastEl.setAttribute('role', 'status');
+      toastEl.setAttribute('aria-live', 'polite');
+      document.body.appendChild(toastEl);
+    }
+    toastEl.textContent = msg || '';
+    toastEl.classList.add('app-toast--visible');
+    if (toastTimer) clearTimeout(toastTimer);
+    toastTimer = setTimeout(function () {
+      if (toastEl) toastEl.classList.remove('app-toast--visible');
+    }, ttlMs || 3000);
+  }
+
   // ===== Groups feature (PR 1): draft state, rail rendering, marker sync ===
 
   function loadGroupDraft() {
@@ -2596,6 +2617,25 @@
       renderGroupDetailPage(parseInt(groupMatch[1], 10));
       return;
     }
+    var editMatch = hash.match(/^#\/edit\/(\d+)$/);
+    if (editMatch) {
+      // PR 3 placeholder. PR 4 replaces this with real edit-mode entry
+      // (snapshot the group, render the directory unrestricted, show the
+      // yellow banner, auto-save on toggle).
+      var editId = editMatch[1];
+      detailEl.innerHTML =
+        '<div class="group-detail-page">' +
+          '<p class="group-detail-breadcrumb">' +
+            '<a href="#/groups">groups</a> › ' +
+            '<a href="#/groups/' + escapeHtml(editId) + '">group</a> › edit' +
+          '</p>' +
+          '<p class="placeholder">' +
+            'Edit mode lands in PR 4. ' +
+            '<a href="#/groups/' + escapeHtml(editId) + '">Back to group</a>.' +
+          '</p>' +
+        '</div>';
+      return;
+    }
     updateDetailFromHash();
   }
 
@@ -2773,6 +2813,63 @@
     });
   }
 
+  // Recipient-count thresholds for the Contact button. mailto: URL length
+  // is the underlying constraint (see docs/persistence_and_upgrades.md and
+  // PR 1 design discussion); recipient count is a friendlier proxy.
+  var GROUPS_CONTACT_WARN_AT = 50;
+  var GROUPS_CONTACT_HARD_AT = 100;
+
+  function collectGroupEmails(group) {
+    var out = [];
+    var missing = 0;
+    if (!group || !group.members) return { emails: out, missing: 0 };
+    group.members.forEach(function (m) {
+      var rid = m.record_id;
+      var fellow = rid && fellowsBySlug.get(rid);
+      var email = fellow && fellow.contact_email;
+      if (email && String(email).trim()) {
+        out.push(String(email).trim());
+      } else {
+        missing += 1;
+      }
+    });
+    return { emails: out, missing: missing };
+  }
+
+  function buildContactMailto(group, mode, emails) {
+    // Email addresses don't need URL-encoding for normal characters; the
+    // mailto: spec accepts them verbatim. encodeURIComponent on the subject
+    // handles spaces / unicode safely.
+    var key = mode === 'bcc' ? 'bcc' : 'cc';
+    var subject = encodeURIComponent(group.name || '');
+    var url = 'mailto:?' + key + '=' + emails.join(',');
+    if (subject) url += '&subject=' + subject;
+    return url;
+  }
+
+  function copyToClipboard(text) {
+    if (navigator.clipboard && navigator.clipboard.writeText) {
+      return navigator.clipboard.writeText(text);
+    }
+    // Fallback: textarea + document.execCommand. Older Safari needs this.
+    return new Promise(function (resolve, reject) {
+      try {
+        var ta = document.createElement('textarea');
+        ta.value = text;
+        ta.style.position = 'fixed';
+        ta.style.opacity = '0';
+        document.body.appendChild(ta);
+        ta.focus();
+        ta.select();
+        document.execCommand('copy');
+        document.body.removeChild(ta);
+        resolve();
+      } catch (e) {
+        reject(e);
+      }
+    });
+  }
+
   function renderGroupDetailPage(groupId) {
     if (!detailEl) return;
     detailEl.innerHTML = '<p class="placeholder">Loading group…</p>';
@@ -2791,7 +2888,11 @@
       var members = group.members || [];
       var memberCount = members.length;
       var memberWord = memberCount === 1 ? ' fellow' : ' fellows';
-      var html = '<div class="group-detail-page">' +
+      var emailInfo = collectGroupEmails(group);
+      var totalEmails = emailInfo.emails.length;
+      var hasNote = !!(group.note && String(group.note).trim());
+      var noteEditLabel = hasNote ? 'edit' : 'add a note';
+      var html = '<div class="group-detail-page" data-group-id="' + escapeHtml(String(group.id)) + '">' +
         '<p class="group-detail-breadcrumb">' +
           '<a href="#/groups">groups</a> › ' + escapeHtml(name) +
         '</p>' +
@@ -2800,9 +2901,90 @@
           escapeHtml(String(memberCount)) + memberWord +
           ' · created ' + escapeHtml((group.created_at || '').slice(0, 10)) +
         '</p>';
-      if (group.note) {
-        html += '<p class="group-detail-note">' + escapeHtml(group.note) + '</p>';
+
+      // Action bar: ✉ Contact (primary, real <a href="mailto:…">) + CC/BCC
+      // pill toggle + ⬇ Export + ✎ Edit. Native <a> means the browser
+      // handles handing the mailto URL off to the user's mail client.
+      // The hard-threshold path intercepts the click and copies addresses
+      // to the clipboard instead.
+      var hasEmails = totalEmails > 0;
+      var hardLimit = totalEmails >= GROUPS_CONTACT_HARD_AT;
+      var initialHref = (hasEmails && !hardLimit)
+        ? buildContactMailto(group, 'cc', emailInfo.emails)
+        : '';
+      var contactClasses = 'group-action-btn group-action-btn--primary' +
+        (hasEmails ? '' : ' group-action-btn--disabled');
+      var contactAttrs = '';
+      if (initialHref) contactAttrs += ' href="' + escapeHtml(initialHref) + '"';
+      if (!hasEmails) contactAttrs += ' aria-disabled="true" title="No email addresses available for this group"';
+      html +=
+        '<div class="group-action-bar">' +
+          '<a class="' + contactClasses + '" id="group-action-contact" role="button"' + contactAttrs + '>' +
+            '✉ Contact the whole group' +
+          '</a>' +
+          '<div class="group-contact-mode" role="group" aria-label="Recipient header">' +
+            '<button type="button" class="group-mode-pill group-mode-pill--active" data-mode="cc" aria-pressed="true">CC</button>' +
+            '<button type="button" class="group-mode-pill" data-mode="bcc" aria-pressed="false">BCC</button>' +
+          '</div>' +
+          '<button type="button" class="group-action-btn" id="group-action-export">⬇ Export a directory</button>' +
+          '<button type="button" class="group-action-btn" id="group-action-edit">✎ Edit group</button>' +
+          '<span class="group-action-helper">opens your mail client with everyone in <span id="group-action-helper-mode">CC</span></span>' +
+        '</div>';
+
+      // Threshold banner. Soft warning between WARN and HARD, hard warning ≥ HARD.
+      if (totalEmails >= GROUPS_CONTACT_HARD_AT) {
+        html +=
+          '<div class="group-contact-banner group-contact-banner--hard" role="status">' +
+            escapeHtml(String(totalEmails)) + ' recipients — too many for one mailto: URL on most clients. ' +
+            '<a href="#" id="group-action-copy-emails">Copy ' + escapeHtml(String(totalEmails)) + ' addresses</a>' +
+            ' and paste them into your mail client manually.' +
+          '</div>';
+      } else if (totalEmails >= GROUPS_CONTACT_WARN_AT) {
+        html +=
+          '<div class="group-contact-banner group-contact-banner--soft" role="status">' +
+            escapeHtml(String(totalEmails)) + ' recipients — long mailto: URLs may be truncated by some clients. ' +
+            '<a href="#" id="group-action-copy-emails">Copy addresses</a> if your client misbehaves.' +
+          '</div>';
+      } else if (emailInfo.missing > 0 && totalEmails > 0) {
+        html +=
+          '<div class="group-contact-banner group-contact-banner--info" role="status">' +
+            escapeHtml(String(emailInfo.missing)) +
+            ' member' + (emailInfo.missing === 1 ? '' : 's') +
+            ' without an email; ' +
+            escapeHtml(String(totalEmails)) +
+            ' will be addressed.' +
+          '</div>';
       }
+
+      // Inline export panel (PR 3 wires the toggle; PR 5 wires Export action).
+      html +=
+        '<div class="group-export-panel hidden" id="group-export-panel" aria-label="Export options">' +
+          '<div class="group-export-head">Export a directory</div>' +
+          '<div class="group-export-options">' +
+            '<label><input type="checkbox" checked> <span><b>PDF directory</b><br><code>' +
+              escapeHtml(slugifyForFilename(name)) + '.pdf</code></span></label>' +
+            '<label><input type="checkbox"> <span><b>HTML directory</b><br><code>' +
+              escapeHtml(slugifyForFilename(name)) + '/</code> · view offline</span></label>' +
+            '<label><input type="checkbox" checked> <span><b>email it to me</b><br>your registered address</span></label>' +
+          '</div>' +
+          '<div class="group-export-actions">' +
+            '<button type="button" class="group-export-cancel">cancel</button>' +
+            '<button type="button" class="group-export-go" disabled title="Export lands in PR 5">Export</button>' +
+          '</div>' +
+          '<p class="group-export-note">Export functionality lands in PR 5 — the panel is wired so you can preview the options.</p>' +
+        '</div>';
+
+      // Cream note callout. Always rendered; "edit" / "add a note" link beside it.
+      html +=
+        '<div class="group-detail-note-wrap" id="group-detail-note-wrap">' +
+          (hasNote
+            ? '<span class="group-detail-note-text" id="group-detail-note-text">' + escapeHtml(group.note) + '</span>'
+            : '<span class="group-detail-note-empty" id="group-detail-note-text">No note yet.</span>') +
+          ' <a href="#" class="group-detail-note-edit" id="group-detail-note-edit">' +
+            escapeHtml(noteEditLabel) +
+          '</a>' +
+        '</div>';
+
       if (memberCount) {
         html +=
           '<table class="group-detail-members">' +
@@ -2821,8 +3003,194 @@
       }
       html += '</div>';
       detailEl.innerHTML = html;
+      wireGroupDetailPage(group, emailInfo);
     }).catch(function () {
       detailEl.innerHTML = '<p class="placeholder">Could not load group.</p>';
+    });
+  }
+
+  function slugifyForFilename(name) {
+    return String(name || '')
+      .toLowerCase()
+      .replace(/^#/, '')
+      .replace(/[^a-z0-9]+/g, '-')
+      .replace(/^-+|-+$/g, '') || 'group';
+  }
+
+  function wireGroupDetailPage(group, emailInfo) {
+    var contactMode = 'cc';
+    var contactBtn = document.getElementById('group-action-contact');
+    var modePills = document.querySelectorAll('.group-mode-pill');
+    var helperModeEl = document.getElementById('group-action-helper-mode');
+    var exportBtn = document.getElementById('group-action-export');
+    var editBtn = document.getElementById('group-action-edit');
+    var exportPanel = document.getElementById('group-export-panel');
+    var exportCancel = document.querySelector('.group-export-cancel');
+    var copyEmailsLink = document.getElementById('group-action-copy-emails');
+    var noteEditLink = document.getElementById('group-detail-note-edit');
+
+    function setMode(next) {
+      contactMode = next;
+      for (var i = 0; i < modePills.length; i++) {
+        var p = modePills[i];
+        var on = p.dataset.mode === next;
+        if (on) p.classList.add('group-mode-pill--active');
+        else p.classList.remove('group-mode-pill--active');
+        p.setAttribute('aria-pressed', on ? 'true' : 'false');
+      }
+      if (helperModeEl) helperModeEl.textContent = next.toUpperCase();
+      refreshContactHref();
+    }
+
+    for (var i = 0; i < modePills.length; i++) {
+      modePills[i].addEventListener('click', function () {
+        setMode(this.dataset.mode);
+      });
+    }
+
+    if (contactBtn) {
+      contactBtn.addEventListener('click', function (ev) {
+        // Disabled state: no emails. Block click so the empty href doesn't
+        // jump to top of page.
+        if (!emailInfo.emails.length) {
+          ev.preventDefault();
+          return;
+        }
+        // Hard threshold: don't navigate. Copy addresses to clipboard.
+        if (emailInfo.emails.length >= GROUPS_CONTACT_HARD_AT) {
+          ev.preventDefault();
+          copyToClipboard(emailInfo.emails.join(', '))
+            .then(function () {
+              showToast(emailInfo.emails.length + ' addresses copied. Paste into the ' +
+                contactMode.toUpperCase() + ' field of a new message.');
+            })
+            .catch(function () {
+              showToast('Could not copy addresses. Open the page console to grab them manually.');
+            });
+          return;
+        }
+        // Normal path: <a href="mailto:..."> handles itself; nothing to do.
+      });
+    }
+
+    // When CC/BCC mode flips, rebuild the mailto: href so the link reflects
+    // the chosen header. Skipped when the button is disabled or in
+    // hard-threshold copy-fallback mode.
+    function refreshContactHref() {
+      if (!contactBtn) return;
+      if (!emailInfo.emails.length) return;
+      if (emailInfo.emails.length >= GROUPS_CONTACT_HARD_AT) return;
+      contactBtn.setAttribute(
+        'href',
+        buildContactMailto(group, contactMode, emailInfo.emails)
+      );
+    }
+
+    if (copyEmailsLink) {
+      copyEmailsLink.addEventListener('click', function (ev) {
+        ev.preventDefault();
+        copyToClipboard(emailInfo.emails.join(', '))
+          .then(function () {
+            showToast(emailInfo.emails.length + ' addresses copied to clipboard.');
+          })
+          .catch(function () {
+            showToast('Could not copy addresses.');
+          });
+      });
+    }
+
+    if (exportBtn && exportPanel) {
+      exportBtn.addEventListener('click', function () {
+        exportPanel.classList.toggle('hidden');
+      });
+    }
+    if (exportCancel && exportPanel) {
+      exportCancel.addEventListener('click', function () {
+        exportPanel.classList.add('hidden');
+      });
+    }
+
+    if (editBtn) {
+      editBtn.addEventListener('click', function () {
+        // PR 3 navigates; PR 4 will replace the placeholder route handler
+        // with the real "directory in edit mode" entry behavior.
+        window.location.hash = '#/edit/' + encodeURIComponent(String(group.id));
+      });
+    }
+
+    if (noteEditLink) {
+      noteEditLink.addEventListener('click', function (ev) {
+        ev.preventDefault();
+        startInlineNoteEdit(group);
+      });
+    }
+  }
+
+  function startInlineNoteEdit(group) {
+    var wrap = document.getElementById('group-detail-note-wrap');
+    if (!wrap) return;
+    var current = group.note || '';
+    wrap.innerHTML = '';
+    wrap.classList.add('group-detail-note-wrap--editing');
+    var textarea = document.createElement('textarea');
+    textarea.className = 'group-detail-note-input';
+    textarea.value = current;
+    textarea.maxLength = 4000;
+    textarea.rows = 3;
+    var actions = document.createElement('div');
+    actions.className = 'group-detail-note-actions';
+    var saveBtn = document.createElement('button');
+    saveBtn.type = 'button';
+    saveBtn.className = 'group-detail-note-save';
+    saveBtn.textContent = 'Save';
+    var cancelBtn = document.createElement('button');
+    cancelBtn.type = 'button';
+    cancelBtn.className = 'group-detail-note-cancel';
+    cancelBtn.textContent = 'Cancel';
+    actions.appendChild(saveBtn);
+    actions.appendChild(cancelBtn);
+    wrap.appendChild(textarea);
+    wrap.appendChild(actions);
+    textarea.focus();
+    textarea.select();
+
+    function restore(noteText) {
+      wrap.classList.remove('group-detail-note-wrap--editing');
+      var hasNote = !!(noteText && String(noteText).trim());
+      wrap.innerHTML =
+        (hasNote
+          ? '<span class="group-detail-note-text" id="group-detail-note-text">' + escapeHtml(noteText) + '</span>'
+          : '<span class="group-detail-note-empty" id="group-detail-note-text">No note yet.</span>') +
+        ' <a href="#" class="group-detail-note-edit" id="group-detail-note-edit">' +
+          (hasNote ? 'edit' : 'add a note') +
+        '</a>';
+      // Re-bind the new edit link.
+      var newLink = document.getElementById('group-detail-note-edit');
+      if (newLink) {
+        newLink.addEventListener('click', function (ev) {
+          ev.preventDefault();
+          startInlineNoteEdit(group);
+        });
+      }
+    }
+
+    cancelBtn.addEventListener('click', function () { restore(current); });
+    saveBtn.addEventListener('click', function () {
+      var next = textarea.value;
+      saveBtn.disabled = true;
+      cancelBtn.disabled = true;
+      dataProvider.updateGroup(group.id, { note: next })
+        .then(function (updated) {
+          var savedNote = (updated && typeof updated.note === 'string') ? updated.note : next;
+          group.note = savedNote;
+          restore(savedNote);
+          showToast('Note saved.');
+        })
+        .catch(function () {
+          saveBtn.disabled = false;
+          cancelBtn.disabled = false;
+          showToast('Could not save note.');
+        });
     });
   }
 

--- a/app/static/styles.css
+++ b/app/static/styles.css
@@ -1493,3 +1493,301 @@ h1 {
   color: #0066cc;
   text-decoration: underline;
 }
+
+/* =========================================================================
+ * Groups feature — PR 3: detail action bar, contact + export panel,
+ * inline note edit, toast.
+ * ========================================================================= */
+
+.group-action-bar {
+  display: flex;
+  flex-wrap: wrap;
+  align-items: center;
+  gap: 0.5rem;
+  padding: 0.5rem 0.6rem;
+  margin: 0.5rem 0;
+  background: #faf8fc;
+  border: 1px solid #dcd6e8;
+  border-radius: 2px;
+}
+
+.group-action-btn {
+  font: inherit;
+  font-size: 0.85rem;
+  padding: 0.3rem 0.7rem;
+  border-radius: 3px;
+  border: 1px solid #ccc;
+  background: #fff;
+  color: #333;
+  cursor: pointer;
+}
+
+.group-action-btn:hover:not(:disabled) {
+  background: #f4eef9;
+}
+
+.group-action-btn:disabled {
+  opacity: 0.5;
+  cursor: not-allowed;
+}
+
+.group-action-btn--primary {
+  background: #4a2c6a;
+  color: #fff;
+  border-color: #4a2c6a;
+  font-weight: 600;
+}
+
+.group-action-btn--primary:hover:not(:disabled):not(.group-action-btn--disabled) {
+  background: #3b2355;
+}
+
+/* <a>-as-button needs explicit defaults to look like a button. */
+a.group-action-btn {
+  text-decoration: none;
+  display: inline-block;
+}
+
+a.group-action-btn:hover {
+  text-decoration: none;
+}
+
+.group-action-btn--disabled,
+.group-action-btn--disabled:hover {
+  opacity: 0.5;
+  cursor: not-allowed;
+  background: #fff !important;
+  color: #333 !important;
+  border-color: #ccc !important;
+}
+
+a.group-action-btn--primary {
+  color: #fff;
+}
+
+.group-contact-mode {
+  display: inline-flex;
+  border: 1px solid #dcd6e8;
+  border-radius: 999px;
+  overflow: hidden;
+  background: #fff;
+}
+
+.group-mode-pill {
+  font: inherit;
+  font-size: 0.78rem;
+  font-weight: 600;
+  padding: 0.2rem 0.55rem;
+  border: 0;
+  background: transparent;
+  color: #3b2355;
+  cursor: pointer;
+  letter-spacing: 0.04em;
+}
+
+.group-mode-pill--active {
+  background: #4a2c6a;
+  color: #fff;
+}
+
+.group-mode-pill:focus {
+  outline: 2px solid #4a2c6a;
+  outline-offset: -2px;
+}
+
+.group-action-helper {
+  font-size: 0.72rem;
+  color: #7a6f91;
+  margin-left: auto;
+  align-self: center;
+}
+
+.group-contact-banner {
+  margin: 0.4rem 0;
+  padding: 0.4rem 0.6rem;
+  font-size: 0.82rem;
+  border-radius: 2px;
+  border: 1px solid;
+}
+
+.group-contact-banner--soft {
+  background: #fff3cd;
+  border-color: #ffe69c;
+  color: #664d03;
+}
+
+.group-contact-banner--hard {
+  background: #fde2e2;
+  border-color: #f0bcbc;
+  color: #6b1f1f;
+}
+
+.group-contact-banner--info {
+  background: #ede7f3;
+  border-color: #dcd6e8;
+  color: #3b2355;
+}
+
+.group-contact-banner a {
+  color: inherit;
+  text-decoration: underline;
+}
+
+/* Inline export panel beneath the action bar (PR 5 wires Export action). */
+.group-export-panel {
+  margin: 0.4rem 0;
+  background: #fff;
+  border: 1px solid #dcd6e8;
+  font-size: 0.85rem;
+}
+
+.group-export-head {
+  background: #4a2c6a;
+  color: #fff;
+  padding: 0.35em 0.5em;
+  font-weight: 600;
+  font-size: 0.95rem;
+}
+
+.group-export-options {
+  display: flex;
+  flex-wrap: wrap;
+  gap: 0.6rem 1.2rem;
+  padding: 0.55rem 0.7rem;
+}
+
+.group-export-options label {
+  display: flex;
+  gap: 0.4rem;
+  align-items: flex-start;
+  cursor: pointer;
+  line-height: 1.35;
+}
+
+.group-export-options code {
+  font-size: 0.78rem;
+  color: #7a6f91;
+}
+
+.group-export-actions {
+  display: flex;
+  gap: 6px;
+  justify-content: flex-end;
+  padding: 0 0.7rem 0.5rem;
+}
+
+.group-export-cancel,
+.group-export-go {
+  font: inherit;
+  font-size: 0.82rem;
+  padding: 0.25rem 0.65rem;
+  border-radius: 3px;
+  border: 1px solid #ccc;
+  background: #fff;
+  cursor: pointer;
+}
+
+.group-export-go:disabled {
+  opacity: 0.5;
+  cursor: not-allowed;
+}
+
+.group-export-note {
+  margin: 0;
+  padding: 0 0.7rem 0.6rem;
+  font-size: 0.72rem;
+  color: #7a6f91;
+}
+
+/* Cream note callout — replaces the simpler PR 2 paragraph. */
+.group-detail-note-wrap {
+  margin: 0.4rem 0 0.75rem 0;
+  padding: 0.4em 0.6em;
+  font-size: 0.85rem;
+  color: #444;
+  background: #fffbe6;
+  border: 1px dashed #e8d77a;
+}
+
+.group-detail-note-text {
+  font-style: italic;
+}
+
+.group-detail-note-empty {
+  color: #888;
+}
+
+.group-detail-note-edit {
+  margin-left: 0.5rem;
+  font-size: 0.78rem;
+  color: #0066cc;
+  text-decoration: underline;
+  font-style: normal;
+}
+
+.group-detail-note-wrap--editing {
+  background: #fffdf2;
+}
+
+.group-detail-note-input {
+  width: 100%;
+  box-sizing: border-box;
+  padding: 0.3rem 0.4rem;
+  font: inherit;
+  font-size: 0.88rem;
+  border: 1px solid #4a2c6a;
+  border-radius: 2px;
+  resize: vertical;
+}
+
+.group-detail-note-actions {
+  display: flex;
+  justify-content: flex-end;
+  gap: 6px;
+  margin-top: 0.4rem;
+}
+
+.group-detail-note-save,
+.group-detail-note-cancel {
+  font: inherit;
+  font-size: 0.82rem;
+  padding: 0.2rem 0.65rem;
+  border-radius: 3px;
+  cursor: pointer;
+}
+
+.group-detail-note-save {
+  background: #4a2c6a;
+  color: #fff;
+  border: 1px solid #4a2c6a;
+}
+
+.group-detail-note-cancel {
+  background: #fff;
+  color: #333;
+  border: 1px solid #ccc;
+}
+
+/* Transient toast — bottom-center, fades. */
+.app-toast {
+  position: fixed;
+  left: 50%;
+  bottom: 1.25rem;
+  transform: translate(-50%, 1rem);
+  z-index: 9990;
+  padding: 0.55rem 0.85rem;
+  font-size: 0.85rem;
+  color: #fff;
+  background: #2d1f3d;
+  border-radius: 6px;
+  box-shadow: 0 4px 16px rgba(0, 0, 0, 0.25);
+  max-width: 90vw;
+  pointer-events: none;
+  opacity: 0;
+  transition: opacity 200ms ease, transform 200ms ease;
+}
+
+.app-toast--visible {
+  opacity: 1;
+  transform: translate(-50%, 0);
+}

--- a/app/static/sw.js
+++ b/app/static/sw.js
@@ -1,4 +1,4 @@
-const CACHE_VERSION = 'v10';
+const CACHE_VERSION = 'v11';
 const APP_SHELL_CACHE = `fellows-app-shell-${CACHE_VERSION}`;
 // Separate cache so shell-version bumps don't evict the ~34 MB of profile images.
 const IMAGES_CACHE = 'fellows-images-v1';

--- a/tests/e2e/test_groups_detail.py
+++ b/tests/e2e/test_groups_detail.py
@@ -1,0 +1,337 @@
+"""E2E for the PR 3 group detail page: action bar + Contact + Export panel
++ Edit nav + inline note edit + threshold banners + toast.
+
+Pins:
+- Action bar shows ✉ Contact / CC|BCC / ⬇ Export / ✎ Edit, with helper text
+  reflecting the active mode.
+- Contact <a> href is mailto:?cc=...&subject=... below the warn threshold.
+- CC ↔ BCC toggle rebuilds the href.
+- Soft warning banner appears at WARN_AT (50) recipients.
+- Hard threshold (≥ HARD_AT = 100): href is removed; click copies addresses
+  to clipboard and shows a toast.
+- Export panel toggles open / closed; Export button is disabled with a
+  PR 5 hint.
+- Edit button navigates to #/edit/<id>; placeholder route renders.
+- Inline note edit saves via PATCH and persists across reload; cancel
+  restores the original.
+"""
+from __future__ import annotations
+
+import json
+import re
+from http.client import HTTPConnection
+from urllib.parse import urlparse
+
+import pytest
+from playwright.sync_api import expect
+
+
+def _conn(base_url):
+    parsed = urlparse(base_url)
+    return HTTPConnection(parsed.hostname, parsed.port, timeout=10)
+
+
+def _wipe_groups(base_url):
+    c = _conn(base_url)
+    c.request("GET", "/api/groups")
+    r = c.getresponse()
+    body = r.read()
+    c.close()
+    if r.status != 200:
+        return
+    try:
+        groups = json.loads(body)
+    except ValueError:
+        return
+    for g in groups:
+        c2 = _conn(base_url)
+        c2.request("DELETE", f"/api/groups/{g['id']}")
+        c2.getresponse().read()
+        c2.close()
+
+
+def _real_fellows(base_url, with_email=True):
+    """Return a list of (record_id, name, contact_email) tuples from the dev API."""
+    c = _conn(base_url)
+    c.request("GET", "/api/fellows?full=1")
+    r = c.getresponse()
+    body = r.read()
+    c.close()
+    rows = json.loads(body)
+    out = []
+    for row in rows:
+        rid = row.get("record_id")
+        name = row.get("name") or ""
+        email = (row.get("contact_email") or "").strip()
+        if with_email and not email:
+            continue
+        out.append((rid, name, email))
+    return out
+
+
+def _create_group(base_url, *, name, fellow_record_ids, note=""):
+    c = _conn(base_url)
+    payload = json.dumps({
+        "name": name,
+        "note": note,
+        "fellow_record_ids": fellow_record_ids,
+    }).encode("utf-8")
+    c.request(
+        "POST",
+        "/api/groups",
+        body=payload,
+        headers={"Content-Type": "application/json", "Content-Length": str(len(payload))},
+    )
+    r = c.getresponse()
+    body = r.read()
+    c.close()
+    assert r.status == 201, body
+    return json.loads(body)
+
+
+def _wait_for_directory(page):
+    page.locator("#loading").wait_for(state="hidden", timeout=10000)
+    page.locator("#directory").wait_for(state="visible", timeout=5000)
+
+
+@pytest.fixture(autouse=True)
+def _reset_relationships_db(base_url_fixture):
+    _wipe_groups(base_url_fixture)
+    yield
+
+
+class TestGroupDetailActionBar:
+    def test_action_bar_renders_three_buttons(
+        self, standalone_page, base_url_fixture
+    ):
+        page = standalone_page
+        fellows = _real_fellows(base_url_fixture)
+        g = _create_group(
+            base_url_fixture,
+            name="Action bar test",
+            fellow_record_ids=[f[0] for f in fellows[:1]],
+        )
+        page.goto(f"{base_url_fixture}/#/groups/{g['id']}", wait_until="domcontentloaded")
+        _wait_for_directory(page)
+        bar = page.locator(".group-action-bar")
+        expect(bar).to_be_visible(timeout=5000)
+        contact = page.locator("#group-action-contact")
+        expect(contact).to_be_visible()
+        expect(contact).to_contain_text("Contact the whole group")
+        expect(page.locator("#group-action-export")).to_contain_text("Export a directory")
+        expect(page.locator("#group-action-edit")).to_contain_text("Edit group")
+        # CC pill is active by default.
+        cc_pill = page.locator('.group-mode-pill[data-mode="cc"]')
+        expect(cc_pill).to_have_class(re.compile(r"\bgroup-mode-pill--active\b"))
+        bcc_pill = page.locator('.group-mode-pill[data-mode="bcc"]')
+        expect(bcc_pill).not_to_have_class(re.compile(r"\bgroup-mode-pill--active\b"))
+
+    def test_contact_href_under_threshold_is_mailto_cc(
+        self, standalone_page, base_url_fixture
+    ):
+        page = standalone_page
+        fellows = _real_fellows(base_url_fixture)
+        chosen = fellows[:3]
+        g = _create_group(
+            base_url_fixture,
+            name="Mailto small",
+            fellow_record_ids=[f[0] for f in chosen],
+        )
+        page.goto(f"{base_url_fixture}/#/groups/{g['id']}", wait_until="domcontentloaded")
+        _wait_for_directory(page)
+        contact = page.locator("#group-action-contact")
+        expect(contact).to_have_attribute(
+            "href", re.compile(r"^mailto:\?cc=.+&subject=Mailto%20small$")
+        )
+
+    def test_cc_bcc_toggle_rewrites_href_and_helper(
+        self, standalone_page, base_url_fixture
+    ):
+        page = standalone_page
+        fellows = _real_fellows(base_url_fixture)
+        g = _create_group(
+            base_url_fixture,
+            name="Toggle test",
+            fellow_record_ids=[f[0] for f in fellows[:2]],
+        )
+        page.goto(f"{base_url_fixture}/#/groups/{g['id']}", wait_until="domcontentloaded")
+        _wait_for_directory(page)
+        helper_mode = page.locator("#group-action-helper-mode")
+        expect(helper_mode).to_have_text("CC")
+        expect(page.locator("#group-action-contact")).to_have_attribute(
+            "href", re.compile(r"^mailto:\?cc=")
+        )
+        page.locator('.group-mode-pill[data-mode="bcc"]').click()
+        expect(helper_mode).to_have_text("BCC")
+        expect(page.locator("#group-action-contact")).to_have_attribute(
+            "href", re.compile(r"^mailto:\?bcc=")
+        )
+        # ARIA pressed states flip.
+        expect(page.locator('.group-mode-pill[data-mode="cc"]')).to_have_attribute(
+            "aria-pressed", "false"
+        )
+        expect(page.locator('.group-mode-pill[data-mode="bcc"]')).to_have_attribute(
+            "aria-pressed", "true"
+        )
+
+    def test_soft_warning_banner_at_warn_threshold(
+        self, standalone_page, base_url_fixture
+    ):
+        page = standalone_page
+        fellows = _real_fellows(base_url_fixture)
+        # 60 recipients — comfortably between WARN (50) and HARD (100).
+        chosen = fellows[:60]
+        assert len(chosen) == 60, "dev dataset must have ≥ 60 fellows with emails"
+        g = _create_group(
+            base_url_fixture,
+            name="Soft warn",
+            fellow_record_ids=[f[0] for f in chosen],
+        )
+        page.goto(f"{base_url_fixture}/#/groups/{g['id']}", wait_until="domcontentloaded")
+        _wait_for_directory(page)
+        soft = page.locator(".group-contact-banner--soft")
+        expect(soft).to_be_visible(timeout=5000)
+        expect(soft).to_contain_text("60 recipients")
+        # Contact link is still a real mailto: URL (the soft path tries it).
+        expect(page.locator("#group-action-contact")).to_have_attribute(
+            "href", re.compile(r"^mailto:\?cc=")
+        )
+
+    def test_hard_threshold_strips_href_and_copies_to_clipboard(
+        self, standalone_page, base_url_fixture, context
+    ):
+        # navigator.clipboard.writeText needs the permission in headless
+        # Chromium. Granting at the browser-context level keeps this
+        # localised to the e2e test.
+        context.grant_permissions(
+            ["clipboard-read", "clipboard-write"], origin=base_url_fixture
+        )
+        page = standalone_page
+        fellows = _real_fellows(base_url_fixture)
+        chosen = fellows[:120]
+        assert len(chosen) == 120, "dev dataset must have ≥ 120 fellows with emails"
+        g = _create_group(
+            base_url_fixture,
+            name="Hard limit",
+            fellow_record_ids=[f[0] for f in chosen],
+        )
+        page.goto(f"{base_url_fixture}/#/groups/{g['id']}", wait_until="domcontentloaded")
+        _wait_for_directory(page)
+        # Hard banner visible.
+        hard = page.locator(".group-contact-banner--hard")
+        expect(hard).to_be_visible(timeout=5000)
+        expect(hard).to_contain_text("120 recipients")
+        # Contact link has NO href in hard mode (so the click handler
+        # intercepts and copies instead of trying a giant mailto URL).
+        contact = page.locator("#group-action-contact")
+        expect(contact).not_to_have_attribute("href", re.compile(r"."))
+        # Click the Contact button → toast appears, addresses on clipboard.
+        contact.click()
+        toast = page.locator("#app-toast")
+        expect(toast).to_be_visible(timeout=3000)
+        expect(toast).to_contain_text("120 addresses copied")
+        clipboard = page.evaluate("navigator.clipboard.readText()")
+        # All 120 emails should be in the clipboard, comma-separated.
+        for _, _, email in chosen:
+            assert email in clipboard, f"missing {email} in clipboard"
+
+
+class TestGroupDetailExportPanel:
+    def test_export_panel_toggles_and_export_disabled_with_pr5_hint(
+        self, standalone_page, base_url_fixture
+    ):
+        page = standalone_page
+        fellows = _real_fellows(base_url_fixture)
+        g = _create_group(
+            base_url_fixture,
+            name="Export panel",
+            fellow_record_ids=[f[0] for f in fellows[:1]],
+        )
+        page.goto(f"{base_url_fixture}/#/groups/{g['id']}", wait_until="domcontentloaded")
+        _wait_for_directory(page)
+        panel = page.locator("#group-export-panel")
+        expect(panel).to_be_hidden()
+        page.locator("#group-action-export").click()
+        expect(panel).to_be_visible()
+        # Export button disabled with PR 5 hint.
+        export_go = page.locator(".group-export-go")
+        expect(export_go).to_be_disabled()
+        expect(export_go).to_have_attribute("title", re.compile(r"PR 5"))
+        # Cancel hides it again.
+        page.locator(".group-export-cancel").click()
+        expect(panel).to_be_hidden()
+
+
+class TestGroupDetailEditNav:
+    def test_edit_button_navigates_to_edit_route_placeholder(
+        self, standalone_page, base_url_fixture
+    ):
+        page = standalone_page
+        fellows = _real_fellows(base_url_fixture)
+        g = _create_group(
+            base_url_fixture,
+            name="Edit nav",
+            fellow_record_ids=[f[0] for f in fellows[:1]],
+        )
+        page.goto(f"{base_url_fixture}/#/groups/{g['id']}", wait_until="domcontentloaded")
+        _wait_for_directory(page)
+        page.locator("#group-action-edit").click()
+        page.wait_for_url(lambda u: f"#/edit/{g['id']}" in u, timeout=3000)
+        # PR 3 placeholder visible until PR 4 lands real edit-mode entry.
+        placeholder = page.locator(".group-detail-page .placeholder")
+        expect(placeholder).to_contain_text("Edit mode lands in PR 4")
+
+
+class TestGroupDetailNoteEdit:
+    def test_inline_note_edit_saves_and_persists(
+        self, standalone_page, base_url_fixture
+    ):
+        page = standalone_page
+        fellows = _real_fellows(base_url_fixture)
+        g = _create_group(
+            base_url_fixture,
+            name="Note flow",
+            fellow_record_ids=[f[0] for f in fellows[:1]],
+        )
+        page.goto(f"{base_url_fixture}/#/groups/{g['id']}", wait_until="domcontentloaded")
+        _wait_for_directory(page)
+        # No note → "add a note" link.
+        edit_link = page.locator("#group-detail-note-edit")
+        expect(edit_link).to_have_text("add a note")
+        edit_link.click()
+        textarea = page.locator(".group-detail-note-input")
+        expect(textarea).to_be_visible()
+        textarea.fill("for the Wellington roundtable")
+        page.locator(".group-detail-note-save").click()
+        expect(page.locator(".group-detail-note-text")).to_contain_text(
+            "for the Wellington roundtable"
+        )
+        # Now the link reads "edit".
+        expect(page.locator("#group-detail-note-edit")).to_have_text("edit")
+        # Persists across reload.
+        page.reload(wait_until="domcontentloaded")
+        _wait_for_directory(page)
+        expect(page.locator(".group-detail-note-text")).to_contain_text(
+            "for the Wellington roundtable"
+        )
+
+    def test_inline_note_edit_cancel_restores_original(
+        self, standalone_page, base_url_fixture
+    ):
+        page = standalone_page
+        fellows = _real_fellows(base_url_fixture)
+        g = _create_group(
+            base_url_fixture,
+            name="Cancel flow",
+            note="original note",
+            fellow_record_ids=[f[0] for f in fellows[:1]],
+        )
+        page.goto(f"{base_url_fixture}/#/groups/{g['id']}", wait_until="domcontentloaded")
+        _wait_for_directory(page)
+        expect(page.locator(".group-detail-note-text")).to_contain_text("original note")
+        page.locator("#group-detail-note-edit").click()
+        textarea = page.locator(".group-detail-note-input")
+        textarea.fill("changed")
+        page.locator(".group-detail-note-cancel").click()
+        # Back to original; no PATCH was sent.
+        expect(page.locator(".group-detail-note-text")).to_contain_text("original note")


### PR DESCRIPTION
## Summary

PR 3 of 5 for the groups feature. The `#/groups/<id>` page gets the
single lavender action bar from the design (Contact / Export / Edit),
the CC/BCC pill toggle, threshold-aware `mailto:` behaviour, an inline
export panel (functionality stubbed for PR 5), an inline note editor,
and a transient toast. PR 4 will replace the new `#/edit/<id>`
placeholder with real edit-mode entry; PR 5 wires the Export action
and the visual portrait directory.

- **`✉ Contact the whole group`** is a real `<a href="mailto:?cc=…&subject=…">`,
  so the browser hands the URL off to the user's mail client natively.
  The **CC | BCC pill toggle** rewrites the `href` in place; helper
  text and `aria-pressed` flip with it.
- **`⬇ Export a directory`** toggles an inline panel with PDF / HTML /
  "email it to me" checkboxes (visual scaffolding from the design).
  The Export button itself is `disabled title="Export lands in PR 5"`
  so testers don't false-fire it.
- **`✎ Edit group`** navigates to `#/edit/<id>`. The route handler
  shows a PR 4 placeholder for now (PR 4 replaces the body with real
  edit-mode entry — yellow banner, snapshot, auto-save).
- **Threshold handling for Contact:** `< 50` → standard `mailto:`;
  `50–99` → soft warning banner with a "Copy addresses" link, link
  still active; `≥ 100` → hard threshold, `href` removed, click →
  `navigator.clipboard.writeText` + toast; `0` → `aria-disabled`.
- **Inline note editor:** cream callout always renders; "edit"
  (or "add a note") swaps to textarea + Save / Cancel; Save →
  `PATCH /api/groups/<id>` → restore + toast "Note saved."
- **Toast:** singleton `#app-toast` bottom-center, `role="status"`,
  fades after 3s. Used by Contact-clipboard fallback and note save.
- **Service worker** bumped `v10` → `v11`. Build badge:
  `app: diag-2026-04q-groups-pr3`.

## Test plan

- [x] `pytest tests/e2e/test_groups_detail.py -v` — 9 new tests:
      action bar renders three buttons + CC pill active; Contact href
      below threshold is `mailto:?cc=…&subject=…`; CC↔BCC toggle
      rewrites href + ARIA + helper; soft warn at 60 recipients
      (mailto still present); hard at 120 (href stripped, click →
      clipboard + toast, real emails verified via
      `navigator.clipboard.readText`); Export panel toggles + Export
      disabled with PR 5 hint; Edit navigates to `#/edit/<id>` with
      placeholder; inline note edit save persists across reload;
      cancel restores original.
- [x] `pytest tests/ --ignore=tests/test_prod_stats.py -q` — **162
      passed** (153 before, +9). `test_prod_stats.py` failures
      pre-date this branch.

## Manual QA for the maintainer

After merging this PR:

```bash
git switch main && git pull
just restart        # reloads the dev server with the new code on disk
```

Then in your browser tab on `localhost:8765`:

- [ ] Hit Cmd-R (hard reload). The build badge should flip to
      `app: diag-2026-04q-groups-pr3`. The shell paths are
      network-first, so a regular reload picks up the new `app.js`
      without needing Clear App Cache. (If it ever doesn't, use the
      DevTools snippet from the PR 1 thread.)
- [ ] Open one of your existing groups (`#/groups/<id>`). You should
      see the new lavender action bar with three buttons and the
      CC|BCC pill toggle.
- [ ] Click `✉ Contact the whole group` on a small group. Your mail
      client should open with `cc=` populated and the group name as
      the subject.
- [ ] Click the BCC pill. Helper text changes to `BCC`. Click
      Contact again — mail client should now show the addresses in
      `bcc=` instead.
- [ ] Build a group with 60+ members (use the directory rail with
      a fellow_type filter or `#tag` search, then bulk-select). Open
      its detail page. You should see the yellow soft-warning banner
      ("X recipients — long mailto: URLs may be truncated…"). The
      Contact link still works; "Copy addresses" copies them all to
      your clipboard.
- [ ] Build a group with 100+ members. The banner turns red. The
      Contact button no longer has an `href`; clicking it copies
      addresses to your clipboard and surfaces a toast at the bottom
      of the page.
- [ ] Click `⬇ Export a directory`. Inline panel appears with PDF /
      HTML / "email it to me" checkboxes. The Export button is
      greyed out — hovering shows "Export lands in PR 5". Click
      cancel to collapse.
- [ ] Click `✎ Edit group`. URL changes to `#/edit/<id>`; the page
      shows "Edit mode lands in PR 4. Back to group." Click "Back to
      group" to return.
- [ ] On a group with no note, click "add a note", type something,
      click Save. The cream callout updates and the link reads
      "edit". Reload — the note persists. Click "edit", change the
      text, click Cancel — original text restored.

Your existing groups, drafts, and `relationships.db` schema are
untouched by PR 3 — only frontend code + 1 SW cache version. No data
migration.

## Deployment note

Same as PRs 1 and 2: do **not** deploy this to production alone.
`deploy/server.py` doesn't yet serve `/api/groups`, so production
browser-tab visitors would see "Could not load groups." The
standalone-PWA path (OPFS) works end-to-end; deploying the bundle
without backend support hides groups from non-installed users.

🤖 Generated with [Claude Code](https://claude.com/claude-code)