### PR TITLE
docs: catch up Architecture / users-manual / README to groups feature

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -21,6 +21,7 @@ Read README.md for project setup, API docs, and test commands. Read docs/Archite
 - The DB file `app/fellows.db` is gitignored; rebuild from JSON source.
 - Always run relevant tests after changes.
 - For deploy- or infra-related work, put **manual QA steps for the maintainer** (smoke scripts, DNS/TLS checks, browser install flow) in the **PR description**, not only in commits or docs.
+- **UI/UX changes belong in `docs/users_manual.md`.** When a feature PR changes user-visible behavior (new screen, new flow, changed control, new option), include the corresponding users-manual update in the same PR — accepting the PR accepts the doc change with it. The user guide is the source of truth for UI/UX from a user's perspective; the app links to it from the About page.
 
 ## Two-DB architecture
 

--- a/README.md
+++ b/README.md
@@ -1,8 +1,8 @@
 # EHF Fellows Local Directory
 
-Local web app to quickly browse Edmund Hillary Fellowship fellow profiles and run experiments. (data only available to EHF fellows)
+Local web app to quickly browse Edmund Hillary Fellowship fellow profiles, organize them into saved groups, and export sub-directories — and to run experiments. (data only available to EHF fellows)
 
-Data and assets are local-first (SQLite + static files), served by Python stdlib.
+Data and assets are local-first (SQLite + static files), served by Python stdlib. User-authored data (groups, notes, settings) lives in a separate per-user SQLite file (`app/relationships.db`) that's durable across app updates.
 
 ## Table of Contents
 
@@ -106,14 +106,35 @@ python app/server.py    # raw foreground server
 
 ### API Endpoints
 
-- `GET /api/fellows` — list only (`record_id`, `slug`, `name`) for fast directory load.
+Fellow data (read-only, served from `app/fellows.db`):
+
+- `GET /api/fellows` — list only (`record_id`, `slug`, `name`, `has_contact_email`) for fast directory load.
 - `GET /api/fellows?full=1` — full fellow rows.
 - `GET /api/fellows/<slug>` — one fellow by slug or `record_id`.
 - `GET /api/search?q=...` — FTS5 search.
 - `GET /api/stats` — aggregates for About page.
+
+Groups (read-write, served from `app/relationships.db` with `app/fellows.db` ATTACHed read-only):
+
+- `GET /api/groups` — list of saved groups with member counts (newest-touched first).
+- `POST /api/groups` — create a group (`{name, note?, fellow_record_ids?}`); 201.
+- `GET /api/groups/<id>` — one group with members joined to fellow names.
+- `PATCH /api/groups/<id>` — partial update (any subset of `name`, `note`, `fellow_record_ids`).
+- `DELETE /api/groups/<id>` — delete; cascades to `group_members`. 204.
+
+Settings (read-write, key/value bag in `app/relationships.db`):
+
+- `GET /api/settings` — full bag.
+- `GET /api/settings/<key>` — one setting; 404 if unset.
+- `PUT /api/settings/<key>` — upsert (`{value: "…"}`); empty value clears.
+
+Static / bootstrap:
+
 - `GET /fellows.db` — raw SQLite file for installed PWA bootstrap.
 - `GET /images/<slug>.jpg|.png` — profile image lookup by slug/name fallback.
 - `GET /` — static app shell.
+
+Production (`deploy/server.py`) adds magic-link auth (`/api/send-unlock`, `/api/verify-token`, `/api/logout`) and build/diagnostics endpoints (`/healthz`, `/build-meta.json`, `/api/debug/diagnostics`); see [`docs/email_gate.md`](docs/email_gate.md).
 
 ### Two-Phase Load
 

--- a/app/static/app.js
+++ b/app/static/app.js
@@ -3109,7 +3109,7 @@
     aboutHtml += 'There is no API, login, or web app, so this can only be shared intentionally. ';
     aboutHtml += 'For support, request to join the github repository or just ask on one of the fellows channels.</p>';
     aboutHtml += '<p class="about-support">Having trouble with the app? Contact the EHF Communications Working Group.</p>';
-    aboutHtml += '<p class="about-users-manual"><a href="https://github.com/richbodo/fellows_local_db/blob/main/docs/users_manual.md" target="_blank" rel="noopener">User Guide</a> \u2014 how to install, update, and clear app data.</p>';
+    aboutHtml += '<p class="about-users-manual"><a href="https://github.com/richbodo/fellows_local_db/blob/main/docs/users_manual.md" target="_blank" rel="noopener">User Guide</a> \u2014 how to install, browse, save groups, export, and manage settings.</p>';
     aboutHtml += '<p class="about-update-check">';
     aboutHtml += '<button type="button" id="about-check-updates" class="about-check-updates-btn">Check for updates</button>';
     aboutHtml += '<span id="about-update-status" class="about-update-status" role="status" aria-live="polite"></span>';

--- a/docs/Architecture.md
+++ b/docs/Architecture.md
@@ -30,7 +30,29 @@ The explicit columns cover the fields needed for display and filtering. Any JSON
 
 The server opens a new SQLite connection per request (no connection pool — unnecessary at local scale). Responses are JSON for API routes and raw bytes for static files and images.
 
-**HTTP API** (see README for the full list): besides fellows list/detail/search, `GET /api/stats` returns aggregate statistics for the About page: total fellow count, breakdowns by fellow type and cohort, per-region counts (splitting comma-separated `global_regions_currently_based_in`), and field completeness (non-empty column counts plus selected keys in `extra_json` via `json_extract`). Heavier than a simple row fetch; still fine at local scale.
+**HTTP API.** The dev server (`app/server.py`) exposes the table below. The production server (`deploy/server.py`) adds magic-link auth (`/api/send-unlock`, `/api/verify-token`, `/api/logout`), build/diagnostics endpoints (`/healthz`, `/build-meta.json`, `/api/debug/diagnostics`, `/allowed_emails.json`), and gates directory `/api/*` paths behind a valid session cookie. The behavioral spec for the auth flow is [`email_gate.md`](email_gate.md).
+
+| Method | Path | Purpose |
+|---|---|---|
+| GET | `/api/fellows` | Minimal list (record_id / slug / name / has_contact_email) for instant directory render. |
+| GET | `/api/fellows?full=1` | Full fellow rows (phase 2 of the two-phase load). |
+| GET | `/api/fellows/<slug>` | One fellow by `slug` or `record_id`. |
+| GET | `/api/search?q=…` | FTS5 search across name / bio / cohort / fellow_type / search_tags / key_links. |
+| GET | `/api/stats` | Aggregates for the About page: total, breakdowns by fellow_type / cohort / region, field completeness. |
+| GET | `/api/groups` | List of saved groups with member counts (newest-touched first). |
+| POST | `/api/groups` | Create a group (`{name, note?, fellow_record_ids?}`). Returns 201 with the new group. |
+| GET | `/api/groups/<id>` | One group with members joined to fellows. 404 if missing. |
+| PATCH | `/api/groups/<id>` | Partial update — any subset of `name`, `note`, `fellow_record_ids` (replaces members in full when given). |
+| DELETE | `/api/groups/<id>` | Delete a group; FK cascade removes its `group_members`. Returns 204. |
+| GET | `/api/settings` | Full settings key/value bag. |
+| GET | `/api/settings/<key>` | One setting; 404 if unset. |
+| PUT | `/api/settings/<key>` | Upsert (`{value: "…"}`). Empty value clears the key. |
+| GET | `/api/auth/status` | Stub in dev (auth disabled). Real shape comes from `deploy/server.py`. |
+| GET | `/fellows.db` | Raw SQLite snapshot for the PWA's OPFS bootstrap. |
+| GET | `/images/<slug>.{jpg,png}` | Profile image; alphanumeric-fallback filename match. |
+| GET | `/` and other static paths | App shell from `app/static/`. |
+
+`/api/stats` is heavier than a simple row fetch (region split + field-completeness pass over `extra_json` via `json_extract`); still fine at local scale. `/api/groups` and `/api/settings` open `relationships.db` per request and ATTACH `fellows.db` read-only — see [Persistence and upgrades](#persistence-and-upgrades).
 
 ### Persistence and upgrades
 
@@ -58,11 +80,20 @@ When a user clicks a fellow before phase 2 completes, the app falls back to `GET
 
 ## Frontend Routing
 
-Hash-based SPA routing with no history API and no router library:
+Hash-based SPA routing with no history API and no router library. Defined in `route()` in `app/static/app.js`.
 
-- `#/` — directory (default when the hash is empty or not matched below)
-- `#/about` — About page; loads fellowship statistics via `GET /api/stats`
-- `#/fellow/<slug>` — fellow detail; `hashchange` runs `updateDetailFromHash()`, which resolves the fellow from the in-memory cache or `GET /api/fellows/<slug>`
+| Route | Purpose |
+|---|---|
+| `#/` (default; empty or unmatched hash) | Directory. Two-phase load: minimal list, then full rows in the background. |
+| `#/about` | About page. Loads fellowship statistics via `GET /api/stats`; links out to the user guide. |
+| `#/fellow/<slug>` | Fellow detail. Resolves from the in-memory cache or `GET /api/fellows/<slug>`. |
+| `#/groups` | Groups index — saved groups with member counts. |
+| `#/groups/<id>` | Group detail. Action bar (Contact / Export / Edit), member list, inline note editor. |
+| `#/groups/<id>/directory` | Visual portrait directory for the group; click a portrait → `#/fellow/<slug>`. |
+| `#/edit/<id>` | Edit-mode entry. Re-uses the right-rail composer against an existing group; auto-saves on toggle, "Cancel edits" reverts to the entry snapshot. |
+| `#/settings` | Settings page. The user's "me" email used for export `mailto:?to=…`; auto-captured from the magic-link gate, persisted to `relationships.settings` and mirrored to localStorage on boot. |
+
+User-facing screen behavior, navigation, and UX flows live in [`users_manual.md`](users_manual.md). Treat the user guide as the source of truth for UI/UX from a user's perspective and keep it in sync when the UI changes.
 
 ## Database Schema
 
@@ -105,6 +136,52 @@ CREATE VIRTUAL TABLE fellows_fts USING fts5(
 ```
 
 FTS5 also creates internal shadow tables (`fellows_fts_data`, `fellows_fts_idx`, etc.); those are SQLite-managed and not altered by hand.
+
+### `relationships.db`
+
+User-authored data. Created on first access by `app.relationships.open_db()`; the same schema is mirrored in the PWA via `RELATIONSHIPS_SCHEMA_SQL` in `app/static/app.js` so the OPFS-backed sqlite3.wasm path matches the dev server. ATTACHed read-only as `f` against `fellows.db` for cross-DB joins (e.g. resolving member names on `GET /api/groups/<id>`); any stray write to `f.*` raises `OperationalError`.
+
+```sql
+CREATE TABLE groups (
+    id INTEGER PRIMARY KEY,
+    name TEXT NOT NULL,
+    note TEXT NOT NULL DEFAULT '',
+    created_at TEXT NOT NULL,
+    updated_at TEXT NOT NULL
+);
+
+CREATE TABLE group_members (
+    group_id INTEGER NOT NULL REFERENCES groups(id) ON DELETE CASCADE,
+    fellow_record_id TEXT NOT NULL,
+    PRIMARY KEY (group_id, fellow_record_id)
+);
+
+CREATE INDEX idx_group_members_group ON group_members(group_id);
+
+-- Reserved for tag/note CRUD UI (designed once, surfaced incrementally).
+CREATE TABLE fellow_tags (
+    fellow_record_id TEXT NOT NULL,
+    tag TEXT NOT NULL,
+    created_at TEXT NOT NULL,
+    PRIMARY KEY (fellow_record_id, tag)
+);
+
+CREATE INDEX idx_fellow_tags_tag ON fellow_tags(tag);
+
+CREATE TABLE fellow_notes (
+    fellow_record_id TEXT PRIMARY KEY,
+    body TEXT NOT NULL,
+    updated_at TEXT NOT NULL
+);
+
+-- Single key/value bag (e.g. `self_email` override for export `mailto:?to=…`).
+CREATE TABLE settings (
+    key TEXT PRIMARY KEY,
+    value TEXT
+);
+```
+
+`PRAGMA user_version` is set to `SCHEMA_VERSION` (currently `1`) at bootstrap so future migrations can branch on it. The file is gitignored, per-user, and durable across both app updates and Clear App Cache — see [`persistence_and_upgrades.md`](persistence_and_upgrades.md) for the full state-survival matrix.
 
 ## Roadmap
 

--- a/docs/persistence_and_upgrades.md
+++ b/docs/persistence_and_upgrades.md
@@ -13,21 +13,21 @@ shared mental model when triaging "why did my X disappear?" reports.
 | Cache API `fellows-images-v1` | Profile photos | No (separate cache name) — re-fetched as needed | Yes |
 | IndexedDB `fellows-local-db` | Offline-fallback full fellow rows | Regenerated on every successful boot | Yes |
 | OPFS `fellows.db` | Imported Knack contact data | **Re-imported** every boot from `/fellows.db` | **No** (gap; see "Open questions") |
-| OPFS `relationships.db` (PR 2+) | Groups, group members, fellow_tags, fellow_notes, settings — all user-authored | **Never** — that's the whole point of this file | **No** |
+| OPFS `relationships.db` | Groups, group members, fellow_tags, fellow_notes, settings — all user-authored | **Never** — that's the whole point of this file | **No** |
 | localStorage `fellows_authenticated_once` | "this origin has authenticated at least once" marker | Untouched | **Preserved by name** in `clearAllAppData` |
 | localStorage `ehf_has_email_only` | Has-email filter pref | Untouched | Cleared |
-| localStorage `ehf.group_draft` (PR 1+) | In-progress group composer state | Untouched | Cleared (acceptable: drafts are unsaved) |
-| localStorage `fellows_self_email` (PR 5+) | User's "me" email for `mailto:?to=…` | Untouched | Cleared, but rehydrated from `relationships.settings` on next boot |
+| localStorage `ehf.group_draft` | In-progress group composer state | Untouched | Cleared (acceptable: drafts are unsaved) |
+| localStorage `fellows_self_email` | User's "me" email for `mailto:?to=…` | Untouched | Cleared, but rehydrated from `relationships.settings` on next boot |
 | Cookie `fellows_session` (HttpOnly) | HMAC'd session, 7-day TTL, contains `token_issued_at` | Untouched (still valid until TTL) | Cleared (best effort — see `clearCookiesBestEffort`) |
 
-The key architectural decision behind PR 1: **`relationships.db` is a
-separate OPFS file from `fellows.db`** rather than a set of new tables
-inside `fellows.db`. That's because `fellows.db` is bundled with the
-build and re-imported on every boot, while OPFS files we don't
-explicitly touch are durable. Cross-DB joins use SQLite `ATTACH
-DATABASE 'fellows.db' AS f ?mode=ro`, which also enforces read-only
-access to contact data at the SQLite level (any stray write into `f.*`
-raises `OperationalError`).
+The key architectural decision: **`relationships.db` is a separate
+OPFS file from `fellows.db`** rather than a set of new tables inside
+`fellows.db`. That's because `fellows.db` is bundled with the build
+and re-imported on every boot, while OPFS files we don't explicitly
+touch are durable. Cross-DB joins use SQLite `ATTACH DATABASE
+'fellows.db' AS f ?mode=ro`, which also enforces read-only access to
+contact data at the SQLite level (any stray write into `f.*` raises
+`OperationalError`).
 
 ## Standard app update flow
 
@@ -63,13 +63,13 @@ recipient.
 What looks "custom per user" is purely client-side state:
 
 - The user's email is captured into `localStorage[fellows_self_email]`
-  the first time they submit the magic-link gate (PR 5).
+  the first time they submit the magic-link gate.
 - It is also written to the `relationships.settings` table so it
   survives Clear App Cache. On boot, `app.js` mirrors the settings
   value back into localStorage for fast read.
-- The Settings page (`#/settings`, PR 5) lets the user override —
-  useful when someone wants exports addressed to a different
-  mailbox than the one they sign in with.
+- The Settings page (`#/settings`) lets the user override — useful
+  when someone wants exports addressed to a different mailbox than
+  the one they sign in with.
 
 A user moving between browsers / devices re-enters their email at
 sign-in (the magic-link form already requires it). After verify, the
@@ -78,14 +78,15 @@ beyond what the magic-link allowlist already requires.
 
 ## Edge cases
 
-### A user upgrades to PR 5 with no `self_email` stashed
+### A user has no `self_email` set yet
 
-On first PR 5 boot, `relationships.settings` has no `self_email`
-row. Surface a one-line nudge on the group-detail Export panel:
-"Set your email in Settings to enable 'email it to me'." Or
-auto-prompt on first export attempt. No data loss; just a one-time
-setup step. Users who installed before PR 5 will all hit this
-exactly once.
+A fresh install (or a returning user from before the Settings page
+shipped) opens the app with no `self_email` in
+`relationships.settings`. The group-detail Export panel surfaces a
+one-line nudge ("Set your email in Settings to enable 'email it to
+me'"). No data loss; just a one-time setup step. After the user
+signs in via the magic-link gate the value is auto-captured, so
+most users hit this only once or never.
 
 ### A user clicks Clear App Cache
 
@@ -141,11 +142,6 @@ either:
   to wipe just that file. If this surfaces, add a separate "wipe local
   data and re-download" hook that deletes `fellows.db` from OPFS but
   leaves `relationships.db` intact.
-- **PR 5 self-email migration.** When `fellows_self_email` is
-  introduced, decide: preserve it across `clearAllAppData` like
-  `fellows_authenticated_once`, or rely on the boot-time mirror from
-  `relationships.settings`. The latter is simpler (one less special
-  case in `clearAllAppData`) and the user-facing behavior is identical.
 - **Future cross-device sync.** Out of scope today, but the layering
   here keeps the door open: `relationships.db` is a single
   self-contained file with stable schemas, suitable for an

--- a/docs/users_manual.md
+++ b/docs/users_manual.md
@@ -10,7 +10,9 @@ technical tour, see [`Architecture.md`](Architecture.md).
 A private, installable directory of Edmund Hillary Fellowship fellow
 profiles. Once installed, the app runs locally on your device — the fellow
 data lives in a local database inside your browser's app storage, so you
-can browse the directory even when you're offline.
+can browse the directory even when you're offline. You can also save your
+own **groups** of fellows for quick contact and export, and store a few
+small **settings** (like the email you want exports addressed from).
 
 The app is only distributed to EHF fellows, by emailed magic link. Please
 keep the data confidential and do not share the link or screenshots
@@ -103,6 +105,135 @@ skip the install landing and go straight to the directory.
 - The visible-count text (e.g. **"142 of 515 fellows visible"**) shows how
   many fellows match your current search + filter.
 
+<!-- screenshot: directory view with search active and visible-count text -->
+
+---
+
+## Groups
+
+Groups let you save a set of fellows for repeat workflows: contacting a
+cohort, exporting a sub-directory, or just keeping track of who you've
+already reached out to. Groups live entirely on your device — they're
+per-browser, never synced to a server, and survive **Clear App Cache**.
+
+### Composing a group
+
+The directory page has a right-side **selection rail** that builds up the
+group you're working on.
+
+1. Browse or search the directory.
+2. Click a fellow to open their profile, then use **Add to selection** to
+   put them on the rail. (Or use the toggle on the directory list itself,
+   if visible.)
+3. The rail shows everyone currently selected, plus a running count.
+4. When you're happy with the set, type a name into the rail and click
+   **Save group**. You're taken to the group's detail page.
+
+Drafts in progress are kept in browser storage, so you can close the tab
+and come back to the same selection later. (The draft is cleared when you
+click **Clear App Cache**, since it's by definition unsaved.)
+
+<!-- screenshot: directory page with right-rail composer mid-selection -->
+
+### Browsing your groups
+
+Open `#/groups` (or use the **Groups** link in the navigation). You'll see
+all your saved groups, newest-touched first, with a member count beside
+each. Click a group's name to open its detail page; click **visual
+directory** to jump straight to its portrait grid (see below).
+
+<!-- screenshot: groups index with two or three saved groups -->
+
+### Group detail
+
+The detail page (`#/groups/<id>`) gives you everything you do *with* the
+group:
+
+- **Member list**, with each fellow's name. Clicking a name opens the
+  fellow's profile.
+- **Note** — a free-text field below the member list. Edit inline; saves
+  automatically.
+- **Action bar** (lavender) with three buttons:
+  - **✉ Contact the whole group** — opens your default mail client with
+    every member's email address pre-filled. By default emails go in
+    **CC** so each member sees the others; toggle the CC/BCC pill to
+    BCC instead. Long member lists may be split across multiple draft
+    emails to fit your mail client's address-line limit.
+  - **Export** — opens the export panel inline (see below).
+  - **Edit** — switches into edit mode (see below).
+
+<!-- screenshot: group detail page with action bar visible -->
+
+### Visual directory
+
+`#/groups/<id>/directory` (or the **visual directory** row link from the
+groups index) shows the group as an alphabetical grid of portrait tiles
+— closer to a yearbook layout than a list. Click any portrait or name to
+open that fellow's profile. The lavender bar at the top has the same
+**Contact the group** action as the detail page, so you can email the
+whole group from this view too.
+
+Portraits that didn't download fall back to a silhouette placeholder.
+
+<!-- screenshot: visual portrait directory -->
+
+### Editing a group
+
+Click **Edit** on the detail page (or visit `#/edit/<id>`). You'll see:
+
+- A **yellow banner** across the top of the app reading "editing group: …".
+- The selection rail flips into **editing group / Done editing** mode and
+  pre-fills with the group's current members.
+- Every add/remove **auto-saves** immediately. There's no separate "save"
+  button.
+- Two ways to exit:
+  - **Done editing** — keeps everything you changed.
+  - **Cancel edits** — reverts to the membership you started this edit
+    session with. Anything you toggled in this session is undone; earlier
+    saves are unaffected.
+
+<!-- screenshot: edit mode with yellow banner and rail in edit state -->
+
+### Deleting a group
+
+From the group detail page, use the **Delete** action. You'll be asked to
+confirm. Only the saved group is removed; the fellows themselves are
+untouched, and any other groups they belong to are untouched.
+
+### Exporting a group
+
+Click **Export** on the group detail page. The export panel offers:
+
+- **HTML / ZIP** — a self-contained directory bundle (one HTML file per
+  fellow, plus the photos that have downloaded). Useful for archiving or
+  forwarding offline.
+- **PDF** — a printable directory generated locally.
+
+Both exports run entirely in your browser. The "from" address used for
+any embedded `mailto:` links is the **"me" email** from Settings (see
+below); if it isn't set yet, the panel will nudge you to set it first.
+
+<!-- screenshot: export panel open on group detail -->
+
+---
+
+## Settings
+
+Open `#/settings` (linked from the navigation). Today there's one
+setting:
+
+- **Your email ("me" email)** — used by group export, "email it to me"
+  links, and any other place the app needs to address something *to you*.
+  It's auto-captured the first time you sign in via a magic link, so most
+  users will never need to touch this page. Override it here if you'd
+  rather receive exports at a different mailbox than the one you sign in
+  with.
+
+The setting is stored in the app's local user-data store and survives
+both app updates and **Clear App Cache**.
+
+<!-- screenshot: settings page with self-email field -->
+
 ---
 
 ## Updates
@@ -135,6 +266,11 @@ server asks for auth again you'll need your install link (or a fresh
 one). The app preserves a small "you've been here before" marker so the
 URL still opens the directory directly and a future server outage won't
 strand you at the error panel.
+
+**What survives a cache clear:** your saved groups, your group notes,
+and your Settings (e.g. your "me" email). These live in a separate
+local store from the app cache and aren't touched by this button. An
+in-progress group draft *is* lost — drafts are by definition unsaved.
 
 ---
 


### PR DESCRIPTION
## Summary

Groups shipped across PRs #53–#57 without keeping developer-facing and user-facing docs in sync. This is a docs-only catch-up (plus one cosmetic string in `app.js`).

- **`docs/Architecture.md`** — complete SPA route map (8 routes), full HTTP API table covering all groups + settings endpoints, `relationships.db` schema, and a pointer making `users_manual.md` the source of truth for UI/UX.
- **`docs/users_manual.md`** — new **Groups** section (compose, browse, detail page, visual directory, edit mode, delete, export) and a **Settings** section. Includes a "what survives Clear App Cache" callout. `<!-- screenshot: ... -->` placeholders are dropped at the natural visual moments for a follow-up screenshot pass.
- **`docs/persistence_and_upgrades.md`** — drops dated `(PR N+)` markers now that the PRs are merged, reframes the "first time without `self_email`" edge case neutrally, and retires the resolved self-email migration future-work item.
- **`README.md`** — API list reorganized into fellow / groups / settings / static-bootstrap blocks; intro mentions saved groups and the per-user `relationships.db`.
- **`CLAUDE.md`** — new convention: UI/UX changes belong in `users_manual.md` and ship in the same PR as the feature; the app links to it from the About page.
- **`app/static/app.js`** — the only code change: About-page User Guide link description updated from `"how to install, update, and clear app data."` → `"how to install, browse, save groups, export, and manage settings."`

## Test plan

- [ ] `just test-e2e -- -k test_users_manual_link_on_about_page` (asserts the GitHub URL still resolves on the About page; the description-text change doesn't break it).
- [ ] Spot-check rendered Markdown on GitHub for `docs/Architecture.md` (route table + API table + relationships schema render correctly) and `docs/users_manual.md` (Groups + Settings sections).
- [ ] Verify the About page in the dev server shows the new User Guide description text.

## Follow-up (separate PR)

Group-detail UX redesign discussed alongside this work — focus mode (hide both rails on `#/groups/<id>` and `#/groups/<id>/directory`), action-bar restructure (**Mail to the whole group** + CC/BCC on row 1, **Edit members** + **Export a directory** on row 2), inline pencil-rename on the group name, and a two-phase export-then-email flow (auto-download + `mailto:` to self). The `users_manual.md` additions in this PR will need small follow-up tweaks once that lands; per the new CLAUDE.md convention they'll ship in the same PR as the implementation.