### PR TITLE
feat(prod-stats): 4xx counters + recent_errors + just prod-errors

### DIFF
--- a/docs/justfile.md
+++ b/docs/justfile.md
@@ -151,6 +151,12 @@ Export them or inline: `FELLOWS_BASE_URL=https://staging.example.com just smoke`
   `/opt/fellows/deploy/dist/fellows.db` and matching against the
   `email_hash_prefix` the server logs per send event. Treat output as
   confidential — it contains fellow email addresses.
+- **`prod-errors [SINCE]`** — focused triage view: prints just the 4xx +
+  5xx counters and the 10 most recent error access lines verbatim.
+  Default window `24 hours ago`. Use this when a user reports "I got a
+  404" / "I got a 403" — pair the timestamp they give you with the
+  recent-error block to find the matching access line. Wraps
+  `prod_stats --errors-only`.
 - **`prod-status`** — SSH + `systemctl status fellows-pwa caddy --no-pager`.
 - **`prod-env`** — dump remote `/etc/fellows/fellows-pwa.env` (prompts for
   sudo password — values shown raw for paste-ready rotation). Wraps

--- a/justfile
+++ b/justfile
@@ -313,6 +313,11 @@ prod-stats since="24 hours ago":
 prod-stats-long:
     ssh -p {{ssh_port}} {{ssh_user}}@{{host}} "/opt/fellows/bin/prod_stats --include-emails"
 
+# 4xx/5xx counters and the 10 most recent error access lines (default 24h).
+[group('prod')]
+prod-errors since="24 hours ago":
+    ssh -p {{ssh_port}} {{ssh_user}}@{{host}} "/opt/fellows/bin/prod_stats --errors-only --since '{{since}}'"
+
 # systemctl status fellows-pwa caddy.
 [group('prod')]
 prod-status:

--- a/scripts/prod_stats.py
+++ b/scripts/prod_stats.py
@@ -99,6 +99,9 @@ def _entry_ts(entry: dict) -> str | None:
         return None
 
 
+RECENT_ERRORS_CAP = 10
+
+
 def tally(entries) -> dict:
     """Count request categories, structured events, and per-hash send events."""
     shell_loads = 0
@@ -106,7 +109,12 @@ def tally(entries) -> dict:
     db_downloads = 0
     verify_ok = 0
     verify_fail = 0
+    errors_4xx: Counter = Counter()
     errors_5xx: Counter = Counter()
+    # All 4xx/5xx access lines, captured verbatim for `--errors-only` recall
+    # ("user said they got a 404 around 3pm — what happened?"). We over-collect
+    # here and trim at the end so the order of the input stream doesn't matter.
+    recent_errors_buf: list = []
     links_sent = 0
     links_send_failed: Counter = Counter()
     # hash_prefix -> {"events": [{"ts", "result"}, ...]}
@@ -159,6 +167,18 @@ def tally(entries) -> dict:
                 verify_fail += 1
         if status >= 500:
             errors_5xx[f"{status} {method} {path_no_query}"] += 1
+        elif status >= 400:
+            errors_4xx[f"{status} {method} {path_no_query}"] += 1
+        if status >= 400:
+            recent_errors_buf.append((ts or "", status, m))
+
+    # Newest first, capped. Sorts on ts then status so a tie on missing ts
+    # still gives a stable order rather than relying on input order.
+    recent_errors_buf.sort(key=lambda t: (t[0], t[1]), reverse=True)
+    recent_errors = [
+        {"ts": t, "status": s, "message": msg}
+        for (t, s, msg) in recent_errors_buf[:RECENT_ERRORS_CAP]
+    ]
 
     return {
         "shell_loads": shell_loads,
@@ -168,7 +188,9 @@ def tally(entries) -> dict:
         "magic_links_send_failed": dict(links_send_failed),
         "magic_links_verified": verify_ok,
         "magic_links_verify_failed": verify_fail,
+        "errors_4xx": dict(errors_4xx),
         "errors_5xx": dict(errors_5xx),
+        "recent_errors": recent_errors,
         "email_events_by_prefix": email_events,
     }
 
@@ -253,21 +275,38 @@ def resolve_recipients(email_events: dict, hash_index: dict) -> list:
 def print_human(
     stats: dict, disk: dict, since: str, unit: str,
     recipients: list | None = None,
+    errors_only: bool = False,
 ) -> None:
     print(f"== {unit} — since {since} ==")
-    print(f"  App-shell loads:         {stats['shell_loads']}")
-    print(f"  Directory API hits:      {stats['api_fellows']}")
-    print(f"  DB downloads:            {stats['db_downloads']}")
-    print(f"  Magic links sent:        {stats['magic_links_sent']}")
-    for result, count in sorted(stats["magic_links_send_failed"].items()):
-        print(f"    └─ send {result:12s} {count}")
-    print(f"  Magic links verified:    {stats['magic_links_verified']}")
-    if stats["magic_links_verify_failed"]:
-        print(f"  Magic links rejected:    {stats['magic_links_verify_failed']}")
+    if not errors_only:
+        print(f"  App-shell loads:         {stats['shell_loads']}")
+        print(f"  Directory API hits:      {stats['api_fellows']}")
+        print(f"  DB downloads:            {stats['db_downloads']}")
+        print(f"  Magic links sent:        {stats['magic_links_sent']}")
+        for result, count in sorted(stats["magic_links_send_failed"].items()):
+            print(f"    └─ send {result:12s} {count}")
+        print(f"  Magic links verified:    {stats['magic_links_verified']}")
+        if stats["magic_links_verify_failed"]:
+            print(f"  Magic links rejected:    {stats['magic_links_verify_failed']}")
+    total_4xx = sum(stats.get("errors_4xx", {}).values())
+    print(f"  4xx errors:              {total_4xx}")
+    for line, count in sorted(stats.get("errors_4xx", {}).items(), key=lambda kv: -kv[1])[:5]:
+        print(f"    └─ {line}: {count}")
     total_5xx = sum(stats["errors_5xx"].values())
     print(f"  5xx errors:              {total_5xx}")
     for line, count in sorted(stats["errors_5xx"].items(), key=lambda kv: -kv[1])[:5]:
         print(f"    └─ {line}: {count}")
+    if errors_only:
+        recent = stats.get("recent_errors") or []
+        print("")
+        print(f"-- {len(recent)} most recent error access line(s) --")
+        if not recent:
+            print("  (none in window)")
+        else:
+            for r in recent:
+                ts = r.get("ts") or "—"
+                print(f"  [{ts}] {r.get('message', '')}")
+        return
     print(
         f"  Disk ({disk['path']}):  "
         f"{disk['used_gib']:.1f} / {disk['total_gib']:.1f} GiB used "
@@ -320,6 +359,11 @@ def main(argv=None) -> int:
         "(joined against /opt/fellows/deploy/dist/fellows.db). When set and "
         "--since is omitted, the window defaults to '@0' (full journal).",
     )
+    parser.add_argument(
+        "--errors-only", action="store_true",
+        help="Print only 4xx/5xx counters and the most recent error access "
+        "lines. Useful for triaging a user-reported error code.",
+    )
     args = parser.parse_args(argv)
 
     if args.since is None:
@@ -348,7 +392,10 @@ def main(argv=None) -> int:
             payload["recipients"] = recipients
         print(json.dumps(payload, sort_keys=True))
     else:
-        print_human(public_stats, disk, args.since, args.unit, recipients=recipients)
+        print_human(
+            public_stats, disk, args.since, args.unit,
+            recipients=recipients, errors_only=args.errors_only,
+        )
     return 0
 
 

--- a/tests/test_prod_stats.py
+++ b/tests/test_prod_stats.py
@@ -126,6 +126,63 @@ def test_tally_bucket_5xx_by_route():
     assert stats["errors_5xx"] == {"500 GET /api/stats": 1}
 
 
+def test_tally_buckets_4xx_by_route_and_excludes_5xx():
+    """4xx access lines bucket separately from 5xx; verify-token 401 already
+    has its own counter (verify_fail) but should still also appear here so
+    the operator sees full per-status breakdown."""
+    entries = [
+        _entry('127.0.0.1 - - [x] "GET /api/fellows/missing HTTP/1.1" 404 -'),
+        _entry('127.0.0.1 - - [x] "GET /fellows.db HTTP/1.1" 403 -'),
+        _entry('127.0.0.1 - - [x] "GET /api/fellows/missing HTTP/1.1" 404 -'),
+        _entry('127.0.0.1 - - [x] "GET /api/stats HTTP/1.1" 500 -'),
+    ]
+    stats = prod_stats.tally(entries)
+    assert stats["errors_4xx"] == {
+        "404 GET /api/fellows/missing": 2,
+        "403 GET /fellows.db": 1,
+    }
+    # 5xx still bucketed independently.
+    assert stats["errors_5xx"] == {"500 GET /api/stats": 1}
+
+
+def test_tally_recent_errors_caps_and_orders_newest_first():
+    """recent_errors carries the verbatim access line for each 4xx/5xx,
+    sorted newest-first and capped at RECENT_ERRORS_CAP. This is what
+    `--errors-only` prints to support 'user reported a 404 at 3pm —
+    what was it?' triage."""
+    msgs = []
+    expected_total = prod_stats.RECENT_ERRORS_CAP + 3
+    for i in range(expected_total):
+        # Increment timestamp so sort order is well-defined.
+        ts = f"2026-04-23T10:{i:02d}:00Z"
+        msgs.append(_entry(f'127.0.0.1 - - [x] "GET /thing/{i} HTTP/1.1" 404 -', ts=ts))
+    # Sprinkle 200s — must NOT show up in recent_errors.
+    msgs.append(_entry('127.0.0.1 - - [x] "GET / HTTP/1.1" 200 -',
+                       ts="2026-04-23T11:00:00Z"))
+    stats = prod_stats.tally(msgs)
+    recent = stats["recent_errors"]
+    assert len(recent) == prod_stats.RECENT_ERRORS_CAP
+    # Newest first: i = expected_total-1 down to expected_total - CAP
+    assert "GET /thing/" + str(expected_total - 1) in recent[0]["message"]
+    assert recent[0]["status"] == 404
+    # All entries must be 4xx/5xx; no 200s
+    for r in recent:
+        assert r["status"] >= 400
+    # Strictly descending ts.
+    timestamps = [r["ts"] for r in recent]
+    assert timestamps == sorted(timestamps, reverse=True)
+
+
+def test_tally_recent_errors_empty_when_no_errors():
+    entries = [
+        _entry('127.0.0.1 - - [x] "GET / HTTP/1.1" 200 -'),
+        _entry('127.0.0.1 - - [x] "GET /api/fellows HTTP/1.1" 200 -'),
+    ]
+    stats = prod_stats.tally(entries)
+    assert stats["recent_errors"] == []
+    assert stats["errors_4xx"] == {}
+
+
 def test_tally_ignores_build_meta_and_rate_limit_lines():
     # Inputs that look structured but aren't send_unlock_email must not count.
     entries = [
@@ -368,11 +425,63 @@ def test_print_human_with_recipients_prints_confidential_block(capsys):
         "shell_loads": 0, "api_fellows": 0, "db_downloads": 0,
         "magic_links_sent": 2, "magic_links_send_failed": {},
         "magic_links_verified": 0, "magic_links_verify_failed": 0,
-        "errors_5xx": {},
+        "errors_4xx": {}, "errors_5xx": {},
     }, disk, "@0", "fellows-pwa", recipients=recipients)
     out = capsys.readouterr().out
     assert "Magic-link recipients" in out
     assert "alice@example.com" in out
+
+
+def test_print_human_errors_only_skips_unrelated_sections(capsys):
+    """In --errors-only mode, print_human prints just the 4xx/5xx counts
+    plus the most recent error access lines. The shell-loads / disk /
+    magic-link sections must NOT appear — that's the whole point of
+    "what just broke?" triage view."""
+    disk = {"path": "/", "total_gib": 25.0, "used_gib": 10.0,
+            "free_gib": 15.0, "pct_used": 40.0}
+    stats = {
+        "shell_loads": 99, "api_fellows": 99, "db_downloads": 99,
+        "magic_links_sent": 7, "magic_links_send_failed": {},
+        "magic_links_verified": 7, "magic_links_verify_failed": 0,
+        "errors_4xx": {"404 GET /thing": 3},
+        "errors_5xx": {"500 GET /api/stats": 1},
+        "recent_errors": [
+            {"ts": "2026-04-23T15:00:00Z", "status": 404,
+             "message": '127.0.0.1 - - [x] "GET /thing HTTP/1.1" 404 -'},
+        ],
+    }
+    prod_stats.print_human(stats, disk, "24 hours ago", "fellows-pwa",
+                           errors_only=True)
+    out = capsys.readouterr().out
+    assert "fellows-pwa" in out
+    assert "4xx errors:" in out and "404 GET /thing: 3" in out
+    assert "5xx errors:" in out and "500 GET /api/stats: 1" in out
+    # The verbatim recent line is the high-value signal.
+    assert "most recent error access line" in out
+    assert "/thing" in out and "2026-04-23T15:00:00Z" in out
+    # Sections that don't belong in errors-only must be absent.
+    assert "App-shell loads:" not in out
+    assert "Magic links sent:" not in out
+    assert "Disk (" not in out
+
+
+def test_print_human_errors_only_with_no_errors_says_so(capsys):
+    """Empty 4xx/5xx + recent_errors should still produce a clean report
+    (no crash, no blank section)."""
+    disk = {"path": "/", "total_gib": 25.0, "used_gib": 10.0,
+            "free_gib": 15.0, "pct_used": 40.0}
+    stats = {
+        "shell_loads": 0, "api_fellows": 0, "db_downloads": 0,
+        "magic_links_sent": 0, "magic_links_send_failed": {},
+        "magic_links_verified": 0, "magic_links_verify_failed": 0,
+        "errors_4xx": {}, "errors_5xx": {}, "recent_errors": [],
+    }
+    prod_stats.print_human(stats, disk, "24 hours ago", "fellows-pwa",
+                           errors_only=True)
+    out = capsys.readouterr().out
+    assert "4xx errors:              0" in out
+    assert "5xx errors:              0" in out
+    assert "(none in window)" in out
 
 
 # ---- main() + --json -----------------------------------------------------
@@ -391,5 +500,34 @@ def test_main_json_output_parses(monkeypatch, capsys):
     assert set(payload["disk"].keys()) == {
         "path", "total_gib", "used_gib", "free_gib", "pct_used",
     }
+    # 4xx + 5xx counters and recent-error list must be in the public JSON
+    # so an automated consumer (e.g. an oncall dashboard) can read them.
+    assert "errors_4xx" in payload["requests"]
+    assert "errors_5xx" in payload["requests"]
+    assert "recent_errors" in payload["requests"]
     # Internal per-prefix bucket must not leak into the public JSON.
     assert "email_events_by_prefix" not in payload["requests"]
+
+
+def test_main_errors_only_flag_routes_to_focused_view(monkeypatch, capsys):
+    """`--errors-only` switches the human output to the focused triage
+    view; it must NOT change the JSON path. Verifies the wiring from
+    argparse → print_human, not the body of print_human itself (which
+    has its own tests above)."""
+    error_entries = [
+        _entry('127.0.0.1 - - [x] "GET /missing HTTP/1.1" 404 -',
+               ts="2026-04-23T15:00:00Z"),
+        _entry('127.0.0.1 - - [x] "GET / HTTP/1.1" 200 -',
+               ts="2026-04-23T15:01:00Z"),
+    ]
+    monkeypatch.setattr(prod_stats, "journal_entries",
+                        lambda unit, since: error_entries)
+    rc = prod_stats.main(["--errors-only", "--since", "1 hour ago"])
+    assert rc == 0
+    out = capsys.readouterr().out
+    assert "4xx errors:" in out
+    assert "404 GET /missing: 1" in out
+    assert "most recent error access line" in out
+    # Non-error sections suppressed.
+    assert "App-shell loads:" not in out
+    assert "Disk (" not in out


### PR DESCRIPTION
## Summary

- `prod_stats.tally` buckets 4xx access lines (parallel to `errors_5xx`) and captures the verbatim message + ISO timestamp for every 4xx/5xx, capped at the 10 most recent. The default `prod-stats` output gains the 4xx breakdown.
- New `--errors-only` flag prints just the 4xx + 5xx counters and the recent-error block — focused triage view for "user said they got a 404 around 3pm — what was it?".
- New `just prod-errors [SINCE]` recipe (default `24 hours ago`) wraps `prod_stats --errors-only` over SSH.
- JSON output picks up `errors_4xx` and `recent_errors` as new public keys; the existing `errors_5xx` key is unchanged. `email_events_by_prefix` is still suppressed.
- 6 new tests in `tests/test_prod_stats.py`: 4xx bucketing, recent_errors cap+ordering, recent_errors empty case, errors-only output trimming, errors-only empty case, main() argparse wiring.
- `docs/justfile.md` documents the new recipe in the `prod` section.

## Test plan

- [ ] `just test-fast` — 70 tests green (was 64 before; +6 here).
- [ ] After deploying to prod (Ansible role auto-installs the updated script): `just prod-errors` returns the focused report. `just prod-errors '7 days ago'` widens the window. `just prod-stats` still works and now shows the 4xx breakdown.
- [ ] `just prod-stats --json` (manual: SSH + run by hand on droplet) returns `errors_4xx` and `recent_errors` keys.

## Notes for the maintainer

This stacks on top of #69 (gate diag block + bug-report correlation). Each PR is self-contained — Bundle 3 (this one) only touches `scripts/prod_stats.py`, `tests/test_prod_stats.py`, and the `justfile` / `docs/justfile.md`, so it can land in either order with no conflict.

The 4xx breakdown is what closes the loop with #69: a user clicks "report a problem" on the gate, their bug-report body includes `last_submit: hash=… at …` (#69), and `just prod-errors` (this PR) on the maintainer side surfaces the matching 4xx access line within seconds.

🤖 Generated with [Claude Code](https://claude.com/claude-code)