### PR TITLE
chore: issue #58 cleanup — meta tag, dev stubs, localhost passthrough

### DIFF
--- a/app/server.py
+++ b/app/server.py
@@ -11,8 +11,10 @@ Then open http://localhost:8765/
 import json
 import re
 import sqlite3
+import subprocess
 import sys
 import urllib.parse
+from datetime import datetime, timezone
 from pathlib import Path
 from http.server import HTTPServer, BaseHTTPRequestHandler
 
@@ -31,6 +33,39 @@ IMAGES_DIR = APP_DIR / "fellow_profile_images_by_name"
 # Fallback: images may live in final_fellows_set when not copied into app/
 IMAGES_DIR_FALLBACK = REPO_ROOT / "final_fellows_set" / "fellow_profile_images_by_name"
 PORT = 8765
+
+
+def _dev_build_meta() -> dict:
+    """Synthesize a build-meta blob for the dev server.
+
+    Mirrors the shape of `deploy/dist/build-meta.json` (written by
+    `build/build_pwa.py`) so the PWA's drift-check, diagnostics panel,
+    and build badge work identically in dev. The `git_sha` reflects
+    the currently checked-out commit when the server was started;
+    `built_at` is the server start time.
+    """
+    git_sha = None
+    try:
+        r = subprocess.run(
+            ["git", "rev-parse", "--short", "HEAD"],
+            cwd=str(REPO_ROOT),
+            capture_output=True,
+            text=True,
+            timeout=5,
+            check=False,
+        )
+        if r.returncode == 0 and (r.stdout or "").strip():
+            git_sha = (r.stdout or "").strip()
+    except (OSError, subprocess.SubprocessError):
+        pass
+    return {
+        "built_at": datetime.now(timezone.utc).strftime("%Y-%m-%dT%H:%M:%SZ"),
+        "git_sha": git_sha,
+        "generator": "app/server.py (dev)",
+    }
+
+
+BUILD_META: dict = _dev_build_meta()
 
 # Columns in fellows table (exclude extra_json for row dict)
 FELLOW_COLUMNS = [
@@ -553,6 +588,35 @@ class Handler(BaseHTTPRequestHandler):
                     "authenticated": False,
                     "hasSessionCookie": False,
                     "installRecentlyAllowed": False,
+                }
+            )
+            return
+
+        # Build fingerprint stub. Prod (`deploy/server.py`) serves the
+        # `dist/build-meta.json` file written by `build/build_pwa.py`;
+        # dev synthesizes the same shape from the live git HEAD so the
+        # build badge, drift check, and diagnostics panel all work
+        # locally. Without this the SW + diag panel both 404 and the
+        # browser console logs `Unexpected token 'N'` parse errors.
+        if path == "/build-meta.json":
+            self.send_json(BUILD_META)
+            return
+
+        # Diagnostics stub for the in-app `?diag=1` panel and the SW
+        # health probe. The dev server has no auth, no allowlist, and no
+        # Postmark wiring, so most fields are inert; this exists purely
+        # so the panel renders cleanly in dev instead of showing a
+        # network error. Mirrors the prod shape in `deploy/server.py`.
+        if path == "/api/debug/diagnostics":
+            self.send_json(
+                {
+                    "authActive": False,
+                    "allowlistHashCount": 0,
+                    "sessionSecretConfigured": False,
+                    "postmarkTokenConfigured": False,
+                    "fellowsDbPresent": DB_PATH.is_file(),
+                    "build": BUILD_META,
+                    "distRoot": str(APP_DIR),
                 }
             )
             return

--- a/app/static/app.js
+++ b/app/static/app.js
@@ -1831,6 +1831,17 @@
     return hasAuthenticatedOnce();
   }
 
+  // True when the current page is being served from the maintainer's
+  // local dev server. Used to fork the `authEnabled === false` branch
+  // of the email-gate decision tree: a dev session should land on the
+  // directory, not on the install landing (issue #58 LOW #2). Tests
+  // that simulate the prod auth flow on localhost mock authEnabled to
+  // true, bypassing this fork.
+  function isLocalhostHostname() {
+    var h = (window.location && window.location.hostname) || '';
+    return h === 'localhost' || h === '127.0.0.1' || h === '::1';
+  }
+
   function setInstallStatus(msg) {
     if (!installStatusEl) return;
     installStatusEl.textContent = msg || '';
@@ -2219,6 +2230,21 @@
           return;
         }
         if (!data.authEnabled) {
+          // Dev passthrough. On localhost we boot the directory directly —
+          // the install landing every time a maintainer hits Clear App
+          // Cache was confusing in practice (issue #58 LOW #2). Boot
+          // shell elements (#site-header, #app-wrap) all start hidden,
+          // so deferring to bootDirectoryAsApp is safe — it reveals
+          // the header itself and renderDirectory shows app-wrap.
+          // On any other host with authEnabled=false (a misconfigured
+          // prod, a staging box without secrets), keep the historical
+          // install-landing behavior so the misconfiguration is
+          // visible.
+          if (isLocalhostHostname()) {
+            authDebugPush('auth disabled on localhost: booting directory directly');
+            bootDirectoryAsApp();
+            return;
+          }
           authDebugPush('auth disabled on server: using install mode');
           initBrowserInstallMode(data, httpStatus);
           return;

--- a/app/static/index.html
+++ b/app/static/index.html
@@ -4,6 +4,7 @@
   <meta charset="utf-8" />
   <meta name="viewport" content="width=device-width, initial-scale=1" />
   <meta name="theme-color" content="#4a2c6a" />
+  <meta name="mobile-web-app-capable" content="yes" />
   <meta name="apple-mobile-web-app-capable" content="yes" />
   <title>EHF Fellows Directory</title>
   <link rel="manifest" href="/manifest.webmanifest" />

--- a/tests/e2e/test_bug_report.py
+++ b/tests/e2e/test_bug_report.py
@@ -66,7 +66,25 @@ class TestBugReportInstallLanding:
     """Pre-app surface: install landing exposes an inline 'report a problem' button."""
 
     def test_install_landing_inline_button_opens_dialog(self, page, base_url_fixture):
-        # Browser-tab mode (no standalone fixture) lands on install-landing.
+        # Mock prod-shaped auth status so the install landing renders even
+        # on the localhost dev server. Without this, issue #58 LOW #2's
+        # localhost passthrough boots straight into the directory and the
+        # install landing is never shown.
+        import json
+
+        def _fulfill(route):
+            route.fulfill(
+                status=200,
+                content_type="application/json",
+                body=json.dumps({
+                    "authEnabled": True,
+                    "authenticated": True,
+                    "hasSessionCookie": True,
+                    "installRecentlyAllowed": True,
+                }),
+                headers={"X-Fellows-Build": "e2e-mock"},
+            )
+        page.route("**/api/auth/status", _fulfill)
         page.goto(base_url_fixture + "/", wait_until="domcontentloaded")
         expect(page.locator("#install-landing")).to_be_visible()
 

--- a/tests/e2e/test_install_landing.py
+++ b/tests/e2e/test_install_landing.py
@@ -1,15 +1,31 @@
-"""E2E: browser tab shows install landing only (Phase 1 PWA)."""
-import pytest
+"""E2E: browser-tab + install-landing routing on localhost.
+
+After issue #58 LOW #2, localhost browser-tab visits act as the app
+(directory) by default — the previous dev passthrough that forced every
+fresh localhost session through the install landing was confusing every
+time after Clear App Cache. The install landing still exists and is
+reachable via `?gate=1` (forces the email gate UI).
+"""
 from playwright.sync_api import expect
 
 
-class TestInstallLanding:
-    """Without standalone display mode, directory must not load."""
+class TestLocalhostBrowserTab:
+    """Localhost browser-tab visits act as the app, not the install landing."""
 
-    def test_browser_tab_shows_install_not_directory(self, page, base_url_fixture):
+    def test_browser_tab_on_localhost_loads_directory(self, page, base_url_fixture):
         page.goto(base_url_fixture + "/", wait_until="domcontentloaded")
-        landing = page.locator("#install-landing")
-        expect(landing).to_be_visible()
-        expect(page.locator("#site-header")).to_be_hidden()
+        # Wait for boot to settle past the loading panel.
+        page.locator("#loading").wait_for(state="hidden", timeout=10000)
+        # Directory app shell should be visible; install landing should not.
+        expect(page.locator("#app-wrap")).to_be_visible()
+        expect(page.locator("#install-landing")).to_be_hidden()
+
+    def test_gate_override_forces_email_gate_panel(self, page, base_url_fixture):
+        """`?gate=1` is the dev escape hatch — must reach the email gate
+        even on localhost where shouldActAsApp() otherwise returns true."""
+        page.goto(base_url_fixture + "/?gate=1", wait_until="domcontentloaded")
+        # The email gate panel renders inside #install-landing; the gate
+        # form's email input is the load-bearing element.
+        email_input = page.locator("input[type='email']").first
+        expect(email_input).to_be_visible(timeout=5000)
         expect(page.locator("#app-wrap")).to_be_hidden()
-        expect(page.get_by_role("button", name="Install app")).to_be_visible()


### PR DESCRIPTION
## Summary

Three small follow-ups from #58, batched. All low-risk, all touch different surfaces.

- **Medium #2** — adds `<meta name=\"mobile-web-app-capable\">` next to the Apple-prefixed one in `app/static/index.html`. Silences the Chrome console-warning. Apple tag stays for iOS Safari compatibility.
- **Low #1** — stubs `/build-meta.json` and `/api/debug/diagnostics` in `app/server.py`. Dev now synthesizes the same shape prod returns from `git rev-parse --short HEAD` at server-start (build-meta) and from inert values (diagnostics). The in-app `?diag=1` panel renders cleanly in dev now and the boot-time `Unexpected token 'N'` parse error in the console is gone.
- **Low #2** — forks the `authEnabled === false` branch of `startBrowserUx` so localhost dev sessions boot the directory instead of the install landing. Other hosts with `authEnabled=false` (a misconfigured prod, a staging box) keep the historical install-landing behavior so the misconfiguration stays visible.

The **Closure** item (persistence-doc open question) was already resolved by PR #60 — the bullet was retired in commit a320f1d. Nothing to do there.

## Why this design for Low #2

The first attempt was a sync short-circuit in `shouldActAsApp()` (\"if hostname is localhost, return true\"). That broke six existing email-gate / bug-report tests because they mock `/api/auth/status` to simulate prod, and `shouldActAsApp` runs *before* the auth fetch — the short-circuit bypassed every test setup.

The right level is the actual dev passthrough: in `startBrowserUx`, after `/api/auth/status` resolves and we see `!authEnabled`, branch on `isLocalhostHostname()`. Tests that mock `authEnabled: true` are unaffected; only the genuine \"dev server with no auth\" case takes the new directory path.

## Test plan

- [x] `just test-fast` — 41/41 pass.
- [x] `just test-e2e \"install_landing or email_gate or bug_report\"` — 17/17 pass.
- [x] `just test-e2e` — 85/86 pass; the 1 failure is the same pre-existing `test_click_aaron_bird_shows_detail` flake from PR #62 (verified on unpatched main last PR).
- [x] Manual smoke: `just serve`, then `curl /build-meta.json` and `curl /api/debug/diagnostics` — both return well-formed JSON with the live git HEAD short SHA.

Manual QA the maintainer should run before merging:
- [ ] After a `just reset` (full Clear App Cache equivalent), open `http://localhost:8765/` in a regular browser tab. Expect the **directory**, not the install landing. Confirms LOW #2.
- [ ] Visit `http://localhost:8765/?gate=1` — expect the **email gate** UI. Confirms `?gate=1` still wins.
- [ ] Visit `http://localhost:8765/?diag=1` — expect Diagnostics panel to populate without console errors. Confirms LOW #1 stubs.
- [ ] Verify the build badge in the top-right shows a recent commit SHA.
- [ ] Open the page on Chrome and check the console — the `apple-mobile-web-app-capable` deprecation warning should be gone (replaced by the modern tag). Confirms Medium #2.

## Out of scope

The Medium #1 `tests/test_prod_stats.py` rewrite (~45–60 min, the only remaining issue-58 item) is a separate PR — it touches test logic and warrants its own review.

🤖 Generated with [Claude Code](https://claude.com/claude-code)