### PR TITLE
feat(groups): detail-page focus mode + email-export flow

### DIFF
--- a/app/static/app.js
+++ b/app/static/app.js
@@ -3213,13 +3213,17 @@
 
     // Tag <body> with the current focus mode so CSS can collapse the
     // global directory + composer rails (and, in edit mode, the central
-    // pane). Always clear all three before adding the matching one so
+    // pane). Always clear all four before adding the matching one so
     // navigating between routes doesn't leave a stale class behind.
     var body = document.body;
-    body.classList.remove('route-group-detail', 'route-group-edit', 'route-group-directory');
+    body.classList.remove(
+      'route-groups-list', 'route-group-detail',
+      'route-group-edit', 'route-group-directory'
+    );
     if (directoryMatch) body.classList.add('route-group-directory');
     else if (groupMatch) body.classList.add('route-group-detail');
     else if (editMatch) body.classList.add('route-group-edit');
+    else if (hash === '#/groups') body.classList.add('route-groups-list');
 
     // Transition out of edit mode if the URL no longer points there. (Same
     // group still in editingGroupId? Different group? Either way, exit

--- a/app/static/app.js
+++ b/app/static/app.js
@@ -3208,6 +3208,19 @@
     var hash = window.location.hash || '';
     var editMatch = hash.match(/^#\/edit\/(\d+)$/);
     var nextEditId = editMatch ? parseInt(editMatch[1], 10) : null;
+    var directoryMatch = hash.match(/^#\/groups\/(\d+)\/directory$/);
+    var groupMatch = !directoryMatch ? hash.match(/^#\/groups\/(\d+)$/) : null;
+
+    // Tag <body> with the current focus mode so CSS can collapse the
+    // global directory + composer rails (and, in edit mode, the central
+    // pane). Always clear all three before adding the matching one so
+    // navigating between routes doesn't leave a stale class behind.
+    var body = document.body;
+    body.classList.remove('route-group-detail', 'route-group-edit', 'route-group-directory');
+    if (directoryMatch) body.classList.add('route-group-directory');
+    else if (groupMatch) body.classList.add('route-group-detail');
+    else if (editMatch) body.classList.add('route-group-edit');
+
     // Transition out of edit mode if the URL no longer points there. (Same
     // group still in editingGroupId? Different group? Either way, exit
     // first; if we're entering a new edit-mode session we re-enter below.)
@@ -3226,25 +3239,21 @@
       renderGroupsPage();
       return;
     }
-    var directoryMatch = hash.match(/^#\/groups\/(\d+)\/directory$/);
     if (directoryMatch) {
       renderGroupDirectoryPage(parseInt(directoryMatch[1], 10));
       return;
     }
-    var groupMatch = hash.match(/^#\/groups\/(\d+)$/);
     if (groupMatch) {
       renderGroupDetailPage(parseInt(groupMatch[1], 10));
       return;
     }
     if (editMatch) {
-      // Edit mode is rail-driven, not detail-pane-driven. The directory
-      // and rail flip into edit mode; the detail pane shows whatever was
-      // there (or a placeholder via updateDetailFromHash). Enter once per
-      // hash visit; re-entering for the same id is a no-op.
+      // Edit mode is rail-driven; the central pane is hidden via CSS so
+      // there's nothing useful to render there. Enter once per hash
+      // visit; re-entering for the same id is a no-op.
       if (groupDraft.editingGroupId !== nextEditId) {
         enterEditMode(nextEditId);
       }
-      updateDetailFromHash();
       return;
     }
     updateDetailFromHash();
@@ -3507,19 +3516,26 @@
       var noteEditLabel = hasNote ? 'edit' : 'add a note';
       var html = '<div class="group-detail-page" data-group-id="' + escapeHtml(String(group.id)) + '">' +
         '<p class="group-detail-breadcrumb">' +
-          '<a href="#/groups">groups</a> › ' + escapeHtml(name) +
+          '<a href="#/groups">groups</a> › ' +
+          '<span id="group-detail-breadcrumb-name">' + escapeHtml(name) + '</span>' +
         '</p>' +
-        '<h2 class="group-detail-title">' + escapeHtml(name) + '</h2>' +
+        '<h2 class="group-detail-title">' +
+          '<span class="group-detail-title-text" id="group-detail-title-text">' + escapeHtml(name) + '</span>' +
+          '<a href="#" class="group-detail-title-edit" id="group-detail-title-edit" role="button" ' +
+            'aria-label="Rename group" title="Rename group">✎</a>' +
+        '</h2>' +
         '<p class="group-detail-meta">' +
           escapeHtml(String(memberCount)) + memberWord +
           ' · created ' + escapeHtml((group.created_at || '').slice(0, 10)) +
         '</p>';
 
-      // Action bar: ✉ Contact (primary, real <a href="mailto:…">) + CC/BCC
-      // pill toggle + ⬇ Export + ✎ Edit. Native <a> means the browser
-      // handles handing the mailto URL off to the user's mail client.
-      // The hard-threshold path intercepts the click and copies addresses
-      // to the clipboard instead.
+      // Action bar, two rows. Row 1 = "✉ Mail to the whole group" + CC/BCC
+      // pill (the primary action and its modifier live together). Row 2 =
+      // "✎ Edit members" + "⬇ Export a directory" (the secondary actions).
+      // The Mail button is a native <a href="mailto:…">; the hard-threshold
+      // path intercepts the click and copies addresses to the clipboard
+      // instead. Group rename is reachable via the pencil next to the
+      // title; "Edit members" is membership-only.
       var hasEmails = totalEmails > 0;
       var hardLimit = totalEmails >= GROUPS_CONTACT_HARD_AT;
       var initialHref = (hasEmails && !hardLimit)
@@ -3532,16 +3548,19 @@
       if (!hasEmails) contactAttrs += ' aria-disabled="true" title="No email addresses available for this group"';
       html +=
         '<div class="group-action-bar">' +
-          '<a class="' + contactClasses + '" id="group-action-contact" role="button"' + contactAttrs + '>' +
-            '✉ Contact the whole group' +
-          '</a>' +
-          '<div class="group-contact-mode" role="group" aria-label="Recipient header">' +
-            '<button type="button" class="group-mode-pill group-mode-pill--active" data-mode="cc" aria-pressed="true">CC</button>' +
-            '<button type="button" class="group-mode-pill" data-mode="bcc" aria-pressed="false">BCC</button>' +
+          '<div class="group-action-row">' +
+            '<a class="' + contactClasses + '" id="group-action-contact" role="button"' + contactAttrs + '>' +
+              '✉ Mail to the whole group' +
+            '</a>' +
+            '<div class="group-contact-mode" role="group" aria-label="Recipient header">' +
+              '<button type="button" class="group-mode-pill group-mode-pill--active" data-mode="cc" aria-pressed="true">CC</button>' +
+              '<button type="button" class="group-mode-pill" data-mode="bcc" aria-pressed="false">BCC</button>' +
+            '</div>' +
           '</div>' +
-          '<button type="button" class="group-action-btn" id="group-action-export">⬇ Export a directory</button>' +
-          '<button type="button" class="group-action-btn" id="group-action-edit">✎ Edit group</button>' +
-          '<span class="group-action-helper">opens your mail client with everyone in <span id="group-action-helper-mode">CC</span></span>' +
+          '<div class="group-action-row">' +
+            '<button type="button" class="group-action-btn" id="group-action-edit">✎ Edit members</button>' +
+            '<button type="button" class="group-action-btn" id="group-action-export">⬇ Export a directory</button>' +
+          '</div>' +
         '</div>';
 
       // Threshold banner. Soft warning between WARN and HARD, hard warning ≥ HARD.
@@ -3569,9 +3588,13 @@
           '</div>';
       }
 
-      // Inline export panel. PDF/HTML are mutually exclusive (radios). The
-      // email input is always visible — prefilled from getSelfEmail() when
-      // the user has one in localStorage / settings, else blank with a cue.
+      // Inline export panel. Two-phase: pick a format and Export → file
+      // is built locally and downloaded. After success, the result row
+      // surfaces an Email button alongside the View link, which opens
+      // the user's mail client with a body referencing the just-saved
+      // file. The email input lives inside the result row (it's only
+      // relevant after the file exists); it prefills from getSelfEmail()
+      // and lets the user override per-export without leaving the page.
       var slugFn = slugifyForFilename(name);
       var initialSelfEmail = getSelfEmail();
       html +=
@@ -3587,27 +3610,25 @@
               '<span><b>HTML directory</b><br><code>' + escapeHtml(slugFn) + '.html</code> · self-contained, view in any browser</span>' +
             '</label>' +
           '</div>' +
-          '<div class="group-export-email-row">' +
-            '<label class="group-export-email-label">' +
-              '<input type="checkbox" id="export-self-email" checked> ' +
-              '<span><b>email it to me</b></span>' +
-            '</label>' +
-            '<input type="email" id="export-self-email-addr" class="group-export-email-input' +
-              (initialSelfEmail ? '' : ' group-export-email-input--empty') + '" ' +
-              'placeholder="your@email.com" autocomplete="email" ' +
-              'value="' + escapeHtml(initialSelfEmail) + '">' +
-            '<span class="group-export-email-cue" id="export-self-email-cue">' +
-              (initialSelfEmail ? 'override here to send to a different address' : 'enter your email — you can save it in Settings later') +
-            '</span>' +
-          '</div>' +
           '<div class="group-export-actions">' +
             '<button type="button" class="group-export-cancel">cancel</button>' +
             '<button type="button" class="group-export-go" id="group-export-go">Export</button>' +
           '</div>' +
           '<div class="group-export-result hidden" id="group-export-result" aria-live="polite">' +
-            '<span class="group-export-result-text" id="group-export-result-text"></span> ' +
-            '<a href="#" class="group-export-view" id="group-export-view" target="_blank" rel="noopener">View</a> ' +
-            '<button type="button" class="group-export-email-btn hidden" id="group-export-email-btn">Email it to me</button>' +
+            '<div class="group-export-result-row">' +
+              '<span class="group-export-result-text" id="group-export-result-text"></span> ' +
+              '<a href="#" class="group-export-view" id="group-export-view" target="_blank" rel="noopener">View</a>' +
+            '</div>' +
+            '<div class="group-export-email-row">' +
+              '<input type="email" id="export-self-email-addr" class="group-export-email-input' +
+                (initialSelfEmail ? '' : ' group-export-email-input--empty') + '" ' +
+                'placeholder="your@email.com" autocomplete="email" ' +
+                'value="' + escapeHtml(initialSelfEmail) + '">' +
+              '<span class="group-export-email-cue" id="export-self-email-cue">' +
+                (initialSelfEmail ? 'override here to send to a different address' : 'enter your email to send the export to yourself') +
+              '</span>' +
+              '<button type="button" class="group-export-email-btn" id="group-export-email-btn">Email it to me</button>' +
+            '</div>' +
           '</div>' +
           '<div class="group-contact-banner hidden" id="group-export-banner" role="status"></div>' +
           '<p class="group-export-note" id="group-export-note">' +
@@ -4278,13 +4299,13 @@
     var contactMode = 'cc';
     var contactBtn = document.getElementById('group-action-contact');
     var modePills = document.querySelectorAll('.group-mode-pill');
-    var helperModeEl = document.getElementById('group-action-helper-mode');
     var exportBtn = document.getElementById('group-action-export');
     var editBtn = document.getElementById('group-action-edit');
     var exportPanel = document.getElementById('group-export-panel');
     var exportCancel = document.querySelector('.group-export-cancel');
     var copyEmailsLink = document.getElementById('group-action-copy-emails');
     var noteEditLink = document.getElementById('group-detail-note-edit');
+    var titleEditLink = document.getElementById('group-detail-title-edit');
 
     function setMode(next) {
       contactMode = next;
@@ -4295,7 +4316,6 @@
         else p.classList.remove('group-mode-pill--active');
         p.setAttribute('aria-pressed', on ? 'true' : 'false');
       }
-      if (helperModeEl) helperModeEl.textContent = next.toUpperCase();
       refreshContactHref();
     }
 
@@ -4374,7 +4394,7 @@
           addrInput.classList.toggle('group-export-email-input--empty', !hasValue);
           cue.textContent = hasValue
             ? 'override here to send to a different address'
-            : 'enter your email — you can save it in Settings later';
+            : 'enter your email to send the export to yourself';
         }
         // Reset any prior post-export state when reopening so the panel
         // doesn't confusingly show a stale "View" link.
@@ -4431,6 +4451,105 @@
         startInlineNoteEdit(group);
       });
     }
+
+    if (titleEditLink) {
+      titleEditLink.addEventListener('click', function (ev) {
+        ev.preventDefault();
+        startInlineGroupRename(group);
+      });
+    }
+  }
+
+  /** Inline rename for the group name (pencil ✎ next to the title on the
+   *  group detail page). Swaps the title h2's text + pencil for an input
+   *  + save/cancel pair. On save, PATCHes the group, mirrors the new
+   *  name into group.name + the in-memory groups list, and re-renders
+   *  the title text and the breadcrumb. The "Edit members" page can
+   *  also rename via the rail input; this is just the primary
+   *  affordance from the detail page. */
+  function startInlineGroupRename(group) {
+    var titleH2 = document.querySelector('.group-detail-title');
+    var crumbName = document.getElementById('group-detail-breadcrumb-name');
+    if (!titleH2) return;
+    var current = group.name || '';
+    titleH2.innerHTML = '';
+    var input = document.createElement('input');
+    input.type = 'text';
+    input.className = 'group-detail-title-input';
+    input.value = current;
+    input.maxLength = 200;
+    input.setAttribute('aria-label', 'Group name');
+    var actions = document.createElement('span');
+    actions.className = 'group-detail-title-actions';
+    var saveBtn = document.createElement('button');
+    saveBtn.type = 'button';
+    saveBtn.className = 'group-detail-title-save';
+    saveBtn.textContent = 'Save';
+    var cancelBtn = document.createElement('button');
+    cancelBtn.type = 'button';
+    cancelBtn.className = 'group-detail-title-cancel';
+    cancelBtn.textContent = 'Cancel';
+    actions.appendChild(saveBtn);
+    actions.appendChild(cancelBtn);
+    titleH2.appendChild(input);
+    titleH2.appendChild(actions);
+    input.focus();
+    input.select();
+
+    function restoreTitle(name) {
+      var safe = escapeHtml(name);
+      titleH2.innerHTML =
+        '<span class="group-detail-title-text" id="group-detail-title-text">' + safe + '</span>' +
+        '<a href="#" class="group-detail-title-edit" id="group-detail-title-edit" role="button" ' +
+          'aria-label="Rename group" title="Rename group">✎</a>';
+      var newLink = document.getElementById('group-detail-title-edit');
+      if (newLink) {
+        newLink.addEventListener('click', function (ev) {
+          ev.preventDefault();
+          startInlineGroupRename(group);
+        });
+      }
+      if (crumbName) crumbName.textContent = name;
+    }
+
+    function commit() {
+      var next = (input.value || '').trim();
+      if (!next) {
+        showToast('Group name cannot be empty.');
+        input.focus();
+        return;
+      }
+      if (next.length > 200) {
+        showToast('Group name is too long (max 200 chars).');
+        input.focus();
+        return;
+      }
+      if (next === current) {
+        restoreTitle(current);
+        return;
+      }
+      saveBtn.disabled = true;
+      cancelBtn.disabled = true;
+      dataProvider.updateGroup(group.id, { name: next })
+        .then(function (updated) {
+          var saved = (updated && typeof updated.name === 'string') ? updated.name : next;
+          group.name = saved;
+          restoreTitle(saved);
+          showToast('Group renamed.');
+        })
+        .catch(function () {
+          saveBtn.disabled = false;
+          cancelBtn.disabled = false;
+          showToast('Could not rename group.');
+        });
+    }
+
+    saveBtn.addEventListener('click', commit);
+    cancelBtn.addEventListener('click', function () { restoreTitle(current); });
+    input.addEventListener('keydown', function (ev) {
+      if (ev.key === 'Enter') { ev.preventDefault(); commit(); }
+      else if (ev.key === 'Escape') { ev.preventDefault(); restoreTitle(current); }
+    });
   }
 
   // Mailto: URL length thresholds for the export "Email it to me" button.
@@ -4535,8 +4654,6 @@
     }
     var ext = formatPdf ? 'pdf' : 'html';
     var filename = slug + '.' + ext;
-    var emailWanted = !!document.getElementById('export-self-email') &&
-      document.getElementById('export-self-email').checked;
     if (button) {
       button.disabled = true;
       button.textContent = 'Exporting…';
@@ -4566,13 +4683,6 @@
         if (viewLink) viewLink.setAttribute('href', lastExportObjectUrl);
         if (resultText) {
           resultText.textContent = 'Created ' + filename + '.';
-        }
-        // Re-query the live email button — the initial-render reference
-        // would be the same node anyway, but re-query keeps this resilient
-        // against future mutations of the post-export row.
-        var liveEmailBtn = document.getElementById('group-export-email-btn');
-        if (liveEmailBtn) {
-          liveEmailBtn.classList.toggle('hidden', !emailWanted);
         }
         if (resultEl) resultEl.classList.remove('hidden');
         showToast('Exported: ' + filename);

--- a/app/static/styles.css
+++ b/app/static/styles.css
@@ -1671,20 +1671,47 @@ h1 {
 }
 
 /* =========================================================================
+ * Groups feature — focus modes for the group routes. Once you've drilled
+ * into a group, the global directory rail and the "add to a group"
+ * composer rail are noise; the route() handler tags <body> so we can
+ * collapse them out of the way and let the central content take the
+ * room. Edit mode is the inverse — both rails matter (left to pick
+ * fellows, right to manage the editing session) and the central pane
+ * has nothing useful to show.
+ * ========================================================================= */
+
+body.route-group-detail #directory,
+body.route-group-detail #group-rail,
+body.route-group-directory #directory,
+body.route-group-directory #group-rail {
+  display: none;
+}
+
+body.route-group-edit #detail {
+  display: none;
+}
+
+/* =========================================================================
  * Groups feature — PR 3: detail action bar, contact + export panel,
  * inline note edit, toast.
  * ========================================================================= */
 
 .group-action-bar {
   display: flex;
-  flex-wrap: wrap;
-  align-items: center;
+  flex-direction: column;
   gap: 0.5rem;
   padding: 0.5rem 0.6rem;
   margin: 0.5rem 0;
   background: #faf8fc;
   border: 1px solid #dcd6e8;
   border-radius: 2px;
+}
+
+.group-action-row {
+  display: flex;
+  flex-wrap: wrap;
+  align-items: center;
+  gap: 0.5rem;
 }
 
 .group-action-btn {
@@ -1771,11 +1798,62 @@ a.group-action-btn--primary {
   outline-offset: -2px;
 }
 
-.group-action-helper {
-  font-size: 0.72rem;
+/* Inline rename: ✎ pencil follows the title; clicking it swaps the
+ * <h2> contents for an <input>+save+cancel triplet. Save PATCHes the
+ * group; the breadcrumb above is re-rendered so it doesn't drift. */
+.group-detail-title-edit {
+  font-size: 0.85rem;
   color: #7a6f91;
-  margin-left: auto;
-  align-self: center;
+  text-decoration: none;
+  margin-left: 0.5rem;
+  cursor: pointer;
+  vertical-align: middle;
+}
+
+.group-detail-title-edit:hover,
+.group-detail-title-edit:focus {
+  color: #4a2c6a;
+}
+
+.group-detail-title-input {
+  font: inherit;
+  font-size: 1.1rem;
+  font-weight: 600;
+  padding: 0.15rem 0.4rem;
+  border: 1px solid #b9add0;
+  border-radius: 2px;
+  min-width: 16ch;
+  max-width: 28rem;
+}
+
+.group-detail-title-actions {
+  display: inline-flex;
+  gap: 0.35rem;
+  margin-left: 0.4rem;
+  vertical-align: middle;
+}
+
+.group-detail-title-save,
+.group-detail-title-cancel {
+  font: inherit;
+  font-size: 0.78rem;
+  padding: 0.2rem 0.55rem;
+  border-radius: 2px;
+  border: 1px solid #ccc;
+  background: #fff;
+  cursor: pointer;
+}
+
+.group-detail-title-save {
+  background: #4a2c6a;
+  color: #fff;
+  border-color: #4a2c6a;
+}
+
+.group-detail-title-save:disabled,
+.group-detail-title-cancel:disabled {
+  opacity: 0.5;
+  cursor: not-allowed;
 }
 
 .group-contact-banner {
@@ -1901,17 +1979,36 @@ a.group-action-btn--primary {
 
 .group-export-result {
   display: flex;
-  flex-wrap: wrap;
-  align-items: center;
-  gap: 0.5rem;
+  flex-direction: column;
+  gap: 0.4rem;
   padding: 0.5rem 0.7rem;
   border-top: 1px solid #ece6f3;
   background: #f7f4fb;
   font-size: 0.85rem;
 }
 
+/* The .hidden utility wins on specificity ties by source order, but it's
+ * declared earlier in this file than .group-export-result — so the flex
+ * display would otherwise override `display: none`. Pin the override. */
+.group-export-result.hidden {
+  display: none;
+}
+
+.group-export-result-row {
+  display: flex;
+  flex-wrap: wrap;
+  align-items: center;
+  gap: 0.5rem;
+}
+
 .group-export-result-text {
   margin-right: 0.3rem;
+}
+
+/* The email-row inside .group-export-result has its own padding default
+ * elsewhere; reset it here so it sits flush within the result block. */
+.group-export-result .group-export-email-row {
+  padding: 0;
 }
 
 .group-export-view {

--- a/app/static/styles.css
+++ b/app/static/styles.css
@@ -1680,6 +1680,8 @@ h1 {
  * has nothing useful to show.
  * ========================================================================= */
 
+body.route-groups-list #directory,
+body.route-groups-list #group-rail,
 body.route-group-detail #directory,
 body.route-group-detail #group-rail,
 body.route-group-directory #directory,

--- a/docs/users_manual.md
+++ b/docs/users_manual.md
@@ -137,10 +137,12 @@ click **Clear App Cache**, since it's by definition unsaved.)
 
 ### Browsing your groups
 
-Open `#/groups` (or use the **Groups** link in the navigation). You'll see
-all your saved groups, newest-touched first, with a member count beside
-each. Click a group's name to open its detail page; click **visual
-directory** to jump straight to its portrait grid (see below).
+Open `#/groups` (or use the **Groups** link in the navigation). The page
+is a focused view — the directory list and the selection rail step out
+of the way so the saved groups are what you see. They're listed
+newest-touched first, with a member count beside each. Click a group's
+name to open its detail page; click **visual directory** to jump
+straight to its portrait grid (see below).
 
 <!-- screenshot: groups index with two or three saved groups -->
 

--- a/docs/users_manual.md
+++ b/docs/users_manual.md
@@ -146,32 +146,38 @@ directory** to jump straight to its portrait grid (see below).
 
 ### Group detail
 
-The detail page (`#/groups/<id>`) gives you everything you do *with* the
-group:
+The detail page (`#/groups/<id>`) is a **focused view** — the directory
+list on the left and the selection rail on the right step out of the way
+so you can concentrate on this one group.
 
-- **Member list**, with each fellow's name. Clicking a name opens the
+- **Title with rename** — click the small **✎** pencil next to the
+  group's name to rename it in place. **Save** commits, **Cancel** (or
+  pressing **Esc**) discards the change.
+- **Member list** with each fellow's name. Clicking a name opens the
   fellow's profile.
 - **Note** — a free-text field below the member list. Edit inline; saves
   automatically.
-- **Action bar** (lavender) with three buttons:
-  - **✉ Contact the whole group** — opens your default mail client with
-    every member's email address pre-filled. By default emails go in
-    **CC** so each member sees the others; toggle the CC/BCC pill to
-    BCC instead. Long member lists may be split across multiple draft
-    emails to fit your mail client's address-line limit.
-  - **Export** — opens the export panel inline (see below).
-  - **Edit** — switches into edit mode (see below).
+- **Action bar** (lavender), arranged in two rows:
+  - **Row 1 — ✉ Mail to the whole group** + a **CC/BCC** pill toggle.
+    Opens your default mail client with every member's email address
+    pre-filled (in CC by default; switch to BCC with the pill if you'd
+    rather members not see each other). Long member lists may be split
+    across multiple draft emails to fit your mail client's address-line
+    limit.
+  - **Row 2 — ✎ Edit members** + **⬇ Export a directory**. Edit
+    members switches into edit mode (see below). Export opens the
+    export panel inline (see below).
 
 <!-- screenshot: group detail page with action bar visible -->
 
 ### Visual directory
 
 `#/groups/<id>/directory` (or the **visual directory** row link from the
-groups index) shows the group as an alphabetical grid of portrait tiles
-— closer to a yearbook layout than a list. Click any portrait or name to
-open that fellow's profile. The lavender bar at the top has the same
-**Contact the group** action as the detail page, so you can email the
-whole group from this view too.
+groups index) shows the group as a full-page alphabetical grid of
+portrait tiles — closer to a yearbook layout than a list. Click any
+portrait or name to open that fellow's profile. The lavender bar at the
+top has the same **Mail to the whole group** action as the detail page,
+so you can email the whole group from this view too.
 
 Portraits that didn't download fall back to a silhouette placeholder.
 
@@ -179,11 +185,14 @@ Portraits that didn't download fall back to a silhouette placeholder.
 
 ### Editing a group
 
-Click **Edit** on the detail page (or visit `#/edit/<id>`). You'll see:
+Click **✎ Edit members** on the detail page (or visit `#/edit/<id>`).
+You'll see:
 
 - A **yellow banner** across the top of the app reading "editing group: …".
-- The selection rail flips into **editing group / Done editing** mode and
-  pre-fills with the group's current members.
+- Edit mode is **rail-driven**: the directory list returns on the left
+  for picking fellows, the selection rail on the right flips into
+  **editing group / Done editing** mode and pre-fills with the group's
+  current members. The center pane stays out of the way.
 - Every add/remove **auto-saves** immediately. There's no separate "save"
   button.
 - Two ways to exit:
@@ -191,6 +200,10 @@ Click **Edit** on the detail page (or visit `#/edit/<id>`). You'll see:
   - **Cancel edits** — reverts to the membership you started this edit
     session with. Anything you toggled in this session is undone; earlier
     saves are unaffected.
+
+(Renaming the group also works from this page — the rail's name field is
+the same group name. The pencil ✎ on the detail page is the primary
+affordance; this is a secondary path.)
 
 <!-- screenshot: edit mode with yellow banner and rail in edit state -->
 
@@ -202,18 +215,27 @@ untouched, and any other groups they belong to are untouched.
 
 ### Exporting a group
 
-Click **Export** on the group detail page. The export panel offers:
+Click **⬇ Export a directory** on the group detail page. Exporting is a
+**two-phase** flow:
 
-- **HTML / ZIP** — a self-contained directory bundle (one HTML file per
-  fellow, plus the photos that have downloaded). Useful for archiving or
-  forwarding offline.
-- **PDF** — a printable directory generated locally.
-
-Both exports run entirely in your browser. The "from" address used for
-any embedded `mailto:` links is the **"me" email** from Settings (see
-below); if it isn't set yet, the panel will nudge you to set it first.
+1. Pick a format and click **Export**:
+   - **PDF** — a printable directory generated locally.
+   - **HTML** — a single self-contained `.html` file you can archive or
+     forward offline.
+   The button shows "Exporting…" while the bundle is built in your
+   browser. When it's done, the file lands in your **Downloads** folder
+   (or via the system share sheet on iOS).
+2. After Export completes, the panel reveals a **View** link (opens the
+   file in a new tab) and an **Email it to me** button alongside an
+   email field. The field prefills from the **"me" email** in Settings;
+   override it for this export if you want it sent somewhere else.
+   Clicking **Email it to me** opens your mail client with a draft
+   addressed to that address — you attach the file from your Downloads
+   folder before sending. (Browsers can't attach files to a `mailto:`
+   automatically.)
 
 <!-- screenshot: export panel open on group detail -->
+<!-- screenshot: post-export result row with View link + Email button -->
 
 ---
 

--- a/tests/e2e/test_groups_detail.py
+++ b/tests/e2e/test_groups_detail.py
@@ -91,7 +91,10 @@ def _create_group(base_url, *, name, fellow_record_ids, note=""):
 
 def _wait_for_directory(page):
     page.locator("#loading").wait_for(state="hidden", timeout=10000)
-    page.locator("#directory").wait_for(state="visible", timeout=5000)
+    # #app-wrap rather than #directory: the directory rail is now
+    # display:none on group routes, so it's no longer a route-independent
+    # readiness signal.
+    page.locator("#app-wrap").wait_for(state="visible", timeout=5000)
 
 
 @pytest.fixture(autouse=True)
@@ -117,9 +120,9 @@ class TestGroupDetailActionBar:
         expect(bar).to_be_visible(timeout=5000)
         contact = page.locator("#group-action-contact")
         expect(contact).to_be_visible()
-        expect(contact).to_contain_text("Contact the whole group")
+        expect(contact).to_contain_text("Mail to the whole group")
         expect(page.locator("#group-action-export")).to_contain_text("Export a directory")
-        expect(page.locator("#group-action-edit")).to_contain_text("Edit group")
+        expect(page.locator("#group-action-edit")).to_contain_text("Edit members")
         # CC pill is active by default.
         cc_pill = page.locator('.group-mode-pill[data-mode="cc"]')
         expect(cc_pill).to_have_class(re.compile(r"\bgroup-mode-pill--active\b"))
@@ -144,7 +147,7 @@ class TestGroupDetailActionBar:
             "href", re.compile(r"^mailto:\?cc=.+&subject=Mailto%20small$")
         )
 
-    def test_cc_bcc_toggle_rewrites_href_and_helper(
+    def test_cc_bcc_toggle_rewrites_href(
         self, standalone_page, base_url_fixture
     ):
         page = standalone_page
@@ -156,13 +159,10 @@ class TestGroupDetailActionBar:
         )
         page.goto(f"{base_url_fixture}/#/groups/{g['id']}", wait_until="domcontentloaded")
         _wait_for_directory(page)
-        helper_mode = page.locator("#group-action-helper-mode")
-        expect(helper_mode).to_have_text("CC")
         expect(page.locator("#group-action-contact")).to_have_attribute(
             "href", re.compile(r"^mailto:\?cc=")
         )
         page.locator('.group-mode-pill[data-mode="bcc"]').click()
-        expect(helper_mode).to_have_text("BCC")
         expect(page.locator("#group-action-contact")).to_have_attribute(
             "href", re.compile(r"^mailto:\?bcc=")
         )
@@ -267,7 +267,7 @@ class TestGroupDetailEditNav:
     def test_edit_button_navigates_and_enters_edit_mode(
         self, standalone_page, base_url_fixture
     ):
-        """Click ✎ Edit group on the detail page → URL flips to
+        """Click ✎ Edit members on the detail page → URL flips to
         #/edit/<id> and the yellow edit-mode banner appears.
         Deeper edit-mode behaviour (auto-save, cancel-edits, etc.)
         is covered in tests/e2e/test_groups_edit.py."""

--- a/tests/e2e/test_groups_edit.py
+++ b/tests/e2e/test_groups_edit.py
@@ -1,7 +1,7 @@
 """E2E for PR 4 edit mode.
 
 Pins:
-- Clicking ✎ Edit group on the detail page enters edit mode: yellow
+- Clicking ✎ Edit members on the detail page enters edit mode: yellow
   banner appears, rail flips to "editing group" / "Done editing",
   members are pre-selected, has-email filter is unchecked, search is
   cleared.
@@ -99,7 +99,10 @@ def _fetch_group(base_url, gid):
 
 def _wait_for_directory(page):
     page.locator("#loading").wait_for(state="hidden", timeout=10000)
-    page.locator("#directory").wait_for(state="visible", timeout=5000)
+    # #app-wrap rather than #directory: the directory rail is now
+    # display:none on the bare group-detail route. Edit mode itself
+    # restores the rail, but readiness needs to fire either way.
+    page.locator("#app-wrap").wait_for(state="visible", timeout=5000)
 
 
 def _aaron_row(page):
@@ -223,8 +226,9 @@ class TestDoneEditing:
         # Rail back to compose mode.
         expect(page.locator("#group-rail-eyebrow")).to_have_text("add to a group")
         expect(page.locator("#group-rail-create")).to_have_text("Create new group")
-        # Detail page renders the group.
-        expect(page.locator(".group-detail-title")).to_have_text("Done flow")
+        # Detail page renders the group. Target the inner title text so
+        # the pencil-rename ✎ link beside it doesn't trip the exact match.
+        expect(page.locator("#group-detail-title-text")).to_have_text("Done flow")
 
 
 class TestCancelEdits:

--- a/tests/e2e/test_groups_export.py
+++ b/tests/e2e/test_groups_export.py
@@ -10,11 +10,11 @@ Pins:
     single self-contained .html file (HTML5 doctype, contains the
     member's name, contact-bar mailto:);
   - selecting PDF produces a .pdf file (magic bytes %PDF-);
-  - the email input is always present, prefilled from settings when set
-    and showing a cue when empty;
+  - the email input lives inside the post-export result row, prefilled
+    from settings when set and showing a cue when empty;
   - Export only creates the file — it does not navigate to mailto: by
-    itself; a post-export result row exposes a View link (always) and
-    an Email button (when "email it to me" was checked).
+    itself; the post-export result row exposes a View link and an
+    Email button (always — there's no upfront opt-in checkbox).
 """
 from __future__ import annotations
 
@@ -110,7 +110,10 @@ def _create_group(base_url, *, name, fellow_record_ids, note=""):
 
 def _wait_for_directory(page):
     page.locator("#loading").wait_for(state="hidden", timeout=10000)
-    page.locator("#directory").wait_for(state="visible", timeout=5000)
+    # #app-wrap rather than #directory: the directory rail is now
+    # display:none on group routes, so it's no longer a route-independent
+    # readiness signal.
+    page.locator("#app-wrap").wait_for(state="visible", timeout=5000)
 
 
 @pytest.fixture(autouse=True)
@@ -216,10 +219,7 @@ class TestExportDownloads:
         page.goto(f"{base_url_fixture}/#/groups/{g['id']}", wait_until="domcontentloaded")
         _wait_for_directory(page)
         page.locator("#group-action-export").click()
-        # Pick HTML; uncheck the auto-email checkbox so Export is the only
-        # navigation we expect.
         page.locator("#export-format-html").check()
-        page.locator("#export-self-email").uncheck()
         with page.expect_download(timeout=20000) as dl_info:
             page.locator("#group-export-go").click()
         download = dl_info.value
@@ -262,7 +262,6 @@ class TestExportDownloads:
         _wait_for_directory(page)
         page.locator("#group-action-export").click()
         page.locator("#export-format-pdf").check()
-        page.locator("#export-self-email").uncheck()
         with page.expect_download(timeout=20000) as dl_info:
             page.locator("#group-export-go").click()
         download = dl_info.value
@@ -335,30 +334,7 @@ class TestExportDownloads:
         cue = page.locator("#export-self-email-cue")
         expect(cue).to_contain_text("enter your email")
 
-    def test_export_unchecked_email_hides_post_export_email_button(
-        self, standalone_page, base_url_fixture
-    ):
-        page = standalone_page
-        fellows = _real_fellows(base_url_fixture)
-        g = _create_group(
-            base_url_fixture, name="Email button gating",
-            fellow_record_ids=[f[0] for f in fellows[:1]],
-        )
-        page.goto(f"{base_url_fixture}/#/groups/{g['id']}", wait_until="domcontentloaded")
-        _wait_for_directory(page)
-        page.locator("#group-action-export").click()
-        page.locator("#export-self-email").uncheck()
-        page.locator("#export-format-pdf").check()
-        with page.expect_download(timeout=20000):
-            page.locator("#group-export-go").click()
-        # Result row + View are always present; the Email button is hidden
-        # because the checkbox was off — Export does not navigate to mailto:
-        # by itself, so we're still on the same page and able to query the DOM.
-        expect(page.locator("#group-export-result")).to_be_visible()
-        expect(page.locator("#group-export-view")).to_be_visible()
-        expect(page.locator("#group-export-email-btn")).to_be_hidden()
-
-    def test_export_checked_email_shows_post_export_email_button(
+    def test_email_button_appears_after_export(
         self, standalone_page, base_url_fixture
     ):
         page = standalone_page
@@ -370,8 +346,11 @@ class TestExportDownloads:
         page.goto(f"{base_url_fixture}/#/groups/{g['id']}", wait_until="domcontentloaded")
         _wait_for_directory(page)
         page.locator("#group-action-export").click()
-        # Default: PDF radio + email checkbox both on. Export creates the
-        # file but does not navigate to mailto: — that's a separate click.
+        # Email button lives inside the post-export result row, which
+        # starts hidden. Export creates the file but does NOT navigate
+        # to mailto: by itself; the result row reveals along with the
+        # View link and the Email button.
+        expect(page.locator("#group-export-result")).to_be_hidden()
         with page.expect_download(timeout=20000):
             page.locator("#group-export-go").click()
         expect(page.locator("#group-export-result")).to_be_visible()

--- a/tests/e2e/test_groups_index.py
+++ b/tests/e2e/test_groups_index.py
@@ -86,9 +86,11 @@ class TestGroupsIndex:
         _aaron_row(page).locator(".dir-mark").click()
         page.locator("#group-rail-title").fill("Smoke group")
         page.locator("#group-rail-create").click()
-        # Hash changes to #/groups/<n>; detail page renders.
+        # Hash changes to #/groups/<n>; detail page renders. Target the
+        # inner title text so the pencil-rename ✎ link beside it doesn't
+        # trip the exact match.
         page.wait_for_url(lambda u: "#/groups/" in u, timeout=5000)
-        title = page.locator(".group-detail-title")
+        title = page.locator("#group-detail-title-text")
         expect(title).to_have_text("Smoke group", timeout=3000)
         # Member count + name resolved via cross-DB JOIN on the dev server.
         expect(page.locator(".group-detail-meta")).to_contain_text("1 fellow")

--- a/tests/e2e/test_groups_index.py
+++ b/tests/e2e/test_groups_index.py
@@ -23,7 +23,10 @@ from playwright.sync_api import expect
 
 def _wait_for_directory(page):
     page.locator("#loading").wait_for(state="hidden", timeout=10000)
-    page.locator("#directory").wait_for(state="visible", timeout=5000)
+    # #app-wrap rather than #directory: the directory rail is now
+    # display:none on group routes (including #/groups itself), so it's
+    # no longer a route-independent readiness signal.
+    page.locator("#app-wrap").wait_for(state="visible", timeout=5000)
 
 
 def _wipe_groups(base_url):

--- a/tests/e2e/test_settings.py
+++ b/tests/e2e/test_settings.py
@@ -65,7 +65,10 @@ def _wipe_settings(base_url):
 
 def _wait_for_directory(page):
     page.locator("#loading").wait_for(state="hidden", timeout=10000)
-    page.locator("#directory").wait_for(state="visible", timeout=5000)
+    # #app-wrap rather than #directory: the directory rail is now
+    # display:none on group routes, so it's no longer a route-independent
+    # readiness signal.
+    page.locator("#app-wrap").wait_for(state="visible", timeout=5000)
 
 
 @pytest.fixture(autouse=True)


### PR DESCRIPTION
## Summary

Addresses the UX issues raised against the bare group-detail page:

- **Focus mode for the group routes.** On `#/groups/<id>` and `#/groups/<id>/directory` the global directory rail (left) and the compose rail (right) collapse so the central content owns the screen. On `#/edit/<id>` it's the inverse — both rails matter, the central pane has nothing useful to render, so it hides instead. Driven by a body class set in `route()`; pure CSS does the rest.
- **Action bar restructured into two rows.**
  - Row 1: **✉ Mail to the whole group** (renamed from "Contact the whole group") + CC/BCC pill.
  - Row 2: **✎ Edit members** (renamed from "Edit group" — rename has its own affordance now) + **⬇ Export a directory**.
  - The helper text *"opens your mail client with everyone in CC"* is gone.
- **Inline rename on the group title** via a ✎ pencil. Save → `PATCH /api/groups/<id>`; Cancel / Esc reverts. Breadcrumb updates in lockstep so it doesn't drift.
- **Two-phase export-then-email.** The upfront "email it to me" checkbox is gone. Click **Export** → bundle builds locally and downloads. On success, a result row reveals with a **View** link and an **Email it to me** button. Clicking Email opens `mailto:?to=<self_email>&subject=…&body=…attach the file you just downloaded…`. Browsers can't attach files to a `mailto:`, so the user attaches manually from Downloads — confirmed UX choice in the spec discussion.
- **users_manual.md Groups section** updated end-to-end (action-bar wording, pencil rename, two-phase export, focused-view note).
- **e2e tests** updated for new labels / locators. The shared `_wait_for_directory` helper now waits on `#app-wrap` (route-independent) since `#directory` is `display: none` on group routes; one test was renamed and one removed since the upfront email checkbox no longer exists.

Behavioural expectations preserved:
- The Mail button is still a real `<a href="mailto:…">`; the hard-threshold "copy addresses to clipboard" path still kicks in over `GROUPS_CONTACT_HARD_AT` recipients.
- Export still produces real `.pdf` / `.html` blobs with the right magic bytes; the existing `test_html_export_downloads_single_self_contained_file` and `test_pdf_export_downloads_with_pdf_magic_bytes` still cover that.
- Edit mode still auto-saves on every toggle, still has Done editing / Cancel edits, still shows the yellow banner. The detail pane just isn't showing under the banner anymore.

## Test plan

- [x] `just test-e2e` — full suite green (85 passed locally).
- [x] `just test-fast` — 41 backend tests green.
- [ ] **Manual smoke (recommended for the maintainer):**
  - On `#/groups/<id>` confirm both rails are gone and the detail content is centered.
  - Click ✎ next to the group name; rename and Save; verify the title and breadcrumb both update.
  - Pencil → Esc cancels.
  - Click ✎ Edit members; both rails return; central pane is hidden; banner shows.
  - On `#/groups/<id>/directory` confirm the portrait grid is full-width.
  - Open Export; pick PDF; click Export; confirm spinner state then file in Downloads; click Email it to me; confirm mailto draft opens.
  - Repeat with HTML.
  - Try renaming with an empty string → toast "Group name cannot be empty."

## Follow-up notes

- The Edit-members / rail-side rename is unchanged. If we eventually decide the rail's name field is redundant given the pencil, that's a follow-up.
- Per the CLAUDE.md convention added in #60, the users_manual.md change ships in this PR alongside the implementation.