### PR TITLE
feat(install): install-funnel telemetry via /api/client-errors

### DIFF
--- a/app/static/app.js
+++ b/app/static/app.js
@@ -3072,6 +3072,42 @@
     });
   }
 
+  // Reports a single install-flow event to /api/client-errors so the
+  // maintainer can grep journald to answer questions like "what fraction
+  // of install-landing visits saw beforeinstallprompt fire vs. timed
+  // out?" Fire-and-forget; never blocks the install UX. The server-side
+  // sanitizer (deploy/client_error_sanitizer.py) is the privacy
+  // boundary — same email-redaction + length cap rules as the existing
+  // kinds. Uses fetch keepalive so the request survives the navigation
+  // that often follows (e.g. user_in_tab_clicked → bootDirectoryAsApp).
+  function reportInstallEvent(name, extra) {
+    if (!name) return;
+    var build = '';
+    if (bootBuildMeta && (bootBuildMeta.git_sha || bootBuildMeta.built_at)) {
+      build = (bootBuildMeta.git_sha || '') +
+        (bootBuildMeta.built_at ? ' @ ' + bootBuildMeta.built_at : '');
+    }
+    var ev = { kind: 'install', msg: String(name) };
+    if (extra) ev.extra = String(extra);
+    var payload = {
+      events: [ev],
+      ua: String(navigator.userAgent || ''),
+      build: build,
+      route: '#install-landing',
+      displayMode: isStandaloneDisplayMode() ? 'standalone' : 'browser-tab'
+    };
+    try { payload.online = Boolean(navigator.onLine); } catch (e) {}
+    try {
+      fetch('/api/client-errors', {
+        method: 'POST',
+        headers: { 'Content-Type': 'application/json' },
+        credentials: 'same-origin',
+        body: JSON.stringify(payload),
+        keepalive: true
+      }).catch(function () { /* ignore — telemetry is best-effort */ });
+    } catch (e) { /* ignore */ }
+  }
+
   function initBrowserInstallMode(authPayload, httpStatus) {
     if (installGatePrivateEl) installGatePrivateEl.classList.add('hidden');
     if (installLandingEl) installLandingEl.classList.remove('hidden');
@@ -3084,21 +3120,44 @@
       showAuthDebugInstall(authPayload, httpStatus != null ? httpStatus : 200);
     }
 
+    reportInstallEvent('landing_shown');
+
     if (isIosSafari() && iosHintEl) {
       iosHintEl.classList.remove('hidden');
       if (installButtonEl) installButtonEl.classList.add('hidden');
+      reportInstallEvent('ios_safari_advised');
     }
 
+    // Track whether beforeinstallprompt arrived. The 5s timer reports
+    // a "never_arrived" event so we can distinguish browsers that
+    // suppress the prompt (already-installed Chrome on the same
+    // profile, engagement heuristic not yet met) from browsers that
+    // genuinely don't support it. Skipped when the iOS Safari path
+    // already advised the user — beforeinstallprompt is iOS-by-design
+    // not-a-thing there, no value reporting it.
+    var beforeInstallPromptSeen = false;
     window.addEventListener('beforeinstallprompt', function (e) {
       e.preventDefault();
       deferredInstallPrompt = e;
+      beforeInstallPromptSeen = true;
+      var platforms = '';
+      try { platforms = (e.platforms || []).join(','); } catch (ePf) {}
+      reportInstallEvent('before_prompt_fired', platforms);
       setInstallStatus('');
       if (installUnsupportedHintEl) installUnsupportedHintEl.classList.add('hidden');
       if (installButtonEl) installButtonEl.classList.remove('hidden');
     });
+    if (!isIosSafari()) {
+      setTimeout(function () {
+        if (!beforeInstallPromptSeen) {
+          reportInstallEvent('before_prompt_never_arrived');
+        }
+      }, 5000);
+    }
 
     window.addEventListener('appinstalled', function () {
       deferredInstallPrompt = null;
+      reportInstallEvent('app_installed');
       setInstallStatus('App installed — open it from your dock or app drawer.');
       if (installButtonEl) installButtonEl.classList.add('hidden');
     });
@@ -3115,21 +3174,27 @@
     if (installButtonEl && !installButtonEl._wired) {
       installButtonEl._wired = true;
       installButtonEl.addEventListener('click', function () {
+        reportInstallEvent('button_clicked');
         if (deferredInstallPrompt) {
           deferredInstallPrompt.prompt();
           deferredInstallPrompt.userChoice
             .then(function (choice) {
               deferredInstallPrompt = null;
-              if (choice && choice.outcome === 'accepted') {
+              var outcome = (choice && choice.outcome) || 'unknown';
+              var platform = (choice && choice.platform) || '';
+              reportInstallEvent('outcome_' + outcome, platform);
+              if (outcome === 'accepted') {
                 setInstallStatus('Installing…');
               }
             })
-            .catch(function () {
+            .catch(function (err) {
               deferredInstallPrompt = null;
+              reportInstallEvent('outcome_error', err && err.message);
             });
         } else if (isIosSafari()) {
           setInstallStatus('Use Share → Add to Home Screen.');
         } else {
+          reportInstallEvent('button_clicked_no_prompt');
           if (installUnsupportedHintEl) installUnsupportedHintEl.classList.remove('hidden');
           if (installButtonEl) installButtonEl.classList.add('hidden');
         }
@@ -3162,6 +3227,7 @@
       installUseInTabEl._wired = true;
       installUseInTabEl.addEventListener('click', function (ev) {
         ev.preventDefault();
+        reportInstallEvent('use_in_tab_clicked');
         markAuthenticatedOnce();
         if (installLandingEl) installLandingEl.classList.add('hidden');
         bootDirectoryAsApp();

--- a/deploy/client_error_sanitizer.py
+++ b/deploy/client_error_sanitizer.py
@@ -53,12 +53,19 @@ MAX_ROUTE_LEN = 240
 MAX_BUILD_LEN = 64
 
 # Restricted set so a caller can't smuggle e.g. `kind=admin_command`.
+# `install` carries install-funnel telemetry from the install landing
+# page (beforeinstallprompt fired / never arrived, button clicked,
+# accept/dismiss outcome, app installed, "use in tab" escape hatch,
+# iOS Safari advisory). The privacy boundary is the same — same
+# free-text sanitization on `msg` and `extra` — so adding the kind
+# doesn't widen what a caller can put in the journald log.
 ALLOWED_EVENT_KINDS = frozenset({
     "http",
     "sw",
     "window.error",
     "unhandledrejection",
     "console.error",
+    "install",
 })
 
 ALLOWED_DISPLAY_MODES = frozenset({"standalone", "browser-tab"})

--- a/docs/email_gate.md
+++ b/docs/email_gate.md
@@ -179,7 +179,7 @@ Request body (POST, `Content-Type: application/json`, max 16 KB):
 {
   "events": [                              // required, array, capped at 20
     {
-      "kind": "http",                       // one of: http, sw, window.error, unhandledrejection, console.error
+      "kind": "http",                       // one of: http, sw, window.error, unhandledrejection, console.error, install
       "ts":   "2026-04-30T15:00:00Z",       // optional, ISO-8601, length-capped
       "msg":  "GET /api/fellows → 404",    // free text, sanitized + truncated to 500
       "extra": "..."                        // optional, sanitized + truncated to 200
@@ -195,6 +195,46 @@ Request body (POST, `Content-Type: application/json`, max 16 KB):
 ```
 
 Unknown top-level keys are silently dropped. Events whose `kind` isn't in the accept-list are silently dropped. Non-conforming `lastSubmitHashPrefix` is silently dropped.
+
+#### `kind=install` events (install-funnel telemetry)
+
+The install landing page (`#install-landing`) fires one-event payloads with `kind=install` at each meaningful step in the install flow, so the maintainer can answer "what fraction of install-landing visits actually saw `beforeinstallprompt` fire vs. timed out?" without instrumenting an analytics pipeline. Same `/api/client-errors` sink, same sanitizer rules — adding the kind to the allowlist doesn't widen what a caller can put in journald.
+
+Event names in `msg`:
+
+| `msg` | Fired when |
+|---|---|
+| `landing_shown` | The install landing first renders. The denominator for everything below. |
+| `ios_safari_advised` | The user is on iOS Safari, where `beforeinstallprompt` doesn't exist; the UI shows the Share → Add to Home Screen hint. |
+| `before_prompt_fired` | Chrome/Edge fired `beforeinstallprompt`; install button now active. `extra` carries the comma-joined `event.platforms` (typically `web`). |
+| `before_prompt_never_arrived` | 5 seconds after `landing_shown`, no `beforeinstallprompt` seen — engagement heuristic not met, already-installed PWA on the same profile, or unsupported browser. Skipped on iOS Safari (where the event doesn't exist by design). |
+| `button_clicked` | User clicked the Install button. |
+| `button_clicked_no_prompt` | User clicked Install but no deferred prompt was available — the unsupported-hint surfaces. |
+| `outcome_accepted` / `outcome_dismissed` / `outcome_unknown` | Result of the OS install dialog; `extra` carries `choice.platform`. |
+| `outcome_error` | The promise from `prompt()` / `userChoice` rejected; `extra` carries the error message (sanitizer-redacted). |
+| `app_installed` | The browser's `appinstalled` event fired — terminal success signal. |
+| `use_in_tab_clicked` | User took the "Use the directory in this tab" escape hatch instead of installing. |
+
+Operator query example — last 24h funnel breakdown:
+
+```bash
+just prod-logs | grep '"kind": "install"' | python3 -c '
+import json, sys
+from collections import Counter
+c = Counter()
+for line in sys.stdin:
+    try:
+        for ev in json.loads(line.split(" ", 4)[-1])["events"]:
+            if ev["kind"] == "install":
+                c[ev["msg"]] += 1
+    except Exception:
+        pass
+for k, v in c.most_common():
+    print(f"{v:>6}  {k}")
+'
+```
+
+A future `just prod-stats` extension could surface the same breakdown alongside the existing `magic_links_sent` / `magic_links_verified` tallies.
 
 ### Anti-abuse posture
 

--- a/tests/e2e/test_email_gate.py
+++ b/tests/e2e/test_email_gate.py
@@ -436,3 +436,70 @@ class TestEmailGate:
             expect(page.locator("#install-gate-private")).to_be_visible()
         finally:
             page.close()
+
+
+class TestInstallTelemetry:
+    """Install-funnel telemetry: every meaningful step in the install
+    landing flow POSTs a `kind=install` event to /api/client-errors so
+    the maintainer can grep journald for "what fraction of install
+    visits actually saw beforeinstallprompt fire vs. timed out?" The
+    /api/client-errors sink is the same one the existing client errors
+    use; the kind allowlist was extended in deploy/client_error_sanitizer.py.
+    """
+
+    def test_landing_shown_posts_install_event(self, context, base_url_fixture):
+        page = context.new_page()
+        try:
+            _mock_auth_status(
+                page,
+                authEnabled=True,
+                authenticated=True,
+                installRecentlyAllowed=True,
+            )
+            with page.expect_request(
+                lambda r: "/api/client-errors" in r.url and r.method == "POST",
+                timeout=5000,
+            ) as req_info:
+                page.goto(base_url_fixture + "/", wait_until="domcontentloaded")
+                expect(page.locator("#install-landing")).to_be_visible()
+            body = req_info.value.post_data_json
+            assert body["events"][0]["kind"] == "install"
+            assert body["events"][0]["msg"] == "landing_shown"
+            # Sanity: build line, route, and displayMode shape match the
+            # rest of the /api/client-errors payloads (and survive the
+            # server-side sanitizer).
+            assert body["route"] == "#install-landing"
+            assert body["displayMode"] in ("standalone", "browser-tab")
+        finally:
+            page.close()
+
+    def test_use_in_tab_click_posts_install_event(self, context, base_url_fixture):
+        """The 'Use the directory in this tab' escape hatch fires its own
+        event so we can tell apart 'never saw the prompt' from 'saw it
+        and decided to escape' in the funnel."""
+        page = context.new_page()
+        try:
+            _mock_auth_status(
+                page,
+                authEnabled=True,
+                authenticated=True,
+                installRecentlyAllowed=True,
+            )
+            page.goto(base_url_fixture + "/", wait_until="domcontentloaded")
+            expect(page.locator("#install-landing")).to_be_visible()
+            # Wait for the landing_shown POST to land so the next
+            # expect_request doesn't race-capture it instead of the click
+            # event we care about.
+            page.wait_for_timeout(200)
+            with page.expect_request(
+                lambda r: "/api/client-errors" in r.url
+                and r.method == "POST"
+                and (r.post_data or "").find("use_in_tab_clicked") >= 0,
+                timeout=5000,
+            ) as req_info:
+                page.locator("#install-use-in-tab").click()
+            body = req_info.value.post_data_json
+            assert body["events"][0]["kind"] == "install"
+            assert body["events"][0]["msg"] == "use_in_tab_clicked"
+        finally:
+            page.close()

--- a/tests/test_client_error_sanitizer.py
+++ b/tests/test_client_error_sanitizer.py
@@ -157,6 +157,34 @@ def test_sanitize_payload_drops_unknown_event_kind():
     assert out["events"] == []
 
 
+def test_sanitize_payload_accepts_install_kind():
+    """Install-funnel telemetry rides the same /api/client-errors sink as
+    the existing kinds. The privacy boundary (free-text sanitizer on
+    msg/extra) is the same; adding the kind to the allowlist doesn't
+    widen what a caller can put in journald."""
+    body = {"events": [
+        {"kind": "install", "msg": "before_prompt_fired"},
+        {"kind": "install", "msg": "outcome_accepted", "extra": "android"},
+        {"kind": "install", "msg": "use_in_tab_clicked"},
+    ]}
+    out = ces.sanitize_payload(body)
+    assert len(out["events"]) == 3
+    assert all(e["kind"] == "install" for e in out["events"])
+    assert out["events"][1]["extra"] == "android"
+
+
+def test_sanitize_payload_install_kind_still_redacts_email_in_msg():
+    """The kind allowlist doesn't bypass the email-redaction rule on
+    free-text fields. A buggy caller that tries to send the user's
+    email in an install event still gets it scrubbed server-side."""
+    body = {"events": [
+        {"kind": "install", "msg": "outcome_accepted by me@example.com"},
+    ]}
+    out = ces.sanitize_payload(body)
+    assert "me@example.com" not in out["events"][0]["msg"]
+    assert "<email>" in out["events"][0]["msg"]
+
+
 def test_sanitize_payload_caps_event_count():
     events = [{"kind": "http", "msg": f"e{i}"} for i in range(50)]
     out = ces.sanitize_payload({"events": events})


### PR DESCRIPTION
## Summary

After we evaluated the [pwa-install web component](https://github.com/ProgressiveWebComponents/pwa-install) and concluded it's a sideways move (the failure modes are at the browser-engine layer, not the JS-plumbing layer), the actual leverage is **knowing which failure mode is hitting fellows**. This PR adds the instrumentation.

Reuses the existing `/api/client-errors` sink — unauthenticated by design, sanitized server-side, rate-limited per-IP, structured journald events, no DB writes. Extending its `ALLOWED_EVENT_KINDS` allowlist with `install` doesn't widen the privacy boundary (same email-redaction + length-cap rules on `msg` / `extra` apply regardless of kind).

## What gets reported

Single-event POSTs from the install landing flow, fire-and-forget with `fetch keepalive` so the request survives the navigation that often follows (e.g. `use_in_tab_clicked` → `bootDirectoryAsApp`):

| `msg` | Fired when |
|---|---|
| `landing_shown` | Install landing first renders. The denominator. |
| `ios_safari_advised` | iOS Safari user got the Share → Add to Home Screen hint. |
| `before_prompt_fired` | Chrome/Edge fired `beforeinstallprompt`. `extra` carries `event.platforms`. |
| `before_prompt_never_arrived` | 5s after `landing_shown`, no event seen. Skipped on iOS Safari. |
| `button_clicked` | User clicked Install. |
| `button_clicked_no_prompt` | Clicked Install but no deferred prompt available. |
| `outcome_accepted` / `outcome_dismissed` / `outcome_unknown` | OS dialog result; `extra` = `choice.platform`. |
| `outcome_error` | `prompt()` / `userChoice` rejected; `extra` = error message. |
| `app_installed` | Browser fired `appinstalled` — terminal success. |
| `use_in_tab_clicked` | User took the escape hatch instead of installing. |

## Files

- **`app/static/app.js`** — new `reportInstallEvent(name, extra)` helper + 9 instrumented call sites in `initBrowserInstallMode`.
- **`deploy/client_error_sanitizer.py`** — one line added to `ALLOWED_EVENT_KINDS`. Comment block explains why the privacy boundary doesn't move.
- **`tests/test_client_error_sanitizer.py`** — two new tests: `kind=install` accepted, email-redaction still applies regardless of kind.
- **`tests/e2e/test_email_gate.py`** — new `TestInstallTelemetry` class: `landing_shown` POSTs on install-landing render, `use_in_tab_clicked` POSTs on the escape-hatch click.
- **`docs/email_gate.md`** — `kind=install` events table + an operator one-liner that buckets events from journald.

## Tests

- `just test-fast` → 73 passed (incl. 2 new sanitizer tests).
- `just test-e2e InstallTelemetry` → 2 new tests pass.
- `just test-e2e "email_gate or install_landing"` → 24 pass; no regression in adjacent install-flow tests.

## Real-world verification (after merge + deploy)

Tail journald for the new events:

```bash
just prod-logs | grep '"kind": "install"'
```

The doc includes a Python one-liner that buckets `msg` counts. A future `just prod-stats` extension to surface the funnel alongside `magic_links_sent` / `magic_links_verified` is the natural follow-up but not in scope here.

## Why not pwa-install

For the record so this evaluation lives in the repo: the library is a clean wrapper around `beforeinstallprompt` + `getInstalledRelatedApps` and exposes telemetry-friendly events, but it duplicates everything the existing handlers already do, and the `getInstalledRelatedApps` API requires `related_applications` in the manifest — which `docs/Architecture.md` § "Manifest gotchas" explicitly warns against because it triggers Samsung WebAPK's "Older Version of Android" install error. Net: zero reliability gain, one more thing to maintain. This PR gets the one useful thing (telemetry) without the dependency.

🤖 Generated with [Claude Code](https://claude.com/claude-code)