### PR TITLE
feat(groups): PR 4 — edit mode (yellow banner, auto-save, cancel edits)

### DIFF
--- a/app/static/app.js
+++ b/app/static/app.js
@@ -86,8 +86,24 @@
     members: new Set(),       // record_id values picked
     memberNames: {},          // record_id -> display name (for chips)
     title: '',
-    titleEdited: false
+    titleEdited: false,
+    // PR 4: when non-null, the rail is editing an existing saved group
+    // instead of composing a new one. editEntrySnapshot is what
+    // "cancel edits" restores.
+    editingGroupId: null,
+    editEntrySnapshot: null   // {name, note, fellow_record_ids: []}
   };
+  // In-memory backup of the compose-mode draft while edit mode is active.
+  // Restored to groupDraft + localStorage when edit mode exits, so the
+  // user's in-progress new group survives a detour into editing an
+  // existing one. NOT persisted itself; reload during edit mode re-derives
+  // this from the localStorage compose draft (which was last written
+  // before edit mode was entered).
+  var composeDraftBackup = null;
+  var editModeBannerEl = document.getElementById('edit-mode-banner');
+  var editModeBannerNameEl = document.getElementById('edit-mode-banner-name');
+  var editModeBannerCancelEl = document.getElementById('edit-mode-banner-cancel');
+  var editTitlePatchTimer = null;
   var installLandingEl = document.getElementById('install-landing');
   var installGatePrivateEl = document.getElementById('install-gate-private');
   var unlockEmailFormEl = document.getElementById('unlock-email-form');
@@ -122,7 +138,7 @@
   /** Bump on every meaningful UI / diagnostics change. Rendered in the
    *  always-visible build badge so a dev can tell at a glance which app.js
    *  is actually running vs what the server was deployed with. */
-  var FELLOWS_UI_DIAG = 'diag-2026-04q-groups-pr3';
+  var FELLOWS_UI_DIAG = 'diag-2026-04r-groups-pr4';
 
   // Persistent marker: "this origin has been authenticated successfully at
   // least once." Preserved across clearAllAppData. Used by startBrowserUx's
@@ -2275,13 +2291,19 @@
 
   function renderRailHeader() {
     if (!groupRailTitleEl || !groupRailHelperEl || !groupRailCreateEl) return;
+    var editing = isEditing();
+    var eyebrowEl = groupRailEyebrowEl;
+    if (eyebrowEl) {
+      eyebrowEl.textContent = editing ? 'editing group' : 'add to a group';
+    }
     var query = (searchInputEl && searchInputEl.value || '').trim();
     var autoTitle = deriveAutoTitle(query);
-    var displayed = groupDraft.titleEdited ? groupDraft.title : autoTitle;
+    var displayed = (editing || groupDraft.titleEdited) ? groupDraft.title : autoTitle;
     if (document.activeElement !== groupRailTitleEl) {
       groupRailTitleEl.value = displayed;
     }
-    if (groupDraft.titleEdited) {
+    // Edit mode: never show the cream auto-state. Compose mode behaves as before.
+    if (editing || groupDraft.titleEdited) {
       groupRailTitleEl.classList.remove('group-rail-title--auto');
     } else {
       groupRailTitleEl.classList.add('group-rail-title--auto');
@@ -2289,7 +2311,9 @@
     var n = groupDraft.members.size;
     var fellows = n + ' fellow' + (n === 1 ? '' : 's');
     var helper;
-    if (groupDraft.titleEdited) {
+    if (editing) {
+      helper = fellows;
+    } else if (groupDraft.titleEdited) {
       helper = fellows;
     } else if (autoTitle) {
       helper = 'auto-named — click to rename · ' + fellows;
@@ -2297,7 +2321,15 @@
       helper = 'type a name, or search to auto-fill · ' + fellows;
     }
     groupRailHelperEl.textContent = helper;
-    groupRailCreateEl.disabled = n === 0;
+    // Edit mode: always enabled (Done editing). Compose mode: disabled when no members.
+    groupRailCreateEl.disabled = !editing && n === 0;
+    groupRailCreateEl.textContent = editing ? 'Done editing' : 'Create new group';
+    var footnoteEl = document.querySelector('.group-rail-footnote');
+    if (footnoteEl) {
+      footnoteEl.textContent = editing
+        ? 'changes save automatically as you add or remove.'
+        : 'saves immediately to your groups. You can rename and edit it later.';
+    }
   }
 
   function renderRailMembers() {
@@ -2370,7 +2402,7 @@
         groupDraft.memberNames[rid] = name;
       }
     }
-    saveGroupDraft();
+    persistDraft();
     renderRail();
     refreshAllMarkers();
     refreshDetailAddLink();
@@ -2409,7 +2441,7 @@
         groupDraft.memberNames[f.record_id] = f.name || f.record_id;
       }
     });
-    saveGroupDraft();
+    persistDraft();
     renderRail();
     refreshAllMarkers();
     refreshDetailAddLink();
@@ -2426,6 +2458,207 @@
     refreshAllMarkers();
     refreshDetailAddLink();
     updateBulkBar();
+  }
+
+  // --- PR 4: edit mode -------------------------------------------------
+
+  function persistDraft() {
+    // Compose mode: the draft IS the saved state, so localStorage is the
+    // store. Edit mode: localStorage is left alone (it holds the user's
+    // backed-up compose draft); persistence happens via PATCH against the
+    // saved group instead.
+    if (groupDraft.editingGroupId == null) {
+      saveGroupDraft();
+    } else {
+      patchEditedGroupMembership();
+    }
+  }
+
+  function patchEditedGroupMembership() {
+    if (groupDraft.editingGroupId == null) return;
+    if (!dataProvider || typeof dataProvider.updateGroup !== 'function') return;
+    var ids = [];
+    groupDraft.members.forEach(function (rid) { ids.push(rid); });
+    dataProvider
+      .updateGroup(groupDraft.editingGroupId, { fellow_record_ids: ids })
+      .catch(function () {
+        showToast('Could not save change');
+      });
+  }
+
+  function patchEditedGroupName(name) {
+    if (groupDraft.editingGroupId == null) return;
+    if (!dataProvider || typeof dataProvider.updateGroup !== 'function') return;
+    var trimmed = (name || '').replace(/^\s+|\s+$/g, '');
+    if (!trimmed) return;
+    dataProvider
+      .updateGroup(groupDraft.editingGroupId, { name: trimmed })
+      .then(function () {
+        // Update banner text in case the user paused editing.
+        if (editModeBannerNameEl) editModeBannerNameEl.textContent = trimmed;
+      })
+      .catch(function () {
+        showToast('Could not save name');
+      });
+  }
+
+  function showEditBanner(name) {
+    if (!editModeBannerEl || !editModeBannerNameEl) return;
+    editModeBannerNameEl.textContent = name || '';
+    editModeBannerEl.classList.remove('hidden');
+  }
+
+  function hideEditBanner() {
+    if (editModeBannerEl) editModeBannerEl.classList.add('hidden');
+  }
+
+  function snapshotComposeDraft() {
+    // Plain object so it isn't tangled with the live Set / mutations.
+    var members = [];
+    groupDraft.members.forEach(function (rid) { members.push(rid); });
+    return {
+      members: members,
+      memberNames: Object.assign({}, groupDraft.memberNames),
+      title: groupDraft.title,
+      titleEdited: groupDraft.titleEdited
+    };
+  }
+
+  function restoreComposeDraft(snap) {
+    if (!snap) snap = { members: [], memberNames: {}, title: '', titleEdited: false };
+    groupDraft.members = new Set(snap.members || []);
+    groupDraft.memberNames = snap.memberNames || {};
+    groupDraft.title = snap.title || '';
+    groupDraft.titleEdited = !!snap.titleEdited;
+    groupDraft.editingGroupId = null;
+    groupDraft.editEntrySnapshot = null;
+  }
+
+  function enterEditMode(groupId) {
+    if (!dataProvider || typeof dataProvider.getGroup !== 'function') {
+      showToast('Edit mode is unavailable in this mode');
+      window.location.hash = '#/groups';
+      return;
+    }
+    // Preserve the user's compose draft so the detour into edit mode
+    // doesn't clobber their in-progress new group.
+    if (groupDraft.editingGroupId == null) {
+      composeDraftBackup = snapshotComposeDraft();
+    }
+    dataProvider.getGroup(groupId)
+      .then(function (group) {
+        if (!group) {
+          showToast('Group not found');
+          window.location.hash = '#/groups';
+          return;
+        }
+        var memberIds = (group.members || []).map(function (m) { return m.record_id; });
+        // Snapshot for cancel-edits.
+        groupDraft.editEntrySnapshot = {
+          name: group.name || '',
+          note: group.note || '',
+          fellow_record_ids: memberIds.slice()
+        };
+        groupDraft.editingGroupId = group.id;
+        // Replace draft with the group's current state. memberNames are
+        // best-effort: members[].name comes from the dev-server JOIN; on
+        // OPFS we resolved them from fellowsBySlug at getGroup time.
+        groupDraft.members = new Set(memberIds);
+        groupDraft.memberNames = {};
+        (group.members || []).forEach(function (m) {
+          if (m.record_id) {
+            groupDraft.memberNames[m.record_id] = m.name || m.record_id;
+          }
+        });
+        groupDraft.title = group.name || '';
+        // In edit mode the title field shows the live group name (no cream
+        // auto-state) — set titleEdited so renderRailHeader treats it as
+        // user-authored.
+        groupDraft.titleEdited = true;
+
+        // Clear search and uncheck has-email so the directory is unrestricted.
+        if (searchInputEl) {
+          searchInputEl.value = '';
+        }
+        if (hasEmailFilterEl) {
+          hasEmailFilterEl.checked = false;
+        }
+        hasEmailOnly = false;
+        showEditBanner(group.name || '(untitled)');
+        // The detail pane during edit mode shows the current fellow detail
+        // (or the group's detail page that brought us here, depending on
+        // hash). We render the directory afresh and let the existing route
+        // handler resolve the detail.
+        if (Array.isArray(list) && list.length) {
+          renderDirectory();
+        }
+        renderRail();
+        refreshAllMarkers();
+        refreshDetailAddLink();
+        updateBulkBar();
+      })
+      .catch(function () {
+        showToast('Could not load group');
+        window.location.hash = '#/groups';
+      });
+  }
+
+  function exitEditMode() {
+    if (groupDraft.editingGroupId == null) return;
+    // Cancel any pending name PATCH; it would race against the snapshot.
+    if (editTitlePatchTimer) {
+      clearTimeout(editTitlePatchTimer);
+      editTitlePatchTimer = null;
+    }
+    hideEditBanner();
+    restoreComposeDraft(composeDraftBackup);
+    composeDraftBackup = null;
+    saveGroupDraft();
+    // Re-derive has-email filter from localStorage so we restore whatever
+    // the user had set before edit mode.
+    hasEmailOnly = loadHasEmailFilter();
+    if (hasEmailFilterEl) hasEmailFilterEl.checked = hasEmailOnly;
+    if (Array.isArray(list) && list.length) {
+      renderDirectory();
+    }
+    renderRail();
+    refreshAllMarkers();
+    refreshDetailAddLink();
+    updateBulkBar();
+  }
+
+  function isEditing() {
+    return groupDraft.editingGroupId != null;
+  }
+
+  function handleCancelEdits() {
+    if (!isEditing()) return;
+    var snapshot = groupDraft.editEntrySnapshot;
+    var gid = groupDraft.editingGroupId;
+    if (!snapshot) {
+      // Nothing to revert to (unexpected — should never happen since
+      // edit-mode-entry only ever fires for saved groups).
+      window.location.hash = '#/groups/' + encodeURIComponent(String(gid));
+      return;
+    }
+    // Cancel any pending name-debounce so it doesn't overwrite the revert.
+    if (editTitlePatchTimer) {
+      clearTimeout(editTitlePatchTimer);
+      editTitlePatchTimer = null;
+    }
+    dataProvider
+      .updateGroup(gid, {
+        name: snapshot.name,
+        note: snapshot.note,
+        fellow_record_ids: snapshot.fellow_record_ids
+      })
+      .then(function () {
+        showToast('Edits reverted.');
+        window.location.hash = '#/groups/' + encodeURIComponent(String(gid));
+      })
+      .catch(function () {
+        showToast('Could not revert edits.');
+      });
   }
 
   function handleCreateGroupClick() {
@@ -2604,6 +2837,14 @@
 
   function route() {
     var hash = window.location.hash || '';
+    var editMatch = hash.match(/^#\/edit\/(\d+)$/);
+    var nextEditId = editMatch ? parseInt(editMatch[1], 10) : null;
+    // Transition out of edit mode if the URL no longer points there. (Same
+    // group still in editingGroupId? Different group? Either way, exit
+    // first; if we're entering a new edit-mode session we re-enter below.)
+    if (isEditing() && nextEditId !== groupDraft.editingGroupId) {
+      exitEditMode();
+    }
     if (hash === '#/about') {
       renderAboutPage();
       return;
@@ -2617,23 +2858,15 @@
       renderGroupDetailPage(parseInt(groupMatch[1], 10));
       return;
     }
-    var editMatch = hash.match(/^#\/edit\/(\d+)$/);
     if (editMatch) {
-      // PR 3 placeholder. PR 4 replaces this with real edit-mode entry
-      // (snapshot the group, render the directory unrestricted, show the
-      // yellow banner, auto-save on toggle).
-      var editId = editMatch[1];
-      detailEl.innerHTML =
-        '<div class="group-detail-page">' +
-          '<p class="group-detail-breadcrumb">' +
-            '<a href="#/groups">groups</a> › ' +
-            '<a href="#/groups/' + escapeHtml(editId) + '">group</a> › edit' +
-          '</p>' +
-          '<p class="placeholder">' +
-            'Edit mode lands in PR 4. ' +
-            '<a href="#/groups/' + escapeHtml(editId) + '">Back to group</a>.' +
-          '</p>' +
-        '</div>';
+      // Edit mode is rail-driven, not detail-pane-driven. The directory
+      // and rail flip into edit mode; the detail pane shows whatever was
+      // there (or a placeholder via updateDetailFromHash). Enter once per
+      // hash visit; re-entering for the same id is a no-op.
+      if (groupDraft.editingGroupId !== nextEditId) {
+        enterEditMode(nextEditId);
+      }
+      updateDetailFromHash();
       return;
     }
     updateDetailFromHash();
@@ -2699,6 +2932,7 @@
           '<td class="groups-cell-date">' + escapeHtml(date) + '</td>' +
           '<td>' + noteHtml + '</td>' +
           '<td class="groups-cell-actions">' +
+            '<a href="#/edit/' + escapeHtml(gidStr) + '" class="groups-action groups-action-edit" data-group-id="' + escapeHtml(gidStr) + '">edit</a>' +
             '<a href="#" class="groups-action groups-action-rename" data-group-id="' + escapeHtml(gidStr) + '">rename</a>' +
             '<a href="#" class="groups-action groups-action-delete" data-group-id="' + escapeHtml(gidStr) + '">delete</a>' +
           '</td>' +
@@ -3759,12 +3993,36 @@
         groupDraft.title = groupRailTitleEl.value;
         groupDraft.titleEdited = true;
         groupRailTitleEl.classList.remove('group-rail-title--auto');
-        saveGroupDraft();
+        if (isEditing()) {
+          // Edit mode: debounce a PATCH so we don't spam the server on
+          // every keystroke. Banner reflects the saved name on success.
+          if (editTitlePatchTimer) clearTimeout(editTitlePatchTimer);
+          editTitlePatchTimer = setTimeout(function () {
+            patchEditedGroupName(groupRailTitleEl.value);
+          }, 600);
+        } else {
+          saveGroupDraft();
+        }
         renderRailHeader();
       });
     }
     if (groupRailCreateEl) {
-      groupRailCreateEl.addEventListener('click', handleCreateGroupClick);
+      groupRailCreateEl.addEventListener('click', function () {
+        if (isEditing()) {
+          // Done editing: bounce back to the detail page. The hashchange
+          // triggers exitEditMode in route().
+          window.location.hash =
+            '#/groups/' + encodeURIComponent(String(groupDraft.editingGroupId));
+        } else {
+          handleCreateGroupClick();
+        }
+      });
+    }
+    if (editModeBannerCancelEl) {
+      editModeBannerCancelEl.addEventListener('click', function (ev) {
+        ev.preventDefault();
+        handleCancelEdits();
+      });
     }
     if (bulkSelectInputEl) {
       bulkSelectInputEl.addEventListener('change', bulkToggleVisible);

--- a/app/static/index.html
+++ b/app/static/index.html
@@ -122,6 +122,19 @@
     </nav>
   </header>
   <div id="connection-banner" class="connection-banner hidden" aria-live="polite"></div>
+  <div id="edit-mode-banner" class="edit-mode-banner hidden" role="status" aria-live="polite">
+    <span class="edit-mode-banner-text">
+      <span aria-hidden="true">✎ </span><b>editing</b>
+      &ldquo;<span id="edit-mode-banner-name"></span>&rdquo;
+      &mdash; search and tap <b>+</b> to add more, tap <b>✓</b> to remove.
+    </span>
+    <a
+      href="#"
+      id="edit-mode-banner-cancel"
+      class="edit-mode-banner-cancel"
+      title="revert this group to the state it was in when you opened edit mode"
+    >cancel edits</a>
+  </div>
   <div id="loading-panel" class="loading-panel hidden">
     <p id="loading">Loading…</p>
     <div id="boot-error-panel" class="boot-error-panel hidden" role="alert">

--- a/app/static/styles.css
+++ b/app/static/styles.css
@@ -1791,3 +1791,43 @@ a.group-action-btn--primary {
   opacity: 1;
   transform: translate(-50%, 0);
 }
+
+/* =========================================================================
+ * Groups feature — PR 4: edit-mode yellow banner.
+ * ========================================================================= */
+
+.edit-mode-banner {
+  display: flex;
+  align-items: center;
+  gap: 0.6rem;
+  padding: 0.4rem 0.75rem;
+  margin-top: 0.5rem;
+  background: #fff3cd;
+  border: 1px solid #ffe69c;
+  border-radius: 2px;
+  color: #664d03;
+  font-size: 0.85rem;
+}
+
+.edit-mode-banner.hidden {
+  display: none;
+}
+
+.edit-mode-banner-text {
+  flex: 1;
+  min-width: 0;
+  overflow: hidden;
+  text-overflow: ellipsis;
+}
+
+.edit-mode-banner-cancel {
+  margin-left: auto;
+  flex: 0 0 auto;
+  color: #664d03;
+  text-decoration: underline;
+  font-weight: 500;
+}
+
+.edit-mode-banner-cancel:hover {
+  color: #4d3902;
+}

--- a/app/static/sw.js
+++ b/app/static/sw.js
@@ -1,4 +1,4 @@
-const CACHE_VERSION = 'v11';
+const CACHE_VERSION = 'v12';
 const APP_SHELL_CACHE = `fellows-app-shell-${CACHE_VERSION}`;
 // Separate cache so shell-version bumps don't evict the ~34 MB of profile images.
 const IMAGES_CACHE = 'fellows-images-v1';

--- a/tests/e2e/test_groups_detail.py
+++ b/tests/e2e/test_groups_detail.py
@@ -263,9 +263,13 @@ class TestGroupDetailExportPanel:
 
 
 class TestGroupDetailEditNav:
-    def test_edit_button_navigates_to_edit_route_placeholder(
+    def test_edit_button_navigates_and_enters_edit_mode(
         self, standalone_page, base_url_fixture
     ):
+        """Click ✎ Edit group on the detail page → URL flips to
+        #/edit/<id> and the yellow edit-mode banner appears.
+        Deeper edit-mode behaviour (auto-save, cancel-edits, etc.)
+        is covered in tests/e2e/test_groups_edit.py."""
         page = standalone_page
         fellows = _real_fellows(base_url_fixture)
         g = _create_group(
@@ -277,9 +281,9 @@ class TestGroupDetailEditNav:
         _wait_for_directory(page)
         page.locator("#group-action-edit").click()
         page.wait_for_url(lambda u: f"#/edit/{g['id']}" in u, timeout=3000)
-        # PR 3 placeholder visible until PR 4 lands real edit-mode entry.
-        placeholder = page.locator(".group-detail-page .placeholder")
-        expect(placeholder).to_contain_text("Edit mode lands in PR 4")
+        banner = page.locator("#edit-mode-banner")
+        expect(banner).to_be_visible(timeout=3000)
+        expect(page.locator("#edit-mode-banner-name")).to_have_text("Edit nav")
 
 
 class TestGroupDetailNoteEdit:

--- a/tests/e2e/test_groups_edit.py
+++ b/tests/e2e/test_groups_edit.py
@@ -1,0 +1,314 @@
+"""E2E for PR 4 edit mode.
+
+Pins:
+- Clicking ✎ Edit group on the detail page enters edit mode: yellow
+  banner appears, rail flips to "editing group" / "Done editing",
+  members are pre-selected, has-email filter is unchecked, search is
+  cleared.
+- Toggling +/✓ in edit mode auto-saves via PATCH /api/groups/<id>; the
+  group's membership reflects the change immediately.
+- Done editing navigates to #/groups/<id>; banner hides; rail returns
+  to compose mode.
+- cancel edits PATCHes the entry-snapshot back; the group ends up as
+  it was when edit mode started.
+- The compose draft (members + title) is preserved across an edit-
+  mode detour.
+- The "edit" row action on /#/groups also enters edit mode.
+- Reloading mid-edit re-enters edit mode (banner reappears).
+- The cancel-edits link carries the design's title attribute.
+"""
+from __future__ import annotations
+
+import json
+import re
+from http.client import HTTPConnection
+from urllib.parse import urlparse
+
+import pytest
+from playwright.sync_api import expect
+
+
+def _conn(base_url):
+    parsed = urlparse(base_url)
+    return HTTPConnection(parsed.hostname, parsed.port, timeout=10)
+
+
+def _wipe_groups(base_url):
+    c = _conn(base_url)
+    c.request("GET", "/api/groups")
+    r = c.getresponse()
+    body = r.read()
+    c.close()
+    if r.status != 200:
+        return
+    try:
+        groups = json.loads(body)
+    except ValueError:
+        return
+    for g in groups:
+        c2 = _conn(base_url)
+        c2.request("DELETE", f"/api/groups/{g['id']}")
+        c2.getresponse().read()
+        c2.close()
+
+
+def _real_fellows(base_url, with_email=True):
+    c = _conn(base_url)
+    c.request("GET", "/api/fellows?full=1")
+    r = c.getresponse()
+    body = r.read()
+    c.close()
+    rows = json.loads(body)
+    out = []
+    for row in rows:
+        rid = row.get("record_id")
+        name = row.get("name") or ""
+        email = (row.get("contact_email") or "").strip()
+        if with_email and not email:
+            continue
+        out.append((rid, name, email))
+    return out
+
+
+def _create_group(base_url, *, name, fellow_record_ids, note=""):
+    c = _conn(base_url)
+    payload = json.dumps({
+        "name": name, "note": note, "fellow_record_ids": fellow_record_ids,
+    }).encode("utf-8")
+    c.request(
+        "POST", "/api/groups", body=payload,
+        headers={"Content-Type": "application/json", "Content-Length": str(len(payload))},
+    )
+    r = c.getresponse()
+    body = r.read()
+    c.close()
+    assert r.status == 201, body
+    return json.loads(body)
+
+
+def _fetch_group(base_url, gid):
+    c = _conn(base_url)
+    c.request("GET", f"/api/groups/{gid}")
+    r = c.getresponse()
+    body = r.read()
+    c.close()
+    if r.status != 200:
+        return None
+    return json.loads(body)
+
+
+def _wait_for_directory(page):
+    page.locator("#loading").wait_for(state="hidden", timeout=10000)
+    page.locator("#directory").wait_for(state="visible", timeout=5000)
+
+
+def _aaron_row(page):
+    link = page.locator("#directory a.dir-link", has_text="Aaron Bird").first
+    expect(link).to_be_visible()
+    return link.locator("xpath=..")
+
+
+@pytest.fixture(autouse=True)
+def _reset_relationships_db(base_url_fixture):
+    _wipe_groups(base_url_fixture)
+    yield
+
+
+class TestEditModeEntry:
+    def test_clicking_edit_on_detail_enters_edit_mode(
+        self, standalone_page, base_url_fixture
+    ):
+        page = standalone_page
+        fellows = _real_fellows(base_url_fixture)
+        chosen = fellows[:2]
+        g = _create_group(
+            base_url_fixture,
+            name="Wellington crew",
+            fellow_record_ids=[f[0] for f in chosen],
+        )
+        page.goto(f"{base_url_fixture}/#/groups/{g['id']}", wait_until="domcontentloaded")
+        _wait_for_directory(page)
+        page.locator("#group-action-edit").click()
+        page.wait_for_url(lambda u: f"#/edit/{g['id']}" in u, timeout=3000)
+        banner = page.locator("#edit-mode-banner")
+        expect(banner).to_be_visible(timeout=3000)
+        expect(page.locator("#edit-mode-banner-name")).to_have_text("Wellington crew")
+        # Cancel link carries the design's title attribute (hover hint).
+        cancel = page.locator("#edit-mode-banner-cancel")
+        expect(cancel).to_have_attribute(
+            "title",
+            "revert this group to the state it was in when you opened edit mode",
+        )
+        # Rail UI flips to edit mode.
+        expect(page.locator("#group-rail-eyebrow")).to_have_text("editing group")
+        expect(page.locator("#group-rail-create")).to_have_text("Done editing")
+        expect(page.locator("#group-rail-create")).to_be_enabled()
+        # has-email filter is unchecked on entry.
+        expect(page.locator("#has-email-filter")).not_to_be_checked()
+        # Search is cleared on entry.
+        expect(page.locator("#search-input")).to_have_value("")
+        # Members are pre-loaded into the rail (chip count = 2).
+        expect(page.locator("#group-rail-members .group-rail-member-name")).to_have_count(2)
+
+    def test_groups_index_edit_row_action_also_enters_edit_mode(
+        self, standalone_page, base_url_fixture
+    ):
+        page = standalone_page
+        fellows = _real_fellows(base_url_fixture)
+        g = _create_group(
+            base_url_fixture,
+            name="Row-action edit",
+            fellow_record_ids=[f[0] for f in fellows[:1]],
+        )
+        page.goto(f"{base_url_fixture}/#/groups", wait_until="domcontentloaded")
+        _wait_for_directory(page)
+        page.locator(".groups-action-edit").click()
+        page.wait_for_url(lambda u: f"#/edit/{g['id']}" in u, timeout=3000)
+        expect(page.locator("#edit-mode-banner")).to_be_visible(timeout=3000)
+
+
+class TestEditModeAutoSave:
+    def test_toggle_in_edit_mode_patches_membership(
+        self, standalone_page, base_url_fixture
+    ):
+        page = standalone_page
+        fellows = _real_fellows(base_url_fixture)
+        # Start with 1 fellow, then add one via the directory + marker.
+        g = _create_group(
+            base_url_fixture,
+            name="Auto-save",
+            fellow_record_ids=[fellows[0][0]],
+        )
+        before = _fetch_group(base_url_fixture, g["id"])
+        assert len(before["members"]) == 1
+
+        page.goto(f"{base_url_fixture}/#/edit/{g['id']}", wait_until="domcontentloaded")
+        _wait_for_directory(page)
+        # Marker for fellow at index 1 (different from the pre-selected member)
+        # — find their name and toggle.
+        target_name = fellows[1][1]
+        target_link = page.locator(
+            "#directory a.dir-link", has_text=re.compile(r"^" + re.escape(target_name) + r"$")
+        ).first
+        target_link.locator("xpath=..").locator(".dir-mark").click()
+        # Wait briefly for the PATCH to land. The chip in the rail updates
+        # synchronously, so we can use that as the in-page signal.
+        expect(
+            page.locator("#group-rail-members .group-rail-member-name")
+        ).to_have_count(2, timeout=3000)
+        # Verify the server actually saved.
+        page.wait_for_timeout(150)
+        after = _fetch_group(base_url_fixture, g["id"])
+        ids = sorted(m["record_id"] for m in after["members"])
+        assert ids == sorted([fellows[0][0], fellows[1][0]])
+
+
+class TestDoneEditing:
+    def test_done_editing_navigates_back_and_exits(
+        self, standalone_page, base_url_fixture
+    ):
+        page = standalone_page
+        fellows = _real_fellows(base_url_fixture)
+        g = _create_group(
+            base_url_fixture,
+            name="Done flow",
+            fellow_record_ids=[f[0] for f in fellows[:1]],
+        )
+        page.goto(f"{base_url_fixture}/#/edit/{g['id']}", wait_until="domcontentloaded")
+        _wait_for_directory(page)
+        # The rail's primary button reads "Done editing" in edit mode.
+        page.locator("#group-rail-create").click()
+        page.wait_for_url(lambda u: f"#/groups/{g['id']}" in u, timeout=3000)
+        expect(page.locator("#edit-mode-banner")).to_be_hidden()
+        # Rail back to compose mode.
+        expect(page.locator("#group-rail-eyebrow")).to_have_text("add to a group")
+        expect(page.locator("#group-rail-create")).to_have_text("Create new group")
+        # Detail page renders the group.
+        expect(page.locator(".group-detail-title")).to_have_text("Done flow")
+
+
+class TestCancelEdits:
+    def test_cancel_edits_reverts_membership_to_snapshot(
+        self, standalone_page, base_url_fixture
+    ):
+        page = standalone_page
+        fellows = _real_fellows(base_url_fixture)
+        # 2 members at entry. We'll add a third in edit mode, then revert.
+        g = _create_group(
+            base_url_fixture,
+            name="Revert test",
+            fellow_record_ids=[fellows[0][0], fellows[1][0]],
+        )
+        page.goto(f"{base_url_fixture}/#/edit/{g['id']}", wait_until="domcontentloaded")
+        _wait_for_directory(page)
+        # Add a third member.
+        third_name = fellows[2][1]
+        third_link = page.locator(
+            "#directory a.dir-link", has_text=re.compile(r"^" + re.escape(third_name) + r"$")
+        ).first
+        third_link.locator("xpath=..").locator(".dir-mark").click()
+        expect(
+            page.locator("#group-rail-members .group-rail-member-name")
+        ).to_have_count(3, timeout=3000)
+        page.wait_for_timeout(150)
+        mid = _fetch_group(base_url_fixture, g["id"])
+        assert len(mid["members"]) == 3
+        # Click cancel-edits → PATCH snapshot back, navigate.
+        page.locator("#edit-mode-banner-cancel").click()
+        page.wait_for_url(lambda u: f"#/groups/{g['id']}" in u, timeout=3000)
+        page.wait_for_timeout(150)
+        after = _fetch_group(base_url_fixture, g["id"])
+        ids = sorted(m["record_id"] for m in after["members"])
+        assert ids == sorted([fellows[0][0], fellows[1][0]])
+
+
+class TestComposeDraftSurvivesEdit:
+    def test_compose_draft_preserved_across_edit_detour(
+        self, standalone_page, base_url_fixture
+    ):
+        page = standalone_page
+        fellows = _real_fellows(base_url_fixture)
+        # Existing group to edit.
+        g = _create_group(
+            base_url_fixture,
+            name="Existing",
+            fellow_record_ids=[fellows[0][0]],
+        )
+        page.goto(f"{base_url_fixture}/", wait_until="domcontentloaded")
+        _wait_for_directory(page)
+        # Compose draft: pick Aaron Bird, type a title.
+        _aaron_row(page).locator(".dir-mark").click()
+        page.locator("#group-rail-title").fill("My in-progress group")
+        # Detour into edit mode.
+        page.goto(f"{base_url_fixture}/#/edit/{g['id']}", wait_until="domcontentloaded")
+        _wait_for_directory(page)
+        expect(page.locator("#edit-mode-banner")).to_be_visible(timeout=3000)
+        # Done editing.
+        page.locator("#group-rail-create").click()
+        page.wait_for_url(lambda u: f"#/groups/{g['id']}" in u, timeout=3000)
+        # Back to directory.
+        page.goto(f"{base_url_fixture}/", wait_until="domcontentloaded")
+        _wait_for_directory(page)
+        # Compose draft is restored.
+        expect(page.locator("#group-rail-title")).to_have_value("My in-progress group")
+        chip = page.locator("#group-rail-members .group-rail-member-name").first
+        expect(chip).to_have_text("Aaron Bird")
+        expect(_aaron_row(page).locator(".dir-mark")).to_have_text("✓")
+
+
+class TestReloadDuringEdit:
+    def test_reload_in_edit_mode_re_enters(self, standalone_page, base_url_fixture):
+        page = standalone_page
+        fellows = _real_fellows(base_url_fixture)
+        g = _create_group(
+            base_url_fixture,
+            name="Reload test",
+            fellow_record_ids=[f[0] for f in fellows[:1]],
+        )
+        page.goto(f"{base_url_fixture}/#/edit/{g['id']}", wait_until="domcontentloaded")
+        _wait_for_directory(page)
+        expect(page.locator("#edit-mode-banner")).to_be_visible(timeout=3000)
+        page.reload(wait_until="domcontentloaded")
+        _wait_for_directory(page)
+        expect(page.locator("#edit-mode-banner")).to_be_visible(timeout=5000)
+        expect(page.locator("#edit-mode-banner-name")).to_have_text("Reload test")


### PR DESCRIPTION
## Summary

PR 4 of 5 for the groups feature. The `#/edit/<id>` placeholder from
PR 3 is replaced with real entry/exit logic: yellow banner across the
top, rail flipped to "editing group" / "Done editing", every toggle
PATCHes the saved group, cancel-edits reverts to the entry-snapshot.
PR 5 will land the visual portrait directory + the PDF / HTML / ZIP
export pipeline.

- **State machine.** `enterEditMode(id)` fetches the group, snapshots
  the current compose draft into in-memory `composeDraftBackup`,
  captures `editEntrySnapshot` (name + note + members) for cancel-
  edits, seeds the rail with the group's state, clears search, and
  unchecks the has-email filter. `exitEditMode()` runs from `route()`
  when the URL leaves `#/edit/<id>` and restores the compose draft.
  Reload mid-edit re-derives `composeDraftBackup` from the on-disk
  compose draft (which was last written before edit mode was
  entered), so reload during edit works without a separate
  persistence layer.
- **Auto-save.** New `persistDraft()` dispatcher: compose mode →
  `localStorage`; edit mode → `PATCH /api/groups/<id>
  {fellow_record_ids}`. Title input debounce-PATCHes `name` after
  600ms. PATCH failures surface as toasts.
- **Rail in edit mode.** Eyebrow: `editing group`. Title input:
  cream auto-state suppressed; live group name. Helper:
  `<n> fellows`. Primary button: `Done editing` (always enabled),
  navigates to `#/groups/<id>`. Footnote: `changes save
  automatically as you add or remove.`
- **cancel edits.** Yellow banner's right-aligned link with the
  design's title attribute. Click → revert PATCH with the entry
  snapshot → toast + back to detail.
- **Routing.** `route()` detects edit-mode transitions and runs
  `exitEditMode` before evaluating the new hash. Re-entering for the
  same id is a no-op.
- **Groups index.** Added the `edit` row action per the design
  (alongside rename + delete). It's an `<a href="#/edit/<id>">`; the
  hash router picks it up.
- **Service worker** bumped `v11` → `v12`. Build badge:
  `app: diag-2026-04r-groups-pr4`.

## Test plan

- [x] `pytest tests/e2e/test_groups_edit.py -v` — **7 new tests:**
      click Edit on detail → banner + rail flip + pre-loaded chips +
      has-email unchecked + search empty; groups index "edit" row
      action also enters edit mode; toggle in edit mode → API GET
      reflects PATCH; Done editing → URL → `#/groups/<id>`, banner
      hides, rail back to compose; cancel edits → API state reverts
      to entry-snapshot; compose draft survives an edit detour;
      reload mid-edit re-enters.
- [x] `pytest tests/e2e/test_groups_detail.py -v` — the PR 3
      placeholder test was rewritten to verify real entry (banner
      visible + name shown).
- [x] `pytest tests/ --ignore=tests/test_prod_stats.py -q` —
      **169 passed** (162 → +7). `test_prod_stats.py` failures
      pre-date this branch.

## Manual QA for the maintainer

After merging this PR:

```bash
git switch main && git pull
just restart
```

Then in your browser tab on `localhost:8765`:

- [ ] Hit Cmd-R. Build badge flips to `app: diag-2026-04r-groups-pr4`.
- [ ] Open one of your groups (`#/groups/<id>`). Click `✎ Edit
      group`. Yellow banner appears across the top reading
      `✎ editing "<group name>" — search and tap + to add more, tap
      ✓ to remove. cancel edits`. The rail's eyebrow now reads
      "editing group" and the primary button reads "Done editing".
      The has-email filter is unchecked; the search box is empty.
      The group's existing members appear as `✓` markers in the
      directory list.
- [ ] Search for a fellow not yet in the group, click `+`. The chip
      appears in the rail. **In another tab**, run
      `curl http://localhost:8765/api/groups/<id> | jq` — the new
      member should be present. (Auto-save fired the moment you
      clicked.)
- [ ] Click `✓` next to one of the original members. Chip
      disappears, the member is removed from the group on the
      server.
- [ ] Type a new name in the rail's title field. After ~600ms the
      banner text updates to show the new name (debounced PATCH
      landed).
- [ ] Click `Done editing`. URL flips to `#/groups/<id>`, banner
      hides, the rail is back to compose mode (`add to a group` /
      `Create new group`).
- [ ] Open another group and click `✎ Edit group`. Make a change.
      Click `cancel edits` in the banner. You bounce back to the
      detail page; the group's membership matches what it was
      before you started editing.
- [ ] Compose-draft preservation: on the directory page (compose
      mode), pick Aaron Bird with `+` and type "Smoke draft" in the
      title field. Click `Groups`, then `edit` on any row to
      detour into edit mode. Click `Done editing`. Navigate back
      to `#/`. The rail still shows your "Smoke draft" with Aaron
      Bird picked.
- [ ] Reload while in edit mode (`#/edit/<id>` in the URL). The
      banner reappears; the rail shows the group's current state;
      auto-save still works.
- [ ] On `/#/groups`, the row action cluster now shows `edit · rename
      · delete`. Clicking `edit` jumps straight into edit mode
      without first stopping at the detail page.

Your existing groups, drafts, and `relationships.db` schema are
untouched by PR 4 — only frontend code + 1 SW cache version. No
data migration.

## Deployment note

Same as PRs 1–3: do **not** deploy this to production alone.
`deploy/server.py` doesn't yet serve `/api/groups`, so production
browser-tab visitors would see "Could not load groups." The
standalone-PWA path (OPFS) works end-to-end. PR 5 may also need
a follow-up to either add the routes to `deploy/server.py` or drop
the standalone-only gate in `shouldTryOpfsProvider`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)