### PR TITLE
ci(claude-review): grant write scopes so review summaries post inline

### DIFF
--- a/.github/workflows/claude-code-review.yml
+++ b/.github/workflows/claude-code-review.yml
@@ -21,8 +21,8 @@ jobs:
     runs-on: ubuntu-latest
     permissions:
       contents: read
-      pull-requests: read
-      issues: read
+      pull-requests: write
+      issues: write
       id-token: write
 
     steps:


### PR DESCRIPTION
## Summary

- The Claude Code Review workflow runs and produces a review (job log shows `"subtype": "success"` after ~2.5 min on PR #67's run), but the action's post step then logs **"No buffered inline comments"** and exits silently.
- Cause is the `permissions:` block: `pull-requests: read` and `issues: read` aren't enough for the workflow's `GITHUB_TOKEN` to create a PR review or post a conversation comment (PR conversation comments use the issues API). The model's output is generated and discarded.
- Confirmed empirically: `gh api repos/.../pulls/<n>/reviews` returns `[]` for every recent PR (59–67), and `gh pr list --json reviews` shows the same on each. No review summaries have been landing inline on any PR.
- Bumping both scopes to `write` restores the inline review summary.

## Test plan
- [ ] Merge this PR and watch its own Claude Code Review run — the summary should post on this PR's conversation thread (or on the next PR opened against `main`).
- [ ] After it does, sanity-check `gh api repos/richbodo/fellows_local_db/pulls/<this-pr>/reviews` returns a non-empty array.

🤖 Generated with [Claude Code](https://claude.com/claude-code)