### PR TITLE
fix(auth): install-landing escape hatch + redeem guard (M1+M2)

### DIFF
--- a/app/static/app.js
+++ b/app/static/app.js
@@ -116,6 +116,7 @@
   var authDebugInstallEl = document.getElementById('auth-debug-install');
   var gateReasonBannerEl = document.getElementById('gate-reason-banner');
   var installUnsupportedHintEl = document.getElementById('install-unsupported-hint');
+  var installUseInTabEl = document.getElementById('install-use-in-tab');
   var backToGateLinkEl = document.getElementById('back-to-gate-link');
   var swUpdateBannerEl = document.getElementById('sw-update-banner');
   var swUpdateReloadEl = document.getElementById('sw-update-reload');
@@ -2317,6 +2318,21 @@
           });
       });
     }
+
+    // "Use the directory in this tab" — escape hatch for users whose browser
+    // never fires beforeinstallprompt (already-installed Chrome, engagement
+    // heuristic not yet met, etc.). Mirrors the path a returning user gets
+    // automatically via shouldActAsApp(): mark this origin as authenticated
+    // and boot the directory in the current tab.
+    if (installUseInTabEl && !installUseInTabEl._wired) {
+      installUseInTabEl._wired = true;
+      installUseInTabEl.addEventListener('click', function (ev) {
+        ev.preventDefault();
+        markAuthenticatedOnce();
+        if (installLandingEl) installLandingEl.classList.add('hidden');
+        bootDirectoryAsApp();
+      });
+    }
   }
 
   function setGateReasonBanner(reason) {
@@ -2389,6 +2405,21 @@
       return Promise.resolve();
     }
     var token = m[1];
+    // Guard against double-fire within the same tab. Magic-link tokens are
+    // single-use server-side, so a second POST returns "invalid" — which the
+    // user sees as "That link isn't valid." iOS Safari's bfcache restore and
+    // back/forward navigation can both resurrect a page with the original
+    // #/unlock/<tok> hash and re-run boot. sessionStorage is per-tab and
+    // cleared on tab close, so a fresh visit (new tab) always retries cleanly.
+    var redeemKey = 'redeeming:' + token;
+    try {
+      if (sessionStorage.getItem(redeemKey)) {
+        // Already in-flight or completed in this tab; strip hash, no-op.
+        window.history.replaceState(null, '', '/#/');
+        return Promise.resolve();
+      }
+      sessionStorage.setItem(redeemKey, String(Date.now()));
+    } catch (e) {}
     return fetch('/api/verify-token', {
       method: 'POST',
       headers: { 'Content-Type': 'application/json' },

--- a/app/static/index.html
+++ b/app/static/index.html
@@ -125,9 +125,17 @@
       <p id="install-ios-hint" class="install-ios-hint hidden">
         On iPhone or iPad: tap <strong>Share</strong>, then <strong>Add to Home Screen</strong>.
       </p>
-      <p id="install-unsupported-hint" class="install-unsupported-hint hidden">
-        Your browser doesn't support install. We don't want to run this as SaaS, so please use Chrome,
-        Edge, Safari, or any other browser that supports installing a progressive web app. Thanks.
+      <div id="install-unsupported-hint" class="install-unsupported-hint hidden">
+        <p class="install-unsupported-hint-lead">No install prompt yet. Two ways forward:</p>
+        <ul class="install-unsupported-hint-list">
+          <li>If you've already installed this app on this device, open it from your dock,
+              Applications folder, or home screen.</li>
+          <li>Otherwise, click <strong>use the directory in this tab</strong> below to start
+              using the app right now without installing.</li>
+        </ul>
+      </div>
+      <p class="install-use-in-tab">
+        <a href="#" id="install-use-in-tab" class="install-use-in-tab-link">Use the directory in this tab</a>
       </p>
       <p class="install-ttl-hint">Install within 30 minutes of requesting the link, or request a new one.</p>
       <p class="install-back-gate">

--- a/app/static/styles.css
+++ b/app/static/styles.css
@@ -1086,6 +1086,34 @@ h1 {
   text-align: left;
 }
 
+.install-unsupported-hint-lead {
+  margin: 0 0 0.4rem;
+  font-weight: 600;
+}
+
+.install-unsupported-hint-list {
+  margin: 0;
+  padding-left: 1.1rem;
+}
+
+.install-unsupported-hint-list li + li {
+  margin-top: 0.3rem;
+}
+
+.install-use-in-tab {
+  margin: 1rem 0 0;
+  font-size: 0.9rem;
+}
+
+.install-use-in-tab-link {
+  color: #4a2c6a;
+  text-decoration: underline;
+}
+
+.install-use-in-tab-link:hover {
+  color: #3d2460;
+}
+
 .install-back-gate {
   margin: 0.75rem 0 0;
   font-size: 0.85rem;

--- a/docs/users_manual.md
+++ b/docs/users_manual.md
@@ -46,8 +46,21 @@ install it anyway.  Do that.  Ask for help.
    background — you should see photos filling in over a minute or so on a
    normal connection.
 
-If you see a message saying your browser doesn't support install, try
-Chrome or Edge on desktop, or Safari on iOS.
+If clicking **Install app** doesn't bring up an install prompt, the
+landing page shows a hint with two options:
+
+- If you've already installed this app on this device, open it from your
+  dock, Applications folder, or home screen (the install prompt is
+  suppressed for already-installed PWAs).
+- Otherwise, click **Use the directory in this tab** below the install
+  button to start using the app immediately in the current browser tab.
+  Search, profiles, and groups all work — it just lives inside the
+  browser instead of as a standalone app icon.
+
+The "in tab" path is also a graceful fallback for older browsers that
+can't run the install prompt at all. You can always come back and try
+the install button later — your browser may need more engagement before
+it offers the prompt.
 
 ---
 

--- a/plans/auth_debug_improvements.md
+++ b/plans/auth_debug_improvements.md
@@ -1,0 +1,337 @@
+# Auth-flow debug improvements
+
+Triggered by two tester reports that exposed real failure modes in the
+email-gate / install-landing flow:
+
+- **Todd** (MacBook Pro, Chrome and Safari): clicked the email link,
+  hit the install landing, clicked **Install app**, got *"Your browser
+  doesn't support install"*. Later opened the bare URL from Slack — it
+  worked.
+- **Anne-Marie** (iOS, Apple Mail): clicked the email link, got
+  *"That link isn't valid. Enter your email to get a new one."*
+
+Two distinct bugs, separate root causes.
+
+---
+
+## Bugs
+
+### Bug A — install-landing dead-end (Todd)
+
+**Symptom:** "Your browser doesn't support install" on a browser that
+plainly does.
+
+**Root cause:** the `#install-unsupported-hint` text
+(`app/static/index.html:132-135`) is revealed by the click-fallback
+branch in `app/static/app.js:2426-2428` when `beforeinstallprompt`
+hasn't fired. The handler treats the missing event as a browser
+limitation, but on Chrome/Edge it's frequently caused by:
+
+1. PWA already installed on this profile (Chrome suppresses the event;
+   the comment at `app.js:2400-2407` already calls this out).
+2. Engagement heuristic not yet satisfied (Chrome may fire the prompt
+   later in the session).
+3. SW not yet activated on the very first load.
+
+The current copy blames the browser for all three.
+
+**Why it self-resolved for Todd later:** `startBrowserUx` calls
+`markAuthenticatedOnce()` at `app.js:2668` *before* it renders the
+install landing. So Todd's first verify-token success set
+`fellows_authenticated_once`. His later bare-URL visit hit
+`shouldActAsApp() === true` (`app.js:2125-2129`) and booted the
+directory directly. Discoverable by accident, not by design.
+
+### Bug B — Anne-Marie's "link isn't valid"
+
+**Symptom:** verify-token returned `error: "invalid"` (not "expired")
+and the gate banner read "That link isn't valid."
+
+**Root cause:** `consume_token`
+(`deploy/magic_link_auth.py:90-108`) returns `"invalid"` only when the
+token is **not in `AuthState.tokens` at consume time**. Distinct from
+"expired", which means it's still in the dict but past TTL. So her
+click wasn't late — the token was *gone* by the time the server saw
+it.
+
+Three plausible explanations, ranked by how cheaply we can confirm
+them:
+
+- **B1 — service restart between send and click.** `AuthState.tokens`
+  is process-local. Any `systemctl restart fellows-pwa` after issue
+  invalidates every outstanding token.
+- **B2 — bfcache restore / back-button replay re-fired
+  `tryUnlockFromHash`.** iOS Safari's bfcache can resurrect a page
+  with the original `#/unlock/<tok>` hash; second POST is "invalid"
+  because the first consumed the token.
+- **B3 — email-side scanner pre-consumed the token.** Less likely on
+  the current hash-based flow (scanners typically don't execute JS),
+  but iOS Mail / Outlook / corporate AV can vary.
+
+We'll run a journald check to disambiguate, but the fix space (M2 +
+M3 below) closes B2 and B3 regardless of which one bit her on the
+day.
+
+---
+
+## Improvements to ship
+
+Three independent changes, each one a net safety win, ordered by
+risk-adjusted value.
+
+### M1 — install-landing escape hatch (fixes Bug A)
+
+**Change:** replace the dead-end "browser doesn't support install"
+copy with a two-action message — open the already-installed app, *or*
+use the directory in this tab — and add an always-visible **use the
+directory in this tab** link to the install landing. Clicking the
+in-tab link calls `markAuthenticatedOnce()` and `bootDirectoryAsApp()`
+— the same path Todd discovered by accident from Slack.
+
+**Files:**
+- `app/static/index.html` — replace the `#install-unsupported-hint`
+  copy; add `#install-use-in-tab` button inside the hint.
+- `app/static/app.js` — wire the `use-in-tab` click in
+  `initBrowserInstallMode`. Make the unsupported-hint visible by
+  default (not just on click) on non-iOS browser-tab visits, so the
+  escape hatch is discoverable without clicking Install first.
+- `docs/users_manual.md` — note the new option in the *Installing the
+  app* section.
+
+**Risk:** low. Purely additive on UX. The Install button remains the
+primary affordance; the in-tab link is secondary. No state
+divergence — `markAuthenticatedOnce` is already called on the same
+code path today.
+
+**Test:** add an e2e in `tests/e2e/test_install_landing.py` that
+simulates a verify-token success in Chromium with `beforeinstallprompt`
+suppressed, clicks "use the directory in this tab", and asserts the
+directory renders. (Existing `tests/e2e/test_install_landing.py`
+covers the install-landing-rendered case; this extends it.)
+
+### M2 — client-side double-fire guard (mitigates Bug B2 and B3)
+
+**Change:** `tryUnlockFromHash` writes
+`sessionStorage['redeeming:<token>'] = Date.now()` before the POST.
+On entry it checks the key; if present, strip the hash and no-op.
+sessionStorage is per-tab and cleared on tab close, so a fresh
+visit always retries cleanly.
+
+```js
+function tryUnlockFromHash() {
+  var hash = window.location.hash || '';
+  var m = hash.match(/^#\/unlock\/(.+)$/);
+  if (!m) return Promise.resolve();
+  var token = m[1];
+  var key = 'redeeming:' + token;
+  try {
+    if (sessionStorage.getItem(key)) {
+      // Already in-flight or completed in this tab; strip and bail.
+      window.history.replaceState(null, '', '/#/');
+      return Promise.resolve();
+    }
+    sessionStorage.setItem(key, String(Date.now()));
+  } catch (e) {}
+  return fetch('/api/verify-token', { /* ...as today */ });
+}
+```
+
+**Files:** `app/static/app.js` (`tryUnlockFromHash`).
+
+**Risk:** low. sessionStorage is universally supported on browsers we
+already gate at OPFS (Chrome 102+, Safari 16.4+, Firefox 111+ — all
+predate sessionStorage by a decade). Worst-case failure is "tab can't
+re-redeem after restore" — the user opens the email link in a fresh
+tab and proceeds.
+
+**Test:** unit test pattern via Playwright e2e — load the unlock URL,
+intercept and *delay* `/api/verify-token`, fire a back-forward
+navigation that would re-trigger boot, assert only one POST was
+issued.
+
+### M3 — server-side grace window for re-consume (mitigates Bug B2 cross-tab and Bug B3)
+
+**Change:** in `deploy/magic_link_auth.py`, keep recently-consumed
+tokens in a small dict for `GRACE_WINDOW = 60` seconds with their
+`issued_at`. A second `consume_token` for the same token within that
+window returns `{"status": "ok", "issued_at": ...}` again — same
+session value, same install-window calculation.
+
+```python
+class AuthState:
+    lock = threading.Lock()
+    tokens: dict[str, float] = {}
+    consumed: dict[str, dict] = {}   # tok -> {issued_at, consumed_at}
+    rate_buckets: dict[str, list[float]] = {}
+
+GRACE_WINDOW = 60
+
+def consume_token(tok: str) -> dict:
+    now = time.time()
+    with AuthState.lock:
+        # Fast path: token still active.
+        exp = AuthState.tokens.pop(tok, None)
+        if exp is not None:
+            if exp < now:
+                return {"status": "expired"}
+            issued_at = exp - TOKEN_TTL
+            AuthState.consumed[tok] = {"issued_at": issued_at, "consumed_at": now}
+            return {"status": "ok", "issued_at": issued_at}
+        # Grace path: was consumed recently?
+        rec = AuthState.consumed.get(tok)
+        if rec and (now - rec["consumed_at"]) < GRACE_WINDOW:
+            return {"status": "ok", "issued_at": rec["issued_at"]}
+        # Drop stale grace records opportunistically.
+        if rec:
+            AuthState.consumed.pop(tok, None)
+        return {"status": "invalid"}
+```
+
+Add cleanup of `consumed` in `cleanup_stale_tokens()` (drop entries
+older than `GRACE_WINDOW`). Bound on memory: at most one grace entry
+per recent click — trivially small at this scale.
+
+**Files:** `deploy/magic_link_auth.py`, `tests/test_magic_link_auth.py`.
+
+**Risk discussion (the threat-model question, since we're widening the
+single-use property):**
+
+- *Today*: a leaked URL is single-use. First clicker wins. Passive
+  scanner that prefetches before the user → user gets "invalid."
+- *With M3*: a leaked URL is reusable for 60s by anyone who has it.
+  Passive scanner that prefetches before the user → user's click
+  within 60s succeeds.
+
+The realistic adversary scenarios:
+1. **Passive scanner** (corporate IT, AV). Prevalent; consumes the
+   token on prefetch; breaks the legit user. M3 makes this case
+   work, not break. **Net positive.**
+2. **Email-account compromise.** Attacker reading the user's mail
+   directly. They can request their own magic link; the 60s window
+   doesn't help them. **No change.**
+3. **URL leak to a co-located attacker** (same network, shoulder-surf,
+   forwarded screenshot). Attacker has 60s to also consume. Today,
+   they have one chance to beat the user; tomorrow, both succeed. The
+   attacker still needs the URL within 60s — not a meaningful
+   weakening compared to the existing 30-min token TTL during which
+   they could already race the user.
+
+Verdict: M3 is a net safety win in the threat model that actually
+applies to this product (small-audience directory, distribution by
+email, no high-value sessions).
+
+**Test plan:** `tests/test_magic_link_auth.py` — three new cases:
+1. Consume within grace window returns `ok` with the original
+   `issued_at`.
+2. Consume after grace window returns `invalid`.
+3. `cleanup_stale_tokens` drops `consumed` entries past
+   `GRACE_WINDOW`.
+
+---
+
+## Considered and rejected
+
+### Path-based magic-link routing (`/unlock/<tok>` → `303 /`)
+
+**Rejected.** The textbook pattern, but a worse fit here.
+
+- A server-handled GET-redeem is consumed by *any* prefetcher — not
+  just JS-running ones. Microsoft Safe Links, Outlook link preview,
+  and most corporate AV happily issue GETs. Today's hash-based flow
+  accidentally requires JS, which is mild but real scanner protection.
+- The only robust mitigation against GET prefetchers is a
+  **POST interstitial** ("Click here to continue") with a same-site
+  cookie. That's an extra click for users — UX-hostile and the kind
+  of thing testers complain about.
+- A meta-refresh redirect from `/unlock/<tok>` → `/unlock/redeem?t=...`
+  defeats simple GET prefetchers but not anything sophisticated;
+  leaky security theater.
+- With M2 + M3 in place, the hash flow's known failure modes
+  (bfcache replay, scanner consumption, double-click) are closed.
+
+So the rewrite would *create* a new failure mode (scanner consumption
+becomes worse) to *solve* problems we already solved another way.
+Doesn't clear the "catches more errors than it creates" bar.
+
+### Proactive `getInstalledRelatedApps()` detection on the install landing
+
+**Rejected for now.** Could potentially detect "PWA already installed
+on this device" and skip the install landing entirely. Promising but:
+- Chrome-only (Firefox / Safari don't implement).
+- Requires `related_applications` configured in the manifest.
+- Returns a Promise that resolves async — would need a loading state,
+  more complexity than M1's in-tab link gives us.
+
+If M1 doesn't fully resolve the dead-end after rollout, revisit as a
+Chrome-only enhancement.
+
+### Invalidate prior tokens on a new send
+
+The chat-thread reply implied this is how the system works
+(*"When you get a new link sent it invalidates any old links"*) —
+but `issue_token` (`magic_link_auth.py:82-87`) doesn't do it; old
+tokens stay valid until TTL or single-use consumption. **The current
+behavior matches the email-gate spec; the chat reply was wrong. No
+change.** If we ever want to enforce "newest send wins," that's a
+separate feature, not a debug fix.
+
+---
+
+## Investigation (run before committing M3)
+
+Confirm or rule out the restart theory for Bug B. Findings won't
+change whether we ship M3, but may downgrade urgency or surface a
+different root cause we haven't enumerated.
+
+```bash
+# 1. Service-state probe — was fellows-pwa restarted on the day of the report?
+ssh -p 52221 rsb@fellows.globaldonut.com \
+  'systemctl show fellows-pwa --property=ActiveEnterTimestamp,ActiveExitTimestamp,NRestarts'
+
+# 2. Window query around Anne-Marie's send (replace dates if her send wasn't on 2026-04-29):
+ssh -p 52221 rsb@fellows.globaldonut.com \
+  'journalctl -u fellows-pwa --since "2026-04-29 08:50" --until "2026-04-29 10:30" --no-pager'
+
+# 3. Anne-Marie's own send_unlock_email events (without typing her email here):
+EMAIL=$(sqlite3 app/fellows.db \
+  "SELECT contact_email FROM fellows WHERE name LIKE '%Anne-Marie%Brook%'")
+just email-debug '2026-04-29 08:50' "$EMAIL"
+```
+
+Decision tree on findings:
+
+- **`ActiveEnterTimestamp` is after Anne-Marie's send time** → Bug B1
+  confirmed. M3 still valuable; also opens a separate question about
+  token persistence across restarts (out of scope for this plan —
+  would need a small SQLite-backed token store).
+- **No restart, exactly one `send_unlock_email` with one
+  verify-token attempt that returned 401 invalid** → Bug B2 (bfcache
+  / replay) or Bug B3 (scanner). M2 + M3 close both.
+- **Multiple verify-token attempts close together** → Bug B2 confirmed.
+  M2 alone may be sufficient; M3 still cheap insurance.
+
+---
+
+## Rollout
+
+Two PRs, in this order:
+
+**PR-1: M1 + M2.** User-visible UX fix + cheap client guard. ~50 LoC
+plus doc and one e2e. Ship via `just ship`. Ask Todd to retry the
+flow that broke for him.
+
+**PR-2: M3.** Server-side change with unit tests. Ship via `just ship`.
+Ask Anne-Marie to retry on iOS.
+
+Both are non-breaking — old clients keep working; new clients pick up
+the improvements after the next SW activation cycle.
+
+---
+
+## Out of scope
+
+- Token persistence across server restarts (would solve Bug B1
+  durably). Material change to the auth model — separate plan.
+- Routing rewrite (see "Considered and rejected").
+- Any changes to the bug-reporter UX (the new bug-reporter shipping
+  this week will catch the next round of reports more cleanly).

--- a/tests/e2e/test_install_landing.py
+++ b/tests/e2e/test_install_landing.py
@@ -5,7 +5,23 @@ After issue #58 LOW #2, localhost browser-tab visits act as the app
 fresh localhost session through the install landing was confusing every
 time after Clear App Cache. The install landing still exists and is
 reachable via `?gate=1` (forces the email gate UI).
+
+The deploy_server-backed test classes at the bottom of this file cover:
+
+- TestInstallLandingEscape (M1): the "use the directory in this tab"
+  link rescues testers whose browser never fires `beforeinstallprompt`
+  (Todd's MacBook Pro Chrome case).
+- TestRedeemDoubleFireGuard (M2): tryUnlockFromHash's sessionStorage
+  guard prevents bfcache / back-button replay from re-POSTing a
+  single-use token (Anne-Marie iOS-class case).
 """
+from __future__ import annotations
+
+import json
+from http.client import HTTPConnection
+from urllib.parse import urlparse
+
+import pytest
 from playwright.sync_api import expect
 
 
@@ -29,3 +45,160 @@ class TestLocalhostBrowserTab:
         email_input = page.locator("input[type='email']").first
         expect(email_input).to_be_visible(timeout=5000)
         expect(page.locator("#app-wrap")).to_be_hidden()
+
+
+def _issue_token(deploy_server):
+    """Drive POST /api/send-unlock and return the token from the recorder."""
+    parsed = urlparse(deploy_server["base_url"])
+    body = json.dumps({"email": deploy_server["test_email"]}).encode("utf-8")
+    conn = HTTPConnection(parsed.hostname, parsed.port, timeout=3)
+    conn.request(
+        "POST",
+        "/api/send-unlock",
+        body=body,
+        headers={
+            "Content-Type": "application/json",
+            "Content-Length": str(len(body)),
+        },
+    )
+    conn.getresponse().read()
+    conn.close()
+    assert deploy_server["sent"], "stubbed Postmark recorder never fired"
+    return deploy_server["sent"][-1]["url"].rsplit("/#/unlock/", 1)[-1]
+
+
+@pytest.fixture
+def deploy_browser_page(context, deploy_server):
+    """Browser-tab Playwright page against the deploy server (no PWA standalone fake).
+
+    Auth state and recorder are reset per test so each starts clean.
+    """
+    page = context.new_page()
+    state = deploy_server["auth_state"]
+    with state.lock:
+        state.tokens.clear()
+        state.rate_buckets.clear()
+    deploy_server["sent"].clear()
+    try:
+        yield page
+    finally:
+        page.close()
+
+
+class TestInstallLandingEscape:
+    """M1: when the install landing renders for a verify-token success in a
+    browser tab, the 'use the directory in this tab' link must boot the
+    directory directly. Covers the case (Todd, MacBook Pro Chrome) where
+    `beforeinstallprompt` never fires — Chrome's engagement heuristic, an
+    already-installed PWA on the profile, or a SW that hasn't activated yet.
+    """
+
+    def test_use_in_tab_link_boots_directory(self, deploy_browser_page, deploy_server):
+        page = deploy_browser_page
+        token = _issue_token(deploy_server)
+
+        # 1. Land on the install landing by clicking the email link in a
+        #    browser tab. tryUnlockFromHash POSTs verify-token, the cookie
+        #    lands, startBrowserUx renders the install landing.
+        with page.expect_response(
+            lambda r: "/api/verify-token" in r.url and r.request.method == "POST",
+            timeout=8000,
+        ) as verify_info:
+            page.goto(
+                f"{deploy_server['base_url']}/#/unlock/{token}", wait_until="load"
+            )
+        assert verify_info.value.status == 200
+
+        # 2. Install landing visible; the use-in-tab link is the affordance
+        #    we're about to exercise.
+        page.wait_for_selector("#install-landing:not(.hidden)", timeout=4000)
+        use_in_tab = page.locator("#install-use-in-tab")
+        expect(use_in_tab).to_be_visible(timeout=2000)
+
+        # 3. Click it. Should: (a) hide the install landing, (b) boot the
+        #    directory (renderDirectory reveals #app-wrap once data lands),
+        #    (c) leave fellows_authenticated_once set so future bare-URL
+        #    visits skip the install landing automatically.
+        use_in_tab.click()
+        # #directory-list is static markup so we can't gate on its presence;
+        # wait on the visibility flip of #app-wrap which renderDirectory
+        # toggles only after data has actually rendered.
+        expect(page.locator("#app-wrap")).to_be_visible(timeout=8000)
+        expect(page.locator("#install-landing")).to_be_hidden()
+
+        marker = page.evaluate("localStorage.getItem('fellows_authenticated_once')")
+        assert marker == "1", "fellows_authenticated_once must be set so future visits skip the landing"
+
+
+class TestRedeemDoubleFireGuard:
+    """M2: a second tryUnlockFromHash invocation with the same token in the
+    same tab must skip the POST entirely. Covers iOS Safari bfcache restore
+    and back-button replay, where today the second POST returns 401 invalid
+    (the first already consumed the single-use token) and the user sees
+    'That link isn't valid' even though they did everything right.
+    """
+
+    def test_second_invocation_skips_verify_token_post(self, context, deploy_server):
+        page = context.new_page()
+        state = deploy_server["auth_state"]
+        with state.lock:
+            state.tokens.clear()
+            state.rate_buckets.clear()
+        deploy_server["sent"].clear()
+        try:
+            # Pre-seed the per-tab guard. The guard's contract: if
+            # sessionStorage['redeeming:<token>'] is already set when
+            # tryUnlockFromHash runs, skip the POST and strip the hash.
+            # add_init_script runs before app.js on every navigation, so the
+            # key is present by the time the IIFE evaluates.
+            page.add_init_script(
+                "sessionStorage.setItem('redeeming:double-fire-test-token', '1');"
+            )
+            verify_post_count = {"n": 0}
+
+            def _count(req):
+                if "/api/verify-token" in req.url and req.method == "POST":
+                    verify_post_count["n"] += 1
+
+            page.on("request", _count)
+
+            page.goto(
+                f"{deploy_server['base_url']}/#/unlock/double-fire-test-token",
+                wait_until="load",
+            )
+            # Give the boot path long enough to either fire or skip the POST.
+            page.wait_for_timeout(1000)
+
+            assert verify_post_count["n"] == 0, (
+                "Guard failed: tryUnlockFromHash POSTed even though the per-tab "
+                "redeeming marker was set"
+            )
+            # The hash must have been stripped — otherwise a subsequent
+            # navigation event could re-arm the loop.
+            assert "/unlock/" not in page.evaluate("location.hash")
+        finally:
+            page.close()
+
+    def test_first_invocation_still_posts_when_guard_absent(
+        self, deploy_browser_page, deploy_server
+    ):
+        """Sanity check: the guard only fires on second invocations. A fresh
+        tab with no pre-existing marker must still hit verify-token, otherwise
+        the guard would lock everyone out on first click."""
+        page = deploy_browser_page
+        token = _issue_token(deploy_server)
+
+        with page.expect_response(
+            lambda r: "/api/verify-token" in r.url and r.request.method == "POST",
+            timeout=8000,
+        ) as verify_info:
+            page.goto(
+                f"{deploy_server['base_url']}/#/unlock/{token}", wait_until="load"
+            )
+        assert verify_info.value.status == 200
+
+        # The guard should now have set the key for this token.
+        marker = page.evaluate(
+            "sessionStorage.getItem('redeeming:" + token + "')"
+        )
+        assert marker, "guard did not record the in-flight redeem"


### PR DESCRIPTION
## Summary

- **M1 — install-landing escape hatch.** Replace the dead-end "browser doesn't support install" copy with a two-action message and add an always-visible **Use the directory in this tab** link. Click → `markAuthenticatedOnce()` + `bootDirectoryAsApp()`, the same path returning users get automatically. Fixes Todd's report (MacBook Pro Chrome, install prompt suppressed because either Chrome's engagement heuristic isn't satisfied or the PWA is already installed on the profile).
- **M2 — sessionStorage redeem guard.** `tryUnlockFromHash` sets `sessionStorage['redeeming:<token>']` before the verify-token POST and skips the POST if the key is already set. Per-tab and cleared on tab close, so a fresh tab always retries cleanly. Defends against the iOS Safari bfcache / back-button replay path of Anne-Marie's "That link isn't valid" report.
- Plan and rejected alternatives (notably hash-routing rewrite — would make scanner consumption strictly worse) live in `plans/auth_debug_improvements.md`. M3 (server-side 60s grace window) is in a separate PR.

## Files

- `app/static/index.html`, `app/static/app.js`, `app/static/styles.css` — UI + handler.
- `docs/users_manual.md` — describe the new in-tab option.
- `tests/e2e/test_install_landing.py` — 3 new e2e cases.
- `plans/auth_debug_improvements.md` — planning doc.

## Automated test results pre-push

- 5/5 install-landing e2e (2 existing + 3 new for M1, M2 happy path, M2 first-invocation sanity).
- 19/19 auth-flow e2e (`test_install_landing` + `test_email_gate` + `test_magic_link_standalone_unlock` + `test_offline_only_mode`).
- 76/76 unit tests across DB / API / magic-link / round-trip / relationships.

## Manual QA for the maintainer

After merge + `just ship`:

- [ ] Visit `https://fellows.globaldonut.com/?gate=1` in a fresh Chrome incognito window, submit an allowlisted email, click the magic link in the resulting email. Install landing should render. Click **Use the directory in this tab** — should boot directly into the directory in the same tab.
- [ ] In the same window, navigate to `https://fellows.globaldonut.com/` (no `?gate=1`, no hash) — should now boot directly into the directory because `fellows_authenticated_once` is set.
- [ ] Repeat against an *already-installed* profile (Chrome where the PWA is installed). Click the email link in a regular browser tab. Click **Install app** — instead of the old "Your browser doesn't support install" copy, you should see the new two-option hint, and **Use the directory in this tab** should still work.
- [ ] iOS Safari: the install landing should still show the "Share → Add to Home Screen" hint as before; no regression for iOS.
- [ ] Bfcache replay smoke test (any browser): click email link, land on install landing, click browser **Back** then **Forward**. The verify-token POST should fire only once (check the Network tab). Without M2, the second POST returned 401 invalid and bounced you to the gate.