### PR TITLE
feat(gate): multi-line diag block + bug-report correlation handle

### DIFF
--- a/README.md
+++ b/README.md
@@ -57,7 +57,7 @@ The origin of this app was [prt](https://github.com/richbodo/prt) and the next v
 
 `requirements-dev.txt` only covers dev/test tools (pytest, Playwright). The app runtime itself does not need them.
 
-> Commands below use the project's `just` command runner. See [`docs/justfile.md`](docs/justfile.md) for the full recipe list and what each one wraps. The long-form scripts still work — `just` is a shortcut, not a replacement.
+> Commands below use the project's `just` command runner. **Run `just` (or `just --list`) at the repo root for a grouped menu of every recipe**; run `just <recipe>` to invoke one (e.g. `just doctor`). Full reference with what each recipe wraps: [`docs/justfile.md`](docs/justfile.md). The long-form scripts still work — `just` is a shortcut, not a replacement.
 
 ### First-Time Setup (Developers)
 

--- a/app/static/app.js
+++ b/app/static/app.js
@@ -113,6 +113,9 @@
   var installStatusEl = document.getElementById('install-status');
   var iosHintEl = document.getElementById('install-ios-hint');
   var authDebugPrivateEl = document.getElementById('auth-debug-private');
+  var authDebugPrivatePreEl = document.getElementById('auth-debug-private-pre');
+  var authDebugPrivateCopyEl = document.getElementById('auth-debug-private-copy');
+  var authDebugPrivateCopyStatusEl = document.getElementById('auth-debug-private-copy-status');
   var authDebugInstallEl = document.getElementById('auth-debug-install');
   var gateReasonBannerEl = document.getElementById('gate-reason-banner');
   var installUnsupportedHintEl = document.getElementById('install-unsupported-hint');
@@ -152,6 +155,31 @@
   // lives in relationships.settings for durability across Clear App Cache;
   // localStorage is just a fast-read cache that boot mirrors from settings.
   var FELLOWS_SELF_EMAIL_KEY = 'fellows_self_email';
+
+  // Last gate submit, used as a correlation handle in the bug-report body
+  // and the gate diag block. Hash matches what deploy/server.py logs as
+  // email_hash_prefix in event=send_unlock_email, so a maintainer can join
+  // a user report to the journald entry without the email leaving the user.
+  var lastSubmitInfo = { emailHashPrefix: null, submittedAt: null };
+
+  function sha256HexBrowser(str) {
+    if (!(window.crypto && window.crypto.subtle && window.TextEncoder)) {
+      return Promise.resolve(null);
+    }
+    try {
+      var bytes = new TextEncoder().encode(str);
+      return window.crypto.subtle.digest('SHA-256', bytes).then(function (buf) {
+        var arr = new Uint8Array(buf);
+        var hex = '';
+        for (var i = 0; i < arr.length; i++) {
+          hex += (arr[i] < 16 ? '0' : '') + arr[i].toString(16);
+        }
+        return hex;
+      }).catch(function () { return null; });
+    } catch (e) {
+      return Promise.resolve(null);
+    }
+  }
 
   function getSelfEmail() {
     try { return localStorage.getItem(FELLOWS_SELF_EMAIL_KEY) || ''; }
@@ -1116,13 +1144,19 @@
       kind: 'api',
       getList: function () {
         return fetch('/api/fellows').then(function (r) {
-          if (!r.ok) throw apiError('/api/fellows', r.status);
+          if (!r.ok) {
+            pushBugReportError('http', 'GET /api/fellows → ' + r.status);
+            throw apiError('/api/fellows', r.status);
+          }
           return r.json();
         });
       },
       getFull: function () {
         return fetch('/api/fellows?full=1').then(function (r) {
-          if (!r.ok) throw apiError('/api/fellows?full=1', r.status);
+          if (!r.ok) {
+            pushBugReportError('http', 'GET /api/fellows?full=1 → ' + r.status);
+            throw apiError('/api/fellows?full=1', r.status);
+          }
           return r.json();
         });
       },
@@ -1744,6 +1778,13 @@
       lines.push('directoryDataSource: ' +
         (typeof directoryDataSource !== 'undefined' ? directoryDataSource : '(unset)'));
     } catch (e) {}
+    if (lastSubmitInfo.emailHashPrefix && lastSubmitInfo.submittedAt) {
+      // Join key into deploy/server.py's event=send_unlock_email log.
+      lines.push(
+        'last_submit: hash=' + lastSubmitInfo.emailHashPrefix +
+        '  at ' + lastSubmitInfo.submittedAt
+      );
+    }
     if (bugReportErrorRing.length === 0) {
       lines.push('recent errors: (none captured)');
     } else {
@@ -1968,6 +2009,7 @@
   function fetchFellowsDbWithProgress(onProgress) {
     return fetch('/fellows.db').then(function (r) {
       if (!r.ok) {
+        pushBugReportError('http', 'GET /fellows.db → ' + r.status);
         throw new Error('GET /fellows.db failed: HTTP ' + r.status);
       }
       var lenHeader = r.headers.get('Content-Length');
@@ -2181,6 +2223,7 @@
         })
         .catch(function (err) {
           logSwLifecycle('register_error', { message: err && err.message });
+          pushBugReportError('sw', 'register_error: ' + (err && err.message));
         });
     });
   }
@@ -2215,14 +2258,52 @@
     );
   }
 
+  // Multi-line diag for the email-gate block. Same fields the bug-report
+  // body uses, minus the recent-error ring — we keep the gate compact and
+  // expect the user to click "report a problem" if they need to send the
+  // full payload. last_submit appears only after a Send link click; that
+  // hash matches deploy/server.py's email_hash_prefix log so a maintainer
+  // can grep journald without the user having to disclose their address.
+  function formatGateDiagSummary(data, httpStatus) {
+    var lines = [];
+    lines.push('time:        ' + new Date().toISOString());
+    lines.push('auth:        ' + formatAuthDebugLine(data, httpStatus));
+    lines.push('app:         ' + FELLOWS_UI_DIAG);
+    var serverLabel = '(unknown)';
+    if (bootBuildMeta && (bootBuildMeta.git_sha || bootBuildMeta.built_at)) {
+      serverLabel = (bootBuildMeta.git_sha || '') +
+        (bootBuildMeta.built_at ? ' @ ' + bootBuildMeta.built_at : '');
+    }
+    lines.push('server:      ' + serverLabel);
+    lines.push('display:     ' + (isStandaloneDisplayMode() ? 'standalone' : 'browser-tab'));
+    try { lines.push('viewport:    ' + window.innerWidth + 'x' + window.innerHeight); } catch (e) {}
+    try { lines.push('online:      ' + Boolean(navigator.onLine)); } catch (e) {}
+    try { lines.push('language:    ' + String(navigator.language || '')); } catch (e) {}
+    try { lines.push('platform:    ' + String(navigator.platform || '')); } catch (e) {}
+    lines.push('userAgent:   ' + String(navigator.userAgent || ''));
+    if (lastSubmitInfo.emailHashPrefix && lastSubmitInfo.submittedAt) {
+      lines.push(
+        'last_submit: hash=' + lastSubmitInfo.emailHashPrefix +
+        '  at ' + lastSubmitInfo.submittedAt
+      );
+    }
+    return lines.join('\n');
+  }
+
   function showAuthDebugInstall(data, httpStatus) {
     if (authDebugPrivateEl) {
       authDebugPrivateEl.classList.add('hidden');
-      authDebugPrivateEl.textContent = '';
     }
+    if (authDebugPrivatePreEl) authDebugPrivatePreEl.textContent = '';
     if (authDebugInstallEl) {
       authDebugInstallEl.textContent = formatAuthDebugLine(data, httpStatus);
       authDebugInstallEl.classList.remove('hidden');
+    }
+  }
+
+  function renderAuthDebugPrivate(data, httpStatus) {
+    if (authDebugPrivatePreEl) {
+      authDebugPrivatePreEl.textContent = formatGateDiagSummary(data, httpStatus);
     }
   }
 
@@ -2232,9 +2313,57 @@
       authDebugInstallEl.textContent = '';
     }
     if (authDebugPrivateEl) {
-      authDebugPrivateEl.textContent = formatAuthDebugLine(data, httpStatus);
+      // Stash the latest payload so a later refresh (e.g. after a submit
+      // populates lastSubmitInfo) can rebuild the block in place.
+      authDebugPrivateEl._lastData = data;
+      authDebugPrivateEl._lastHttpStatus = httpStatus;
+      renderAuthDebugPrivate(data, httpStatus);
       authDebugPrivateEl.classList.remove('hidden');
     }
+  }
+
+  function refreshAuthDebugPrivate() {
+    if (!authDebugPrivateEl) return;
+    if (authDebugPrivateEl.classList.contains('hidden')) return;
+    renderAuthDebugPrivate(
+      authDebugPrivateEl._lastData || null,
+      authDebugPrivateEl._lastHttpStatus
+    );
+  }
+
+  function setAuthDebugCopyStatus(msg) {
+    if (!authDebugPrivateCopyStatusEl) return;
+    authDebugPrivateCopyStatusEl.textContent = msg || '';
+  }
+
+  function initAuthDebugCopyButton() {
+    if (!authDebugPrivateCopyEl || authDebugPrivateCopyEl._wired) return;
+    authDebugPrivateCopyEl._wired = true;
+    authDebugPrivateCopyEl.addEventListener('click', function () {
+      var text = (authDebugPrivatePreEl && authDebugPrivatePreEl.textContent) || '';
+      function fallback() {
+        try {
+          var sel = window.getSelection();
+          var range = document.createRange();
+          range.selectNodeContents(authDebugPrivatePreEl);
+          sel.removeAllRanges();
+          sel.addRange(range);
+          if (document.execCommand && document.execCommand('copy')) {
+            setAuthDebugCopyStatus('Copied.');
+            sel.removeAllRanges();
+            return;
+          }
+        } catch (e) {}
+        setAuthDebugCopyStatus('Copy failed — select the box above and copy manually.');
+      }
+      if (navigator.clipboard && navigator.clipboard.writeText) {
+        navigator.clipboard.writeText(text).then(function () {
+          setAuthDebugCopyStatus('Copied.');
+        }, fallback);
+      } else {
+        fallback();
+      }
+    });
   }
 
   function initBrowserInstallMode(authPayload, httpStatus) {
@@ -2349,24 +2478,44 @@
     if (authPayload) {
       showAuthDebugPrivate(authPayload, httpStatus != null ? httpStatus : 200);
     }
+    initAuthDebugCopyButton();
 
     if (unlockEmailFormEl && !unlockEmailFormEl._wired) {
       unlockEmailFormEl._wired = true;
       unlockEmailFormEl.addEventListener('submit', function (ev) {
         ev.preventDefault();
         var email = (unlockEmailInputEl && unlockEmailInputEl.value) || '';
+        var trimmed = email.trim();
         // Capture the user's own email for the export "email it to me"
         // feature (PR 5). Mirrors to relationships.settings on next boot.
         setSelfEmailLocal(email);
         if (unlockStatusEl) unlockStatusEl.textContent = 'Sending…';
         setGateReasonBanner('');
+        // Hash the submitted email locally so the bug-report and gate diag
+        // block carry a stable join key into deploy/server.py's journald
+        // event=send_unlock_email.email_hash_prefix without ever sending
+        // the address itself out-of-band.
+        var submittedAt = new Date().toISOString();
+        var hashPromise = trimmed
+          ? sha256HexBrowser(trimmed.toLowerCase())
+          : Promise.resolve(null);
+        hashPromise.then(function (hex) {
+          lastSubmitInfo = {
+            emailHashPrefix: hex ? hex.slice(0, 12) : null,
+            submittedAt: submittedAt
+          };
+          refreshAuthDebugPrivate();
+        });
         fetch('/api/send-unlock', {
           method: 'POST',
           headers: { 'Content-Type': 'application/json' },
           credentials: 'same-origin',
-          body: JSON.stringify({ email: email.trim() })
+          body: JSON.stringify({ email: trimmed })
         })
           .then(function (r) {
+            if (!r.ok) {
+              pushBugReportError('http', 'POST /api/send-unlock → ' + r.status);
+            }
             return r.json();
           })
           .then(function () {
@@ -2375,7 +2524,8 @@
                 'If that email is on file, you will receive a link shortly. Check your inbox.';
             }
           })
-          .catch(function () {
+          .catch(function (err) {
+            pushBugReportError('http', 'POST /api/send-unlock failed: ' + (err && err.message));
             if (unlockStatusEl) unlockStatusEl.textContent = 'Could not send. Try again later.';
           });
       });
@@ -2405,13 +2555,21 @@
             window.history.replaceState(null, '', '/#/');
             return;
           }
+          pushBugReportError(
+            'http',
+            'POST /api/verify-token → ' + r.status + ' error=' + (j && j.error)
+          );
           var reason = (j && j.error) === 'expired' ? 'expired' : 'invalid';
           window.location.replace('/?gate=1&reason=' + reason);
           // stall remaining chain — the replace will reload us
           return new Promise(function () {});
         });
       })
-      .catch(function () {
+      .catch(function (err) {
+        pushBugReportError(
+          'http',
+          'POST /api/verify-token failed: ' + (err && err.message)
+        );
         window.location.replace('/?gate=1&reason=invalid');
         return new Promise(function () {});
       });
@@ -2453,6 +2611,7 @@
           return new Promise(function () {});
         }
         if (!r.ok) {
+          pushBugReportError('http', 'GET /api/auth/status → ' + r.status);
           throw new Error('/api/auth/status failed with HTTP ' + r.status);
         }
         return r.json().then(function (data) {

--- a/app/static/index.html
+++ b/app/static/index.html
@@ -86,7 +86,11 @@
       <p class="install-lead install-lead--private">
         This is a private app for EHF Fellows. Enter your fellowship email to receive a sign-in link.
       </p>
-      <p id="auth-debug-private" class="auth-debug-line hidden" aria-live="polite"></p>
+      <div id="auth-debug-private" class="auth-debug-block hidden" role="region" aria-label="Diagnostics">
+        <pre id="auth-debug-private-pre" class="auth-debug-pre" aria-live="polite"></pre>
+        <button type="button" id="auth-debug-private-copy" class="auth-debug-copy">Copy diagnostics</button>
+        <span id="auth-debug-private-copy-status" class="auth-debug-copy-status" aria-live="polite"></span>
+      </div>
       <form id="unlock-email-form" class="unlock-email-form" action="#" method="post">
         <label class="unlock-label" for="unlock-email">Fellowship email</label>
         <input

--- a/app/static/styles.css
+++ b/app/static/styles.css
@@ -1131,6 +1131,46 @@ h1 {
   word-break: break-word;
 }
 
+.auth-debug-block {
+  margin: 0 0 0.75rem;
+  padding: 0.45rem 0.55rem;
+  text-align: left;
+  color: #3d3550;
+  background: #f3f0f8;
+  border: 1px solid #dcd6e8;
+  border-radius: 4px;
+}
+
+.auth-debug-pre {
+  margin: 0 0 0.4rem;
+  padding: 0;
+  font-size: 0.72rem;
+  line-height: 1.35;
+  font-family: ui-monospace, "Cascadia Code", Menlo, Monaco, Consolas, monospace;
+  white-space: pre-wrap;
+  word-break: break-word;
+}
+
+.auth-debug-copy {
+  font-size: 0.72rem;
+  padding: 0.2rem 0.55rem;
+  background: #e7e1f2;
+  color: #3d3550;
+  border: 1px solid #c8bedc;
+  border-radius: 4px;
+  cursor: pointer;
+}
+
+.auth-debug-copy:hover {
+  background: #ddd4ec;
+}
+
+.auth-debug-copy-status {
+  margin-left: 0.55rem;
+  font-size: 0.72rem;
+  color: #3d3550;
+}
+
 .sw-update-banner {
   margin: 0 0 0.75rem;
   padding: 0.5rem 0.75rem;

--- a/docs/justfile.md
+++ b/docs/justfile.md
@@ -5,8 +5,11 @@ scripts in `scripts/`, `build/`, `run.sh`, and the `ansible/` playbooks. It
 does not replace any of them — every recipe shells out to the underlying
 script. You can keep typing the long forms; `just` exists to save typing.
 
+**Discoverability:** run `just` (or `just --list`) at the repo root for a
+grouped menu of every recipe. Then `just <recipe>` invokes one. The rest
+of this doc is the long-form annotated reference for the same list.
+
 Install: `brew install just` (already present on the maintainer's laptop).
-Run `just` with no arguments for the live menu.
 
 ## Conventions
 

--- a/docs/users_manual.md
+++ b/docs/users_manual.md
@@ -362,6 +362,12 @@ to help.
   ask Rich.
 - **Install link expired or lost**: request a fresh one from the
   operator.
+- **Stuck at the email-gate page** (no link arriving, error on submit, or
+  any other "I can't get in"): the gate shows a small diagnostics block
+  below the form with your browser, OS, viewport, and the most recent
+  request. Click **Copy diagnostics** and paste it into your message
+  along with the time you tried — that's enough for us to find the
+  matching server-side log entry.
 
 ---
 

--- a/tests/e2e/test_bug_report.py
+++ b/tests/e2e/test_bug_report.py
@@ -1,6 +1,24 @@
-"""E2E: bug-report dialog (in-app + install-landing surfaces)."""
+"""E2E: bug-report dialog (in-app + install-landing + gate surfaces)."""
+import json
 import pytest
 from playwright.sync_api import expect
+
+
+def _mock_auth_status_for_gate(page):
+    page.route(
+        "**/api/auth/status",
+        lambda r: r.fulfill(
+            status=200,
+            content_type="application/json",
+            body=json.dumps({
+                "authEnabled": True,
+                "authenticated": False,
+                "hasSessionCookie": False,
+                "installRecentlyAllowed": False,
+            }),
+            headers={"X-Fellows-Build": "e2e-mock"},
+        ),
+    )
 
 
 class TestBugReportInApp:
@@ -101,3 +119,93 @@ class TestBugReportInstallLanding:
         assert "display: browser-tab" in body
         # Sync-only path means the in-app extra block is NOT appended
         assert "additional diagnostics" not in body
+
+
+class TestBugReportGate:
+    """Pre-app surface: email gate exposes the same inline 'report a problem' button."""
+
+    def test_gate_inline_button_includes_browser_and_no_submit_yet(
+        self, page, base_url_fixture
+    ):
+        _mock_auth_status_for_gate(page)
+        page.goto(base_url_fixture + "/", wait_until="domcontentloaded")
+        expect(page.locator("#install-gate-private")).to_be_visible()
+
+        page.locator("#bug-report-button-gate").click()
+        dialog = page.locator("#bug-report-dialog")
+        expect(dialog).to_be_visible()
+
+        body = page.locator("#bug-report-textarea").input_value()
+        assert "userAgent:" in body
+        assert "platform:" in body
+        assert "display: browser-tab" in body
+        assert "last_submit:" not in body  # nothing submitted yet
+
+    def test_gate_bug_report_includes_last_submit_correlation_handle(
+        self, page, base_url_fixture
+    ):
+        """Submit on the gate, then open the bug report — body must carry the
+        same hash+timestamp the server's event=send_unlock_email logs.
+        """
+        _mock_auth_status_for_gate(page)
+        page.route(
+            "**/api/send-unlock",
+            lambda r: r.fulfill(
+                status=200,
+                content_type="application/json",
+                body=json.dumps({"sent": True}),
+            ),
+        )
+        page.goto(base_url_fixture + "/", wait_until="domcontentloaded")
+        page.locator("#unlock-email").fill("foo@bar.com")
+        with page.expect_request("**/api/send-unlock"):
+            page.locator("#unlock-submit").click()
+        # Wait for the async sha256 to populate lastSubmitInfo.
+        page.wait_for_function(
+            "el => el && el.textContent && el.textContent.indexOf('last_submit:') !== -1",
+            arg=page.locator("#auth-debug-private-pre").element_handle(),
+            timeout=3000,
+        )
+
+        page.locator("#bug-report-button-gate").click()
+        body = page.locator("#bug-report-textarea").input_value()
+        assert "last_submit: hash=" in body
+
+        import re
+        # foo@bar.com → sha256 → 'b19d...' — assert the 12-hex shape, not value.
+        m = re.search(r"last_submit: hash=([0-9a-f]{12})\s+at\s+(\S+)", body)
+        assert m, f"expected last_submit line, got: {body[-400:]}"
+
+
+class TestBugReportHttpCapture:
+    """Boot-path non-2xx fetches push into the bug-report ring buffer so the
+    body shows users the server returned an error code (e.g. 404) — without
+    making them play journald-grep with the maintainer.
+    """
+
+    def test_404_on_api_fellows_appears_in_bug_report_body(
+        self, context, base_url_fixture
+    ):
+        page = context.new_page()
+        # Marker set + standalone fixture path forces app boot via API
+        # provider on dev (where fellows.db isn't fetched in OPFS by default).
+        page.add_init_script(
+            "window.localStorage.setItem('fellows_authenticated_once', '1');"
+        )
+        page.route(
+            "**/api/fellows*",
+            lambda r: r.fulfill(status=404, body="Not Found"),
+        )
+        try:
+            page.goto(base_url_fixture + "/", wait_until="domcontentloaded")
+            # Boot will fail; surfaces will switch to email gate fallback.
+            # Wait for some quiescence and then click the gate's bug-report
+            # button (which is reliably present in the gate fallback DOM).
+            page.locator("#install-gate-private").wait_for(
+                state="visible", timeout=5000
+            )
+            page.locator("#bug-report-button-gate").click()
+            body = page.locator("#bug-report-textarea").input_value()
+            assert "GET /api/fellows" in body and "→ 404" in body
+        finally:
+            page.close()

--- a/tests/e2e/test_email_gate.py
+++ b/tests/e2e/test_email_gate.py
@@ -218,6 +218,74 @@ class TestEmailGate:
         finally:
             page.close()
 
+    def test_gate_diag_block_renders_expected_fields(self, context, base_url_fixture):
+        """The gate's auth-debug block carries enough environment info to triage
+        an install/email-gate problem from a screenshot. Asserting the field
+        labels (rather than full values) keeps the test stable across
+        browsers/builds.
+        """
+        page = context.new_page()
+        try:
+            _mock_auth_status(page, authEnabled=True, authenticated=False)
+            page.goto(base_url_fixture + "/", wait_until="domcontentloaded")
+            block = page.locator("#auth-debug-private")
+            expect(block).to_be_visible()
+            pre = page.locator("#auth-debug-private-pre")
+            text = pre.inner_text()
+            assert "auth:" in text
+            assert "GET /api/auth/status → HTTP 200" in text
+            assert "authEnabled=True" in text or "authEnabled=true" in text
+            assert "app:" in text
+            assert "userAgent:" in text
+            assert "platform:" in text
+            assert "viewport:" in text
+            assert "display:" in text
+            # last_submit only appears after a Send link click — not yet.
+            assert "last_submit:" not in text
+            expect(page.locator("#auth-debug-private-copy")).to_be_visible()
+        finally:
+            page.close()
+
+    def test_gate_diag_block_includes_last_submit_after_send(self, context, base_url_fixture):
+        """Submitting the form populates a hash + ISO timestamp inside the diag
+        block. The hash matches deploy/server.py's email_hash_prefix
+        (sha256(email).slice(0,12)) so a maintainer can join a screenshot
+        to a journald event without the user disclosing their address.
+        """
+        import json
+
+        page = context.new_page()
+        try:
+            _mock_auth_status(page, authEnabled=True, authenticated=False)
+            page.route(
+                "**/api/send-unlock",
+                lambda r: r.fulfill(
+                    status=200,
+                    content_type="application/json",
+                    body=json.dumps({"sent": True}),
+                ),
+            )
+            page.goto(base_url_fixture + "/", wait_until="domcontentloaded")
+            page.locator("#unlock-email").fill("foo@bar.com")
+            with page.expect_request("**/api/send-unlock"):
+                page.locator("#unlock-submit").click()
+            # Wait for the post-submit refresh to land in the pre block.
+            pre = page.locator("#auth-debug-private-pre")
+            page.wait_for_function(
+                "el => el && el.textContent && el.textContent.indexOf('last_submit:') !== -1",
+                arg=pre.element_handle(),
+                timeout=3000,
+            )
+            text = pre.inner_text()
+            assert "last_submit: hash=" in text
+            # 12-hex prefix exactly.
+            import re
+
+            m = re.search(r"last_submit: hash=([0-9a-f]{12})\s+at\s+(\S+)", text)
+            assert m, f"expected last_submit hash+ts, got: {text}"
+        finally:
+            page.close()
+
     def test_back_to_gate_link_posts_logout_and_navigates(self, context, base_url_fixture):
         page = context.new_page()
 


### PR DESCRIPTION
## Summary

- Email gate now shows a multi-line diagnostics block (build sha, browser/OS, viewport, display mode, online status, ISO time) with a **Copy diagnostics** button. On submit, a `last_submit:` line appears with `sha256(email).slice(0,12)` + ISO timestamp — the same hash deploy/server.py logs as `email_hash_prefix` in `event=send_unlock_email`, so a maintainer can join a user's screenshot to a journald entry without the user disclosing their address.
- Bug-report body picks up the same `last_submit:` correlation handle automatically.
- Boot-path HTTP non-2xx responses (`/api/auth/status`, `/api/fellows[?full=1]`, `/fellows.db`, `/api/verify-token`, `/api/send-unlock`, SW `register_error`) now push into the bug-report ring buffer instead of being silently swallowed by `r.ok` branches. A user who got a 404 will see it in the body they paste.
- README + `docs/justfile.md` hoist `just` / `just --list` to the first sentence about the command runner; `docs/users_manual.md` now points stuck users at the Copy button.
- Tests: 5 new Playwright cases — gate diag block fields, gate diag `last_submit:` after Send, gate-specific bug-report inline button, gate bug-report includes correlation handle, 404-on-`/api/fellows` shows up in bug-report body.

## Test plan

Maintainer smoke (after pulling):
- [ ] `just test-fast` — unit + API + prod-stats green (64 tests).
- [ ] `just test-e2e "test_email_gate or test_bug_report"` — 20 tests green, including 5 new ones above.
- [ ] `just serve` then visit `http://localhost:8765/?gate=1` — the diag block renders with userAgent / platform / viewport / display / online; **Copy diagnostics** copies the multi-line text. (Localhost passthrough means the gate only renders with `?gate=1` or an `authEnabled:true` mock.)
- [ ] In a browser DevTools console, simulate a 404 on `/api/fellows` (via `fetch` override or a network panel block), reload, click "report a problem to the maintainer" on the gate, confirm the body contains `http: GET /api/fellows → 404`.
- [ ] Submit `foo@bar.com` on the gate; confirm `last_submit: hash=… at …` appears in the diag block, and that the same line shows up in the bug-report dialog body.

## Notes for the maintainer

The 12-hex prefix is small enough to be safe to paste in screenshots / chat (it's not reversible to an email) but unique enough to grep journald: `journalctl -u fellows-pwa | grep email_hash_prefix...ab12cd34ef56`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)