### PR TITLE
docs: install-funnel references in email_gate.md + DevOps.md

### DIFF
--- a/docs/DevOps.md
+++ b/docs/DevOps.md
@@ -135,8 +135,9 @@ just smoke              # /healthz, /manifest.webmanifest, /api/debug/diagnostic
 just check-env          # DNS + TLS + healthz
 just prod-status        # systemctl status fellows-pwa caddy (over SSH)
 just drift              # prod git SHA vs local HEAD + origin/main (SHA-aligned)
-just prod-stats         # summarise last 24h: page loads, magic-link sends/verifies, 5xx, disk
-just prod-stats-long    # full retained journal + plaintext recipient list (every magic-link send)
+just prod-stats                # 24h: page loads, magic-link sends/verifies, install funnel, 5xx, disk
+just prod-stats '7 days ago'   # weekly view (any "since" that journalctl accepts)
+just prod-stats-long           # full retained journal + plaintext recipient list (every magic-link send)
 ```
 
 Lower-level equivalents (what each recipe runs):
@@ -179,7 +180,7 @@ That wraps `./scripts/configure_email_auth_env.sh`, which prompts for `FELLOWS_M
 ## Debugging
 
 - **Service**: `just prod-logs` (`journalctl -u fellows-pwa -f`) streams structured JSON (`event=auth_status`, `event=send_unlock_email`, `event=build_meta`). Pass a different unit with `just prod-logs caddy`.
-- **Activity summary**: `just prod-stats` reads journald on the droplet and prints a tally of page loads, directory-API hits, DB downloads, magic-link sends/verifies, 5xx errors, and disk usage over a window (default `24 hours ago`; try `just prod-stats '7 days ago'`). `just prod-stats-long` extends the window to the full retained journal and lists the plaintext email of every magic-link recipient (joined against `/opt/fellows/deploy/dist/fellows.db` on the droplet). The remote binary is `/opt/fellows/bin/prod_stats` (source: `scripts/prod_stats.py`, deployed by the `fellows_app` Ansible role). No sudo needed — journal-read access is granted by the `systemd-journal` and `adm` group memberships that the `common` role adds to the operator. If `just prod-stats` starts returning all zeros (and the script also prints a "journalctl returned 0 entries" warning on stderr), that membership has drifted; re-run `just bootstrap` to re-apply it.
+- **Activity summary**: `just prod-stats` reads journald on the droplet and prints a tally of page loads, directory-API hits, DB downloads, magic-link sends/verifies, the **install funnel** (denominator `landing_shown` + per-step counts down through `app_installed` and `use_in_tab_clicked`, with per-platform splits on `outcome_*` accept/dismiss), 5xx errors, client error reports, and disk usage. Default window is `24 hours ago`; pass any string `journalctl --since` accepts. Common examples: `just prod-stats` for a daily check, `just prod-stats '7 days ago'` for a weekly view (more useful for the install funnel since installs are sparse — answers "of N landing visits this week, what fraction installed vs. timed out vs. used the in-tab escape hatch?"). `just prod-stats-long` extends the window to the full retained journal and lists the plaintext email of every magic-link recipient (joined against `/opt/fellows/deploy/dist/fellows.db` on the droplet). The remote binary is `/opt/fellows/bin/prod_stats` (source: `scripts/prod_stats.py`, deployed by the `fellows_app` Ansible role). No sudo needed — journal-read access is granted by the `systemd-journal` and `adm` group memberships that the `common` role adds to the operator. If `just prod-stats` starts returning all zeros (and the script also prints a "journalctl returned 0 entries" warning on stderr), that membership has drifted; re-run `just bootstrap` to re-apply it.
 - **Bundle drift**: `just drift` shows prod's `X-Fellows-Build` alongside local `HEAD` and `origin/main`. The browser's Diagnostics panel (`?diag=1`) shows the same header plus auth state and Cache API contents. Pair with `just prod-logs` to confirm client and server are on the same build.
 - **Send-flow failures**: `just email-debug` mines recent `event=send_unlock_email` entries from journald and optionally resolves Postmark `MessageID`s.
 - **Deploy failures**: `ansible-playbook … -vvv` for SSH/module detail. Log path is `ansible/ansible.log` relative to the repo root.

--- a/docs/email_gate.md
+++ b/docs/email_gate.md
@@ -215,26 +215,14 @@ Event names in `msg`:
 | `app_installed` | The browser's `appinstalled` event fired — terminal success signal. |
 | `use_in_tab_clicked` | User took the "Use the directory in this tab" escape hatch instead of installing. |
 
-Operator query example — last 24h funnel breakdown:
+Operator query — funnel breakdown:
 
 ```bash
-just prod-logs | grep '"kind": "install"' | python3 -c '
-import json, sys
-from collections import Counter
-c = Counter()
-for line in sys.stdin:
-    try:
-        for ev in json.loads(line.split(" ", 4)[-1])["events"]:
-            if ev["kind"] == "install":
-                c[ev["msg"]] += 1
-    except Exception:
-        pass
-for k, v in c.most_common():
-    print(f"{v:>6}  {k}")
-'
+just prod-stats                # last 24h
+just prod-stats '7 days ago'   # weekly view
 ```
 
-A future `just prod-stats` extension could surface the same breakdown alongside the existing `magic_links_sent` / `magic_links_verified` tallies.
+`just prod-stats` parses these events out of journald and renders an `Install funnel:` section under `Client error reports`. Each row counts events by `msg`; `outcome_*` rows include a per-platform breakdown from `extra` (typically `web` for Chrome/Edge/Android Chrome). The section is hidden when there's no install activity in the window. See `scripts/prod_stats.py:_print_install_funnel` for the renderer.
 
 ### Anti-abuse posture
 


### PR DESCRIPTION
## Summary

Cherry-pick of two doc-only commits that were pushed to PRs #89 / #90 after they merged, so they didn't make it to main with the rest of those PRs. Re-landing here.

## Commits

1. **`docs(email_gate): point install-funnel triage at just prod-stats`** — replaces the Python journald one-liner in `docs/email_gate.md` § \`kind=install\` events (added in #89) with `just prod-stats` / `just prod-stats '7 days ago'`. Operators now have one obvious thing to type instead of a paste-friendly script.
2. **`docs(devops): surface 7-day install-funnel example for prod-stats`** — lifts `just prod-stats '7 days ago'` from a parenthetical inside a debugging paragraph to its own line in the post-deploy bash block in `docs/DevOps.md`. Updates the prose to call out the install funnel by name and explain why the weekly view matters more for it (installs are sparse — a single day isn't enough to read the funnel reliably).

## Scope

Doc-only. Net: 8 lines added, 19 removed. No code or test changes.

🤖 Generated with [Claude Code](https://claude.com/claude-code)