### PR TITLE
test(detail_view): rewrite test_click_aaron_bird_shows_detail with real assertions

### DIFF
--- a/tests/e2e/test_detail_view.py
+++ b/tests/e2e/test_detail_view.py
@@ -7,16 +7,26 @@ class TestDetailView:
     """Detail view: hash shows fellow detail; image or placeholder."""
 
     def test_click_aaron_bird_shows_detail(self, standalone_page, base_url_fixture):
+        """Click "Aaron Bird" in the directory list — URL updates to that fellow's
+        hash and the detail pane renders the heading, at least one field, and
+        the profile-image wrap."""
         standalone_page.goto(base_url_fixture + "/", wait_until="domcontentloaded")
         standalone_page.locator("#loading").wait_for(state="hidden", timeout=10000)
-        standalone_page.get_by_role("link", name="Aaron Bird").first.click()
+        standalone_page.locator("#directory").wait_for(state="visible", timeout=5000)
+        aaron_link = standalone_page.get_by_role("link", name="Aaron Bird").first
+        expect(aaron_link).to_be_visible()
+        aaron_link.click()
         standalone_page.wait_for_url("**/#/fellow/aaron_bird", timeout=5000)
         detail = standalone_page.locator("#detail")
         detail.wait_for(state="visible", timeout=5000)
-        assert "Aaron Bird" in detail.inner_text()
-        has_image = standalone_page.locator("#detail .profile-image").count() >= 1
-        has_placeholder = "No image" in detail.inner_text() or "Select a fellow" in detail.inner_text()
-        assert has_image or has_placeholder or "Aaron Bird" in detail.inner_text()
+        detail.get_by_role("heading", name="Aaron Bird").wait_for(
+            state="visible", timeout=5000
+        )
+        text = detail.inner_text()
+        assert any(
+            label in text for label in ["Tagline", "Cohort", "Type", "Email", "Based in", "Links"]
+        ), "Detail should show at least one field (Tagline, Cohort, Type, etc.)"
+        assert standalone_page.locator("#detail .profile-image-wrap").count() == 1
 
     def test_direct_hash_shows_fellow_detail(self, standalone_page, base_url_fixture):
         """Navigate to #/fellow/aaron_bird — name, at least one other field, image box present."""


### PR DESCRIPTION
## Summary

- The old `test_click_aaron_bird_shows_detail` was effectively a no-op: its image/placeholder OR-chain ended in `"Aaron Bird" in detail.inner_text()` — already asserted on the previous line — so the chain always passed.
- The image branch queried `.profile-image` (real class is `.profile-image-wrap`) and the placeholder branch checked for `"No image"` / `"Select a fellow"` — strings the app never renders. Both never matched anything; the test only "passed" via the tautology fall-through.
- Rewrite preserves the original intent (directory click → URL change → detail renders for that fellow) and applies the same DOM contract `test_direct_hash_shows_fellow_detail` already enforces: heading scoped to `#detail`, at least one field label, exactly one `.profile-image-wrap`. Also waits for `#directory` to be visible (not just `#loading` hidden) so the click target is reliably present.

## Test plan
- [x] `pytest tests/e2e/test_detail_view.py::TestDetailView::test_click_aaron_bird_shows_detail` — 10/10 green in repeat runs locally
- [x] `pytest tests/e2e/test_detail_view.py -v` — full file 12/12 green

🤖 Generated with [Claude Code](https://claude.com/claude-code)