### PR TITLE
docs(readme): standard "Shipping a change" rubric in DevOps section

### DIFF
--- a/README.md
+++ b/README.md
@@ -25,6 +25,7 @@ Data and assets are local-first (SQLite + static files), served by Python stdlib
   - [JSON To SQLite + FTS5](#json-to-sqlite-fts5)
   - [PWA Static Bundle](#pwa-static-bundle)
 - [Production / DevOps](#production--devops)
+  - [Shipping a change (the standard rubric)](#shipping-a-change-the-standard-rubric)
 - [Local Dev Notes](#local-dev-notes)
 - [Before Making This Repo Public](#before-making-this-repo-public)
 - [Project Layout](#project-layout)
@@ -303,6 +304,25 @@ just prod-stats-long    # full-history tally + plaintext list of every magic-lin
 ```
 
 Under the hood: `./scripts/deploy_pwa.sh --ask-become-pass` runs the `ansible/deploy_pwa.yml` playbook (build → rsync → restart → HTTPS smoke).
+
+### Shipping a change (the standard rubric)
+
+After PRs merge to `main`, deploy with:
+
+```bash
+git checkout main && git pull         # confirm merges are local
+just bump [<label>]                   # one chore(version): commit on main
+git push                              # push the bump to origin/main
+just ship                             # build → test → deploy → smoke (refuses if you forgot to bump)
+just whats-running                    # confirm prod's git SHA matches local HEAD
+```
+
+A few rules of thumb:
+
+- **Bump on `main`, not on a PR branch.** The bump is a deploy marker, not a PR marker. Bumping on a feature branch creates noise (every PR carries its own bump, only the last-merged wins) and obscures the deploy boundary in `main`'s history. The exception is PR #80's own bump infrastructure — the very first deploy after that merged needs `just bump initial` once, then the normal rubric.
+- **The label is optional but useful.** `just bump groups-fab` produces `2026-05-02-<sha>-groups-fab`, which reads more memorably in the build badge than a bare timestamp + SHA.
+- **Test on prod, not localhost, when the change touches auth or session state.** The dev server returns `authEnabled: false` and skips the email gate entirely — checks like "Clear App Cache lands me at the gate" don't reproduce locally. The Playwright e2e suite (`just test-e2e ...`) mocks the prod auth path; `https://fellows.globaldonut.com` is the real verification.
+- **Hotfix override.** `BUMP_GUARD=skip just deploy` bypasses the bump guard for a fix that can't wait. The in-app version label stays behind one deploy until you bump and re-ship.
 
 ## Local Dev Notes
 


### PR DESCRIPTION
## Summary

You called out that the bump-on-main-not-on-PR-branch process note was useful and might belong as a standard rubric in the README's DevOps section. This adds it.

## What's new

A new subsection under **Production / DevOps** in `README.md`, between the command list and Local Dev Notes:

- **The 5-line standard sequence** — `git pull → just bump → git push → just ship → just whats-running`.
- **Four rules of thumb** that came out of the PR #79–#82 session:
  1. Bump on `main`, not on PR branches (with the one-time `just bump initial` exception called out).
  2. Labels are optional but read better in the build badge.
  3. Test on prod for auth/session-touching changes — localhost's dev server returns `authEnabled: false` and skips the email gate, so verifications there give false negatives.
  4. `BUMP_GUARD=skip just deploy` is the hotfix override.

Plus a TOC entry pointing at the new subsection.

## Why these specifically

These are the four things that bit during the PR #79–#82 work:

- I bumped on a PR branch and force-pushed to fix it (process slip). → rule 1.
- The `whats-running` output before any `chore(version):` commit existed → rule 1's exception.
- You ran the PR #79 manual test on `localhost:8765`, didn't see the email gate, and we worked out it was the dev server's `authEnabled: false` path. → rule 3.
- The PR #80 body documented the override env var; surfacing it in the README means it's discoverable when needed without re-reading PR descriptions. → rule 4.

## Scope

Doc-only. No code or test changes. README structure and tone unchanged elsewhere.

🤖 Generated with [Claude Code](https://claude.com/claude-code)