### PR TITLE
build(just): bump recipe + deploy guard + whats-running

### DIFF
--- a/docs/justfile.md
+++ b/docs/justfile.md
@@ -107,13 +107,24 @@ Export them or inline: `FELLOWS_BASE_URL=https://staging.example.com just smoke`
 - **`build`** — assemble `deploy/dist/` (runs `build/build_pwa.py`).
 - **`build-meta`** — print `deploy/dist/build-meta.json` (timestamp + git sha
   of the last build). Useful to pair with `drift`.
+- **`bump [LABEL]`** — bump `CACHE_VERSION` (sw.js) and `FELLOWS_UI_DIAG`
+  (app.js) in lock-step, then commit with a `chore(version):` prefix. The
+  diag string becomes `<YYYY-MM-DD>-<short-sha>[-<LABEL>]`. Run before
+  `just deploy` so the in-app build label matches the code being shipped.
+  Requires a clean working tree (the bump commit is just the version
+  files). The `_bump-guard` (gated on `deploy` and `deploy-fast`) finds
+  the bump commit via `git log --grep=^chore\(version\):`.
 
 ### deploy
 
 - **`deploy`** — full prod deploy. Wraps `./scripts/deploy_pwa.sh --ask-become-pass`,
   which runs `ansible/deploy_pwa.yml`: build → rsync → restart → HTTPS smoke.
+  Refuses if HEAD has commits past the most recent `chore(version):` bump
+  (run `just bump` first). Bypass with `BUMP_GUARD=skip just deploy` for
+  hotfixes where you accept the in-app label staying behind.
 - **`deploy-fast`** — deploy without rebuilding `deploy/dist/` (sets
-  `fellows_skip_build=true`). Use when the bundle is already fresh.
+  `fellows_skip_build=true`). Use when the bundle is already fresh. Same
+  bump guard as `deploy`.
 - **`deploy-check`** — Ansible `--check` mode: reports what would change, but
   doesn't touch anything. Good before a risky deploy.
 - **`ship`** — **`test-fast` → `deploy`**. The full "build-test-deploy-test"
@@ -138,6 +149,12 @@ Export them or inline: `FELLOWS_BASE_URL=https://staging.example.com just smoke`
   `FELLOWS_HOST`. Non-intrusive pre-/post-deploy probe.
 - **`drift`** — compare prod's `X-Fellows-Build` response header with local
   `HEAD` and `origin/main`. One glance tells you whether prod is current.
+- **`whats-running`** — full version report: local HEAD, on-disk
+  `CACHE_VERSION` + `FELLOWS_UI_DIAG`, the most recent `chore(version):`
+  commit and how many commits HEAD is past it, prod's `/build-meta.json`,
+  and a refresh cheat-sheet (Cmd-Shift-R bypasses the SW shell cache;
+  Clear App Cache preserves OPFS; incognito is the nuclear baseline).
+  Use when "is this the version I think it is?" comes up.
 - **`prod-logs [UNIT]`** — SSH + `journalctl -u UNIT -f`. Default unit
   `fellows-pwa`; try `just prod-logs caddy` for the reverse proxy.
 - **`prod-stats [SINCE]`** — summary of page views, magic-link send/verify
@@ -191,8 +208,12 @@ Export them or inline: `FELLOWS_BASE_URL=https://staging.example.com just smoke`
 - **Reset after dev-DB got weird**: `just reset` (stop, snapshot, canonical
   rebuild, start, open browser).
 - **Before merging to main**: `just test` (all tests, port-safe).
-- **Ship a PR to prod**: `just ship` (fast tests, then ansible build+deploy+smoke).
-- **Check whether prod is current**: `just drift`.
+- **Ship a PR to prod**: `just bump [<label>]` then `just ship` (the
+  bump guard refuses if you skip the bump). Bump is its own commit so
+  the in-app `app: …` build label always tracks the code that was
+  shipped — no more "which PR is this badge from?" guessing.
+- **Check whether prod is current**: `just drift` (one-line diff) or
+  `just whats-running` (full local + prod report with refresh tips).
 - **How is prod doing?** `just prod-stats` (last 24h of page loads,
   magic-link sends, verifies, 5xx, disk). For a weekly view:
   `just prod-stats '7 days ago'`.

--- a/justfile
+++ b/justfile
@@ -256,14 +256,91 @@ build:
 build-meta:
     @if [ -f deploy/dist/build-meta.json ]; then cat deploy/dist/build-meta.json; else echo "No deploy/dist/build-meta.json — run 'just build' first."; fi
 
+# Bump CACHE_VERSION (sw.js) and FELLOWS_UI_DIAG (app.js) and commit.
+#
+# The diag string becomes <YYYY-MM-DD>-<short-sha>[-<label>]. Examples:
+#   just bump                    -> '2026-05-02-7b5f548'
+#   just bump groups-fab         -> '2026-05-02-7b5f548-groups-fab'
+#
+# Requires a clean working tree so the bump commit is just the version
+# files. The bump commit message starts with 'chore(version):' so the
+# deploy guard can find it via git log --grep.
+#
+# Bump versions and commit so 'just deploy' will let you ship.
+[group('build')]
+bump label="":
+    #!/usr/bin/env bash
+    set -euo pipefail
+    if ! git diff --quiet || ! git diff --cached --quiet; then
+        echo "ERROR: working tree has uncommitted changes."
+        echo "Commit or stash first; 'just bump' should be its own commit."
+        exit 1
+    fi
+    sha=$(git rev-parse --short HEAD)
+    today=$(date +%Y-%m-%d)
+    label="{{label}}"
+    if [ -n "${label}" ]; then
+        new_diag="${today}-${sha}-${label}"
+    else
+        new_diag="${today}-${sha}"
+    fi
+    cur_n=$(grep -oE "CACHE_VERSION = 'v[0-9]+'" app/static/sw.js | grep -oE '[0-9]+' | head -1)
+    if [ -z "${cur_n}" ]; then
+        echo "ERROR: could not parse CACHE_VERSION from app/static/sw.js"
+        exit 1
+    fi
+    new_n=$((cur_n + 1))
+    new_cache="v${new_n}"
+    sed -i.bak -E "s|CACHE_VERSION = 'v[0-9]+'|CACHE_VERSION = '${new_cache}'|" app/static/sw.js
+    sed -i.bak -E "s|var FELLOWS_UI_DIAG = '[^']*'|var FELLOWS_UI_DIAG = '${new_diag}'|" app/static/app.js
+    rm -f app/static/sw.js.bak app/static/app.js.bak
+    grep -F "CACHE_VERSION = '${new_cache}'" app/static/sw.js >/dev/null || { echo "ERROR: sw.js bump did not apply"; exit 1; }
+    grep -F "FELLOWS_UI_DIAG = '${new_diag}'" app/static/app.js >/dev/null || { echo "ERROR: app.js bump did not apply"; exit 1; }
+    git add app/static/sw.js app/static/app.js
+    git commit -m "chore(version): bump to ${new_diag} (cache ${new_cache})"
+    echo
+    echo "Bumped to: ${new_diag}"
+    echo "         CACHE_VERSION = ${new_cache}"
+    echo "         FELLOWS_UI_DIAG = ${new_diag}"
+    echo "         commit $(git rev-parse --short HEAD)"
+    echo
+    echo "Push when ready:  git push"
+
+# Internal: refuse to deploy if HEAD has commits past the most recent
+# 'chore(version):' commit. Bypass with BUMP_GUARD=skip for emergencies
+# (e.g. a hotfix where you accept the version label staying behind).
+_bump-guard:
+    #!/usr/bin/env bash
+    set -uo pipefail
+    if [ "${BUMP_GUARD:-}" = "skip" ]; then
+        echo "WARN: bump guard skipped via BUMP_GUARD=skip"
+        exit 0
+    fi
+    bump=$(git log --grep='^chore(version):' -1 --format=%H 2>/dev/null || true)
+    if [ -z "${bump}" ]; then
+        echo "ERROR: no chore(version) commit found in history."
+        echo "Run:  just bump [<label>]"
+        echo "Override: BUMP_GUARD=skip just deploy"
+        exit 1
+    fi
+    n=$(git rev-list "${bump}..HEAD" --count)
+    if [ "${n}" -gt 0 ]; then
+        echo "ERROR: ${n} commit(s) on HEAD past last version bump (${bump:0:7})."
+        echo "Run:  just bump [<label>]   to bump versions to current HEAD."
+        echo "      just whats-running    to see drift detail."
+        echo "Override: BUMP_GUARD=skip just deploy"
+        exit 1
+    fi
+    echo "[bump-guard] OK: HEAD is the latest version bump."
+
 # Deploy to prod (build + ansible + HTTPS smoke, via ansible/deploy_pwa.yml).
 [group('deploy')]
-deploy:
+deploy: _bump-guard
     ./scripts/deploy_pwa.sh --ask-become-pass
 
 # Deploy, reusing existing deploy/dist/ (skips the build step).
 [group('deploy')]
-deploy-fast:
+deploy-fast: _bump-guard
     ansible-playbook ansible/deploy_pwa.yml --ask-become-pass --extra-vars "fellows_skip_build=true"
 
 # Ansible --check (dry run, no changes made).
@@ -312,6 +389,45 @@ smoke url="":
 [group('prod')]
 check-env:
     ./scripts/check_deploy_env.sh
+
+# Show local HEAD, on-disk CACHE_VERSION + FELLOWS_UI_DIAG, the most
+# recent 'chore(version):' commit, prod's build-meta, and a refresh
+# cheat-sheet for the SW shell-cache gotcha.
+#
+# Show local + prod build versions and refresh tips.
+[group('prod')]
+whats-running:
+    #!/usr/bin/env bash
+    set -uo pipefail
+    head_sha=$(git rev-parse --short HEAD)
+    head_subject=$(git log -1 --format=%s HEAD)
+    cache_v=$(grep -oE "CACHE_VERSION = 'v[0-9]+'" app/static/sw.js | grep -oE 'v[0-9]+' | head -1)
+    diag=$(grep -E "var FELLOWS_UI_DIAG = '[^']*'" app/static/app.js | head -1 | sed -E "s|.*'([^']*)'.*|\\1|")
+    last_bump=$(git log --grep='^chore(version):' -1 --format='%h %ci %s' 2>/dev/null || echo "(none)")
+    drift_n=$(if [ -n "$(git log --grep='^chore(version):' -1 --format=%H 2>/dev/null)" ]; then git rev-list "$(git log --grep='^chore(version):' -1 --format=%H)..HEAD" --count; else echo "?"; fi)
+    echo "Local"
+    echo "  HEAD:                ${head_sha} ${head_subject}"
+    echo "  CACHE_VERSION:       ${cache_v}"
+    echo "  FELLOWS_UI_DIAG:     ${diag}"
+    echo "  Last version bump:   ${last_bump}"
+    echo "  Commits past bump:   ${drift_n}"
+    echo
+    echo "Prod ({{base_url}})"
+    if curl -sf "{{base_url}}/build-meta.json" -o /tmp/_fellows_bm.json 2>/dev/null; then
+        prod_sha=$(python3 -c "import json,sys; print(json.load(open('/tmp/_fellows_bm.json')).get('git_sha','?'))" 2>/dev/null || echo '?')
+        prod_built=$(python3 -c "import json,sys; print(json.load(open('/tmp/_fellows_bm.json')).get('built_at','?'))" 2>/dev/null || echo '?')
+        echo "  git_sha:             ${prod_sha}"
+        echo "  built_at:            ${prod_built}"
+        rm -f /tmp/_fellows_bm.json
+    else
+        echo "  (could not fetch /build-meta.json)"
+    fi
+    echo
+    echo "Browser refresh tips"
+    echo "  - Cmd-Shift-R (Ctrl-Shift-R on Linux/Win) bypasses the SW shell cache."
+    echo "  - Clear App Cache & Reload: cookie + IndexedDB + caches go; OPFS"
+    echo "    (groups, settings, fellows.db) survives by design."
+    echo "  - Incognito window: nuclear-clean baseline (no SW, no OPFS, no cookie)."
 
 # Compare local HEAD to prod's X-Fellows-Build header.
 [group('prod')]


### PR DESCRIPTION
## Summary

Closes the second of two long-standing pains: the in-app build label (`app: …` in the build badge, also shown in About / diagnostics) drifts behind `main` because nothing forces it to track merges. Multiple PRs land, the constant stays the same, and "what version is this user actually running?" turns into a SHA-comparison exercise.

This PR adds the missing tooling: a one-command bump, a deploy-time guard that refuses to ship if you forgot, and a `whats-running` diagnostic.

## What's new

- **`just bump [<label>]`** — increments `CACHE_VERSION` (sw.js) and rewrites `FELLOWS_UI_DIAG` (app.js) to `<YYYY-MM-DD>-<short-sha>[-<label>]`, then commits with a `chore(version):` prefix. Requires a clean working tree so the bump commit is just the version files.
- **`_bump-guard`** — gates `deploy` and `deploy-fast` (so it covers both `ship` and `ship-fast` automatically). Refuses if HEAD has commits past the most recent `chore(version):` commit. Bypass with `BUMP_GUARD=skip just deploy` for emergency hotfixes.
- **`just whats-running`** — prints local HEAD, on-disk versions, last bump commit + drift count, prod's `/build-meta.json`, and a refresh cheat-sheet (Cmd-Shift-R, Clear App Cache, incognito).
- **`docs/justfile.md`** updated with all three; "Ship a PR to prod" sequence rewritten to lead with `just bump`.

## Test plan

Manually exercised on this branch (test commits dropped before pushing the PR):

- [x] `just bump test-run` → produced `2026-05-02-357830e-test-run`, `CACHE_VERSION = 'v15'`, committed as `chore(version):` — verified both files updated.
- [x] `just _bump-guard` after the bump → `OK: HEAD is the latest version bump`.
- [x] `git commit --allow-empty -m "test"` then `just _bump-guard` → `ERROR: 1 commit(s) on HEAD past last version bump`. Refuses with helpful instruction + the override env var.
- [x] `BUMP_GUARD=skip just _bump-guard` → `WARN: bump guard skipped via BUMP_GUARD=skip`, exits 0.
- [x] `just whats-running` before and after a bump — both render correctly; "Last version bump:" is empty before, populated after.
- [x] `just --list` summaries are useful (recipe descriptions surface, not the last comment line).

**For the operator on first deploy after this merges:** the first `just deploy` will refuse because there's no `chore(version):` commit in history yet. Run `just bump initial` once to install the marker, then deploy.

## Notes for follow-up

- This is PR B in the four-PR sequence. PR A (Clear App Cache POSTs `/api/logout`) is #79; PR C (Reset everything kebab item) and PR D (auto-backup `relationships.db` + Settings export) are next.

🤖 Generated with [Claude Code](https://claude.com/claude-code)