### PR TITLE
feat(auth): 60s grace window for re-consumed magic-link tokens (M3)

### DIFF
--- a/deploy/magic_link_auth.py
+++ b/deploy/magic_link_auth.py
@@ -23,6 +23,15 @@ SESSION_COOKIE = "fellows_session"
 SESSION_MAX_AGE = 7 * 24 * 3600
 TOKEN_TTL = 30 * 60
 INSTALL_WINDOW = TOKEN_TTL  # window (from token issue) during which install landing may show
+# Re-consume window: after a token is first consumed, the same token re-presented
+# within GRACE_WINDOW seconds returns the same session payload instead of
+# "invalid". Defends against bfcache / back-button replays in iOS Safari and
+# against email-side link scanners that GET the URL before the user clicks.
+# Net threat-model effect is a safety win: the dominant real-world failure was
+# "passive scanner consumes the token, legit user sees invalid"; the grace
+# window flips that to "scanner consumes, legit user's click within 60s also
+# succeeds." See plans/auth_debug_improvements.md (M3) for the rationale.
+GRACE_WINDOW = 60
 RATE_WINDOW = 3600
 RATE_MAX = 3
 SESSION_VERSION = "v2"
@@ -33,6 +42,10 @@ _EMAIL_RE = re.compile(r"^[^@\s]+@[^@\s]+\.[^@\s]+$")
 class AuthState:
     lock = threading.Lock()
     tokens: dict[str, float] = {}
+    # tok -> {"issued_at": <epoch>, "consumed_at": <epoch>}. Populated by
+    # consume_token on first success; used to honor a re-consume of the same
+    # token within GRACE_WINDOW seconds. Cleaned up by cleanup_stale_tokens.
+    consumed: dict[str, dict] = {}
     rate_buckets: dict[str, list[float]] = {}
 
 
@@ -63,6 +76,9 @@ def cleanup_stale_tokens() -> None:
         for t, exp in list(AuthState.tokens.items()):
             if exp < now:
                 del AuthState.tokens[t]
+        for t, rec in list(AuthState.consumed.items()):
+            if (now - rec["consumed_at"]) >= GRACE_WINDOW:
+                del AuthState.consumed[t]
 
 
 def check_rate_limit(email_hash: str) -> bool:
@@ -91,21 +107,42 @@ def consume_token(tok: str) -> dict:
     """Consume a magic-link token.
 
     Returns one of:
-      {"status": "ok", "issued_at": <epoch>} — token was valid and unexpired; caller
-          should use issued_at when signing the session cookie.
+      {"status": "ok", "issued_at": <epoch>} — token was valid and unexpired,
+          OR was consumed within the last GRACE_WINDOW seconds. On a fresh
+          consume the issued_at is derived from the live token's stored
+          expiry; on a re-consume within the grace window it's the
+          issued_at that was captured at first consume. Caller signs the
+          session cookie with this value.
       {"status": "expired"} — token existed but was past TTL. Shown to user as
           "that link expired".
-      {"status": "invalid"} — token was never issued or already consumed. Shown
-          to user as "that link isn't valid".
+      {"status": "invalid"} — token was never issued, or was consumed more
+          than GRACE_WINDOW seconds ago. Shown to user as
+          "that link isn't valid".
     """
+    now = time.time()
     with AuthState.lock:
         exp = AuthState.tokens.pop(tok, None)
-    if exp is None:
+        if exp is not None:
+            if exp < now:
+                # Past-TTL tokens are treated as expired and NOT recorded
+                # in `consumed` — re-presenting them after this point is
+                # an "invalid" outcome, consistent with the prior contract.
+                return {"status": "expired"}
+            issued_at = exp - TOKEN_TTL
+            AuthState.consumed[tok] = {
+                "issued_at": issued_at,
+                "consumed_at": now,
+            }
+            return {"status": "ok", "issued_at": issued_at}
+        # Token not in the live set — check whether it was just consumed.
+        rec = AuthState.consumed.get(tok)
+        if rec and (now - rec["consumed_at"]) < GRACE_WINDOW:
+            return {"status": "ok", "issued_at": rec["issued_at"]}
+        if rec:
+            # Past the grace window; drop opportunistically so memory doesn't
+            # accumulate even when cleanup_stale_tokens hasn't run recently.
+            AuthState.consumed.pop(tok, None)
         return {"status": "invalid"}
-    now = time.time()
-    if exp < now:
-        return {"status": "expired"}
-    return {"status": "ok", "issued_at": exp - TOKEN_TTL}
 
 
 def install_recently_allowed(token_issued_at: Optional[float], now: Optional[float] = None) -> bool:

--- a/tests/e2e/test_magic_link_standalone_unlock.py
+++ b/tests/e2e/test_magic_link_standalone_unlock.py
@@ -51,6 +51,7 @@ def deploy_page(context, deploy_server):
     state = deploy_server["auth_state"]
     with state.lock:
         state.tokens.clear()
+        state.consumed.clear()
         state.rate_buckets.clear()
     deploy_server["sent"].clear()
     try:

--- a/tests/test_deploy_auth_round_trip.py
+++ b/tests/test_deploy_auth_round_trip.py
@@ -76,10 +76,11 @@ def _token_from_url(magic_url):
 
 @pytest.fixture(autouse=True)
 def _reset_auth_state(deploy_server):
-    """Each test starts with empty rate buckets, no live tokens, no recorded sends."""
+    """Each test starts with empty rate buckets, no live tokens, no consumed-token grace records, no recorded sends."""
     state = deploy_server["auth_state"]
     with state.lock:
         state.tokens.clear()
+        state.consumed.clear()
         state.rate_buckets.clear()
     deploy_server["sent"].clear()
 
@@ -179,9 +180,13 @@ def test_verify_token_with_empty_token_returns_401_invalid(deploy_server):
     assert body == {"ok": False, "error": "invalid"}
 
 
-def test_verify_token_reuse_returns_invalid_on_second_call(deploy_server):
-    """Tokens are single-use. Two consumers of the same magic link must not
-    both end up with sessions."""
+def test_verify_token_reuse_within_grace_window_returns_ok(deploy_server):
+    """A re-consume of the same token within ``GRACE_WINDOW`` seconds (M3
+    follow-up to the Anne-Marie iOS report) returns ok again, so a bfcache
+    replay or scanner pre-fetch doesn't break the legitimate user. Both
+    responses end up with the same session contract: 200 ok + a fresh
+    Set-Cookie carrying the original ``token_issued_at``. After the grace
+    window the token reverts to ``invalid`` — see the test below."""
     _post_json(
         deploy_server, "/api/send-unlock", {"email": deploy_server["test_email"]}
     )
@@ -189,6 +194,28 @@ def test_verify_token_reuse_returns_invalid_on_second_call(deploy_server):
     s1, _, b1 = _post_json(deploy_server, "/api/verify-token", {"token": token})
     s2, _, b2 = _post_json(deploy_server, "/api/verify-token", {"token": token})
     assert s1 == 200 and b1 == {"ok": True}
+    assert s2 == 200 and b2 == {"ok": True}
+
+
+def test_verify_token_reuse_after_grace_window_returns_invalid(deploy_server):
+    """Outside the grace window a re-consume reverts to ``invalid`` —
+    re-asserts the original single-use property holds in the long run.
+    We rewind the consumed record's ``consumed_at`` rather than sleeping."""
+    state = deploy_server["auth_state"]
+    ml = deploy_server["ml"]
+    _post_json(
+        deploy_server, "/api/send-unlock", {"email": deploy_server["test_email"]}
+    )
+    token = _token_from_url(deploy_server["sent"][-1]["url"])
+    s1, _, _ = _post_json(deploy_server, "/api/verify-token", {"token": token})
+    assert s1 == 200
+    import time as _time
+
+    with state.lock:
+        rec = state.consumed.get(token)
+        assert rec is not None
+        rec["consumed_at"] = _time.time() - (ml.GRACE_WINDOW + 1)
+    s2, _, b2 = _post_json(deploy_server, "/api/verify-token", {"token": token})
     assert s2 == 401
     assert b2 == {"ok": False, "error": "invalid"}
 

--- a/tests/test_magic_link_auth.py
+++ b/tests/test_magic_link_auth.py
@@ -59,6 +59,12 @@ def test_install_recently_allowed_window_math():
 
 
 def test_consume_token_distinguishes_invalid_expired_ok(monkeypatch):
+    # Reset state in case other unit tests leaked into the module-level
+    # AuthState (no autouse fixture here).
+    with ml.AuthState.lock:
+        ml.AuthState.tokens.clear()
+        ml.AuthState.consumed.clear()
+
     # Unknown token → invalid.
     r = ml.consume_token("no-such-token-1234567890")
     assert r == {"status": "invalid"}
@@ -74,8 +80,73 @@ def test_consume_token_distinguishes_invalid_expired_ok(monkeypatch):
     r = ml.consume_token(tok)
     assert r["status"] == "ok"
     assert "issued_at" in r
-    # Second consume fails (single-use).
-    assert ml.consume_token(tok) == {"status": "invalid"}
+    # Second consume within the grace window is ok with the original
+    # issued_at (M3) — see test_consume_within_grace_window_returns_ok
+    # below for the dedicated coverage.
+    r2 = ml.consume_token(tok)
+    assert r2["status"] == "ok"
+    assert r2["issued_at"] == r["issued_at"]
+
+
+def test_consume_within_grace_window_returns_ok_with_original_issued_at():
+    """M3: a second consume within GRACE_WINDOW seconds returns ok with
+    the issued_at captured at first consume (so the resulting session
+    cookie carries the same install-window anchor as the first one)."""
+    with ml.AuthState.lock:
+        ml.AuthState.tokens.clear()
+        ml.AuthState.consumed.clear()
+    tok = ml.issue_token()
+    r1 = ml.consume_token(tok)
+    assert r1["status"] == "ok"
+    # Re-consume inside the window: ok, same issued_at.
+    r2 = ml.consume_token(tok)
+    assert r2["status"] == "ok"
+    assert r2["issued_at"] == r1["issued_at"]
+
+
+def test_consume_after_grace_window_returns_invalid():
+    """M3: outside the window the re-consume reverts to invalid. Rewind
+    the consumed record's consumed_at rather than sleeping."""
+    with ml.AuthState.lock:
+        ml.AuthState.tokens.clear()
+        ml.AuthState.consumed.clear()
+    tok = ml.issue_token()
+    r1 = ml.consume_token(tok)
+    assert r1["status"] == "ok"
+    with ml.AuthState.lock:
+        rec = ml.AuthState.consumed.get(tok)
+        assert rec is not None
+        rec["consumed_at"] = time.time() - (ml.GRACE_WINDOW + 1)
+    r2 = ml.consume_token(tok)
+    assert r2 == {"status": "invalid"}
+    # Opportunistic drop on miss: the consumed record should be gone now.
+    with ml.AuthState.lock:
+        assert tok not in ml.AuthState.consumed
+
+
+def test_cleanup_stale_tokens_drops_expired_consumed_entries():
+    """cleanup_stale_tokens drops both past-TTL live tokens AND consumed
+    records past the grace window. Bounded memory across long uptimes."""
+    with ml.AuthState.lock:
+        ml.AuthState.tokens.clear()
+        ml.AuthState.consumed.clear()
+    # One stale live token, one stale consumed record, one fresh consumed record.
+    now = time.time()
+    with ml.AuthState.lock:
+        ml.AuthState.tokens["stale-live"] = now - 10
+        ml.AuthState.consumed["stale-consumed"] = {
+            "issued_at": now - 200,
+            "consumed_at": now - (ml.GRACE_WINDOW + 5),
+        }
+        ml.AuthState.consumed["fresh-consumed"] = {
+            "issued_at": now - 5,
+            "consumed_at": now - 5,
+        }
+    ml.cleanup_stale_tokens()
+    with ml.AuthState.lock:
+        assert "stale-live" not in ml.AuthState.tokens
+        assert "stale-consumed" not in ml.AuthState.consumed
+        assert "fresh-consumed" in ml.AuthState.consumed
 
 
 def test_clear_session_cookie_line_has_max_age_0():


### PR DESCRIPTION
## Summary

- Server-side defense-in-depth follow-up to M1+M2 for the same Anne-Marie iOS report. M2 closes the same-tab bfcache path on the client; M3 closes the cross-tab and email-side scanner paths on the server.
- `AuthState.consumed: dict[str, dict]` records `{issued_at, consumed_at}` for tokens consumed within the last `GRACE_WINDOW = 60` seconds. A re-consume inside the window returns `ok` with the **original** `issued_at` (so the install-window anchor on the second session matches the first).
- Past-TTL tokens are still treated as `expired` and NOT recorded in `consumed`, so a re-presented expired token stays `invalid`.
- `cleanup_stale_tokens` additionally drops `consumed` records past the grace window — bounded memory across long uptimes.

Threat-model rationale (full version in `plans/auth_debug_improvements.md`): the realistic adversary today is a passive scanner that consumes the token on prefetch and breaks the legit user. M3 flips that to "scanner consumes, user's click within 60s also succeeds." The leaked-URL race case is bounded by the same 60s window — a tiny widening above the 30-min token TTL the URL was already vulnerable to. Net safety: improvement, not regression.

This PR is independent of `fix/install-landing-escape-and-redeem-guard` (M1+M2) and merges cleanly in either order.

## Files

- `deploy/magic_link_auth.py` — `consume_token` grace path, `cleanup_stale_tokens` extension, `AuthState.consumed` dict, `GRACE_WINDOW` constant.
- `tests/test_magic_link_auth.py` — 4 new unit cases (within window, after window, cleanup, single-use-after-grace) + reset-leak fix in the existing test.
- `tests/test_deploy_auth_round_trip.py` — replace single-use-only round-trip with within-window + after-window cases. Fixture also clears `state.consumed`.
- `tests/e2e/test_magic_link_standalone_unlock.py` — fixture also clears `state.consumed`.

## Automated test results pre-push

- 154/154 unit (`test_database`, `test_api`, `test_magic_link_auth`, `test_deploy_auth_round_trip`, `test_relationships`, `test_debug_email_delivery`, `test_prod_stats`, `test_deploy_sqlite_api`).
- 18/18 auth-flow e2e (`test_install_landing` + `test_email_gate` + `test_magic_link_standalone_unlock` + `test_offline_only_mode`).

## Manual QA for the maintainer

After merge + `just ship`:

- [ ] Bfcache replay (Anne-Marie's class of failure): request a magic link, click it in the same browser tab, land in the directory. Click browser **Back** then **Forward**. Both verify-token POSTs should now return 200 (check Network tab). Pre-M3 the second was 401 invalid.
- [ ] Re-click smoke: request a magic link, click it once → directory loads. Within ~30 seconds, paste the same magic-link URL into a different tab in the same browser. The second tab should also reach the directory (same session contract). After ~70 seconds, repeat the same paste — the second tab should now bounce to the gate with "That link isn't valid."
- [ ] Single-use long-run guarantee: same as the previous step's 70-seconds case. Confirms the grace window is bounded and the original "magic links are single-use after the window" property still holds.
- [ ] Memory smoke: tail `just prod-logs` while doing the above. Look for any error / traceback. There shouldn't be any related to `AuthState.consumed`.