### PR TITLE
feat(ui): copy-to-clipboard buttons next to mailto:/tel: links

### DIFF
--- a/app/static/app.js
+++ b/app/static/app.js
@@ -2739,8 +2739,23 @@
       }).join(', ');
       howRows.push(fieldRow('Key Links', linkHtml));
     }
-    if (fellow.contact_email) howRows.push(fieldRow('Contact Email', '<a href="mailto:' + escapeHtml(fellow.contact_email) + '">' + escapeHtml(fellow.contact_email) + '</a>'));
-    if (fellow.mobile_number) howRows.push(fieldRow('Mobile Number', escapeHtml(String(fellow.mobile_number))));
+    if (fellow.contact_email) {
+      var emailVal = String(fellow.contact_email);
+      howRows.push(fieldRow(
+        'Contact Email',
+        '<a href="mailto:' + escapeHtml(emailVal) + '">' + escapeHtml(emailVal) + '</a>' +
+          copyButton(emailVal, 'email')
+      ));
+    }
+    if (fellow.mobile_number) {
+      var phoneText = String(fellow.mobile_number).trim();
+      var phoneTel = phoneText.replace(/[^+\d]/g, '');
+      howRows.push(fieldRow(
+        'Mobile Number',
+        '<a href="tel:' + escapeHtml(phoneTel) + '">' + escapeHtml(phoneText) + '</a>' +
+          copyButton(phoneText, 'phone number')
+      ));
+    }
     if (fellow.cohort) howRows.push(fieldRow('Cohort', escapeHtml(fellow.cohort)));
     leftRest += section('How to Connect', tableFromRows(howRows));
 
@@ -3798,6 +3813,42 @@
     });
   }
 
+  // Inline 📋 button rendered next to mailto:/tel: links. The label is the
+  // noun ("email", "phone number") used for both the hover/aria title and
+  // the toast on success. A single delegated handler (wireCopyButtons,
+  // installed once at boot) reads data-copy and copies it.
+  function copyButton(value, label) {
+    if (value == null || String(value) === '') return '';
+    return ' <button type="button" class="copy-btn" data-copy="' +
+      escapeHtml(String(value)) + '" data-copy-label="' + escapeHtml(label) +
+      '" aria-label="Copy ' + escapeHtml(label) + '" title="Copy ' +
+      escapeHtml(label) + '">📋</button>';
+  }
+
+  // Single document-level click delegate for every .copy-btn the app
+  // renders (per-fellow rows, modal rows, group action bar). Idempotent —
+  // wireCopyButtons() is called once during init.
+  var copyButtonsWired = false;
+  function wireCopyButtons() {
+    if (copyButtonsWired) return;
+    copyButtonsWired = true;
+    document.addEventListener('click', function (ev) {
+      var btn = ev.target.closest && ev.target.closest('.copy-btn');
+      if (!btn) return;
+      ev.preventDefault();
+      var value = btn.getAttribute('data-copy') || '';
+      var label = btn.getAttribute('data-copy-label') || 'value';
+      if (!value) return;
+      copyToClipboard(value).then(
+        function () {
+          var ucfirst = label.charAt(0).toUpperCase() + label.slice(1);
+          showToast(ucfirst + ' copied');
+        },
+        function () { showToast('Copy failed'); }
+      );
+    });
+  }
+
   function renderGroupDetailPage(groupId) {
     if (!detailEl) return;
     detailEl.innerHTML = '<p class="placeholder">Loading group…</p>';
@@ -3852,6 +3903,17 @@
       var contactAttrs = '';
       if (initialHref) contactAttrs += ' href="' + escapeHtml(initialHref) + '"';
       if (!hasEmails) contactAttrs += ' aria-disabled="true" title="No email addresses available for this group"';
+      // Always-on "Copy email addresses" affordance. Sits on Row 1 next
+      // to the CC/BCC pill so users whose mailto: handler is broken or
+      // missing have an unconditional path to the addresses (no need to
+      // hit the recipient threshold to discover it).
+      var copyAttrs = '';
+      if (!hasEmails) {
+        copyAttrs += ' disabled aria-disabled="true" title="No email addresses available for this group"';
+      } else {
+        copyAttrs += ' title="Copy ' + escapeHtml(String(totalEmails)) +
+          ' email address' + (totalEmails === 1 ? '' : 'es') + ' to the clipboard"';
+      }
       html +=
         '<div class="group-action-bar">' +
           '<div class="group-action-row">' +
@@ -3862,6 +3924,9 @@
               '<button type="button" class="group-mode-pill group-mode-pill--active" data-mode="cc" aria-pressed="true">CC</button>' +
               '<button type="button" class="group-mode-pill" data-mode="bcc" aria-pressed="false">BCC</button>' +
             '</div>' +
+            '<button type="button" class="group-action-btn" id="group-action-copy-emails"' + copyAttrs + '>' +
+              '📋 Copy email addresses' +
+            '</button>' +
           '</div>' +
           '<div class="group-action-row">' +
             '<button type="button" class="group-action-btn" id="group-action-edit">✎ Edit members</button>' +
@@ -3870,18 +3935,19 @@
         '</div>';
 
       // Threshold banner. Soft warning between WARN and HARD, hard warning ≥ HARD.
+      // The "Copy email addresses" button on the action bar is always present;
+      // the banners now point users to it rather than carrying their own copy link.
       if (totalEmails >= GROUPS_CONTACT_HARD_AT) {
         html +=
           '<div class="group-contact-banner group-contact-banner--hard" role="status">' +
             escapeHtml(String(totalEmails)) + ' recipients — too many for one mailto: URL on most clients. ' +
-            '<a href="#" id="group-action-copy-emails">Copy ' + escapeHtml(String(totalEmails)) + ' addresses</a>' +
-            ' and paste them into your mail client manually.' +
+            'Use <b>Copy email addresses</b> above and paste into a new message.' +
           '</div>';
       } else if (totalEmails >= GROUPS_CONTACT_WARN_AT) {
         html +=
           '<div class="group-contact-banner group-contact-banner--soft" role="status">' +
             escapeHtml(String(totalEmails)) + ' recipients — long mailto: URLs may be truncated by some clients. ' +
-            '<a href="#" id="group-action-copy-emails">Copy addresses</a> if your client misbehaves.' +
+            'Use <b>Copy email addresses</b> above if your client misbehaves.' +
           '</div>';
       } else if (emailInfo.missing > 0 && totalEmails > 0) {
         html +=
@@ -4173,9 +4239,12 @@
       rowsHtml +=
         '<li class="fellow-modal-row">' +
           '<span class="fellow-modal-label">email</span>' +
-          '<a class="fellow-modal-value" href="mailto:' + escapeHtml(email) + '">' +
-            escapeHtml(email) +
-          '</a>' +
+          '<span class="fellow-modal-value">' +
+            '<a href="mailto:' + escapeHtml(email) + '">' +
+              escapeHtml(email) +
+            '</a>' +
+            copyButton(email, 'email') +
+          '</span>' +
         '</li>';
     }
     if (m.mobile_number) {
@@ -4184,9 +4253,12 @@
       rowsHtml +=
         '<li class="fellow-modal-row">' +
           '<span class="fellow-modal-label">phone</span>' +
-          '<a class="fellow-modal-value" href="tel:' + escapeHtml(phoneTel) + '">' +
-            escapeHtml(phoneText) +
-          '</a>' +
+          '<span class="fellow-modal-value">' +
+            '<a href="tel:' + escapeHtml(phoneTel) + '">' +
+              escapeHtml(phoneText) +
+            '</a>' +
+            copyButton(phoneText, 'phone number') +
+          '</span>' +
         '</li>';
     }
     if (Array.isArray(m.key_links_urls) && m.key_links_urls.length) {
@@ -5461,6 +5533,7 @@
   initClearCacheButton();
   initDiagnosticsPanel();
   initBugReportButtons();
+  wireCopyButtons();
 
   function bootDirectoryAsApp() {
     bootDebugLines.length = 0;

--- a/app/static/styles.css
+++ b/app/static/styles.css
@@ -1694,6 +1694,39 @@ body.route-group-edit #detail {
 }
 
 /* =========================================================================
+ * Inline 📋 copy button. Renders next to mailto: / tel: links on the
+ * fellow detail page and in the visual-directory contact modal. Subtle
+ * by default, full opacity on hover/focus. data-copy carries the value
+ * the delegated click handler writes to the clipboard.
+ * ========================================================================= */
+
+.copy-btn {
+  font: inherit;
+  font-size: 0.85em;
+  line-height: 1;
+  padding: 0 0.25em;
+  margin-left: 0.15em;
+  border: 0;
+  background: transparent;
+  color: inherit;
+  cursor: pointer;
+  opacity: 0.55;
+  vertical-align: baseline;
+  border-radius: 2px;
+}
+
+.copy-btn:hover,
+.copy-btn:focus-visible {
+  opacity: 1;
+  outline: none;
+}
+
+.copy-btn:focus-visible {
+  outline: 2px solid #4a2c6a;
+  outline-offset: 1px;
+}
+
+/* =========================================================================
  * Groups feature — PR 3: detail action bar, contact + export panel,
  * inline note edit, toast.
  * ========================================================================= */
@@ -2371,7 +2404,8 @@ a.group-action-btn--primary {
   word-break: break-word;
 }
 
-.fellow-modal-value[href] {
+.fellow-modal-value[href],
+.fellow-modal-value > a[href] {
   color: #0066cc;
   text-decoration: underline;
 }

--- a/docs/users_manual.md
+++ b/docs/users_manual.md
@@ -104,6 +104,11 @@ skip the install landing and go straight to the directory.
   scrolling is fast and works offline.
 - The visible-count text (e.g. **"142 of 515 fellows visible"**) shows how
   many fellows match your current search + filter.
+- **Copy contact info.** Every email and phone number on a fellow's profile
+  (and inside the visual-directory contact card) has a small **📋** button
+  next to it. Click it to copy that one value to your clipboard — handy if
+  your default mail client is misconfigured and the underlined link does
+  nothing when you click it.
 
 <!-- screenshot: directory view with search active and visible-count text -->
 
@@ -160,12 +165,15 @@ so you can concentrate on this one group.
 - **Note** — a free-text field below the member list. Edit inline; saves
   automatically.
 - **Action bar** (lavender), arranged in two rows:
-  - **Row 1 — ✉ Mail to the whole group** + a **CC/BCC** pill toggle.
-    Opens your default mail client with every member's email address
-    pre-filled (in CC by default; switch to BCC with the pill if you'd
-    rather members not see each other). Long member lists may be split
-    across multiple draft emails to fit your mail client's address-line
-    limit.
+  - **Row 1 — ✉ Mail to the whole group** + a **CC/BCC** pill toggle +
+    **📋 Copy email addresses**. *Mail* opens your default mail client
+    with every member's email address pre-filled (in CC by default;
+    switch to BCC with the pill if you'd rather members not see each
+    other). Long member lists may be split across multiple draft emails
+    to fit your mail client's address-line limit. *Copy email addresses*
+    puts the same comma-separated list on your clipboard — useful when
+    your mail client isn't set up to handle the Mail link, or when you
+    want to paste into a different tool.
   - **Row 2 — ✎ Edit members** + **⬇ Export a directory**. Edit
     members switches into edit mode (see below). Export opens the
     export panel inline (see below).

--- a/tests/e2e/test_copy_buttons.py
+++ b/tests/e2e/test_copy_buttons.py
@@ -1,0 +1,235 @@
+"""E2E for the copy-to-clipboard buttons next to mailto:/tel: links.
+
+Pins:
+- Fellow detail page: email row and mobile-number row each render a
+  `.copy-btn` whose `data-copy` matches the value in the link.
+- Visual-directory contact modal: same pattern.
+- Group detail action bar: a permanent `#group-action-copy-emails` button
+  is always rendered. Disabled when the group has no addresses; otherwise
+  click → toast + addresses on the clipboard.
+- The threshold banners no longer carry their own copy link (the action
+  bar button is the canonical affordance).
+"""
+from __future__ import annotations
+
+import json
+import re
+from http.client import HTTPConnection
+from urllib.parse import urlparse
+
+import pytest
+from playwright.sync_api import expect
+
+
+def _conn(base_url):
+    parsed = urlparse(base_url)
+    return HTTPConnection(parsed.hostname, parsed.port, timeout=10)
+
+
+def _fetch(base_url, path):
+    c = _conn(base_url)
+    c.request("GET", path)
+    r = c.getresponse()
+    body = r.read()
+    c.close()
+    if r.status != 200:
+        raise AssertionError(f"GET {path} → {r.status}")
+    return json.loads(body)
+
+
+def _wipe_groups(base_url):
+    groups = _fetch(base_url, "/api/groups")
+    for g in groups:
+        c = _conn(base_url)
+        c.request("DELETE", f"/api/groups/{g['id']}")
+        c.getresponse().read()
+        c.close()
+
+
+def _create_group(base_url, *, name, fellow_record_ids, note=""):
+    c = _conn(base_url)
+    payload = json.dumps({
+        "name": name,
+        "note": note,
+        "fellow_record_ids": fellow_record_ids,
+    }).encode("utf-8")
+    c.request(
+        "POST",
+        "/api/groups",
+        body=payload,
+        headers={"Content-Type": "application/json", "Content-Length": str(len(payload))},
+    )
+    r = c.getresponse()
+    body = r.read()
+    c.close()
+    assert r.status == 201, body
+    return json.loads(body)
+
+
+def _wait_for_directory(page):
+    page.locator("#loading").wait_for(state="hidden", timeout=10000)
+    page.locator("#app-wrap").wait_for(state="visible", timeout=5000)
+
+
+@pytest.fixture(autouse=True)
+def _reset_groups(base_url_fixture):
+    _wipe_groups(base_url_fixture)
+    yield
+
+
+class TestFellowDetailCopyButtons:
+    """Per-fellow copy icons next to mailto:/tel: links on the profile page."""
+
+    def test_email_row_has_copy_button_with_correct_value(
+        self, standalone_page, base_url_fixture
+    ):
+        page = standalone_page
+        # aaron_bird is the canonical detail-view fixture and is known to
+        # have both contact_email and mobile_number in the rebuilt DB.
+        fellow = _fetch(base_url_fixture, "/api/fellows/aaron_bird")
+        expected_email = fellow["contact_email"]
+        page.goto(f"{base_url_fixture}/#/fellow/aaron_bird", wait_until="domcontentloaded")
+        _wait_for_directory(page)
+        # The button sits inside the "Contact Email" row, immediately
+        # after the <a href="mailto:..."> link.
+        btn = page.locator(
+            f'#detail .copy-btn[data-copy="{expected_email}"]'
+        )
+        expect(btn).to_be_visible(timeout=5000)
+        expect(btn).to_have_attribute("data-copy-label", "email")
+        expect(btn).to_have_attribute("title", "Copy email")
+
+    def test_phone_row_has_copy_button_and_tel_link(
+        self, standalone_page, base_url_fixture
+    ):
+        page = standalone_page
+        fellow = _fetch(base_url_fixture, "/api/fellows/aaron_bird")
+        expected_phone = str(fellow["mobile_number"]).strip()
+        page.goto(f"{base_url_fixture}/#/fellow/aaron_bird", wait_until="domcontentloaded")
+        _wait_for_directory(page)
+        # tel: link wraps the display form (added in this PR — previously
+        # mobile_number was plain text).
+        tel_link = page.locator('#detail a[href^="tel:"]')
+        expect(tel_link).to_have_count(1, timeout=5000)
+        # Copy button carries the *display* form, not the digits-only tel: form.
+        btn = page.locator(
+            f'#detail .copy-btn[data-copy="{expected_phone}"]'
+        )
+        expect(btn).to_be_visible()
+        expect(btn).to_have_attribute("data-copy-label", "phone number")
+
+    def test_clicking_copy_button_writes_to_clipboard_and_toasts(
+        self, standalone_page, base_url_fixture, context
+    ):
+        # writeText needs explicit permission in headless Chromium.
+        context.grant_permissions(
+            ["clipboard-read", "clipboard-write"], origin=base_url_fixture
+        )
+        page = standalone_page
+        fellow = _fetch(base_url_fixture, "/api/fellows/aaron_bird")
+        expected_email = fellow["contact_email"]
+        page.goto(f"{base_url_fixture}/#/fellow/aaron_bird", wait_until="domcontentloaded")
+        _wait_for_directory(page)
+        page.locator(f'#detail .copy-btn[data-copy="{expected_email}"]').click()
+        toast = page.locator("#app-toast")
+        expect(toast).to_be_visible(timeout=3000)
+        expect(toast).to_have_text("Email copied")
+        clipboard = page.evaluate("navigator.clipboard.readText()")
+        assert clipboard == expected_email
+
+
+class TestGroupActionBarCopyButton:
+    """Permanent 'Copy email addresses' button next to CC/BCC."""
+
+    def test_button_is_present_and_enabled_for_group_with_emails(
+        self, standalone_page, base_url_fixture
+    ):
+        page = standalone_page
+        # Pull two real fellows (every fellow has contact_email in the
+        # canonical Knack rebuild).
+        fellows = _fetch(base_url_fixture, "/api/fellows?full=1")
+        chosen = [f for f in fellows if (f.get("contact_email") or "").strip()][:2]
+        g = _create_group(
+            base_url_fixture,
+            name="Copy button visible",
+            fellow_record_ids=[f["record_id"] for f in chosen],
+        )
+        page.goto(f"{base_url_fixture}/#/groups/{g['id']}", wait_until="domcontentloaded")
+        _wait_for_directory(page)
+        btn = page.locator("#group-action-copy-emails")
+        expect(btn).to_be_visible(timeout=5000)
+        expect(btn).to_be_enabled()
+        expect(btn).to_contain_text("Copy email addresses")
+        # Tooltip carries the recipient count.
+        expect(btn).to_have_attribute("title", re.compile(r"Copy 2 email addresses"))
+
+    def test_clicking_copies_all_addresses_and_toasts(
+        self, standalone_page, base_url_fixture, context
+    ):
+        context.grant_permissions(
+            ["clipboard-read", "clipboard-write"], origin=base_url_fixture
+        )
+        page = standalone_page
+        fellows = _fetch(base_url_fixture, "/api/fellows?full=1")
+        chosen = [f for f in fellows if (f.get("contact_email") or "").strip()][:5]
+        emails = [f["contact_email"].strip() for f in chosen]
+        g = _create_group(
+            base_url_fixture,
+            name="Copy click test",
+            fellow_record_ids=[f["record_id"] for f in chosen],
+        )
+        page.goto(f"{base_url_fixture}/#/groups/{g['id']}", wait_until="domcontentloaded")
+        _wait_for_directory(page)
+        page.locator("#group-action-copy-emails").click()
+        toast = page.locator("#app-toast")
+        expect(toast).to_be_visible(timeout=3000)
+        expect(toast).to_contain_text("addresses copied")
+        clipboard = page.evaluate("navigator.clipboard.readText()")
+        # All chosen emails must appear in the clipboard payload.
+        for e in emails:
+            assert e in clipboard, f"missing {e!r} in clipboard {clipboard!r}"
+
+    def test_button_renders_below_warn_threshold(
+        self, standalone_page, base_url_fixture
+    ):
+        """The button is permanent — it shows up even on small groups
+        where no threshold banner is present."""
+        page = standalone_page
+        fellows = _fetch(base_url_fixture, "/api/fellows?full=1")
+        chosen = [f for f in fellows if (f.get("contact_email") or "").strip()][:3]
+        g = _create_group(
+            base_url_fixture,
+            name="Three members",
+            fellow_record_ids=[f["record_id"] for f in chosen],
+        )
+        page.goto(f"{base_url_fixture}/#/groups/{g['id']}", wait_until="domcontentloaded")
+        _wait_for_directory(page)
+        # No threshold banner.
+        expect(page.locator(".group-contact-banner--soft")).to_have_count(0)
+        expect(page.locator(".group-contact-banner--hard")).to_have_count(0)
+        # But the copy button is there.
+        expect(page.locator("#group-action-copy-emails")).to_be_visible()
+
+    def test_threshold_banners_no_longer_carry_inline_copy_link(
+        self, standalone_page, base_url_fixture
+    ):
+        """Soft and hard banners now point at the action-bar button
+        instead of carrying their own copy link. Regression guard so
+        the new permanent button doesn't end up duplicated."""
+        page = standalone_page
+        fellows = _fetch(base_url_fixture, "/api/fellows?full=1")
+        chosen = [f for f in fellows if (f.get("contact_email") or "").strip()][:60]
+        assert len(chosen) == 60, "dev dataset must have ≥ 60 fellows with emails"
+        g = _create_group(
+            base_url_fixture,
+            name="Soft banner",
+            fellow_record_ids=[f["record_id"] for f in chosen],
+        )
+        page.goto(f"{base_url_fixture}/#/groups/{g['id']}", wait_until="domcontentloaded")
+        _wait_for_directory(page)
+        soft = page.locator(".group-contact-banner--soft")
+        expect(soft).to_be_visible(timeout=5000)
+        # No <a> inside the soft banner anymore.
+        expect(soft.locator("a")).to_have_count(0)
+        # Banner refers users to the (one) permanent button.
+        expect(soft).to_contain_text("Copy email addresses")


### PR DESCRIPTION
## Summary

- Adds an inline 📋 copy button next to every email and phone number on the fellow detail page and inside the visual-directory contact modal. Hover/aria title is `Copy email` / `Copy phone number`; click → toast + clipboard.
- Adds a permanent **📋 Copy email addresses** button to the group action bar (Row 1, next to CC/BCC). Disabled when the group has no addresses; otherwise click → toast + comma-separated emails on the clipboard.
- Removes the threshold-banner inline copy links (≥50 / ≥100 recipients) — the action-bar button is now the canonical copy affordance, and the banners point users to it.
- Wraps `mobile_number` in a `tel:` link on the fellow detail page (was previously plain text), matching the visual-directory modal.

Why: users with a misconfigured default mail handler (a surprisingly large slice on macOS / Linux) currently have no path to the email or phone — clicking the link does nothing. The 📋 button is the universal "give me the value" affordance.

Implementation:
- One small `copyButton(value, label)` HTML helper + one document-level delegated click handler (`wireCopyButtons`), both colocated with the existing `copyToClipboard` helper. Reuses the existing `showToast` and clipboard-with-execCommand-fallback machinery.
- The new permanent button reuses the existing `#group-action-copy-emails` ID, so the existing click handler in `renderGroupDetailPage` still wires it.
- One `.copy-btn` CSS rule, plus a small fix to `.fellow-modal-value > a[href]` since the modal's email/phone links now sit inside a span wrapper.

## Test plan

- [x] `just test-fast` — 64 passed
- [x] `just test -- tests/e2e/test_copy_buttons.py tests/e2e/test_groups_detail.py` — 16 passed (7 new + 9 pre-existing)
- [x] `just test-e2e` — 92 passed; 1 pre-existing flake in `test_click_aaron_bird_shows_detail` (race in directory-list click → detail panel resolution; passes on retry; doesn't touch any code in this PR)

## Manual QA for maintainer

- [ ] `just serve` and visit `#/fellow/aaron_bird`. Confirm 📋 button appears next to email and phone; click each → toast reads "Email copied" / "Phone number copied" and clipboard holds the value.
- [ ] Open the visual-directory modal from a group's directory grid. Same 📋 affordance for email and phone rows.
- [ ] Create a group with 3 fellows. Confirm `📋 Copy email addresses` button is present on Row 1 of the action bar, enabled, with tooltip `Copy 3 email addresses to the clipboard`. Click → toast + comma-separated emails on clipboard.
- [ ] Create a group with 60 fellows (soft threshold). Banner now reads `Use **Copy email addresses** above…` (no inline link). Action-bar button still works.
- [ ] Create a group with 120 fellows (hard threshold). Hard banner points to the same button. The Mail-button-copies-on-hard-threshold behavior is unchanged.
- [ ] Create a group with 0 emails (synthetic, or a fellow with no email). Confirm copy button is `disabled` with tooltip "No email addresses available for this group".

🤖 Generated with [Claude Code](https://claude.com/claude-code)