### PR TITLE
fix(groups): OPFS in browser-tab mode + actionable unsupported-browser panel

### DIFF
--- a/app/static/app.js
+++ b/app/static/app.js
@@ -883,12 +883,233 @@
     return err;
   }
 
+  // Thrown by the API provider when groups/settings endpoints don't exist
+  // on this server (production deploy/server.py) AND the OPFS path was
+  // unavailable (browser too old, missing sqlite3.wasm, insecure context,
+  // …). Render paths catch this and show the unsupported-browser panel
+  // built by renderLocalDataUnavailablePanel(). See docs/browser_support.md.
+  function localDataUnavailableError(reason) {
+    var err = new Error('local user data unavailable: ' + (reason || 'unknown'));
+    err.localDataUnavailable = true;
+    err.reason = reason || 'unknown';
+    return err;
+  }
+
+  // OPFS + SQLite-WASM (FileSystemSyncAccessHandle) version floors. Used by
+  // renderLocalDataUnavailablePanel to tell the user exactly what version
+  // they need. If you bump sqlite3.wasm and the floors shift, update these
+  // and docs/browser_support.md together.
+  var OPFS_MIN_VERSIONS = {
+    chrome: 102,   // FileSystemSyncAccessHandle landed Chrome 102 (May 2022)
+    edge: 102,     // Same engine as Chrome
+    safari: 16.4,  // iOS/macOS Safari 16.4 (Mar 2023) — first OPFS+SAH release
+    firefox: 111   // Firefox 111 (Mar 2023)
+  };
+
+  // Best-effort UA parsing. Modern UA-CH would be cleaner but is not
+  // available in Safari. We use the parsed values only to build a helpful
+  // message — never to gate features (the OPFS capability gates do that
+  // directly via shouldTryOpfsProvider). Returns:
+  //   { name: 'chrome'|'edge'|'safari'|'firefox'|'opera'|'samsung'|'unknown',
+  //     version: number|null,  // major.minor as float for safari, integer otherwise
+  //     versionString: string,  // raw version captured from UA
+  //     onIos: boolean,         // iPhone/iPad/iPod, including iPadOS desktop UA
+  //     minVersion: number|null // floor for this browser, or null if unknown
+  //   }
+  function detectBrowserSupport() {
+    var ua = (navigator.userAgent || '');
+    var onIos = /iPad|iPhone|iPod/.test(ua) ||
+      (navigator.platform === 'MacIntel' && navigator.maxTouchPoints > 1);
+    var name = 'unknown';
+    var versionString = '';
+    var version = null;
+    var m;
+    // Order matters — Edge/Opera/Samsung UA strings also contain "Chrome".
+    if ((m = ua.match(/EdgiOS\/([\d.]+)/)) || (m = ua.match(/Edg(?:e|A|iOS)?\/([\d.]+)/))) {
+      name = 'edge';
+      versionString = m[1];
+    } else if ((m = ua.match(/OPR\/([\d.]+)/)) || (m = ua.match(/Opera\/([\d.]+)/))) {
+      name = 'opera';
+      versionString = m[1];
+    } else if ((m = ua.match(/SamsungBrowser\/([\d.]+)/))) {
+      name = 'samsung';
+      versionString = m[1];
+    } else if ((m = ua.match(/FxiOS\/([\d.]+)/)) || (m = ua.match(/Firefox\/([\d.]+)/))) {
+      name = 'firefox';
+      versionString = m[1];
+    } else if ((m = ua.match(/CriOS\/([\d.]+)/)) || (m = ua.match(/Chrome\/([\d.]+)/))) {
+      name = 'chrome';
+      versionString = m[1];
+    } else if ((m = ua.match(/Version\/([\d.]+).*Safari/))) {
+      name = 'safari';
+      versionString = m[1];
+    }
+    if (versionString) {
+      // For Safari, capture major.minor (e.g. 16.4); for others, the major
+      // is enough — but parseFloat handles both consistently.
+      version = parseFloat(versionString);
+      if (isNaN(version)) version = null;
+    }
+    return {
+      name: name,
+      version: version,
+      versionString: versionString,
+      onIos: onIos,
+      minVersion: OPFS_MIN_VERSIONS[name] != null ? OPFS_MIN_VERSIONS[name] : null
+    };
+  }
+
+  // Build the "your browser can't store groups locally" panel. Returns an
+  // HTML string. Caller decides which container to drop it into.
+  // `feature` is what the user was trying to do — "groups", "this group",
+  // "settings", "save this group". Used in the headline only.
+  function renderLocalDataUnavailablePanel(feature) {
+    var b = detectBrowserSupport();
+    var label = feature || 'this feature';
+    var browserHuman =
+      b.name === 'chrome' ? 'Chrome' :
+      b.name === 'edge' ? 'Edge' :
+      b.name === 'safari' ? 'Safari' :
+      b.name === 'firefox' ? 'Firefox' :
+      b.name === 'opera' ? 'Opera' :
+      b.name === 'samsung' ? 'Samsung Internet' :
+      'your browser';
+    var versionTxt = b.versionString ? (' ' + b.versionString) : '';
+    var detailLines = [];
+    if (b.onIos) {
+      // iOS forces every browser engine to WebKit, so the only fix is to
+      // upgrade iOS itself (iOS 16.4+ ships Safari 16.4+).
+      detailLines.push(
+        'You\'re on an iPhone or iPad. iOS uses Safari\'s engine for every browser, ' +
+        'so changing browsers won\'t help — only an iOS upgrade will. ' +
+        'Update to <b>iOS 16.4 or newer</b> in <i>Settings → General → Software Update</i>, ' +
+        'then reload this page. (iPhone 8 and newer support iOS 16.4+; iPhone 7 and older do not.)'
+      );
+      detailLines.push(
+        'If you can\'t upgrade iOS on this device, open this app on a desktop or laptop ' +
+        'using Chrome 102+, Edge 102+, Safari 16.4+, or Firefox 111+.'
+      );
+    } else if (b.name === 'safari') {
+      detailLines.push(
+        'You\'re running ' + browserHuman + versionTxt + '. ' +
+        'This app needs <b>Safari 16.4 or newer</b> on macOS 13.3+ ' +
+        '(<i>Apple menu → System Settings → General → Software Update</i>).'
+      );
+      detailLines.push(
+        'If you can\'t upgrade macOS, install the latest <b>Chrome</b>, <b>Edge</b>, or <b>Firefox</b> ' +
+        'on this Mac and open the app there instead.'
+      );
+    } else if (b.name === 'chrome' || b.name === 'edge') {
+      detailLines.push(
+        'You\'re running ' + browserHuman + versionTxt + '. ' +
+        'This app needs <b>' + browserHuman + ' 102 or newer</b> ' +
+        '(open the menu → Help → About ' + browserHuman + ' to update).'
+      );
+      detailLines.push(
+        'If your operating system can\'t run a current ' + browserHuman + ', try installing the latest <b>Firefox</b> ' +
+        '— or use a different device with a current browser.'
+      );
+    } else if (b.name === 'firefox') {
+      detailLines.push(
+        'You\'re running ' + browserHuman + versionTxt + '. ' +
+        'This app needs <b>Firefox 111 or newer</b> ' +
+        '(menu → Help → About Firefox to update).'
+      );
+      detailLines.push(
+        'You can also use the latest <b>Chrome</b>, <b>Edge</b>, or <b>Safari 16.4+</b>.'
+      );
+    } else if (b.name === 'opera' || b.name === 'samsung') {
+      detailLines.push(
+        'You\'re running ' + browserHuman + versionTxt + '. ' +
+        'This app hasn\'t been verified on ' + browserHuman + '; even up-to-date versions may not support ' +
+        'the local-storage feature it needs.'
+      );
+      detailLines.push(
+        'Open the app in <b>Chrome 102+</b>, <b>Edge 102+</b>, <b>Safari 16.4+</b>, or <b>Firefox 111+</b> instead.'
+      );
+    } else {
+      detailLines.push(
+        'Couldn\'t identify your browser, but the local-storage feature this app needs ' +
+        '(<a href="https://caniuse.com/native-filesystem-api" target="_blank" rel="noopener">OPFS with SyncAccessHandle</a>) ' +
+        'isn\'t available here.'
+      );
+      detailLines.push(
+        'Open the app in <b>Chrome 102+</b>, <b>Edge 102+</b>, <b>Safari 16.4+</b>, or <b>Firefox 111+</b>.'
+      );
+    }
+    if (!globalThis.isSecureContext) {
+      detailLines.unshift(
+        'This page isn\'t in a secure context, which the local-storage feature requires. ' +
+        'Open <code>https://fellows.globaldonut.com/</code> directly (not over an http:// link or a file:// path).'
+      );
+    }
+    var detailHtml = detailLines.map(function (l) { return '<p>' + l + '</p>'; }).join('');
+    return (
+      '<div class="local-data-unavailable">' +
+        '<h3>Can\'t open ' + escapeHtml(label) + ' on this browser</h3>' +
+        '<p class="local-data-unavailable-lede">' +
+          'Saved groups and per-device settings live in your browser\'s local storage. ' +
+          'On this device, that storage isn\'t available — so the rest of the app works, but ' +
+          escapeHtml(label) + ' can\'t.' +
+        '</p>' +
+        detailHtml +
+        '<p class="local-data-unavailable-foot">' +
+          'If none of these options work for you, please reach out — we\'re happy to help.' +
+        '</p>' +
+      '</div>'
+    );
+  }
+
   function createApiDataProvider() {
     function jsonOr(url, opts, expectedShapeOnEmpty) {
       return fetch(url, opts || {}).then(function (r) {
         if (r.status === 204) return expectedShapeOnEmpty;
         if (!r.ok) throw apiError(url, r.status);
         return r.json();
+      });
+    }
+
+    // Production (deploy/server.py) does not serve /api/groups or
+    // /api/settings — OPFS is the canonical store for those. When OPFS
+    // capability gates fail (older browser, insecure context, …) we
+    // land on this provider on prod and need to surface a helpful
+    // unsupported-browser panel rather than a generic "Could not load
+    // groups." error. The collection endpoint /api/groups is the
+    // unambiguous probe: dev returns 200 (`[]` if empty), prod returns
+    // 404 (no route). Cache the result so per-id 404s on getGroup,
+    // updateGroup, etc. can be disambiguated correctly:
+    //  - groupsRouteSupported === true  → 404 means "id not found"
+    //  - groupsRouteSupported === false → all groups/settings calls
+    //                                     reject with localDataUnavailable
+    //  - groupsRouteSupported === null  → not yet probed; settings
+    //                                     methods do their own probe
+    //                                     before the first call
+    var groupsRouteSupported = null; // null | true | false
+    function probeGroupsRoute() {
+      if (groupsRouteSupported !== null) {
+        return Promise.resolve(groupsRouteSupported);
+      }
+      return fetch('/api/groups').then(function (r) {
+        if (r.status === 404) {
+          groupsRouteSupported = false;
+        } else {
+          groupsRouteSupported = true;
+        }
+        return groupsRouteSupported;
+      }).catch(function () {
+        // Network error: don't lock the user out. Treat as "supported"
+        // and let the actual call surface a real error.
+        groupsRouteSupported = true;
+        return true;
+      });
+    }
+    function rejectIfUnsupported() {
+      if (groupsRouteSupported === false) {
+        return Promise.reject(localDataUnavailableError('server-no-local-data'));
+      }
+      return probeGroupsRoute().then(function (ok) {
+        if (!ok) throw localDataUnavailableError('server-no-local-data');
+        return true;
       });
     }
     return {
@@ -923,83 +1144,117 @@
 
       // ===== Groups (HTTP fallback) =================================
       // Same JSON shape as the SQLite path. Resolves member names via
-      // ATTACHed f.fellows on the dev server. In production (deploy/
-      // server.py), these endpoints don't exist yet — the SQLite path
-      // is the canonical production implementation.
+      // ATTACHed f.fellows on the dev server. On production
+      // (deploy/server.py) these routes don't exist; the OPFS path is
+      // the canonical production implementation. When OPFS is also
+      // unavailable, every call here rejects with
+      // localDataUnavailableError so the UI can render the unsupported-
+      // browser panel.
       listGroups: function () {
-        return jsonOr('/api/groups', null, []);
-      },
-      getGroup: function (id) {
-        return fetch('/api/groups/' + encodeURIComponent(id)).then(function (r) {
-          if (r.status === 404) return null;
-          if (!r.ok) throw apiError('/api/groups/' + id, r.status);
-          return r.json();
-        });
-      },
-      createGroup: function (data) {
-        return fetch('/api/groups', {
-          method: 'POST',
-          headers: { 'Content-Type': 'application/json' },
-          credentials: 'same-origin',
-          body: JSON.stringify(data || {})
-        }).then(function (r) {
+        // listGroups doubles as the route probe — its 404 is the
+        // signal that prod doesn't serve groups.
+        return fetch('/api/groups').then(function (r) {
+          if (r.status === 404) {
+            groupsRouteSupported = false;
+            throw localDataUnavailableError('server-no-local-data');
+          }
+          groupsRouteSupported = true;
+          if (r.status === 204) return [];
           if (!r.ok) throw apiError('/api/groups', r.status);
           return r.json();
         });
       },
+      getGroup: function (id) {
+        return rejectIfUnsupported().then(function () {
+          return fetch('/api/groups/' + encodeURIComponent(id)).then(function (r) {
+            if (r.status === 404) return null; // legitimate "id not found"
+            if (!r.ok) throw apiError('/api/groups/' + id, r.status);
+            return r.json();
+          });
+        });
+      },
+      createGroup: function (data) {
+        return rejectIfUnsupported().then(function () {
+          return fetch('/api/groups', {
+            method: 'POST',
+            headers: { 'Content-Type': 'application/json' },
+            credentials: 'same-origin',
+            body: JSON.stringify(data || {})
+          }).then(function (r) {
+            if (!r.ok) throw apiError('/api/groups', r.status);
+            return r.json();
+          });
+        });
+      },
       updateGroup: function (id, patch) {
-        return fetch('/api/groups/' + encodeURIComponent(id), {
-          method: 'PATCH',
-          headers: { 'Content-Type': 'application/json' },
-          credentials: 'same-origin',
-          body: JSON.stringify(patch || {})
-        }).then(function (r) {
-          if (r.status === 404) return null;
-          if (!r.ok) throw apiError('/api/groups/' + id, r.status);
-          return r.json();
+        return rejectIfUnsupported().then(function () {
+          return fetch('/api/groups/' + encodeURIComponent(id), {
+            method: 'PATCH',
+            headers: { 'Content-Type': 'application/json' },
+            credentials: 'same-origin',
+            body: JSON.stringify(patch || {})
+          }).then(function (r) {
+            if (r.status === 404) return null;
+            if (!r.ok) throw apiError('/api/groups/' + id, r.status);
+            return r.json();
+          });
         });
       },
       deleteGroup: function (id) {
-        return fetch('/api/groups/' + encodeURIComponent(id), {
-          method: 'DELETE',
-          credentials: 'same-origin'
-        }).then(function (r) {
-          if (r.status === 204) return true;
-          if (r.status === 404) return false;
-          throw apiError('/api/groups/' + id, r.status);
+        return rejectIfUnsupported().then(function () {
+          return fetch('/api/groups/' + encodeURIComponent(id), {
+            method: 'DELETE',
+            credentials: 'same-origin'
+          }).then(function (r) {
+            if (r.status === 204) return true;
+            if (r.status === 404) return false;
+            throw apiError('/api/groups/' + id, r.status);
+          });
         });
       },
       getSetting: function (key) {
-        return fetch('/api/settings/' + encodeURIComponent(key)).then(function (r) {
-          if (r.status === 404) return null;
-          if (!r.ok) throw apiError('/api/settings/' + key, r.status);
-          return r.json().then(function (d) { return d && d.value; });
+        return rejectIfUnsupported().then(function () {
+          return fetch('/api/settings/' + encodeURIComponent(key)).then(function (r) {
+            if (r.status === 404) return null;
+            if (!r.ok) throw apiError('/api/settings/' + key, r.status);
+            return r.json().then(function (d) { return d && d.value; });
+          });
         });
       },
       getSettings: function () {
-        return fetch('/api/settings').then(function (r) {
-          if (!r.ok) return {};
-          return r.json();
+        return rejectIfUnsupported().then(function () {
+          return fetch('/api/settings').then(function (r) {
+            if (!r.ok) return {};
+            return r.json();
+          });
         });
       },
       setSetting: function (key, value) {
-        return fetch('/api/settings/' + encodeURIComponent(key), {
-          method: 'PUT',
-          headers: { 'Content-Type': 'application/json' },
-          credentials: 'same-origin',
-          body: JSON.stringify({ value: value })
-        }).then(function (r) {
-          if (!r.ok) throw apiError('/api/settings/' + key, r.status);
-          return r.json();
+        return rejectIfUnsupported().then(function () {
+          return fetch('/api/settings/' + encodeURIComponent(key), {
+            method: 'PUT',
+            headers: { 'Content-Type': 'application/json' },
+            credentials: 'same-origin',
+            body: JSON.stringify({ value: value })
+          }).then(function (r) {
+            if (!r.ok) throw apiError('/api/settings/' + key, r.status);
+            return r.json();
+          });
         });
       }
     };
   }
 
   function shouldTryOpfsProvider() {
-    if (!isStandaloneDisplayMode()) {
-      return false;
-    }
+    // OPFS is the canonical store for user-authored data (groups,
+    // settings) in BOTH standalone PWA and browser-tab modes.
+    // Production's deploy/server.py does not serve /api/groups or
+    // /api/settings; OPFS is what makes those features work end-to-end
+    // for browser-tab visitors. The capability gates below decide
+    // whether the visitor's browser can run the OPFS path; if any
+    // fails, the API provider takes over (which works on dev) and the
+    // groups/settings UI surfaces an unsupported-browser panel on prod
+    // via localDataUnavailableError. See docs/browser_support.md.
     if (typeof globalThis.sqlite3InitModule !== 'function') {
       return false;
     }
@@ -1022,7 +1277,7 @@
 
   function describeOpfsGates() {
     var lines = [];
-    lines.push('standalone display-mode: ' + isStandaloneDisplayMode());
+    lines.push('standalone display-mode: ' + isStandaloneDisplayMode() + ' (informational; not a gate)');
     lines.push('globalThis.sqlite3InitModule: ' + typeof globalThis.sqlite3InitModule);
     lines.push('navigator.storage: ' + (navigator.storage ? 'present' : 'missing'));
     lines.push(
@@ -2966,7 +3221,12 @@
         refreshDetailAddLink();
         updateBulkBar();
       })
-      .catch(function () {
+      .catch(function (err) {
+        if (err && err.localDataUnavailable) {
+          // listGroups will surface the full panel on the destination page.
+          window.location.hash = '#/groups';
+          return;
+        }
         showToast('Could not load group');
         window.location.hash = '#/groups';
       });
@@ -3065,6 +3325,15 @@
         window.location.hash = '#/groups/' + encodeURIComponent(String(group.id));
       })
       .catch(function (err) {
+        if (err && err.localDataUnavailable) {
+          setRailStatus(
+            'This browser can\'t save groups locally. Open Groups for details.',
+            'warn'
+          );
+          groupRailCreateEl.disabled = groupDraft.members.size === 0;
+          window.location.hash = '#/groups';
+          return;
+        }
         setRailStatus(
           'Could not save: ' + (err && err.message ? err.message : 'unknown error'),
           'warn'
@@ -3287,9 +3556,16 @@
     }
     dataProvider.listGroups()
       .then(function (groups) { renderGroupsList(groups || []); })
-      .catch(function () {
+      .catch(function (err) {
         var wrap = document.getElementById('groups-list-wrap');
-        if (wrap) wrap.innerHTML = '<p class="placeholder">Could not load groups.</p>';
+        var meta = document.getElementById('groups-meta');
+        if (meta) meta.textContent = '';
+        if (!wrap) return;
+        if (err && err.localDataUnavailable) {
+          wrap.innerHTML = renderLocalDataUnavailablePanel('groups');
+        } else {
+          wrap.innerHTML = '<p class="placeholder">Could not load groups.</p>';
+        }
       });
   }
 
@@ -3671,8 +3947,12 @@
       html += '</div>';
       detailEl.innerHTML = html;
       wireGroupDetailPage(group, emailInfo);
-    }).catch(function () {
-      detailEl.innerHTML = '<p class="placeholder">Could not load group.</p>';
+    }).catch(function (err) {
+      if (err && err.localDataUnavailable) {
+        detailEl.innerHTML = renderLocalDataUnavailablePanel('this group');
+      } else {
+        detailEl.innerHTML = '<p class="placeholder">Could not load group.</p>';
+      }
     });
   }
 
@@ -3823,8 +4103,12 @@
       html += '</div></div>';
       detailEl.innerHTML = html;
       wireGroupDirectoryCells(detailEl, members);
-    }).catch(function () {
-      detailEl.innerHTML = '<p class="placeholder">Could not load group directory.</p>';
+    }).catch(function (err) {
+      if (err && err.localDataUnavailable) {
+        detailEl.innerHTML = renderLocalDataUnavailablePanel('this group directory');
+      } else {
+        detailEl.innerHTML = '<p class="placeholder">Could not load group directory.</p>';
+      }
     });
   }
 
@@ -4247,6 +4531,10 @@
     var status = document.getElementById('settings-status');
     var form = document.getElementById('settings-form');
 
+    function showUnsupportedAndDisable() {
+      detailEl.innerHTML = renderLocalDataUnavailablePanel('settings');
+    }
+
     // Seed from localStorage immediately for snappy paint, then refresh
     // from relationships.settings (the durable source) when it returns.
     if (input) input.value = getSelfEmail();
@@ -4256,7 +4544,10 @@
           input.value = val;
           setSelfEmailLocal(val);
         }
-      }).catch(function () { /* ignore */ });
+      }).catch(function (err) {
+        if (err && err.localDataUnavailable) showUnsupportedAndDisable();
+        // else: ignore — localStorage seed still gives them something useful
+      });
     }
 
     if (form) {
@@ -4272,7 +4563,11 @@
             setSelfEmailLocal(next);
             if (status) status.textContent = 'Saved.';
           })
-          .catch(function () {
+          .catch(function (err) {
+            if (err && err.localDataUnavailable) {
+              showUnsupportedAndDisable();
+              return;
+            }
             if (status) status.textContent = 'Could not save.';
           });
       });

--- a/app/static/styles.css
+++ b/app/static/styles.css
@@ -2472,3 +2472,53 @@ a.group-action-btn--primary {
   font-size: 0.85rem;
   color: #5a5a5a;
 }
+
+/* ===== Local-data-unavailable panel ===================================
+   Shown when groups/settings can't be reached locally — typically a
+   browser too old for OPFS+SyncAccessHandle on the production server
+   (where there is no /api/groups fallback). Built by
+   renderLocalDataUnavailablePanel() in app.js. See docs/browser_support.md.
+*/
+.local-data-unavailable {
+  margin: 1.5rem auto;
+  max-width: 42rem;
+  padding: 1.25rem 1.5rem;
+  background: #fff8e1;
+  border: 1px solid #e7c873;
+  border-radius: 6px;
+  color: #3a3a3a;
+  line-height: 1.5;
+}
+
+.local-data-unavailable h3 {
+  margin: 0 0 0.5rem 0;
+  font-size: 1.1rem;
+  color: #5a4200;
+}
+
+.local-data-unavailable p {
+  margin: 0.5rem 0;
+  font-size: 0.95rem;
+}
+
+.local-data-unavailable .local-data-unavailable-lede {
+  font-weight: 500;
+  color: #444;
+}
+
+.local-data-unavailable code {
+  background: #fff3c7;
+  padding: 0.05rem 0.3rem;
+  border-radius: 3px;
+  font-size: 0.9em;
+}
+
+.local-data-unavailable a {
+  color: #4a2c6a;
+}
+
+.local-data-unavailable .local-data-unavailable-foot {
+  margin-top: 1rem;
+  font-size: 0.85rem;
+  color: #6a5800;
+}

--- a/docs/Architecture.md
+++ b/docs/Architecture.md
@@ -63,6 +63,18 @@ contact data read-only at the SQLite level. `relationships.db` is
 durable across both app updates and Clear App Cache; `fellows.db` is
 re-imported on every boot.
 
+In the browser this lives in OPFS (`sqlite3.wasm` + `relationships.db`)
+in **both** standalone PWA mode and browser-tab mode. Production's
+`deploy/server.py` does not serve `/api/groups` or `/api/settings`;
+OPFS is the canonical store there. The dev server's HTTP routes for
+groups and settings exist only to support the dev round-trip — they
+are not part of the production API surface. When a visitor's browser
+can't run OPFS (older Safari, missing `FileSystemSyncAccessHandle`,
+insecure context), the API provider tags those endpoints unreachable
+and the UI surfaces an unsupported-browser panel via
+`renderLocalDataUnavailablePanel()` — see
+[`docs/browser_support.md`](browser_support.md).
+
 The full state-survival matrix (which storage layers survive which
 events, plus the standard upgrade flow) lives in
 [`docs/persistence_and_upgrades.md`](persistence_and_upgrades.md).

--- a/docs/browser_support.md
+++ b/docs/browser_support.md
@@ -1,0 +1,154 @@
+# Browser Support
+
+How we triage long-tail browser-compatibility issues for this app. The
+audience is small (~hundreds of fellows) and the distribution model is
+"by emailed magic link, install once" — but each one of those users
+runs a different browser/OS combo, and we will keep meeting people
+whose device falls outside what we tested. This doc captures the
+policy so we react consistently when that happens.
+
+## Stance
+
+1. **Local-first.** User-authored data (groups, per-fellow notes,
+   per-fellow tags, settings) lives in the browser's OPFS-backed
+   `relationships.db`, not on a server. That gives us per-device
+   privacy and offline-by-default — at the cost of needing a browser
+   that supports OPFS + `FileSystemSyncAccessHandle`.
+2. **Capability-detect, don't UA-sniff for gating.** We test the
+   capability (`navigator.storage.getDirectory`,
+   `globalThis.sqlite3InitModule`, `globalThis.isSecureContext`).
+   UA strings are used **only** to render a more helpful unsupported
+   message — never to allow/deny features.
+3. **Be specific in the message.** "Your browser doesn't support this"
+   is unactionable. "You're on Safari 15.6; this needs Safari 16.4 or
+   newer; here's how to upgrade or which browser to switch to"
+   converts a 0% recovery rate to something useful. The
+   unsupported-browser panel exists because we hit this with a real
+   user on Safari and "Could not load groups." was the message.
+4. **Don't polyfill what we can't test.** OPFS doesn't have a
+   reasonable polyfill path; building one would mean shipping a
+   server-backed groups feature for a handful of users on browsers
+   we can't soak-test. Better to tell the user clearly and route them
+   to a working device.
+5. **Failure should never look like a bug.** A user with no fix
+   available should still understand their situation isn't broken —
+   it's the limit of what their device can do.
+
+## Required versions
+
+Driven by what `sqlite3.wasm` needs to use OPFS — specifically
+`FileSystemSyncAccessHandle`, which the wasm runtime requires for
+durable writes:
+
+| Browser  | Minimum | Released | Notes                                              |
+|----------|---------|----------|----------------------------------------------------|
+| Chrome   | 102     | May 2022 | First version with `FileSystemSyncAccessHandle`.   |
+| Edge     | 102     | May 2022 | Same engine as Chrome.                             |
+| Safari   | 16.4    | Mar 2023 | Requires iOS 16.4+ / macOS 13.3+.                  |
+| Firefox  | 111     | Mar 2023 | OPFS + SAH landed together.                        |
+| Opera    | —       | —        | Untested. UA branch in detect; routes user away.   |
+| Samsung  | —       | —        | Untested. UA branch in detect; routes user away.   |
+
+These floors live in `OPFS_MIN_VERSIONS` in `app/static/app.js`. If
+you bump `sqlite3.wasm` and the floors shift, update both places
+together.
+
+iOS deserves a callout: every browser on iOS uses Safari's WebKit
+engine, so installing Chrome/Firefox on an iPhone will not help.
+The only fix on iOS is to upgrade iOS itself. iPhone 8 and newer
+support iOS 16.4+; iPhone 7 and older do not. The unsupported-browser
+panel says this explicitly when it detects iOS.
+
+## How a user without OPFS reaches the panel
+
+1. They open the app — install landing or browser-tab.
+2. `pickDataProvider()` runs the OPFS gates. They fail (older browser,
+   insecure context, etc.).
+3. Provider falls back to the API provider.
+4. On dev, the API provider serves `/api/groups` and `/api/settings`,
+   so groups/settings work for the dev round-trip.
+5. **On prod** (`deploy/server.py`), those routes don't exist. The
+   first call (typically `listGroups`) gets a 404, the API provider
+   marks the route unsupported, and every subsequent groups/settings
+   call rejects with `localDataUnavailableError`.
+6. The render path catches the error and calls
+   `renderLocalDataUnavailablePanel(feature)`, which builds an
+   HTML panel keyed off `detectBrowserSupport()` — browser name,
+   parsed version, and an iOS flag — and renders concrete next
+   steps.
+
+The directory itself, search, and fellow profiles still work. Only
+the local-data features (groups, settings) show the panel.
+
+## Adding a new local-data feature: checklist
+
+When you add a feature backed by `relationships.db` (tags, notes UI,
+saved searches, …):
+
+- [ ] Surface it through the same `dataProvider` pattern; reuse
+      `rejectIfUnsupported()` in the API provider so 404s on prod
+      become `localDataUnavailableError`s.
+- [ ] In every render path that calls the new method, catch the error
+      and render `renderLocalDataUnavailablePanel('<feature label>')`.
+- [ ] Pick a `feature` label that completes the headline naturally:
+      "Can't open <label> on this browser." Good: `'tags'`,
+      `'this group'`, `'saved searches'`. Bad: `'the tags feature'`.
+- [ ] Add a small e2e in `tests/e2e/` that exercises the happy path
+      with the OPFS provider; we don't have a clean way to e2e the
+      panel itself yet, so cover the regression by smoke testing on
+      Safari < 16.4 manually before each release.
+
+## Adding a non-OPFS capability check
+
+When a feature depends on a Web API outside OPFS (e.g. clipboard,
+mailto fallback, share target):
+
+- [ ] Capability-detect the API directly. Don't UA-sniff.
+- [ ] If the API is missing, decide between three responses up front:
+      (a) **degrade silently** when there's a genuinely usable
+      fallback (e.g. "click to copy" instead of "share to…");
+      (b) **show an inline note** when there's a workaround the user
+      can take (e.g. open in Chrome);
+      (c) **surface the unsupported panel** when the feature is
+      blocked entirely. Default to (b) when in doubt — most "missing
+      API" cases have a workaround.
+- [ ] Document the floor in this table if it's a new floor we're
+      committing to.
+
+## What we deliberately don't do
+
+- **No server-side storage of user-authored data.** Adding it for a
+  handful of older-browser users would create per-user RW state on
+  prod with no notion of ownership, plus a sync surface we'd have
+  to maintain forever. Not worth it at this scale.
+- **No browser blocklist.** Capability gates are the gate; UA strings
+  inform messaging only.
+- **No silent degradation for blocked features.** When groups or
+  settings can't run, we tell the user — explicitly — rather than
+  showing an empty/no-op UI. The audience is small enough that the
+  cost of confusion outweighs the cost of a panel.
+- **No polyfill investment** for OPFS, IndexedDB-as-OPFS shims, etc.
+  We'd be shipping untested code to the smallest sliver of users.
+
+## When you find a new long-tail bug
+
+The likely sequence:
+
+1. A user reports something doesn't work. Get their browser version,
+   OS version, and one screenshot.
+2. Reproduce in `chrome-devtools-mcp` against your own Chrome (see
+   `docs/debugging.md`) if you can — or have them run a one-line
+   probe in their console (`navigator.userAgent`,
+   `'storage' in navigator && 'getDirectory' in navigator.storage`,
+   `globalThis.isSecureContext`).
+3. Decide which of the three outcomes above applies (degrade / note /
+   panel).
+4. If a panel is right and the existing one covers it, you're done —
+   the user just needs to land on it.
+5. If the existing panel doesn't cover the case, add a new branch in
+   `renderLocalDataUnavailablePanel()` — keep messages concrete
+   (named browser, version floor, what to upgrade or switch to).
+6. Update this doc's table or section if the floor moved.
+
+The cost of getting this right per case is low; the cost of a user
+giving up because the message was generic is high.

--- a/docs/persistence_and_upgrades.md
+++ b/docs/persistence_and_upgrades.md
@@ -29,6 +29,17 @@ touch are durable. Cross-DB joins use SQLite `ATTACH DATABASE
 contact data at the SQLite level (any stray write into `f.*` raises
 `OperationalError`).
 
+The OPFS path is used in **both** standalone PWA mode and browser-tab
+mode. Production's `deploy/server.py` does not serve `/api/groups` or
+`/api/settings`, so OPFS is the only place groups and settings can
+live for prod visitors regardless of how they opened the app. Browsers
+that can't run OPFS + `FileSystemSyncAccessHandle` (Safari < 16.4,
+Chrome/Edge < 102, Firefox < 111, insecure contexts) see the
+unsupported-browser panel for those features instead — the rest of
+the app still works (directory, search, profiles). See
+[`browser_support.md`](browser_support.md) for the full version
+floors and triage policy.
+
 ## Standard app update flow
 
 1. Operator runs `just ship`. Bundle goes out to the droplet.

--- a/docs/users_manual.md
+++ b/docs/users_manual.md
@@ -316,6 +316,35 @@ in-progress group draft *is* lost — drafts are by definition unsaved.
 
 ---
 
+## Supported browsers
+
+Saved groups and settings are stored locally on your device using a
+browser feature called OPFS. Most modern browsers support it, but a
+few older ones don't — you'll still be able to browse the directory,
+search, and read fellow profiles, but creating groups or saving
+settings will show an "Can't open groups on this browser" panel
+explaining what to do.
+
+If you can, run one of these or newer:
+
+- **Chrome 102+** (May 2022 or later)
+- **Edge 102+** (May 2022 or later)
+- **Safari 16.4+** on **macOS 13.3+** or **iOS 16.4+** (March 2023 or later)
+- **Firefox 111+** (March 2023 or later)
+
+A note about iPhone and iPad: every browser on iOS uses Safari's
+underlying engine, so installing Chrome or Firefox on an iPhone won't
+help. The fix is to update iOS itself (iPhone 8 and newer support
+iOS 16.4+). If your device can't be updated, you can still use the
+directory and profiles — just open the app on a desktop or laptop
+when you want to use groups.
+
+If you hit the "Can't open groups on this browser" panel and the
+suggestions there don't work for you, please reach out — we're happy
+to help.
+
+---
+
 ## Getting help
 
 - **General questions**: ask on one of the fellows channels, or contact


### PR DESCRIPTION
## Summary

- Closes the **HIGH** item in #58: drops the `isStandaloneDisplayMode()` gate inside `shouldTryOpfsProvider()` so browser-tab visitors on production also use OPFS (same path as standalone PWA). This unbreaks `/groups` and `/settings` for browser-tab visitors without adding a per-user RW route to `deploy/server.py`.
- Adds a real unsupported-browser flow for the long tail (Safari < 16.4, Chrome/Edge < 102, Firefox < 111, insecure contexts). Instead of a generic "Could not load groups," the user now sees an actionable panel naming their browser + version, the version they need, and the concrete fix — including the iOS-specific "you must upgrade iOS itself, no other browser will help" branch.
- Adds `docs/browser_support.md` as the policy doc for handling long-tail browser/distribution issues across this project (per maintainer's note on the same theme).

## Why option 2 over option 1

Option 1 (mirror `/api/groups` and `/api/settings` into `deploy/server.py`) would create per-user RW state on production with no clear ownership model. OPFS is the canonical store everywhere; the dev server's HTTP groups/settings endpoints exist only to support the local round-trip and are not part of the production API surface.

## What changed

`app/static/app.js`:
- `shouldTryOpfsProvider()`: removed the standalone gate; capability gates (sqlite3-wasm, `storage.getDirectory`, secure context) still apply.
- New `localDataUnavailableError(reason)` factory near `apiError`.
- New `OPFS_MIN_VERSIONS` table + `detectBrowserSupport()` (best-effort UA parse — used **only** for messaging, not for gating).
- New `renderLocalDataUnavailablePanel(feature)` builds the unsupported-browser panel with branch-by-browser guidance.
- API provider: `listGroups()` doubles as the route probe; on 404 it caches "unsupported" and rejects with `localDataUnavailableError`. `getGroup`, `createGroup`, `updateGroup`, `deleteGroup`, `getSetting`, `getSettings`, `setSetting` all `rejectIfUnsupported()` first, so per-id 404s on dev still mean "id not found" and never get conflated with "route missing."
- Render paths (`renderGroupsPage`, `renderGroupDetailPage`, `renderGroupDirectoryPage`, `renderSettingsPage`, group composer save, edit-mode entry) catch `err.localDataUnavailable` and render the panel (or route to `#/groups` where the panel will surface). All other failure modes keep their existing toast/placeholder.
- `describeOpfsGates()`: standalone display-mode line is now labeled `(informational; not a gate)` so the diag panel doesn't mislead.

`app/static/styles.css`: styles for `.local-data-unavailable` (warm-yellow info panel matching existing palette).

Docs:
- `docs/browser_support.md` (new): policy for the long-tail browser problem — version floors, capability-detect-only stance, three response patterns (degrade silently / inline note / unsupported panel), and a checklist for adding new local-data features.
- `docs/Architecture.md`: clarified OPFS is the canonical store in **both** modes; production has no `/api/groups` or `/api/settings`.
- `docs/persistence_and_upgrades.md`: added the browser-version floors with a link to `browser_support.md`.
- `docs/users_manual.md`: added a "Supported browsers" section so users hitting the panel can find the version requirements without reading source.

## A note for the maintainer

Browser-tab mode now exercises the OPFS path on every dev session, which is a net win for catching OPFS regressions earlier — the production code path (which doesn't have a server-side groups/settings fallback) is now the path you hit on `localhost:8765` too.

## Test plan

Automated:
- [x] `just test-fast` — 41/41 pass (DB + API; dev `/api/groups` unchanged for the round-trip).
- [x] `just test-e2e groups` — 43/43 pass (Playwright Chromium with standalone-faked fixture, OPFS path).
- [x] `just test-e2e` — 84/85 pass; the 1 failure is `test_click_aaron_bird_shows_detail` and is pre-existing on `main` (verified by `git stash && just test-e2e` on the same branch off the same SHA — same failure).
- [x] Browser-tab smoke (Playwright Chromium, no standalone fake): all OPFS gates green → confirms `shouldTryOpfsProvider()` returns `true` in browser-tab mode and OPFS is selected.

Manual QA the maintainer should run before merging:
- [ ] On a clean install of **Safari < 16.4** (or any iOS device on iOS < 16.4), open `https://fellows.globaldonut.com/?gate=1`, get a magic link, click into `/#/groups`. Expect the "Can't open groups on this browser" panel, with iPhone-specific "upgrade iOS" guidance on iOS.
- [ ] On **Chrome 102+** desktop, open the same URL in a regular browser tab (not as installed PWA). Create a group, reload, confirm it persists.
- [ ] On the installed PWA on the same device: confirm the existing standalone path still works as before (no regression).
- [ ] Open `?diag=1` in browser-tab mode, confirm the boot log shows `provider ready kind=sqlite` (not `kind=api`) on a capable browser.

## Out of scope (deferred from #58)

The MEDIUM and LOW items in #58 (deprecated meta tag, `/build-meta.json` 404 on dev, localhost install-landing loop, persistence-doc closure, `tests/test_prod_stats.py` ignored on `main`) are left for follow-up PRs.

🤖 Generated with [Claude Code](https://claude.com/claude-code)