### PR TITLE
test: magic-link round-trip + standalone unlock e2e (issue #18)

### DIFF
--- a/justfile
+++ b/justfile
@@ -210,10 +210,10 @@ test-e2e filter="":
         ./scripts/ensure_port_8765_free.sh tests/e2e/ -v -k "{{filter}}"
     fi
 
-# DB + API only (skip Playwright; ~10x faster).
+# DB + API + prod-stats only (skip Playwright; ~10x faster).
 [group('test')]
 test-fast:
-    ./scripts/ensure_port_8765_free.sh tests/test_database.py tests/test_api.py -v
+    ./scripts/ensure_port_8765_free.sh tests/test_database.py tests/test_api.py tests/test_prod_stats.py -v
 
 
 # ---- build / deploy ------------------------------------------------------

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -1,11 +1,15 @@
 """Pytest configuration and shared fixtures."""
+import hashlib
+import json
 import os
+import shutil
 import sqlite3
 import subprocess
 import sys
 import threading
 import time
 from http.client import HTTPConnection
+from pathlib import Path
 
 import pytest
 
@@ -15,6 +19,10 @@ if REPO_ROOT not in sys.path:
     sys.path.insert(0, REPO_ROOT)
 
 DB_PATH = os.path.join(REPO_ROOT, "app", "fellows.db")
+# Production server runs on a separate port so tests can keep the dev
+# (`app/server.py`, port 8765) and prod-shape (`deploy/server.py`, port 8766)
+# servers up at the same time without colliding.
+DEPLOY_PORT = 8766
 
 
 @pytest.fixture(scope="module")
@@ -99,3 +107,136 @@ def app_server(tmp_path_factory):
     if _server:
         _server.shutdown()
         _server = None
+
+
+@pytest.fixture(scope="session")
+def deploy_server(tmp_path_factory):
+    """Start ``deploy/server.py`` in-process on ``DEPLOY_PORT`` with auth on.
+
+    The Postmark sender is replaced at the function-reference level — no
+    ``FELLOWS_POSTMARK_TOKEN`` is consulted, so a real token in the dev shell
+    cannot leak into the test path. The fixture yields a handle the tests use
+    to drive the round-trip:
+
+        {"base_url": "http://127.0.0.1:8766",
+         "test_email": "<allowlisted address>",
+         "sent": [{"to", "url"}, ...],   # recorder of stubbed Postmark calls
+         "auth_state": ml.AuthState,     # in-memory token + rate-bucket dict
+         "ml": <magic_link_auth module>,
+         "dist_dir": Path}
+
+    Why in-process rather than subprocess: the production server logs only the
+    first 12 chars of an issued token, so a subprocess'd server would give
+    tests no way to consume the token in /api/verify-token. Importing the
+    module here lets us read tokens straight from ``AuthState`` (or, more
+    cleanly, from the recorder's captured magic-link URL).
+    """
+    if os.environ.get("E2E_BASE_URL"):
+        pytest.skip("deploy_server is local-only; unset E2E_BASE_URL to run")
+
+    repo_root = Path(REPO_ROOT)
+    src_db = repo_root / "app" / "fellows.db"
+    if not src_db.is_file():
+        pytest.skip(
+            f"DB not found at {src_db}. Run: python build/restore_from_knack_scrapefile.py"
+        )
+
+    # Build a tmp dist root: app shell + a copy of fellows.db + a single-entry
+    # allowlist for the test email. Copy (not symlink) so a stray write through
+    # any future code path can't corrupt the dev DB.
+    dist_dir = tmp_path_factory.mktemp("deploy_dist")
+    shutil.copytree(repo_root / "app" / "static", dist_dir, dirs_exist_ok=True)
+    shutil.copy2(src_db, dist_dir / "fellows.db")
+
+    test_email = "round-trip-tester@example.com"
+    email_hash = hashlib.sha256(test_email.strip().lower().encode("utf-8")).hexdigest()
+    (dist_dir / "allowed_emails.json").write_text(
+        json.dumps({"hashes": [email_hash]}), encoding="utf-8"
+    )
+
+    # `deploy/server.py` reads DIST_DIR / PORT at import time. Set env first,
+    # save originals so teardown leaves the process clean.
+    saved_env = {}
+    for k in (
+        "FELLOWS_DIST_ROOT",
+        "FELLOWS_SESSION_SECRET",
+        "FELLOWS_COOKIE_INSECURE",
+        "PORT",
+        "FELLOWS_POSTMARK_TOKEN",
+    ):
+        saved_env[k] = os.environ.get(k)
+    os.environ["FELLOWS_DIST_ROOT"] = str(dist_dir)
+    os.environ["FELLOWS_SESSION_SECRET"] = "test-secret-for-round-trip-suite"
+    os.environ["FELLOWS_COOKIE_INSECURE"] = "1"
+    os.environ["PORT"] = str(DEPLOY_PORT)
+    os.environ.pop("FELLOWS_POSTMARK_TOKEN", None)
+
+    deploy_dir = str(repo_root / "deploy")
+    if deploy_dir not in sys.path:
+        sys.path.insert(0, deploy_dir)
+    # Force re-import so module-level globals (DIST_DIR, PORT) pick up our env.
+    for mod_name in ("server", "magic_link_auth", "sqlite_api_support"):
+        sys.modules.pop(mod_name, None)
+    import server as deploy_srv  # noqa: E402
+    import magic_link_auth as ml  # noqa: E402
+
+    sent: list[dict] = []
+    real_send = ml.send_postmark_magic_link
+
+    def fake_send(to_email, magic_url):
+        sent.append({"to": to_email, "url": magic_url})
+        return {
+            "status": 200,
+            "message_id": "stub-message-id",
+            "error_code": 0,
+            "message": "OK (test stub)",
+            "to": to_email,
+            "submitted_at": None,
+            "raw": {},
+        }
+
+    ml.send_postmark_magic_link = fake_send
+
+    deploy_srv.init_auth()
+    deploy_srv.BUILD_META = {}
+
+    # SimpleHTTPRequestHandler resolves static paths against ``self.directory``
+    # if set, falling back to cwd otherwise. ``deploy/server.py`` itself
+    # chdirs in main(), but doing that from a session-scoped pytest fixture
+    # leaks the cwd change into every later test, which destabilizes other
+    # e2e tests. Wire the directory via partial() instead — same effect, no
+    # process-global side effect.
+    from functools import partial
+
+    handler_factory = partial(deploy_srv.Handler, directory=str(dist_dir))
+
+    _free_port(DEPLOY_PORT)
+    httpd = deploy_srv.ThreadingHTTPServer(
+        ("127.0.0.1", DEPLOY_PORT), handler_factory
+    )
+    thread = threading.Thread(target=httpd.serve_forever, daemon=True)
+    thread.start()
+    if not _wait_for_server(DEPLOY_PORT):
+        httpd.shutdown()
+        raise RuntimeError(
+            f"deploy server did not start on port {DEPLOY_PORT}"
+        )
+
+    handle = {
+        "base_url": f"http://127.0.0.1:{DEPLOY_PORT}",
+        "test_email": test_email,
+        "sent": sent,
+        "auth_state": ml.AuthState,
+        "ml": ml,
+        "dist_dir": dist_dir,
+    }
+    try:
+        yield handle
+    finally:
+        httpd.shutdown()
+        ml.send_postmark_magic_link = real_send
+        for k, v in saved_env.items():
+            if v is None:
+                os.environ.pop(k, None)
+            else:
+                os.environ[k] = v

--- a/tests/e2e/test_magic_link_standalone_unlock.py
+++ b/tests/e2e/test_magic_link_standalone_unlock.py
@@ -1,0 +1,132 @@
+"""E2E: standalone PWA unlock round-trip against deploy/server.py.
+
+Issue #18, item 5. Regression guard for PR #16: a real browser running in
+PWA standalone display mode must follow the SPA hash-route handler from
+``#/unlock/<token>`` through ``POST /api/verify-token``, land the
+``fellows_session`` cookie, and transition into the directory (not the
+install landing — that path is only reached in browser-tab mode).
+
+The other items in issue #18 (1-4, 6) are HTTP-only and live in
+``tests/test_deploy_auth_round_trip.py``; this file is the one piece that
+genuinely needs a browser to drive the SPA's standalone code path.
+"""
+
+from __future__ import annotations
+
+import json
+from http.client import HTTPConnection
+from urllib.parse import urlparse
+
+import pytest
+
+
+_STANDALONE_DISPLAY_INIT = """
+(function () {
+  var orig = window.matchMedia.bind(window);
+  window.matchMedia = function (q) {
+    q = String(q);
+    if (q.indexOf('display-mode: standalone') !== -1) {
+      return {
+        matches: true,
+        media: q,
+        addEventListener: function () {},
+        removeEventListener: function () {}
+      };
+    }
+    return orig(q);
+  };
+})();
+"""
+
+
+@pytest.fixture
+def deploy_page(context, deploy_server):
+    """Playwright page faking PWA standalone display mode against the deploy server.
+
+    Auth state is reset per test (rate-limit and token dicts cleared) so a
+    test that issues a token starts from a known-clean ``AuthState``.
+    """
+    page = context.new_page()
+    page.add_init_script(_STANDALONE_DISPLAY_INIT)
+    state = deploy_server["auth_state"]
+    with state.lock:
+        state.tokens.clear()
+        state.rate_buckets.clear()
+    deploy_server["sent"].clear()
+    try:
+        yield page
+    finally:
+        page.close()
+
+
+def _issue_token(deploy_server):
+    """Drive ``POST /api/send-unlock`` and return the token from the recorder."""
+    parsed = urlparse(deploy_server["base_url"])
+    body = json.dumps({"email": deploy_server["test_email"]}).encode("utf-8")
+    conn = HTTPConnection(parsed.hostname, parsed.port, timeout=3)
+    conn.request(
+        "POST",
+        "/api/send-unlock",
+        body=body,
+        headers={
+            "Content-Type": "application/json",
+            "Content-Length": str(len(body)),
+        },
+    )
+    conn.getresponse().read()
+    conn.close()
+    assert deploy_server["sent"], "stubbed Postmark recorder never fired"
+    return deploy_server["sent"][-1]["url"].rsplit("/#/unlock/", 1)[-1]
+
+
+def test_standalone_unlock_lands_session_cookie_and_loads_directory(
+    deploy_page, deploy_server
+):
+    """PR #16 regression guard.
+
+    In standalone mode the SPA's PWA decision tree is just::
+
+        1. authStatus.authenticated?  → DIRECTORY
+        2. otherwise                  → EMAIL GATE
+
+    So the success signal for unlock is: verify-token POST succeeds, the
+    HttpOnly session cookie appears in the jar, and the directory mounts
+    (we wait for ``#directory-list`` to render, i.e. ``app-wrap`` no longer
+    hidden — the same DOM that ``app/static/index.html`` defines).
+    """
+    token = _issue_token(deploy_server)
+
+    # 1. Wrap the navigation so we deterministically capture the SPA's
+    #    POST /api/verify-token. ``expect_response`` is the sync-API primitive
+    #    for "do this action, then wait for a matching response".
+    with deploy_page.expect_response(
+        lambda r: "/api/verify-token" in r.url and r.request.method == "POST",
+        timeout=8000,
+    ) as verify_info:
+        deploy_page.goto(
+            f"{deploy_server['base_url']}/#/unlock/{token}", wait_until="load"
+        )
+    assert verify_info.value.status == 200
+
+    # 2. Session cookie landed. ``fellows_session`` is HttpOnly so
+    #    ``document.cookie`` cannot see it; read the context jar instead.
+    cookies = deploy_page.context.cookies(deploy_server["base_url"])
+    sessions = [c for c in cookies if c["name"] == "fellows_session"]
+    assert len(sessions) == 1, f"expected one fellows_session cookie, got {cookies!r}"
+    sc = sessions[0]
+    assert sc["httpOnly"] is True
+    # Playwright reports SameSite as "Strict" / "Lax" / "None" / unset.
+    assert sc.get("sameSite", "").lower() == "strict"
+    assert sc["value"]
+
+    # 3. The hash was rewritten by tryUnlockFromHash() so a refresh wouldn't
+    #    re-submit the (now-consumed) token.
+    assert "/unlock/" not in deploy_page.evaluate("location.hash")
+
+    # 4. Directory mounted (not the gate). #app-wrap drops `hidden` once the
+    #    directory route renders; #directory-list is its inner list container.
+    deploy_page.wait_for_selector("#directory-list", state="attached", timeout=8000)
+    app_wrap_hidden = deploy_page.evaluate(
+        "document.getElementById('app-wrap')?.classList.contains('hidden')"
+    )
+    assert app_wrap_hidden is False, "#app-wrap should be visible after unlock"

--- a/tests/test_deploy_auth_round_trip.py
+++ b/tests/test_deploy_auth_round_trip.py
@@ -1,0 +1,261 @@
+"""End-to-end round-trip tests for deploy/server.py magic-link auth (issue #18).
+
+The dev server (app/server.py) has no auth, so the directory of e2e tests
+under tests/e2e/ exercises gate UX against a server that returns
+``authEnabled: false`` and never actually issues tokens. These tests fill the
+gap: they spawn ``deploy/server.py`` in-process with auth on, a tmp dist root,
+and a stubbed Postmark sender, then exercise the real send → verify → cookie →
+gated-API path that PR #16 (standalone unlock) and PR #17 (silent send-unlock)
+broke without anyone noticing.
+
+The ``deploy_server`` fixture lives in ``tests/conftest.py``.
+"""
+
+from __future__ import annotations
+
+import json
+from http.client import HTTPConnection
+from urllib.parse import urlparse
+
+import pytest
+
+
+def _conn(handle):
+    parsed = urlparse(handle["base_url"])
+    return HTTPConnection(parsed.hostname, parsed.port, timeout=3)
+
+
+def _post_json(handle, path, body):
+    conn = _conn(handle)
+    payload = json.dumps(body).encode("utf-8")
+    conn.request(
+        "POST",
+        path,
+        body=payload,
+        headers={
+            "Content-Type": "application/json",
+            "Content-Length": str(len(payload)),
+        },
+    )
+    resp = conn.getresponse()
+    raw = resp.read()
+    conn.close()
+    return resp.status, dict(resp.getheaders()), (json.loads(raw) if raw else {})
+
+
+def _get(handle, path, cookie=None):
+    conn = _conn(handle)
+    headers = {}
+    if cookie:
+        headers["Cookie"] = cookie
+    conn.request("GET", path, headers=headers)
+    resp = conn.getresponse()
+    raw = resp.read()
+    conn.close()
+    return resp.status, dict(resp.getheaders()), raw
+
+
+def _set_cookie_header(headers):
+    return headers.get("Set-Cookie") or headers.get("set-cookie") or ""
+
+
+def _extract_session_cookie(headers):
+    """Return the ``fellows_session=<value>`` portion of Set-Cookie, or None."""
+    sc = _set_cookie_header(headers)
+    if not sc:
+        return None
+    head = sc.split(";", 1)[0].strip()
+    if not head.startswith("fellows_session="):
+        return None
+    return head
+
+
+def _token_from_url(magic_url):
+    return magic_url.rsplit("/#/unlock/", 1)[-1]
+
+
+@pytest.fixture(autouse=True)
+def _reset_auth_state(deploy_server):
+    """Each test starts with empty rate buckets, no live tokens, no recorded sends."""
+    state = deploy_server["auth_state"]
+    with state.lock:
+        state.tokens.clear()
+        state.rate_buckets.clear()
+    deploy_server["sent"].clear()
+
+
+# --- Item 1: unauthenticated landing -------------------------------------
+
+
+def test_directory_api_is_403_without_session(deploy_server):
+    status, headers, _ = _get(deploy_server, "/api/fellows")
+    assert status == 403
+    assert _extract_session_cookie(headers) is None
+
+
+def test_auth_status_reports_unauthenticated_when_cookieless(deploy_server):
+    status, _, raw = _get(deploy_server, "/api/auth/status")
+    assert status == 200
+    body = json.loads(raw)
+    assert body["authEnabled"] is True
+    assert body["authenticated"] is False
+    assert body["hasSessionCookie"] is False
+
+
+# --- Item 2: send-unlock round-trip --------------------------------------
+
+
+def test_send_unlock_for_allowlisted_email_invokes_sender(deploy_server):
+    status, _, body = _post_json(
+        deploy_server, "/api/send-unlock", {"email": deploy_server["test_email"]}
+    )
+    assert status == 200
+    assert body == {"sent": True}
+    assert len(deploy_server["sent"]) == 1
+    record = deploy_server["sent"][0]
+    assert record["to"] == deploy_server["test_email"]
+    assert "/#/unlock/" in record["url"]
+    # Token in the magic-link URL is 64 hex chars (secrets.token_hex(32)).
+    token = _token_from_url(record["url"])
+    assert len(token) == 64
+    assert all(c in "0123456789abcdef" for c in token)
+
+
+def test_send_unlock_for_unknown_email_does_not_invoke_sender(deploy_server):
+    """Anti-enumeration: response is identical, sender never runs."""
+    status, _, body = _post_json(
+        deploy_server, "/api/send-unlock", {"email": "stranger@example.com"}
+    )
+    assert status == 200
+    assert body == {"sent": True}
+    assert deploy_server["sent"] == []
+
+
+def test_send_unlock_with_malformed_email_does_not_invoke_sender(deploy_server):
+    status, _, body = _post_json(
+        deploy_server, "/api/send-unlock", {"email": "not-an-email"}
+    )
+    assert status == 200
+    assert body == {"sent": True}
+    assert deploy_server["sent"] == []
+
+
+# --- Item 3: token verification ------------------------------------------
+
+
+def test_verify_token_sets_session_cookie_with_required_attributes(deploy_server):
+    _post_json(
+        deploy_server, "/api/send-unlock", {"email": deploy_server["test_email"]}
+    )
+    token = _token_from_url(deploy_server["sent"][-1]["url"])
+    status, headers, body = _post_json(
+        deploy_server, "/api/verify-token", {"token": token}
+    )
+    assert status == 200
+    assert body == {"ok": True}
+    sc = _set_cookie_header(headers)
+    assert "fellows_session=" in sc
+    assert "HttpOnly" in sc
+    assert "SameSite=Strict" in sc
+    assert "Path=/" in sc
+    # Secure is environment-dependent: the localhost gate in
+    # should_use_secure_cookie() (and FELLOWS_COOKIE_INSECURE=1 in this
+    # fixture) suppresses it. Production sets it via the
+    # X-Forwarded-Proto: https header from Caddy. Asserting it here would
+    # fail-positive in the loopback test setup, so we don't.
+
+
+def test_verify_token_with_unknown_token_returns_401_invalid(deploy_server):
+    status, _, body = _post_json(
+        deploy_server, "/api/verify-token", {"token": "0" * 64}
+    )
+    assert status == 401
+    assert body == {"ok": False, "error": "invalid"}
+
+
+def test_verify_token_with_empty_token_returns_401_invalid(deploy_server):
+    status, _, body = _post_json(deploy_server, "/api/verify-token", {"token": ""})
+    assert status == 401
+    assert body == {"ok": False, "error": "invalid"}
+
+
+def test_verify_token_reuse_returns_invalid_on_second_call(deploy_server):
+    """Tokens are single-use. Two consumers of the same magic link must not
+    both end up with sessions."""
+    _post_json(
+        deploy_server, "/api/send-unlock", {"email": deploy_server["test_email"]}
+    )
+    token = _token_from_url(deploy_server["sent"][-1]["url"])
+    s1, _, b1 = _post_json(deploy_server, "/api/verify-token", {"token": token})
+    s2, _, b2 = _post_json(deploy_server, "/api/verify-token", {"token": token})
+    assert s1 == 200 and b1 == {"ok": True}
+    assert s2 == 401
+    assert b2 == {"ok": False, "error": "invalid"}
+
+
+def test_verify_token_after_ttl_expiry_returns_401_expired(deploy_server):
+    """Past-TTL tokens fail with the distinct ``expired`` error so the gate
+    can render the right banner. We inject a stale token directly into
+    AuthState rather than waiting 30 minutes."""
+    state = deploy_server["auth_state"]
+    expired_token = "deadbeef" * 8  # 64 hex chars
+    with state.lock:
+        # exp is ``time.time() + TOKEN_TTL`` at issue, so a value 10s in the
+        # past makes the token's ``exp < now`` branch fire in consume_token.
+        import time as _time
+
+        state.tokens[expired_token] = _time.time() - 10
+    status, _, body = _post_json(
+        deploy_server, "/api/verify-token", {"token": expired_token}
+    )
+    assert status == 401
+    assert body == {"ok": False, "error": "expired"}
+
+
+# --- Item 4: gated API after cookie --------------------------------------
+
+
+def test_directory_api_succeeds_with_session_cookie_and_fails_without(deploy_server):
+    _post_json(
+        deploy_server, "/api/send-unlock", {"email": deploy_server["test_email"]}
+    )
+    token = _token_from_url(deploy_server["sent"][-1]["url"])
+    _, vh, _ = _post_json(deploy_server, "/api/verify-token", {"token": token})
+    cookie = _extract_session_cookie(vh)
+    assert cookie is not None
+
+    # With cookie: 200 + non-empty list (the fixture seeds a copy of the dev
+    # fellows.db, which has 515 rows on the canonical Knack rebuild).
+    status, _, raw = _get(deploy_server, "/api/fellows", cookie=cookie)
+    assert status == 200
+    fellows = json.loads(raw)
+    assert isinstance(fellows, list)
+    assert len(fellows) > 0
+
+    # Without cookie: still 403, even after another request had a valid one.
+    status, _, _ = _get(deploy_server, "/api/fellows")
+    assert status == 403
+
+
+def test_protected_image_path_is_403_without_session(deploy_server):
+    """Per is_protected_data_path, /images/* is gated alongside /fellows.db."""
+    status, _, _ = _get(deploy_server, "/images/anyone.jpg")
+    assert status == 403
+
+
+# --- Item 6: rate limit --------------------------------------------------
+
+
+def test_send_unlock_rate_limit_silently_drops_after_three(deploy_server):
+    """Per RATE_MAX=3 in magic_link_auth: the 4th call still returns 200
+    {sent:true} (anti-enum), but Postmark is not invoked. This is the silent
+    failure mode that motivated the smoke-check hardening in PR #17."""
+    email = deploy_server["test_email"]
+    for _ in range(3):
+        s, _, b = _post_json(deploy_server, "/api/send-unlock", {"email": email})
+        assert s == 200 and b == {"sent": True}
+    assert len(deploy_server["sent"]) == 3
+
+    s4, _, b4 = _post_json(deploy_server, "/api/send-unlock", {"email": email})
+    assert s4 == 200 and b4 == {"sent": True}  # response shape unchanged
+    assert len(deploy_server["sent"]) == 3  # but no fourth send actually happened

--- a/tests/test_prod_stats.py
+++ b/tests/test_prod_stats.py
@@ -1,14 +1,22 @@
 """Unit tests for scripts/prod_stats.py.
 
 The script is stdlib-only and lives under scripts/ (not a package), so we
-load it by path. Tests exercise the pure functions (tally, disk_usage,
-print_human) against fixture MESSAGE strings — no real journalctl or SSH.
+load it by path. Tests exercise the pure functions (``tally``,
+``disk_usage``, ``print_human``, ``build_email_hash_index``,
+``resolve_recipients``, plus the small ``_entry_*`` helpers) against
+synthetic journald entries — no real journalctl or SSH.
+
+Fixtures match what ``journalctl -u fellows-pwa --since … -o json --no-pager``
+emits: each entry is a dict with at least ``MESSAGE`` and
+``__REALTIME_TIMESTAMP`` (microseconds since the epoch, as a string).
 """
+import hashlib
 import importlib.util
-import io
 import json
 import os
+import sqlite3
 import sys
+from datetime import datetime, timezone
 
 REPO_ROOT = os.path.dirname(os.path.dirname(os.path.abspath(__file__)))
 SCRIPT_PATH = os.path.join(REPO_ROOT, "scripts", "prod_stats.py")
@@ -18,84 +26,113 @@ prod_stats = importlib.util.module_from_spec(_spec)
 _spec.loader.exec_module(prod_stats)
 
 
-# ---- fixture: representative journald MESSAGE strings --------------------
+# ---- helpers -------------------------------------------------------------
 
-FIXTURE_MESSAGES = [
+def _entry(message: str, ts: str = "2026-04-23T10:17:00Z") -> dict:
+    """Synthesize a journald entry dict matching `journalctl -o json` output.
+
+    ``ts`` is an ISO-8601 Zulu string for readability; converted to
+    microseconds-since-epoch (string) the way real journald serializes
+    ``__REALTIME_TIMESTAMP``.
+    """
+    epoch_us = int(
+        datetime.fromisoformat(ts.replace("Z", "+00:00")).timestamp() * 1_000_000
+    )
+    return {"MESSAGE": message, "__REALTIME_TIMESTAMP": str(epoch_us)}
+
+
+def _sha256_hex(s: str) -> str:
+    return hashlib.sha256(s.encode("utf-8")).hexdigest()
+
+
+# ---- fixture: representative journald entries ----------------------------
+
+FIXTURE_ENTRIES = [
     # App-shell loads
-    '127.0.0.1 - - [23/Apr/2026 10:15:32] "GET / HTTP/1.1" 200 -',
-    '127.0.0.1 - - [23/Apr/2026 10:15:33] "GET /index.html HTTP/1.1" 200 -',
-    '127.0.0.1 - - [23/Apr/2026 10:16:01] "GET / HTTP/1.1" 304 -',
+    _entry('127.0.0.1 - - [23/Apr/2026 10:15:32] "GET / HTTP/1.1" 200 -'),
+    _entry('127.0.0.1 - - [23/Apr/2026 10:15:33] "GET /index.html HTTP/1.1" 200 -'),
+    _entry('127.0.0.1 - - [23/Apr/2026 10:16:01] "GET / HTTP/1.1" 304 -'),
     # Directory API (count both list and detail)
-    '127.0.0.1 - - [23/Apr/2026 10:15:34] "GET /api/fellows HTTP/1.1" 200 -',
-    '127.0.0.1 - - [23/Apr/2026 10:15:35] "GET /api/fellows?full=1 HTTP/1.1" 200 -',
-    '127.0.0.1 - - [23/Apr/2026 10:16:00] "GET /api/fellows/jane-doe HTTP/1.1" 200 -',
+    _entry('127.0.0.1 - - [23/Apr/2026 10:15:34] "GET /api/fellows HTTP/1.1" 200 -'),
+    _entry('127.0.0.1 - - [23/Apr/2026 10:15:35] "GET /api/fellows?full=1 HTTP/1.1" 200 -'),
+    _entry('127.0.0.1 - - [23/Apr/2026 10:16:00] "GET /api/fellows/jane-doe HTTP/1.1" 200 -'),
     # DB downloads
-    '127.0.0.1 - - [23/Apr/2026 10:15:36] "GET /fellows.db HTTP/1.1" 200 -',
+    _entry('127.0.0.1 - - [23/Apr/2026 10:15:36] "GET /fellows.db HTTP/1.1" 200 -'),
     # Magic-link verify: one success, one 401
-    '127.0.0.1 - - [23/Apr/2026 10:17:00] "POST /api/verify-token HTTP/1.1" 200 -',
-    '127.0.0.1 - - [23/Apr/2026 10:17:05] "POST /api/verify-token HTTP/1.1" 401 -',
+    _entry('127.0.0.1 - - [23/Apr/2026 10:17:00] "POST /api/verify-token HTTP/1.1" 200 -'),
+    _entry('127.0.0.1 - - [23/Apr/2026 10:17:05] "POST /api/verify-token HTTP/1.1" 401 -'),
     # 5xx error (should bucket under errors_5xx)
-    '127.0.0.1 - - [23/Apr/2026 10:18:00] "GET /api/stats HTTP/1.1" 500 -',
-    # Send-unlock structured events: two sent, one http_error
-    json.dumps({"event": "send_unlock_email", "result": "sent",
-                "email_hash_prefix": "deadbeef1234", "token_prefix": "aaaaaaaaaaaa",
-                "postmark": {"MessageID": "m1"}}),
-    json.dumps({"event": "send_unlock_email", "result": "sent",
-                "email_hash_prefix": "cafebabe5678", "token_prefix": "bbbbbbbbbbbb",
-                "postmark": {"MessageID": "m2"}}),
-    json.dumps({"event": "send_unlock_email", "result": "http_error",
-                "email_hash_prefix": "feedface9abc", "token_prefix": "cccccccccccc",
-                "status": 422}),
+    _entry('127.0.0.1 - - [23/Apr/2026 10:18:00] "GET /api/stats HTTP/1.1" 500 -'),
+    # Send-unlock structured events: two sent (distinct prefixes), one http_error.
+    # Distinct timestamps so first/last ordering is testable downstream.
+    _entry(
+        json.dumps({"event": "send_unlock_email", "result": "sent",
+                    "email_hash_prefix": "deadbeef1234", "token_prefix": "aaaaaaaaaaaa",
+                    "postmark": {"MessageID": "m1"}}),
+        ts="2026-04-23T10:17:00Z",
+    ),
+    _entry(
+        json.dumps({"event": "send_unlock_email", "result": "sent",
+                    "email_hash_prefix": "cafebabe5678", "token_prefix": "bbbbbbbbbbbb",
+                    "postmark": {"MessageID": "m2"}}),
+        ts="2026-04-23T10:17:02Z",
+    ),
+    _entry(
+        json.dumps({"event": "send_unlock_email", "result": "http_error",
+                    "email_hash_prefix": "feedface9abc", "token_prefix": "cccccccccccc",
+                    "status": 422}),
+        ts="2026-04-23T10:17:30Z",
+    ),
     # Noise that must not bump any counter
-    "Rate limit: send-unlock for hash prefix deadbeef1234",
-    '{"event": "build_meta", "build": {"built_at": "2026-04-23T09:00Z"}}',
-    "",
-    "not-a-log-line at all",
+    _entry("Rate limit: send-unlock for hash prefix deadbeef1234"),
+    _entry('{"event": "build_meta", "build": {"built_at": "2026-04-23T09:00Z"}}'),
+    _entry(""),
+    _entry("not-a-log-line at all"),
 ]
 
 
 # ---- tally() -------------------------------------------------------------
 
 def test_tally_counts_shell_loads():
-    stats = prod_stats.tally(FIXTURE_MESSAGES)
+    stats = prod_stats.tally(FIXTURE_ENTRIES)
     assert stats["shell_loads"] == 3
 
 
 def test_tally_counts_directory_api():
-    stats = prod_stats.tally(FIXTURE_MESSAGES)
+    stats = prod_stats.tally(FIXTURE_ENTRIES)
     # list + ?full=1 + detail
     assert stats["api_fellows"] == 3
 
 
 def test_tally_counts_db_downloads():
-    stats = prod_stats.tally(FIXTURE_MESSAGES)
+    stats = prod_stats.tally(FIXTURE_ENTRIES)
     assert stats["db_downloads"] == 1
 
 
 def test_tally_counts_magic_link_verifications():
-    stats = prod_stats.tally(FIXTURE_MESSAGES)
+    stats = prod_stats.tally(FIXTURE_ENTRIES)
     assert stats["magic_links_verified"] == 1
     assert stats["magic_links_verify_failed"] == 1
 
 
 def test_tally_counts_magic_links_sent_and_failures():
-    stats = prod_stats.tally(FIXTURE_MESSAGES)
+    stats = prod_stats.tally(FIXTURE_ENTRIES)
     assert stats["magic_links_sent"] == 2
     assert stats["magic_links_send_failed"] == {"http_error": 1}
 
 
 def test_tally_bucket_5xx_by_route():
-    stats = prod_stats.tally(FIXTURE_MESSAGES)
+    stats = prod_stats.tally(FIXTURE_ENTRIES)
     assert stats["errors_5xx"] == {"500 GET /api/stats": 1}
 
 
 def test_tally_ignores_build_meta_and_rate_limit_lines():
     # Inputs that look structured but aren't send_unlock_email must not count.
-    msgs = [
-        '{"event": "build_meta", "build": {"built_at": "x"}}',
-        "Rate limit: send-unlock for hash prefix deadbeef1234",
+    entries = [
+        _entry('{"event": "build_meta", "build": {"built_at": "x"}}'),
+        _entry("Rate limit: send-unlock for hash prefix deadbeef1234"),
     ]
-    stats = prod_stats.tally(msgs)
+    stats = prod_stats.tally(entries)
     assert stats["magic_links_sent"] == 0
     assert stats["shell_loads"] == 0
 
@@ -106,16 +143,95 @@ def test_tally_empty_input_returns_zeros():
     assert stats["magic_links_sent"] == 0
     assert stats["errors_5xx"] == {}
     assert stats["magic_links_send_failed"] == {}
+    assert stats["email_events_by_prefix"] == {}
 
 
 def test_tally_distinguishes_api_fellows_from_api_stats():
     # /api/stats must not be counted as /api/fellows.
-    msgs = [
-        '127.0.0.1 - - [x] "GET /api/stats HTTP/1.1" 200 -',
-        '127.0.0.1 - - [x] "GET /api/fellows HTTP/1.1" 200 -',
+    entries = [
+        _entry('127.0.0.1 - - [x] "GET /api/stats HTTP/1.1" 200 -'),
+        _entry('127.0.0.1 - - [x] "GET /api/fellows HTTP/1.1" 200 -'),
     ]
-    stats = prod_stats.tally(msgs)
+    stats = prod_stats.tally(entries)
     assert stats["api_fellows"] == 1
+
+
+# ---- _entry_message + _entry_ts (load-bearing helpers) -------------------
+
+def test_entry_message_returns_string_payload():
+    assert prod_stats._entry_message({"MESSAGE": "hello"}) == "hello"
+
+
+def test_entry_message_skips_byte_array_messages():
+    # journalctl emits MESSAGE as a list[int] for non-UTF8 payloads. The
+    # fellows-pwa server never emits those, so the helper deliberately
+    # skips them rather than trying to decode.
+    assert prod_stats._entry_message({"MESSAGE": [104, 105]}) is None
+
+
+def test_entry_message_handles_missing_key():
+    assert prod_stats._entry_message({}) is None
+
+
+def test_entry_ts_converts_microseconds_to_iso_z():
+    # 2026-04-23T10:17:00Z → epoch us
+    ts_iso = "2026-04-23T10:17:00Z"
+    epoch_us = int(
+        datetime.fromisoformat(ts_iso.replace("Z", "+00:00")).timestamp() * 1_000_000
+    )
+    out = prod_stats._entry_ts({"__REALTIME_TIMESTAMP": str(epoch_us)})
+    assert out == ts_iso
+
+
+def test_entry_ts_returns_none_on_missing_or_garbage():
+    assert prod_stats._entry_ts({}) is None
+    assert prod_stats._entry_ts({"__REALTIME_TIMESTAMP": "not-a-number"}) is None
+
+
+# ---- tally(): per-prefix send buckets with timestamps -------------------
+
+def test_tally_buckets_send_events_per_prefix_with_timestamps():
+    """Two events with the same hash prefix produce a single bucket
+    containing both events, each carrying its own timestamp. This is the
+    foundation prod-stats-long uses to compute first_ts/last_ts per
+    recipient — a regression here would silently break the recipient
+    list."""
+    entries = [
+        _entry(
+            json.dumps({"event": "send_unlock_email", "result": "sent",
+                        "email_hash_prefix": "abcdef012345"}),
+            ts="2026-04-23T10:00:00Z",
+        ),
+        _entry(
+            json.dumps({"event": "send_unlock_email", "result": "sent",
+                        "email_hash_prefix": "abcdef012345"}),
+            ts="2026-04-23T10:30:00Z",
+        ),
+        _entry(
+            json.dumps({"event": "send_unlock_email", "result": "http_error",
+                        "email_hash_prefix": "999999999999"}),
+            ts="2026-04-23T11:00:00Z",
+        ),
+    ]
+    stats = prod_stats.tally(entries)
+    by_prefix = stats["email_events_by_prefix"]
+    assert set(by_prefix.keys()) == {"abcdef012345", "999999999999"}
+    same_prefix = by_prefix["abcdef012345"]["events"]
+    assert len(same_prefix) == 2
+    assert {e["result"] for e in same_prefix} == {"sent"}
+    assert {e["ts"] for e in same_prefix} == {
+        "2026-04-23T10:00:00Z", "2026-04-23T10:30:00Z",
+    }
+    other = by_prefix["999999999999"]["events"]
+    assert len(other) == 1 and other[0]["result"] == "http_error"
+
+
+def test_tally_does_not_bucket_http_lines_under_email_events():
+    entries = [
+        _entry('127.0.0.1 - - [x] "GET /api/fellows HTTP/1.1" 200 -'),
+    ]
+    stats = prod_stats.tally(entries)
+    assert stats["email_events_by_prefix"] == {}
 
 
 # ---- disk_usage() --------------------------------------------------------
@@ -128,10 +244,102 @@ def test_disk_usage_shape():
     assert 0.0 <= disk["pct_used"] <= 100.0
 
 
+# ---- build_email_hash_index() -------------------------------------------
+
+def _make_fellows_db(path, rows):
+    """Create a minimal fellows.db at `path` with the columns build_email_hash_index reads."""
+    conn = sqlite3.connect(str(path))
+    try:
+        conn.execute(
+            "CREATE TABLE fellows ("
+            "  record_id TEXT PRIMARY KEY,"
+            "  name TEXT,"
+            "  contact_email TEXT"
+            ")"
+        )
+        conn.executemany(
+            "INSERT INTO fellows (record_id, name, contact_email) VALUES (?,?,?)",
+            rows,
+        )
+        conn.commit()
+    finally:
+        conn.close()
+
+
+def test_build_email_hash_index_joins_emails_to_fellows(tmp_path):
+    """Happy path: builds sha256-keyed dict with lowercased+trimmed emails.
+    Empty/null emails skipped. Always pass an explicit db_path so a stray
+    test never falls back to the production default
+    (/opt/fellows/deploy/dist/fellows.db)."""
+    db_path = tmp_path / "fellows.db"
+    _make_fellows_db(db_path, [
+        ("rec_1", "Alice Aardvark", "Alice@Example.com  "),  # mixed case + trailing ws
+        ("rec_2", "Bob Brown", "bob@example.com"),
+        ("rec_3", "Carol No-Email", ""),                      # skipped (empty)
+        ("rec_4", "Dana NULL", None),                          # skipped (NULL)
+    ])
+    idx = prod_stats.build_email_hash_index(db_path=str(db_path))
+    assert len(idx) == 2
+    expected_alice_key = _sha256_hex("alice@example.com")
+    expected_bob_key = _sha256_hex("bob@example.com")
+    assert idx[expected_alice_key] == {"email": "alice@example.com", "name": "Alice Aardvark"}
+    assert idx[expected_bob_key] == {"email": "bob@example.com", "name": "Bob Brown"}
+
+
+def test_build_email_hash_index_returns_empty_on_unopenable_db(tmp_path, capsys):
+    """Path under a nonexistent directory: sqlite3.connect raises
+    OperationalError; the function catches it and returns {}, plus a
+    note on stderr. Don't pass a path that points at a missing file in
+    an *existing* directory — sqlite3 silently creates an empty DB
+    there, which then crashes on the SELECT (a different code path)."""
+    bad_path = tmp_path / "nope" / "fellows.db"  # parent dir doesn't exist
+    out = prod_stats.build_email_hash_index(db_path=str(bad_path))
+    assert out == {}
+    err = capsys.readouterr().err
+    assert "Cannot open fellows DB" in err
+
+
+# ---- resolve_recipients() -----------------------------------------------
+
+def test_resolve_recipients_matches_prefix_and_sorts_newest_first():
+    """Recipient row resolution: prefix-prefix match against the hash
+    index, accumulated send count + timestamps, sorted newest last_ts
+    first. Unmatched prefixes still produce a row with email=None."""
+    alice_full = _sha256_hex("alice@example.com")  # 64 hex chars
+    bob_full = _sha256_hex("bob@example.com")
+    hash_index = {
+        alice_full: {"email": "alice@example.com", "name": "Alice"},
+        bob_full: {"email": "bob@example.com", "name": "Bob"},
+    }
+    email_events = {
+        alice_full[:12]: {"events": [
+            {"ts": "2026-04-23T10:00:00Z", "result": "sent"},
+            {"ts": "2026-04-23T10:30:00Z", "result": "sent"},
+        ]},
+        bob_full[:12]: {"events": [
+            {"ts": "2026-04-23T12:00:00Z", "result": "sent"},
+        ]},
+        "ffffffffffff": {"events": [  # no match
+            {"ts": "2026-04-23T11:00:00Z", "result": "http_error"},
+        ]},
+    }
+    rows = prod_stats.resolve_recipients(email_events, hash_index)
+    assert len(rows) == 3
+    # Sorted by last_ts desc → Bob (12:00), unknown (11:00), Alice (10:30).
+    assert rows[0]["email"] == "bob@example.com"
+    assert rows[0]["sent"] == 1
+    assert rows[0]["last_ts"] == "2026-04-23T12:00:00Z"
+    assert rows[1]["email"] is None and rows[1]["prefix"] == "ffffffffffff"
+    assert rows[2]["email"] == "alice@example.com"
+    assert rows[2]["sent"] == 2
+    assert rows[2]["first_ts"] == "2026-04-23T10:00:00Z"
+    assert rows[2]["last_ts"] == "2026-04-23T10:30:00Z"
+
+
 # ---- print_human() -------------------------------------------------------
 
 def test_print_human_includes_expected_sections(capsys):
-    stats = prod_stats.tally(FIXTURE_MESSAGES)
+    stats = prod_stats.tally(FIXTURE_ENTRIES)
     disk = {"path": "/", "total_gib": 25.0, "used_gib": 10.0,
             "free_gib": 15.0, "pct_used": 40.0}
     prod_stats.print_human(stats, disk, "24 hours ago", "fellows-pwa")
@@ -141,13 +349,38 @@ def test_print_human_includes_expected_sections(capsys):
     assert "Magic links sent:" in out
     assert "Disk (/)" in out
     assert "40.0%" in out
+    # Without recipients, the confidential block must NOT appear.
+    assert "Magic-link recipients" not in out
+
+
+def test_print_human_with_recipients_prints_confidential_block(capsys):
+    """When recipients are passed, print_human appends the recipient list
+    (header + each row). Header text is the contract; address presence
+    is the regression guard. Only synthetic emails here."""
+    disk = {"path": "/", "total_gib": 25.0, "used_gib": 10.0,
+            "free_gib": 15.0, "pct_used": 40.0}
+    recipients = [
+        {"prefix": "abcdef012345", "email": "alice@example.com", "name": "Alice",
+         "sent": 2, "results": {"sent": 2}, "first_ts": "2026-04-23T10:00:00Z",
+         "last_ts": "2026-04-23T10:30:00Z", "collisions": 0},
+    ]
+    prod_stats.print_human({
+        "shell_loads": 0, "api_fellows": 0, "db_downloads": 0,
+        "magic_links_sent": 2, "magic_links_send_failed": {},
+        "magic_links_verified": 0, "magic_links_verify_failed": 0,
+        "errors_5xx": {},
+    }, disk, "@0", "fellows-pwa", recipients=recipients)
+    out = capsys.readouterr().out
+    assert "Magic-link recipients" in out
+    assert "alice@example.com" in out
 
 
 # ---- main() + --json -----------------------------------------------------
 
 def test_main_json_output_parses(monkeypatch, capsys):
-    # Short-circuit journal_messages so the test doesn't shell out to journalctl.
-    monkeypatch.setattr(prod_stats, "journal_messages", lambda unit, since: FIXTURE_MESSAGES)
+    # Short-circuit journal_entries so the test doesn't shell out to journalctl.
+    monkeypatch.setattr(prod_stats, "journal_entries",
+                        lambda unit, since: FIXTURE_ENTRIES)
     rc = prod_stats.main(["--json", "--since", "1 hour ago"])
     assert rc == 0
     payload = json.loads(capsys.readouterr().out)
@@ -158,3 +391,5 @@ def test_main_json_output_parses(monkeypatch, capsys):
     assert set(payload["disk"].keys()) == {
         "path", "total_gib", "used_gib", "free_gib", "pct_used",
     }
+    # Internal per-prefix bucket must not leak into the public JSON.
+    assert "email_events_by_prefix" not in payload["requests"]


### PR DESCRIPTION
## Summary
Closes #18.

- New `deploy_server` pytest fixture runs `deploy/server.py` in-process on port 8766 with auth on, a tmp dist root, and `send_postmark_magic_link` monkeypatched at the function-reference level. No real Postmark token is consulted; no real email can be sent.
- 13 HTTP-only tests in `tests/test_deploy_auth_round_trip.py` cover items 1–4 + 6 from the issue: unauth 403, anti-enumeration on send-unlock, verify-token success/invalid/expired/empty/reuse, gated `/api/fellows` + `/images`, `RATE_MAX=3` silent-drop on the 4th call.
- 1 Playwright test in `tests/e2e/test_magic_link_standalone_unlock.py` covers item 5 — the PR #16 regression. Standalone display mode is emulated; `/#/unlock/<token>` must drive verify-token, land an `HttpOnly; SameSite=Strict` session cookie, and mount the directory (`#app-wrap` un-hidden, `#directory-list` attached).

## Why this exists
Before this PR, magic-link auth had **zero** end-to-end coverage. `tests/e2e/test_email_gate.py` mocks `/api/auth/status` via `context.route()` and never hits a real auth server. PR #16 (broken standalone unlock) and PR #17 (silent `/api/send-unlock` failures) were both regressions that would have been caught by the tests in this PR.

## Implementation notes
- **In-process, not subprocess**: the production server logs only the first 12 chars of an issued token, so a subprocess'd server gives tests no way to consume the token. Importing the module here lets the recorder capture the full magic-link URL.
- **No `chdir`**: an earlier draft of the fixture chdir'd into the tmp dist for `SimpleHTTPRequestHandler` to find static files. Because the fixture is session-scoped, that leaked into every later test and destabilized other e2e tests (intermittent failures in `test_detail_view`, `test_settings`). The fix uses `functools.partial(Handler, directory=…)` — same effect, no process-global side effect.
- **No new pip deps.** Stdlib `http.client` for the HTTP tests, existing Playwright for the e2e test.
- **Dev DB not touched.** The fixture copies (not symlinks) `app/fellows.db` into the tmp dist; the dev DB cannot be written to even via a hypothetical future code path.
- **`relationships.db` is not involved.** `deploy/server.py` doesn't expose groups/settings endpoints, so the user-data store is out of scope here.

## Test plan
- [x] `just test` passes 231/231 — two consecutive clean runs to confirm the chdir flake is gone.
- [x] `pytest tests/test_deploy_auth_round_trip.py -v` passes 13/13 in ~0.6s.
- [x] `pytest tests/e2e/test_magic_link_standalone_unlock.py -v` passes 1/1 in ~2s.
- [x] Verified `Set-Cookie` carries `HttpOnly`, `SameSite=Strict`, `Path=/`. `Secure` is environment-dependent (suppressed on localhost / `FELLOWS_COOKIE_INSECURE=1`); production sets it via `X-Forwarded-Proto: https` from Caddy and is unit-tested separately in `tests/test_magic_link_auth.py`.
- [x] No real Postmark calls: the recorder is asserted to be the only sender invoked.

🤖 Generated with [Claude Code](https://claude.com/claude-code)