### PR TITLE
feat(redesign): mobile shell — appbar, tabs, focus-mode, kebab sheet (PR 1 of 2)

### DIFF
--- a/app/static/app.js
+++ b/app/static/app.js
@@ -125,6 +125,15 @@
   var swUpdateBannerEl = document.getElementById('sw-update-banner');
   var swUpdateReloadEl = document.getElementById('sw-update-reload');
   var siteHeaderEl = document.getElementById('site-header');
+  // Mobile shell (≤1024px): appbar + tab strip + kebab sheet. Hidden on
+  // desktop via CSS, hidden during install/boot via the same .hidden
+  // toggle as siteHeaderEl. setShellVisible() keeps the three in lockstep.
+  var appbarEl = document.getElementById('appbar');
+  var appbarTitleEl = document.getElementById('appbar-title');
+  var appbarKebabEl = document.getElementById('appbar-kebab');
+  var tabsEl = document.getElementById('tabs');
+  var kebabSheetEl = document.getElementById('kebab-sheet');
+  var kebabScrimEl = document.getElementById('kebab-scrim');
   var deferredInstallPrompt = null;
   var directoryDataSource = 'api';
   var dataProvider = null;
@@ -1972,6 +1981,108 @@
     });
   }
 
+  // ===== Mobile shell: appbar + tabs + kebab sheet =======================
+  // Phase 3 of the mobile redesign (plans/mobile_redesign/). The appbar
+  // and tab strip are mobile-only persistent chrome (CSS hides them at
+  // >1024px). The kebab sheet consolidates the floating Diagnostics /
+  // Report bug / Clear App Cache controls into one bottom sheet on
+  // mobile; the same controls remain on screen at desktop widths.
+
+  function setShellVisible(visible) {
+    var hide = !visible;
+    if (siteHeaderEl) siteHeaderEl.classList.toggle('hidden', hide);
+    if (appbarEl) appbarEl.classList.toggle('hidden', hide);
+    if (tabsEl) tabsEl.classList.toggle('hidden', hide);
+  }
+
+  function setShellChrome(routeKey, title) {
+    if (appbarTitleEl && typeof title === 'string' && title) {
+      appbarTitleEl.textContent = title;
+    }
+    if (tabsEl) {
+      var tabs = tabsEl.querySelectorAll('.tabs__tab');
+      for (var i = 0; i < tabs.length; i++) {
+        var t = tabs[i];
+        t.classList.toggle('tabs__tab--active', t.getAttribute('data-tab') === routeKey);
+      }
+    }
+  }
+
+  function isKebabSheetOpen() {
+    return !!(kebabSheetEl && !kebabSheetEl.classList.contains('hidden'));
+  }
+
+  function openKebabSheet() {
+    if (!kebabSheetEl) return;
+    // Mirror the current build-badge values into the sheet so users on
+    // mobile (where the badge is hidden) still see what they're running.
+    var appBadge = document.getElementById('build-badge-client');
+    var serverBadge = document.getElementById('build-badge-server');
+    var appOut = document.getElementById('kebab-sheet-build-app');
+    var serverOut = document.getElementById('kebab-sheet-build-server');
+    if (appOut && appBadge) appOut.textContent = (appBadge.textContent || '').replace(/^app:\s*/, '');
+    if (serverOut && serverBadge) serverOut.textContent = (serverBadge.textContent || '').replace(/^server:\s*/, '');
+    kebabSheetEl.classList.remove('hidden');
+    kebabSheetEl.removeAttribute('hidden');
+    if (kebabScrimEl) {
+      kebabScrimEl.classList.remove('hidden');
+      kebabScrimEl.removeAttribute('hidden');
+    }
+    if (appbarKebabEl) appbarKebabEl.setAttribute('aria-expanded', 'true');
+  }
+
+  function closeKebabSheet() {
+    if (!kebabSheetEl) return;
+    kebabSheetEl.classList.add('hidden');
+    kebabSheetEl.setAttribute('hidden', '');
+    if (kebabScrimEl) {
+      kebabScrimEl.classList.add('hidden');
+      kebabScrimEl.setAttribute('hidden', '');
+    }
+    if (appbarKebabEl) appbarKebabEl.setAttribute('aria-expanded', 'false');
+  }
+
+  function initKebabSheet() {
+    if (!appbarKebabEl || !kebabSheetEl) return;
+    appbarKebabEl.addEventListener('click', function () {
+      if (isKebabSheetOpen()) closeKebabSheet();
+      else openKebabSheet();
+    });
+    if (kebabScrimEl) {
+      kebabScrimEl.addEventListener('click', closeKebabSheet);
+    }
+    var closeBtn = document.getElementById('kebab-sheet-close');
+    if (closeBtn) closeBtn.addEventListener('click', closeKebabSheet);
+    document.addEventListener('keydown', function (e) {
+      if (e.key === 'Escape' && isKebabSheetOpen()) closeKebabSheet();
+    });
+    // Each sheet action proxies to the existing floating-button handler
+    // by clicking the original element. Means we don't reimplement any
+    // of the dialog/diag/clear-cache logic — same code path as the
+    // desktop floating buttons.
+    var actions = kebabSheetEl.querySelectorAll('[data-kebab-action]');
+    for (var i = 0; i < actions.length; i++) {
+      var btn = actions[i];
+      btn.addEventListener('click', function (ev) {
+        var action = ev.currentTarget.getAttribute('data-kebab-action');
+        closeKebabSheet();
+        var targetId = null;
+        if (action === 'diagnostics') targetId = 'diag-toggle';
+        else if (action === 'report-bug') targetId = 'bug-report-button';
+        else if (action === 'clear-cache') targetId = 'clear-app-cache-button';
+        if (!targetId) return;
+        var target = document.getElementById(targetId);
+        if (target) target.click();
+      });
+    }
+    // Tab clicks should close the sheet too if it happens to be open.
+    if (tabsEl) {
+      tabsEl.addEventListener('click', function () {
+        if (isKebabSheetOpen()) closeKebabSheet();
+      });
+    }
+  }
+
   function showAuthFailure(reason, extra) {
     var lines = [];
     lines.push('=== Fellows auth check failure ===');
@@ -1997,7 +2108,7 @@
     if (installLandingEl) installLandingEl.classList.add('hidden');
     if (installGatePrivateEl) installGatePrivateEl.classList.add('hidden');
     if (appWrapEl) appWrapEl.classList.add('hidden');
-    if (siteHeaderEl) siteHeaderEl.classList.add('hidden');
+    setShellVisible(false);
     if (connectionBannerEl) connectionBannerEl.classList.add('hidden');
     if (authErrorPanelEl) authErrorPanelEl.classList.remove('hidden');
     if (authErrorPreEl) authErrorPreEl.textContent = lines.join('\n');
@@ -2442,7 +2553,7 @@
   function initBrowserInstallMode(authPayload, httpStatus) {
     if (installGatePrivateEl) installGatePrivateEl.classList.add('hidden');
     if (installLandingEl) installLandingEl.classList.remove('hidden');
-    if (siteHeaderEl) siteHeaderEl.classList.add('hidden');
+    setShellVisible(false);
     showLoading(false);
     showApp(false);
     if (connectionBannerEl) connectionBannerEl.classList.add('hidden');
@@ -2556,7 +2667,7 @@
   function initEmailGate(authPayload, httpStatus, reason) {
     if (installGatePrivateEl) installGatePrivateEl.classList.remove('hidden');
     if (installLandingEl) installLandingEl.classList.add('hidden');
-    if (siteHeaderEl) siteHeaderEl.classList.add('hidden');
+    setShellVisible(false);
     showLoading(false);
     showApp(false);
     if (connectionBannerEl) connectionBannerEl.classList.add('hidden');
@@ -2954,6 +3065,9 @@
       return;
     }
     var name = fellow.name || fellow.slug || 'Unknown';
+    if (window.location.hash.indexOf('#/fellow/') === 0) {
+      setShellChrome('directory', name);
+    }
     var slug = fellow.slug || '';
     var rid = fellow.record_id || '';
     var inDraft = !!(rid && groupDraft.members.has(rid));
@@ -3791,12 +3905,27 @@
     var body = document.body;
     body.classList.remove(
       'route-groups-list', 'route-group-detail',
-      'route-group-edit', 'route-group-directory'
+      'route-group-edit', 'route-group-directory',
+      'route-directory', 'route-about', 'route-settings', 'route-fellow'
     );
     if (directoryMatch) body.classList.add('route-group-directory');
     else if (groupMatch) body.classList.add('route-group-detail');
     else if (editMatch) body.classList.add('route-group-edit');
     else if (hash === '#/groups') body.classList.add('route-groups-list');
+    else if (hash === '#/about') body.classList.add('route-about');
+    else if (hash === '#/settings') body.classList.add('route-settings');
+    else if (hash.indexOf('#/fellow/') === 0) body.classList.add('route-fellow');
+    else body.classList.add('route-directory');
+
+    // Mobile shell chrome — appbar title + active tab. Renderers that
+    // know a richer title (group name, fellow name) can overwrite by
+    // calling setShellChrome again after their data resolves.
+    if (hash === '#/about') setShellChrome('about', 'About');
+    else if (hash === '#/settings') setShellChrome('settings', 'Settings');
+    else if (hash === '#/groups') setShellChrome('groups', 'Groups');
+    else if (groupMatch || directoryMatch || editMatch) setShellChrome('groups', 'Group');
+    else if (hash.indexOf('#/fellow/') === 0) setShellChrome('directory', 'Fellow');
+    else setShellChrome('directory', 'Directory');
 
     // Transition out of edit mode if the URL no longer points there. (Same
     // group still in editingGroupId? Different group? Either way, exit
@@ -4127,6 +4256,7 @@
         return;
       }
       var name = group.name || '(untitled)';
+      setShellChrome('groups', name);
       var members = group.members || [];
       var memberCount = members.length;
       var memberWord = memberCount === 1 ? ' fellow' : ' fellows';
@@ -4418,6 +4548,7 @@
       var members = resolveMembersForView(group);
       var contact = buildContactBarMailto(group, members);
       var name = group.name || '(untitled)';
+      setShellChrome('groups', name + ' — Visual');
       var html = '<div class="group-directory-page" data-group-id="' + escapeHtml(String(group.id)) + '">' +
         '<p class="group-detail-breadcrumb">' +
           '<a href="#/groups">groups</a> › ' +
@@ -5796,11 +5927,12 @@
   initClearCacheButton();
   initDiagnosticsPanel();
   initBugReportButtons();
+  initKebabSheet();
   wireCopyButtons();
 
   function bootDirectoryAsApp() {
     bootDebugLines.length = 0;
-    if (siteHeaderEl) siteHeaderEl.classList.remove('hidden');
+    setShellVisible(true);
     if (loadingPanelEl) {
       loadingPanelEl.classList.remove('hidden');
     }
@@ -5942,7 +6074,7 @@
         if (!isStandaloneDisplayMode() && hasAuthenticatedOnce()) {
           bootDebugPush('as-app boot failed; handing off to startBrowserUx: ' +
             (err && err.message ? err.message : String(err)));
-          if (siteHeaderEl) siteHeaderEl.classList.add('hidden');
+          setShellVisible(false);
           if (loadingPanelEl) loadingPanelEl.classList.add('hidden');
           if (loadingEl) loadingEl.classList.add('hidden');
           startBrowserUx();

--- a/app/static/index.html
+++ b/app/static/index.html
@@ -159,6 +159,31 @@
     </div>
   </div>
 
+  <header id="appbar" class="appbar hidden" role="banner">
+    <h1 class="appbar__title" id="appbar-title">Directory</h1>
+    <button
+      type="button"
+      id="appbar-kebab"
+      class="appbar__kebab"
+      aria-label="More"
+      aria-haspopup="dialog"
+      aria-expanded="false"
+      aria-controls="kebab-sheet"
+    >
+      <svg viewBox="0 0 24 24" width="20" height="20" aria-hidden="true" focusable="false">
+        <circle cx="12" cy="5" r="1.7" fill="currentColor" />
+        <circle cx="12" cy="12" r="1.7" fill="currentColor" />
+        <circle cx="12" cy="19" r="1.7" fill="currentColor" />
+      </svg>
+    </button>
+  </header>
+  <nav id="tabs" class="tabs hidden" aria-label="Primary">
+    <a class="tabs__tab" href="#/" data-tab="directory">Directory</a>
+    <a class="tabs__tab" href="#/groups" data-tab="groups">Groups</a>
+    <a class="tabs__tab" href="#/settings" data-tab="settings">Settings</a>
+    <a class="tabs__tab" href="#/about" data-tab="about">About</a>
+  </nav>
+
   <header id="site-header" class="site-header hidden">
     <h1><a href="#/" class="site-title-link">EHF Fellows Directory</a></h1>
     <div id="search-container" class="header-search">
@@ -280,6 +305,29 @@
       <p id="group-rail-status" class="group-rail-status" aria-live="polite"></p>
     </aside>
   </div>
+  <div id="kebab-scrim" class="sheet-scrim hidden" hidden></div>
+  <aside
+    id="kebab-sheet"
+    class="sheet sheet--kebab hidden"
+    role="dialog"
+    aria-modal="true"
+    aria-labelledby="kebab-sheet-title"
+    hidden
+  >
+    <div class="sheet__handle" aria-hidden="true"></div>
+    <div class="sheet__head">
+      <div class="sheet__title" id="kebab-sheet-title">App info</div>
+      <button type="button" id="kebab-sheet-close" class="sheet__close" aria-label="Close">×</button>
+    </div>
+    <ul class="diag-list" id="kebab-sheet-build">
+      <li><span>app</span><b id="kebab-sheet-build-app">…</b></li>
+      <li><span>server</span><b id="kebab-sheet-build-server">…</b></li>
+    </ul>
+    <div class="sheet__divider" aria-hidden="true"></div>
+    <button type="button" class="sheet-action" data-kebab-action="diagnostics">Diagnostics…</button>
+    <button type="button" class="sheet-action" data-kebab-action="report-bug">Report a bug…</button>
+    <button type="button" class="sheet-action sheet-action--danger" data-kebab-action="clear-cache">Clear app cache &amp; reload</button>
+  </aside>
   <script src="/vendor/sqlite3.js"></script>
   <script src="/vendor/jspdf-2.5.1.umd.min.js"></script>
   <script src="/app.js"></script>

--- a/app/static/styles.css
+++ b/app/static/styles.css
@@ -1157,7 +1157,7 @@ h1 {
 }
 
 .install-use-in-tab-link {
-  color: #4a2c6a;
+  color: var(--accent);
   text-decoration: underline;
 }
 
@@ -2683,4 +2683,320 @@ a.group-action-btn--primary {
   margin-top: 1rem;
   font-size: 0.85rem;
   color: #6a5800;
+}
+
+/* =========================================================================
+ * Mobile redesign — Phase 3 step 2: shell chrome (appbar, tab nav, kebab
+ * bottom-sheet) and focus-mode-by-default at the mobile breakpoint.
+ *
+ * The new shell is mobile-only. It's hidden by default (the `.hidden` class
+ * is used during install-landing / boot to suppress all top chrome; the
+ * `@media (min-width: 1025px)` block hides it on desktop). The existing
+ * `#site-header` keeps doing its job above 1024px; below that, it
+ * collapses to just the search bar on the directory route and disappears
+ * entirely on every other route.
+ *
+ * Spec: plans/mobile_redesign/DESIGN.md (§3 layout primitives, §4 focus
+ * mode by default). Porting notes: plans/mobile_redesign/css_porting_notes.md.
+ * ========================================================================= */
+
+/* ----- App bar -------------------------------------------------------- */
+
+.appbar {
+  display: flex;
+  align-items: center;
+  height: 48px;
+  padding: 0 4px 0 12px;
+  background: var(--surface);
+  border-bottom: 1px solid var(--border);
+  position: sticky;
+  top: 0;
+  z-index: 5;
+  /* Bleed past body's 0.75rem padding so the bar reaches viewport edges. */
+  margin: -0.75rem -0.75rem 0;
+}
+
+.appbar.hidden {
+  display: none;
+}
+
+.appbar__title {
+  flex: 1;
+  font-size: 16px;
+  font-weight: 600;
+  color: var(--ink-deep);
+  margin: 0;
+  white-space: nowrap;
+  overflow: hidden;
+  text-overflow: ellipsis;
+}
+
+.appbar__kebab {
+  width: 44px;
+  height: 44px;
+  border: 0;
+  background: transparent;
+  border-radius: 6px;
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  cursor: pointer;
+  color: var(--accent);
+  flex: 0 0 44px;
+}
+
+.appbar__kebab:hover {
+  background: var(--accent-soft);
+}
+
+.appbar__kebab:focus-visible {
+  outline: 2px solid var(--accent);
+  outline-offset: 2px;
+}
+
+/* ----- Tab strip ------------------------------------------------------ */
+
+.tabs {
+  display: flex;
+  gap: 0;
+  height: 40px;
+  background: var(--surface);
+  border-bottom: 1px solid var(--border);
+  overflow-x: auto;
+  scrollbar-width: none;
+  position: sticky;
+  top: 48px;
+  z-index: 4;
+  margin: 0 -0.75rem;
+}
+
+.tabs.hidden {
+  display: none;
+}
+
+.tabs::-webkit-scrollbar {
+  display: none;
+}
+
+.tabs__tab {
+  flex: 1;
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  font-size: 14px;
+  font-weight: 600;
+  color: var(--accent);
+  text-decoration: none;
+  border-bottom: 2px solid transparent;
+  padding: 0 8px;
+  min-width: 72px;
+  white-space: nowrap;
+}
+
+.tabs__tab:hover {
+  background: var(--accent-soft);
+}
+
+.tabs__tab--active {
+  color: var(--ink-deep);
+  border-bottom-color: var(--accent);
+}
+
+.tabs__tab:focus-visible {
+  outline: 2px solid var(--accent);
+  outline-offset: -3px;
+}
+
+/* ----- Bottom-sheet shell + scrim ------------------------------------ */
+/* The kebab sheet is the first user; PR 2 will reuse the same .sheet /
+ * .sheet-scrim classes for the FAB composer and the per-card kebab on
+ * the groups index. */
+
+.sheet {
+  position: fixed;
+  inset: auto 0 0 0;
+  background: var(--surface);
+  border-top: 1px solid var(--border-strong);
+  border-radius: 12px 12px 0 0;
+  box-shadow: 0 -8px 28px rgba(0, 0, 0, 0.18);
+  padding: 10px 14px calc(16px + env(safe-area-inset-bottom, 0));
+  z-index: 12;
+  max-height: 80vh;
+  overflow-y: auto;
+}
+
+.sheet.hidden {
+  display: none;
+}
+
+.sheet__handle {
+  width: 40px;
+  height: 4px;
+  background: var(--border-strong);
+  border-radius: 2px;
+  margin: 0 auto 10px;
+}
+
+.sheet__head {
+  display: flex;
+  justify-content: space-between;
+  align-items: baseline;
+  margin-bottom: 10px;
+}
+
+.sheet__title {
+  font-size: 16px;
+  font-weight: 600;
+  color: var(--ink-deep);
+}
+
+.sheet__close {
+  border: 0;
+  background: transparent;
+  font-size: 24px;
+  line-height: 1;
+  color: var(--muted);
+  cursor: pointer;
+  padding: 0 6px;
+  min-width: 32px;
+  min-height: 32px;
+}
+
+.sheet__close:hover {
+  color: var(--ink-deep);
+}
+
+.sheet__divider {
+  height: 1px;
+  background: var(--border);
+  margin: 10px -14px;
+}
+
+.sheet-action {
+  display: flex;
+  align-items: center;
+  gap: 12px;
+  padding: 12px 8px;
+  font: inherit;
+  font-size: 15px;
+  width: 100%;
+  background: transparent;
+  border: 0;
+  color: var(--ink-deep);
+  text-align: left;
+  cursor: pointer;
+  border-radius: 4px;
+  min-height: 44px;
+}
+
+.sheet-action:hover {
+  background: var(--accent-soft);
+}
+
+.sheet-action--danger {
+  color: var(--danger);
+}
+
+.sheet-action--danger:hover {
+  background: var(--danger-bg);
+}
+
+.sheet-scrim {
+  position: fixed;
+  inset: 0;
+  background: rgba(20, 16, 30, 0.55);
+  z-index: 11;
+}
+
+.sheet-scrim.hidden {
+  display: none;
+}
+
+.diag-list {
+  padding: 4px 0 0;
+  margin: 0;
+  list-style: none;
+}
+
+.diag-list li {
+  display: flex;
+  justify-content: space-between;
+  font-family: var(--font-mono);
+  font-size: 12px;
+  color: var(--muted);
+  padding: 5px 0;
+  border-bottom: 1px solid var(--border);
+  word-break: break-all;
+}
+
+.diag-list li b {
+  color: var(--ink-deep);
+  font-weight: 600;
+  margin-left: 8px;
+  text-align: right;
+}
+
+/* ----- Desktop: hide the mobile shell -------------------------------- */
+
+@media (min-width: 1025px) {
+  .appbar,
+  .tabs {
+    display: none;
+  }
+}
+
+/* ----- Mobile (≤1024px): focus mode by default ----------------------- *
+ * Hide the directory chrome on every non-directory route so About,
+ * Settings, Groups, Group detail, Fellow detail render full-width.
+ * Hide the floating chrome — those controls now live inside the kebab
+ * sheet. PR 2 will turn `#group-rail` into a FAB-driven bottom sheet;
+ * for now we keep it visible on the directory route so mobile users
+ * can still create groups during the rollout window.
+ * ===================================================================== */
+
+@media (max-width: 1024px) {
+  /* Existing `#site-header`: full hide off-directory; on directory keep
+     it as a thin wrapper for the search bar by suppressing the title
+     and nav children. */
+  body:not(.route-directory) #site-header {
+    display: none;
+  }
+
+  body.route-directory #site-header > h1,
+  body.route-directory #site-header > .site-nav {
+    display: none;
+  }
+
+  body.route-directory #site-header {
+    flex-wrap: nowrap;
+    gap: 0;
+    margin: 0 -0.75rem;
+    padding: 8px 12px;
+    background: var(--surface);
+    border-bottom: 1px solid var(--border);
+  }
+
+  body.route-directory #site-header > #search-container {
+    flex: 1;
+    max-width: none;
+    min-width: 0;
+    margin: 0;
+  }
+
+  /* Focus mode: hide the directory list and composer rail on every
+     non-directory route. The rail stays visible on the directory route
+     in PR 1; PR 2 will turn it into a FAB-driven bottom sheet. */
+  body:not(.route-directory) #directory,
+  body:not(.route-directory) #group-rail {
+    display: none;
+  }
+
+  /* Floating chrome → kebab sheet. The originals remain in the DOM so
+     desktop continues to use them; mobile users hit the kebab menu. */
+  #build-badge,
+  #clear-app-cache-button,
+  #diag-toggle,
+  #bug-report-button {
+    display: none;
+  }
 }

--- a/docs/users_manual.md
+++ b/docs/users_manual.md
@@ -299,11 +299,16 @@ When an update is available, a banner appears across the top of the app:
 ## Clearing app data
 
 If the app gets into a weird state (corrupt cache, stuck banner, stale
-data), you can reset it:
+data), you can reset it.
 
-1. Go to the **About** page.
-2. Scroll to **Diagnostics** → **Clear app cache**.
-3. Confirm. The app wipes its local storage and reloads.
+- **On a phone or tablet:** tap the **⋮** kebab in the top-right of the
+  app bar → **Clear app cache & reload**. Confirm.
+- **On desktop:** click the red **Clear App Cache & Reload** button in
+  the bottom-right corner. Confirm.
+
+The app wipes its local storage and reloads. The same kebab menu also
+holds **Diagnostics…** and **Report a bug…**, which on desktop appear
+as separate floating buttons.
 
 **Heads-up:** clearing the cache also re-downloads the fellow data and
 photos on the next launch. The session cookie is cleared, so if the


### PR DESCRIPTION
## Summary

PR 1 of the Phase 3 mobile redesign (see `plans/mobile_redesign/`). Lands the persistent mobile shell + focus-mode-by-default and consolidates floating chrome (Diagnostics, Report bug, Clear App Cache, build badge) into a kebab bottom-sheet.

- New `<header.appbar>` + `<nav.tabs>` at narrow widths (≤1024px). Tabs cover Directory / Groups / Settings / About; active tab set per-route via `setShellChrome()`.
- Every route now gets exactly one `route-*` body class — extends the existing four group variants with `route-directory`, `route-about`, `route-settings`, `route-fellow`. Mobile CSS hides the directory list + composer rail on every non-directory route.
- Floating chrome consolidates into a single bottom-sheet behind the appbar's kebab. Sheet actions proxy to the existing floating-button handlers via `.click()` — no logic reimplementation. Esc + tap-outside dismiss.
- `#site-header` collapses to just the search bar on the directory route at mobile, hides entirely off-directory.
- Composer rail (`#group-rail`) stays visible on the **directory route only** in this PR; PR 2 turns it into a FAB-driven bottom sheet.
- Bonus cleanup: stray `#4a2c6a` literal at `styles.css:1160` swapped to `var(--accent)`. Last holdout from the brand swap in #73.
- `docs/users_manual.md` "Clearing app data" updated to describe the kebab path on mobile alongside the existing desktop floating button.

## Desktop (>1024px)

No visible change. `.appbar` / `.tabs` are `display: none`; the existing site-header, floating buttons, and two-rail layout are untouched.

## Test plan

Automated:

- [x] `just test-fast` — 73 passed.
- [x] `just test-mobile` — 24 captures regenerated; `current_state/` PNGs visually confirm appbar + tabs + focus mode at narrow-360 / Pixel 5 / iPhone 13 across every route. Baselines aren't being promoted yet (per the agreed plan, that lands in PR 2).

Maintainer manual QA before merge:

- [ ] Visit `#/`, `#/about`, `#/settings`, `#/groups`, a group detail, and a fellow detail at **360**, **768**, **1024**, and **1440** widths. Appbar + tabs at the three narrower widths; original layout at 1440. Active tab matches the route.
- [ ] On mobile, tap kebab (⋮) → sheet opens. Each action (Diagnostics, Report a bug, Clear app cache & reload) does the same thing as the desktop floating button. Esc and tap-outside both dismiss.
- [ ] Walk About → Settings → Groups → Group detail → Fellow detail → Directory at 360 — directory list and composer rail are visible **only** on the directory route.
- [ ] Install landing and email gate (`/?gate=1`) still render unchanged at every width (they share the `.hidden` toggle the new shell rides on).
- [ ] Existing `route-groups-list`, `route-group-detail`, `route-group-edit`, `route-group-directory` body classes still work on desktop (group routes still hide directory + rail).
- [ ] Groups index table is unchanged at narrow widths in this PR — that's intentional. PR 2 ports it to cards.

## Next: PR 2

Interaction surfaces — FAB + composer bottom-sheet, groups index card list (Path A: render both, CSS picks), sticky group-detail action bar, fellow-detail polish, and snapshot baselines committed.