### PR TITLE
test(prod_stats): catch up to prod-stats-long API; cover new surface

### DIFF
--- a/justfile
+++ b/justfile
@@ -210,10 +210,10 @@ test-e2e filter="":
         ./scripts/ensure_port_8765_free.sh tests/e2e/ -v -k "{{filter}}"
     fi
 
-# DB + API only (skip Playwright; ~10x faster).
+# DB + API + prod-stats only (skip Playwright; ~10x faster).
 [group('test')]
 test-fast:
-    ./scripts/ensure_port_8765_free.sh tests/test_database.py tests/test_api.py -v
+    ./scripts/ensure_port_8765_free.sh tests/test_database.py tests/test_api.py tests/test_prod_stats.py -v
 
 
 # ---- build / deploy ------------------------------------------------------

--- a/tests/test_prod_stats.py
+++ b/tests/test_prod_stats.py
@@ -1,14 +1,22 @@
 """Unit tests for scripts/prod_stats.py.
 
 The script is stdlib-only and lives under scripts/ (not a package), so we
-load it by path. Tests exercise the pure functions (tally, disk_usage,
-print_human) against fixture MESSAGE strings — no real journalctl or SSH.
+load it by path. Tests exercise the pure functions (``tally``,
+``disk_usage``, ``print_human``, ``build_email_hash_index``,
+``resolve_recipients``, plus the small ``_entry_*`` helpers) against
+synthetic journald entries — no real journalctl or SSH.
+
+Fixtures match what ``journalctl -u fellows-pwa --since … -o json --no-pager``
+emits: each entry is a dict with at least ``MESSAGE`` and
+``__REALTIME_TIMESTAMP`` (microseconds since the epoch, as a string).
 """
+import hashlib
 import importlib.util
-import io
 import json
 import os
+import sqlite3
 import sys
+from datetime import datetime, timezone
 
 REPO_ROOT = os.path.dirname(os.path.dirname(os.path.abspath(__file__)))
 SCRIPT_PATH = os.path.join(REPO_ROOT, "scripts", "prod_stats.py")
@@ -18,84 +26,113 @@ prod_stats = importlib.util.module_from_spec(_spec)
 _spec.loader.exec_module(prod_stats)
 
 
-# ---- fixture: representative journald MESSAGE strings --------------------
+# ---- helpers -------------------------------------------------------------
 
-FIXTURE_MESSAGES = [
+def _entry(message: str, ts: str = "2026-04-23T10:17:00Z") -> dict:
+    """Synthesize a journald entry dict matching `journalctl -o json` output.
+
+    ``ts`` is an ISO-8601 Zulu string for readability; converted to
+    microseconds-since-epoch (string) the way real journald serializes
+    ``__REALTIME_TIMESTAMP``.
+    """
+    epoch_us = int(
+        datetime.fromisoformat(ts.replace("Z", "+00:00")).timestamp() * 1_000_000
+    )
+    return {"MESSAGE": message, "__REALTIME_TIMESTAMP": str(epoch_us)}
+
+
+def _sha256_hex(s: str) -> str:
+    return hashlib.sha256(s.encode("utf-8")).hexdigest()
+
+
+# ---- fixture: representative journald entries ----------------------------
+
+FIXTURE_ENTRIES = [
     # App-shell loads
-    '127.0.0.1 - - [23/Apr/2026 10:15:32] "GET / HTTP/1.1" 200 -',
-    '127.0.0.1 - - [23/Apr/2026 10:15:33] "GET /index.html HTTP/1.1" 200 -',
-    '127.0.0.1 - - [23/Apr/2026 10:16:01] "GET / HTTP/1.1" 304 -',
+    _entry('127.0.0.1 - - [23/Apr/2026 10:15:32] "GET / HTTP/1.1" 200 -'),
+    _entry('127.0.0.1 - - [23/Apr/2026 10:15:33] "GET /index.html HTTP/1.1" 200 -'),
+    _entry('127.0.0.1 - - [23/Apr/2026 10:16:01] "GET / HTTP/1.1" 304 -'),
     # Directory API (count both list and detail)
-    '127.0.0.1 - - [23/Apr/2026 10:15:34] "GET /api/fellows HTTP/1.1" 200 -',
-    '127.0.0.1 - - [23/Apr/2026 10:15:35] "GET /api/fellows?full=1 HTTP/1.1" 200 -',
-    '127.0.0.1 - - [23/Apr/2026 10:16:00] "GET /api/fellows/jane-doe HTTP/1.1" 200 -',
+    _entry('127.0.0.1 - - [23/Apr/2026 10:15:34] "GET /api/fellows HTTP/1.1" 200 -'),
+    _entry('127.0.0.1 - - [23/Apr/2026 10:15:35] "GET /api/fellows?full=1 HTTP/1.1" 200 -'),
+    _entry('127.0.0.1 - - [23/Apr/2026 10:16:00] "GET /api/fellows/jane-doe HTTP/1.1" 200 -'),
     # DB downloads
-    '127.0.0.1 - - [23/Apr/2026 10:15:36] "GET /fellows.db HTTP/1.1" 200 -',
+    _entry('127.0.0.1 - - [23/Apr/2026 10:15:36] "GET /fellows.db HTTP/1.1" 200 -'),
     # Magic-link verify: one success, one 401
-    '127.0.0.1 - - [23/Apr/2026 10:17:00] "POST /api/verify-token HTTP/1.1" 200 -',
-    '127.0.0.1 - - [23/Apr/2026 10:17:05] "POST /api/verify-token HTTP/1.1" 401 -',
+    _entry('127.0.0.1 - - [23/Apr/2026 10:17:00] "POST /api/verify-token HTTP/1.1" 200 -'),
+    _entry('127.0.0.1 - - [23/Apr/2026 10:17:05] "POST /api/verify-token HTTP/1.1" 401 -'),
     # 5xx error (should bucket under errors_5xx)
-    '127.0.0.1 - - [23/Apr/2026 10:18:00] "GET /api/stats HTTP/1.1" 500 -',
-    # Send-unlock structured events: two sent, one http_error
-    json.dumps({"event": "send_unlock_email", "result": "sent",
-                "email_hash_prefix": "deadbeef1234", "token_prefix": "aaaaaaaaaaaa",
-                "postmark": {"MessageID": "m1"}}),
-    json.dumps({"event": "send_unlock_email", "result": "sent",
-                "email_hash_prefix": "cafebabe5678", "token_prefix": "bbbbbbbbbbbb",
-                "postmark": {"MessageID": "m2"}}),
-    json.dumps({"event": "send_unlock_email", "result": "http_error",
-                "email_hash_prefix": "feedface9abc", "token_prefix": "cccccccccccc",
-                "status": 422}),
+    _entry('127.0.0.1 - - [23/Apr/2026 10:18:00] "GET /api/stats HTTP/1.1" 500 -'),
+    # Send-unlock structured events: two sent (distinct prefixes), one http_error.
+    # Distinct timestamps so first/last ordering is testable downstream.
+    _entry(
+        json.dumps({"event": "send_unlock_email", "result": "sent",
+                    "email_hash_prefix": "deadbeef1234", "token_prefix": "aaaaaaaaaaaa",
+                    "postmark": {"MessageID": "m1"}}),
+        ts="2026-04-23T10:17:00Z",
+    ),
+    _entry(
+        json.dumps({"event": "send_unlock_email", "result": "sent",
+                    "email_hash_prefix": "cafebabe5678", "token_prefix": "bbbbbbbbbbbb",
+                    "postmark": {"MessageID": "m2"}}),
+        ts="2026-04-23T10:17:02Z",
+    ),
+    _entry(
+        json.dumps({"event": "send_unlock_email", "result": "http_error",
+                    "email_hash_prefix": "feedface9abc", "token_prefix": "cccccccccccc",
+                    "status": 422}),
+        ts="2026-04-23T10:17:30Z",
+    ),
     # Noise that must not bump any counter
-    "Rate limit: send-unlock for hash prefix deadbeef1234",
-    '{"event": "build_meta", "build": {"built_at": "2026-04-23T09:00Z"}}',
-    "",
-    "not-a-log-line at all",
+    _entry("Rate limit: send-unlock for hash prefix deadbeef1234"),
+    _entry('{"event": "build_meta", "build": {"built_at": "2026-04-23T09:00Z"}}'),
+    _entry(""),
+    _entry("not-a-log-line at all"),
 ]
 
 
 # ---- tally() -------------------------------------------------------------
 
 def test_tally_counts_shell_loads():
-    stats = prod_stats.tally(FIXTURE_MESSAGES)
+    stats = prod_stats.tally(FIXTURE_ENTRIES)
     assert stats["shell_loads"] == 3
 
 
 def test_tally_counts_directory_api():
-    stats = prod_stats.tally(FIXTURE_MESSAGES)
+    stats = prod_stats.tally(FIXTURE_ENTRIES)
     # list + ?full=1 + detail
     assert stats["api_fellows"] == 3
 
 
 def test_tally_counts_db_downloads():
-    stats = prod_stats.tally(FIXTURE_MESSAGES)
+    stats = prod_stats.tally(FIXTURE_ENTRIES)
     assert stats["db_downloads"] == 1
 
 
 def test_tally_counts_magic_link_verifications():
-    stats = prod_stats.tally(FIXTURE_MESSAGES)
+    stats = prod_stats.tally(FIXTURE_ENTRIES)
     assert stats["magic_links_verified"] == 1
     assert stats["magic_links_verify_failed"] == 1
 
 
 def test_tally_counts_magic_links_sent_and_failures():
-    stats = prod_stats.tally(FIXTURE_MESSAGES)
+    stats = prod_stats.tally(FIXTURE_ENTRIES)
     assert stats["magic_links_sent"] == 2
     assert stats["magic_links_send_failed"] == {"http_error": 1}
 
 
 def test_tally_bucket_5xx_by_route():
-    stats = prod_stats.tally(FIXTURE_MESSAGES)
+    stats = prod_stats.tally(FIXTURE_ENTRIES)
     assert stats["errors_5xx"] == {"500 GET /api/stats": 1}
 
 
 def test_tally_ignores_build_meta_and_rate_limit_lines():
     # Inputs that look structured but aren't send_unlock_email must not count.
-    msgs = [
-        '{"event": "build_meta", "build": {"built_at": "x"}}',
-        "Rate limit: send-unlock for hash prefix deadbeef1234",
+    entries = [
+        _entry('{"event": "build_meta", "build": {"built_at": "x"}}'),
+        _entry("Rate limit: send-unlock for hash prefix deadbeef1234"),
     ]
-    stats = prod_stats.tally(msgs)
+    stats = prod_stats.tally(entries)
     assert stats["magic_links_sent"] == 0
     assert stats["shell_loads"] == 0
 
@@ -106,16 +143,95 @@ def test_tally_empty_input_returns_zeros():
     assert stats["magic_links_sent"] == 0
     assert stats["errors_5xx"] == {}
     assert stats["magic_links_send_failed"] == {}
+    assert stats["email_events_by_prefix"] == {}
 
 
 def test_tally_distinguishes_api_fellows_from_api_stats():
     # /api/stats must not be counted as /api/fellows.
-    msgs = [
-        '127.0.0.1 - - [x] "GET /api/stats HTTP/1.1" 200 -',
-        '127.0.0.1 - - [x] "GET /api/fellows HTTP/1.1" 200 -',
+    entries = [
+        _entry('127.0.0.1 - - [x] "GET /api/stats HTTP/1.1" 200 -'),
+        _entry('127.0.0.1 - - [x] "GET /api/fellows HTTP/1.1" 200 -'),
     ]
-    stats = prod_stats.tally(msgs)
+    stats = prod_stats.tally(entries)
     assert stats["api_fellows"] == 1
+
+
+# ---- _entry_message + _entry_ts (load-bearing helpers) -------------------
+
+def test_entry_message_returns_string_payload():
+    assert prod_stats._entry_message({"MESSAGE": "hello"}) == "hello"
+
+
+def test_entry_message_skips_byte_array_messages():
+    # journalctl emits MESSAGE as a list[int] for non-UTF8 payloads. The
+    # fellows-pwa server never emits those, so the helper deliberately
+    # skips them rather than trying to decode.
+    assert prod_stats._entry_message({"MESSAGE": [104, 105]}) is None
+
+
+def test_entry_message_handles_missing_key():
+    assert prod_stats._entry_message({}) is None
+
+
+def test_entry_ts_converts_microseconds_to_iso_z():
+    # 2026-04-23T10:17:00Z → epoch us
+    ts_iso = "2026-04-23T10:17:00Z"
+    epoch_us = int(
+        datetime.fromisoformat(ts_iso.replace("Z", "+00:00")).timestamp() * 1_000_000
+    )
+    out = prod_stats._entry_ts({"__REALTIME_TIMESTAMP": str(epoch_us)})
+    assert out == ts_iso
+
+
+def test_entry_ts_returns_none_on_missing_or_garbage():
+    assert prod_stats._entry_ts({}) is None
+    assert prod_stats._entry_ts({"__REALTIME_TIMESTAMP": "not-a-number"}) is None
+
+
+# ---- tally(): per-prefix send buckets with timestamps -------------------
+
+def test_tally_buckets_send_events_per_prefix_with_timestamps():
+    """Two events with the same hash prefix produce a single bucket
+    containing both events, each carrying its own timestamp. This is the
+    foundation prod-stats-long uses to compute first_ts/last_ts per
+    recipient — a regression here would silently break the recipient
+    list."""
+    entries = [
+        _entry(
+            json.dumps({"event": "send_unlock_email", "result": "sent",
+                        "email_hash_prefix": "abcdef012345"}),
+            ts="2026-04-23T10:00:00Z",
+        ),
+        _entry(
+            json.dumps({"event": "send_unlock_email", "result": "sent",
+                        "email_hash_prefix": "abcdef012345"}),
+            ts="2026-04-23T10:30:00Z",
+        ),
+        _entry(
+            json.dumps({"event": "send_unlock_email", "result": "http_error",
+                        "email_hash_prefix": "999999999999"}),
+            ts="2026-04-23T11:00:00Z",
+        ),
+    ]
+    stats = prod_stats.tally(entries)
+    by_prefix = stats["email_events_by_prefix"]
+    assert set(by_prefix.keys()) == {"abcdef012345", "999999999999"}
+    same_prefix = by_prefix["abcdef012345"]["events"]
+    assert len(same_prefix) == 2
+    assert {e["result"] for e in same_prefix} == {"sent"}
+    assert {e["ts"] for e in same_prefix} == {
+        "2026-04-23T10:00:00Z", "2026-04-23T10:30:00Z",
+    }
+    other = by_prefix["999999999999"]["events"]
+    assert len(other) == 1 and other[0]["result"] == "http_error"
+
+
+def test_tally_does_not_bucket_http_lines_under_email_events():
+    entries = [
+        _entry('127.0.0.1 - - [x] "GET /api/fellows HTTP/1.1" 200 -'),
+    ]
+    stats = prod_stats.tally(entries)
+    assert stats["email_events_by_prefix"] == {}
 
 
 # ---- disk_usage() --------------------------------------------------------
@@ -128,10 +244,102 @@ def test_disk_usage_shape():
     assert 0.0 <= disk["pct_used"] <= 100.0
 
 
+# ---- build_email_hash_index() -------------------------------------------
+
+def _make_fellows_db(path, rows):
+    """Create a minimal fellows.db at `path` with the columns build_email_hash_index reads."""
+    conn = sqlite3.connect(str(path))
+    try:
+        conn.execute(
+            "CREATE TABLE fellows ("
+            "  record_id TEXT PRIMARY KEY,"
+            "  name TEXT,"
+            "  contact_email TEXT"
+            ")"
+        )
+        conn.executemany(
+            "INSERT INTO fellows (record_id, name, contact_email) VALUES (?,?,?)",
+            rows,
+        )
+        conn.commit()
+    finally:
+        conn.close()
+
+
+def test_build_email_hash_index_joins_emails_to_fellows(tmp_path):
+    """Happy path: builds sha256-keyed dict with lowercased+trimmed emails.
+    Empty/null emails skipped. Always pass an explicit db_path so a stray
+    test never falls back to the production default
+    (/opt/fellows/deploy/dist/fellows.db)."""
+    db_path = tmp_path / "fellows.db"
+    _make_fellows_db(db_path, [
+        ("rec_1", "Alice Aardvark", "Alice@Example.com  "),  # mixed case + trailing ws
+        ("rec_2", "Bob Brown", "bob@example.com"),
+        ("rec_3", "Carol No-Email", ""),                      # skipped (empty)
+        ("rec_4", "Dana NULL", None),                          # skipped (NULL)
+    ])
+    idx = prod_stats.build_email_hash_index(db_path=str(db_path))
+    assert len(idx) == 2
+    expected_alice_key = _sha256_hex("alice@example.com")
+    expected_bob_key = _sha256_hex("bob@example.com")
+    assert idx[expected_alice_key] == {"email": "alice@example.com", "name": "Alice Aardvark"}
+    assert idx[expected_bob_key] == {"email": "bob@example.com", "name": "Bob Brown"}
+
+
+def test_build_email_hash_index_returns_empty_on_unopenable_db(tmp_path, capsys):
+    """Path under a nonexistent directory: sqlite3.connect raises
+    OperationalError; the function catches it and returns {}, plus a
+    note on stderr. Don't pass a path that points at a missing file in
+    an *existing* directory — sqlite3 silently creates an empty DB
+    there, which then crashes on the SELECT (a different code path)."""
+    bad_path = tmp_path / "nope" / "fellows.db"  # parent dir doesn't exist
+    out = prod_stats.build_email_hash_index(db_path=str(bad_path))
+    assert out == {}
+    err = capsys.readouterr().err
+    assert "Cannot open fellows DB" in err
+
+
+# ---- resolve_recipients() -----------------------------------------------
+
+def test_resolve_recipients_matches_prefix_and_sorts_newest_first():
+    """Recipient row resolution: prefix-prefix match against the hash
+    index, accumulated send count + timestamps, sorted newest last_ts
+    first. Unmatched prefixes still produce a row with email=None."""
+    alice_full = _sha256_hex("alice@example.com")  # 64 hex chars
+    bob_full = _sha256_hex("bob@example.com")
+    hash_index = {
+        alice_full: {"email": "alice@example.com", "name": "Alice"},
+        bob_full: {"email": "bob@example.com", "name": "Bob"},
+    }
+    email_events = {
+        alice_full[:12]: {"events": [
+            {"ts": "2026-04-23T10:00:00Z", "result": "sent"},
+            {"ts": "2026-04-23T10:30:00Z", "result": "sent"},
+        ]},
+        bob_full[:12]: {"events": [
+            {"ts": "2026-04-23T12:00:00Z", "result": "sent"},
+        ]},
+        "ffffffffffff": {"events": [  # no match
+            {"ts": "2026-04-23T11:00:00Z", "result": "http_error"},
+        ]},
+    }
+    rows = prod_stats.resolve_recipients(email_events, hash_index)
+    assert len(rows) == 3
+    # Sorted by last_ts desc → Bob (12:00), unknown (11:00), Alice (10:30).
+    assert rows[0]["email"] == "bob@example.com"
+    assert rows[0]["sent"] == 1
+    assert rows[0]["last_ts"] == "2026-04-23T12:00:00Z"
+    assert rows[1]["email"] is None and rows[1]["prefix"] == "ffffffffffff"
+    assert rows[2]["email"] == "alice@example.com"
+    assert rows[2]["sent"] == 2
+    assert rows[2]["first_ts"] == "2026-04-23T10:00:00Z"
+    assert rows[2]["last_ts"] == "2026-04-23T10:30:00Z"
+
+
 # ---- print_human() -------------------------------------------------------
 
 def test_print_human_includes_expected_sections(capsys):
-    stats = prod_stats.tally(FIXTURE_MESSAGES)
+    stats = prod_stats.tally(FIXTURE_ENTRIES)
     disk = {"path": "/", "total_gib": 25.0, "used_gib": 10.0,
             "free_gib": 15.0, "pct_used": 40.0}
     prod_stats.print_human(stats, disk, "24 hours ago", "fellows-pwa")
@@ -141,13 +349,38 @@ def test_print_human_includes_expected_sections(capsys):
     assert "Magic links sent:" in out
     assert "Disk (/)" in out
     assert "40.0%" in out
+    # Without recipients, the confidential block must NOT appear.
+    assert "Magic-link recipients" not in out
+
+
+def test_print_human_with_recipients_prints_confidential_block(capsys):
+    """When recipients are passed, print_human appends the recipient list
+    (header + each row). Header text is the contract; address presence
+    is the regression guard. Only synthetic emails here."""
+    disk = {"path": "/", "total_gib": 25.0, "used_gib": 10.0,
+            "free_gib": 15.0, "pct_used": 40.0}
+    recipients = [
+        {"prefix": "abcdef012345", "email": "alice@example.com", "name": "Alice",
+         "sent": 2, "results": {"sent": 2}, "first_ts": "2026-04-23T10:00:00Z",
+         "last_ts": "2026-04-23T10:30:00Z", "collisions": 0},
+    ]
+    prod_stats.print_human({
+        "shell_loads": 0, "api_fellows": 0, "db_downloads": 0,
+        "magic_links_sent": 2, "magic_links_send_failed": {},
+        "magic_links_verified": 0, "magic_links_verify_failed": 0,
+        "errors_5xx": {},
+    }, disk, "@0", "fellows-pwa", recipients=recipients)
+    out = capsys.readouterr().out
+    assert "Magic-link recipients" in out
+    assert "alice@example.com" in out
 
 
 # ---- main() + --json -----------------------------------------------------
 
 def test_main_json_output_parses(monkeypatch, capsys):
-    # Short-circuit journal_messages so the test doesn't shell out to journalctl.
-    monkeypatch.setattr(prod_stats, "journal_messages", lambda unit, since: FIXTURE_MESSAGES)
+    # Short-circuit journal_entries so the test doesn't shell out to journalctl.
+    monkeypatch.setattr(prod_stats, "journal_entries",
+                        lambda unit, since: FIXTURE_ENTRIES)
     rc = prod_stats.main(["--json", "--since", "1 hour ago"])
     assert rc == 0
     payload = json.loads(capsys.readouterr().out)
@@ -158,3 +391,5 @@ def test_main_json_output_parses(monkeypatch, capsys):
     assert set(payload["disk"].keys()) == {
         "path", "total_gib", "used_gib", "free_gib", "pct_used",
     }
+    # Internal per-prefix bucket must not leak into the public JSON.
+    assert "email_events_by_prefix" not in payload["requests"]


### PR DESCRIPTION
## Summary

Closes **Medium #1** in #58 — the 10 reds on `just test` since PR #52 (`75a6775`, prod-stats-long).

The script's API changed but the tests didn't follow:

| Then (PR #51 era) | Now (PR #52+) |
|---|---|
| `journal_messages(unit, since) -> list[str]` | `journal_entries(unit, since) -> list[dict]` |
| `tally(messages: list[str])` | `tally(entries: list[dict])` |

The reshape was load-bearing: prod-stats-long needs `__REALTIME_TIMESTAMP` per send event to order the recipient list by recency. A `journal_messages = lambda u,s: [...]` shim would be ~5 lines, but it'd silently null out every `email_events_by_prefix` timestamp without breaking a single test. **Reshaped the fixture instead** — the path the issue's \"rewrite the tests\" sentence calls for.

## What changed

`tests/test_prod_stats.py`:

- Reshaped `FIXTURE_MESSAGES` → `FIXTURE_ENTRIES` (dicts with `MESSAGE` + `__REALTIME_TIMESTAMP`). New `_entry(message, ts)` helper synthesizes entries from ISO-Z the way real `journalctl -o json` emits them.
- The 9 existing tally-shape tests carry over verbatim except for the fixture name.
- Fixed `test_main_json_output_parses` to monkeypatch `journal_entries` (the function that exists today) instead of `journal_messages`.
- **Added coverage for the post-rename surface** — none of these had tests before:
  - `_entry_message`: returns string payload, skips byte-array `MESSAGE` (real journald emits this for non-UTF8), handles missing key.
  - `_entry_ts`: microseconds → ISO-Z; `None` on missing/garbage.
  - `tally` per-prefix bucketing: same prefix → one bucket, two events each carrying its own `ts`. This is the foundation for the recipient list — a regression here would silently break it.
  - `tally` does **not** bucket HTTP lines under `email_events_by_prefix`.
  - `build_email_hash_index`: happy path against a `tmp_path` sqlite DB (lowercased+trimmed emails, SHA-256 keys, empty/null skipped); returns `{}` + stderr note when the DB path is unopenable. Every call passes an explicit `db_path` so no test ever falls back to the prod default `/opt/fellows/deploy/dist/fellows.db`.
  - `resolve_recipients`: prefix-prefix match against the hash index, accumulated send count + first/last ts, sorted newest-last-ts first, unmatched prefix produces a row with `email=None`.
  - `print_human` with `recipients=` prints the confidential block; without `recipients=` does **not** (regression guard).
  - `test_main_json_output_parses` now also asserts the internal `email_events_by_prefix` is stripped from the public JSON shape.

`justfile`:

- Added `tests/test_prod_stats.py` to `test-fast`. Stdlib-only, pure-function, no server dep — same speed class as `test_database.py`. Adds ~6ms.

## Test plan

- [x] `pytest tests/test_prod_stats.py -v` → 23/23 pass.
- [x] `just test-fast` → 64 pass (was 41).
- [x] `just test` → 217 pass; the chronic 10 prod_stats reds are gone.
- [x] No production code touched (only `tests/test_prod_stats.py` and `justfile`).

## What I deliberately didn't do

- **No shim in `scripts/prod_stats.py`.** The rename was deliberate and load-bearing; a shim would silently break the timestamp path without breaking any test.
- **No tests for `journal_entries()` itself.** Mocking `subprocess.run` to inject fake journalctl JSON is brittle; the `tally`-against-synthetic-entries tests already exercise everything downstream.
- **No new test file.** Single-file shape is fine at this scale (~330 lines, 23 tests).
- **No touching the production-default `FELLOWS_DB_PATH`** — every test passes an explicit `db_path=`. Prevents any future test from accidentally reading a real prod DB.

## Closes the #58 cleanup checklist

With this, all High/Medium/Low/Closure items in #58 are addressed — High in #62, Medium #2 + Low #1 + Low #2 + Closure in #63, Medium #1 here.

🤖 Generated with [Claude Code](https://claude.com/claude-code)