### PR TITLE
fix(opfs): unbreak SAH-pool init + COOP/COEP on dev + hide broken settings sections

### DIFF
--- a/app/server.py
+++ b/app/server.py
@@ -282,6 +282,20 @@ class Handler(BaseHTTPRequestHandler):
     def log_message(self, format, *args):
         pass  # quiet by default; override to log
 
+    def end_headers(self):
+        # Cross-origin isolation. sqlite3-wasm's OPFS-SAH-Pool VFS gates
+        # SharedArrayBuffer / Atomics on this; without crossOriginIsolated
+        # the VFS install fails ("Cannot install OPFS: Missing
+        # SharedArrayBuffer and/or Atomics"), and the dev server falls back
+        # to the API provider — which has no live relationships.db, so
+        # backup/restore in Settings don't function. Setting these here
+        # mirrors what a properly-configured production reverse proxy
+        # should set; the app is fully first-party so require-corp is
+        # safe (no cross-origin scripts / fonts / images to break).
+        self.send_header("Cross-Origin-Opener-Policy", "same-origin")
+        self.send_header("Cross-Origin-Embedder-Policy", "require-corp")
+        super().end_headers()
+
     def send_json(self, data, status=200):
         self.send_response(status)
         self.send_header("Content-Type", "application/json; charset=utf-8")

--- a/app/static/app.js
+++ b/app/static/app.js
@@ -2929,9 +2929,25 @@
     setSetupStatus('Setting up your local directory…');
     return globalThis
       .sqlite3InitModule()
-      .then(function (Module) {
+      .then(function (sqlite3) {
+        // sqlite3-wasm's init wrapper resolves with the sqlite3
+        // namespace itself (see vendor/sqlite3.js's `globalThis.sqlite3InitModule`
+        // override — it returns the result of `s.asyncPostInit()`,
+        // where `s` is the sqlite3 namespace). Earlier code here
+        // treated the resolved value as an EmscriptenModule with a
+        // `.sqlite3` child, which made `installOpfsSAHPoolVfs` look
+        // undefined and silently dropped every browser to the API
+        // provider — so backup/restore (PR #84 + #88) only ever
+        // worked in theory. Calling it directly on the namespace
+        // is what the upstream API expects.
         bootDebugPush('sqlite3InitModule: OK');
-        return Module.sqlite3.installOpfsSAHPoolVfs();
+        if (typeof sqlite3.installOpfsSAHPoolVfs !== 'function') {
+          throw new Error(
+            'sqlite3.installOpfsSAHPoolVfs missing from this build (' +
+            (sqlite3.version && sqlite3.version.libVersion || 'unknown version') + ')'
+          );
+        }
+        return sqlite3.installOpfsSAHPoolVfs();
       })
       .then(function (poolUtil) {
         bootDebugPush('installOpfsSAHPoolVfs: OK');
@@ -6112,6 +6128,23 @@
     var downloadBtn = document.getElementById('settings-download-userdata');
     var downloadStatus = document.getElementById('settings-download-status');
     var exportSection = document.getElementById('settings-export-section');
+
+    // Backup + restore both depend on the OPFS-backed sqlite provider —
+    // the API provider has no live relationships.db to export or
+    // overwrite. Hide both sections up front when we're on the API
+    // provider (typical on dev localhost without the SAH-pool VFS, or
+    // any browser that fell back to API mode). PR #84's behavior was
+    // to hide the export section only on click rejection; this matches
+    // it for both sections at render time so users don't see broken
+    // affordances. The localDataUnavailable click-rejection paths
+    // below remain for paranoia / late provider downgrades.
+    var localPersistenceAvailable = !!(dataProvider && dataProvider.kind === 'sqlite');
+    if (!localPersistenceAvailable) {
+      var preExport = document.getElementById('settings-export-section');
+      if (preExport) preExport.style.display = 'none';
+      var preRestore = document.getElementById('settings-restore-section');
+      if (preRestore) preRestore.style.display = 'none';
+    }
 
     if (downloadBtn) {
       downloadBtn.addEventListener('click', function () {

--- a/tests/e2e/test_settings.py
+++ b/tests/e2e/test_settings.py
@@ -141,48 +141,40 @@ class TestSettingsPage:
         addr = page.locator("#export-self-email-addr")
         expect(addr).to_have_value("rich@example.com")
 
-    def test_download_userdata_button_present(
+    def test_userdata_sections_in_dom_and_hidden_in_api_mode(
         self, standalone_page, base_url_fixture
     ):
-        """PR D: Settings page exposes a Download my user data button.
-        The actual export only works on the OPFS path (which the dev e2e
-        harness doesn't have — see the SharedArrayBuffer warning in
-        console). This test asserts the markup is in place; the OPFS
-        round-trip is real-browser-only."""
-        page = standalone_page
-        page.goto(f"{base_url_fixture}/#/settings", wait_until="domcontentloaded")
-        _wait_for_directory(page)
-        expect(page.locator("#settings-export-section")).to_be_visible()
-        expect(page.locator("#settings-download-userdata")).to_be_visible()
-        expect(page.locator(".settings-section-title").first).to_contain_text("Your saved data")
+        """The Settings page emits both the "Your saved data" (PR #84) and
+        "Restore from backup" (PR #88) sections in the DOM. Their *visibility*
+        depends on the data provider:
+        - OPFS-backed sqlite provider → both sections visible.
+        - API provider → both sections hidden up front, because there's no
+          live relationships.db to export or overwrite (PR #88's fix to the
+          silent-fail Download bug).
 
-    def test_restore_section_renders_with_picker_and_backup_list(
-        self, standalone_page, base_url_fixture
-    ):
-        """Issue #85: Settings exposes a Restore from a file button + a
-        Recent auto-backups list. Like the export half (PR #84), the
-        actual restore round-trip needs OPFS, which the dev e2e harness
-        doesn't have. This test asserts the markup renders; the OPFS
-        round-trip is verified manually on prod (see issue #85 test plan)."""
+        Dev e2e runs in API-provider mode (Playwright's chromium does not
+        expose `FileSystemFileHandle.prototype.createSyncAccessHandle` on the
+        main thread, so the SAH-pool VFS can't install). The OPFS round-trip
+        is verified on prod manually — see issue #85 test plan."""
         page = standalone_page
         page.goto(f"{base_url_fixture}/#/settings", wait_until="domcontentloaded")
         _wait_for_directory(page)
-        # Restore section + heading.
-        expect(page.locator("#settings-restore-section")).to_be_visible()
-        expect(
-            page.locator("#settings-restore-section .settings-section-title")
-        ).to_contain_text("Restore from backup")
-        # File-picker affordance: input is hidden by design; the visible
-        # button click()s the input. Both must exist.
-        expect(page.locator("#settings-restore-pick")).to_be_visible()
+        export_section = page.locator("#settings-export-section")
+        restore_section = page.locator("#settings-restore-section")
+        # Both sections must be in the DOM (so OPFS-mode users see them).
+        expect(export_section).to_have_count(1)
+        expect(restore_section).to_have_count(1)
+        # Markup details that don't depend on visibility.
+        expect(page.locator("#settings-download-userdata")).to_have_count(1)
+        expect(page.locator("#settings-restore-pick")).to_have_count(1)
         file_input = page.locator("#settings-restore-file")
         expect(file_input).to_have_count(1)
         accept = file_input.get_attribute("accept") or ""
         assert ".db" in accept and ".sqlite" in accept
-        # Recent auto-backups list region: in API mode (dev) the list
-        # resolves to [] and the empty-state hint is what the user sees.
-        expect(page.locator("#settings-backup-list-empty")).to_be_visible()
-        # Live list itself is hidden until populated.
-        backup_list = page.locator("#settings-backup-list")
-        expect(backup_list).to_have_count(1)
-        assert backup_list.evaluate("el => el.hidden") is True
+        # In dev (API provider), proactive hide kicks in.
+        assert export_section.evaluate("el => el.style.display") == "none", (
+            "expected export section hidden in API-provider mode"
+        )
+        assert restore_section.evaluate("el => el.style.display") == "none", (
+            "expected restore section hidden in API-provider mode"
+        )


### PR DESCRIPTION
Three fixes for the same observable bug — Settings → **Download my user data** silently fails and the section disappears, then PR #88's new Restore section sits there pretending to work. Root cause: the OPFS-backed sqlite provider has not actually initialized in any browser since PR #84 — every browser has been silently falling back to the API provider, which has no live `relationships.db` to export or overwrite.

## Why nobody caught this earlier

PR #84's plan said *"Real verification path is on prod after merge"* — that manual round-trip apparently never happened, or the failure looked like a refresh issue. PR #88 inherited the same untested OPFS path and broke its own Restore section in the same way, on top.

The user's Diagnostics block shows `last_seen_sha.txt: (none)` against `15a51bb` (PR #88's tip), confirming `maybeBackupRelationshipsDb` has never run on their machine. Same on every browser I checked.

## What changed

### 1. `sqlite3InitModule` resolves with the namespace, not a Module wrapper

PR #84's `app.js` wrote:

\`\`\`js
globalThis.sqlite3InitModule().then(function (Module) {
  return Module.sqlite3.installOpfsSAHPoolVfs();
});
\`\`\`

But the sqlite3-wasm wrapper (`vendor/sqlite3.js:12111-12124`) returns the `sqlite3` namespace itself from `s.asyncPostInit()`, not an EmscriptenModule with a `.sqlite3` child. So `Module.sqlite3` is undefined, the call throws *"Cannot read properties of undefined (reading 'installOpfsSAHPoolVfs')"*, and the catch in `pickDataProvider` falls back to the API provider.

Fix: rename the parameter to `sqlite3` and call `sqlite3.installOpfsSAHPoolVfs()` directly. Also throws a louder error if the SAH-pool function is missing from the build, so future silent-fall-throughs at this layer are noisy.

### 2. Dev server emits COOP/COEP headers

`sqlite3-wasm`'s SAH-pool VFS additionally requires `SharedArrayBuffer` (through `Atomics`), which browsers gate behind `crossOriginIsolated`. That needs `Cross-Origin-Opener-Policy: same-origin` and `Cross-Origin-Embedder-Policy: require-corp` on every response. Adding them in `Handler.end_headers()` makes localhost a working OPFS environment for manual round-trip testing.

The app is fully first-party — vendor scripts, images, API all from the same origin — so `require-corp` is safe.

### 3. Settings hides export + restore sections in API mode

Even with #1 and #2, browsers without main-thread `FileSystemFileHandle.prototype.createSyncAccessHandle` (Chromium <121, Playwright's bundled chromium) will keep falling back to API. PR #84's existing behavior was to hide the export section only after the click handler caught the rejection — users click and watch the button vanish silently. PR #88's Restore section doesn't even hide.

Proactive fix: at `renderSettingsPage` time, check `dataProvider.kind === 'sqlite'` and hide both `#settings-export-section` and `#settings-restore-section` up front when the OPFS provider didn't come up. No flicker, no broken affordance.

## Test plan

- [x] `just test-e2e` — 139 passed.
- [ ] Manual on dev (after merge):
  - [ ] Open `http://localhost:8765/#/settings`. Both **Your saved data** and **Restore from backup** sections render (OPFS now initializes).
  - [ ] Click **Download my user data** → file downloads.
  - [ ] Open `?diag=1`. `relationships.db backups` lists at least the auto-backup written on this build's first boot. `last_seen_sha.txt:` shows the current SHA.
  - [ ] Restore from the downloaded file → confirm dialog with row counts → success → backup list shows a new pre-restore snapshot.
  - [ ] Restore from the auto-backup picker → reverses the file restore.
- [ ] Manual on prod (after deploy): same as above against `https://fellows.globaldonut.com/`.

## Why this matters for PR #88

PR #88's restore feature literally can't run today — every browser falls back to API mode where the restore methods reject with `localDataUnavailable`. Without these fixes, issue #85's manual prod test plan would fail at step 1. This PR unblocks PR #88's actual functionality and the auto-backup feature from PR #84 alongside.

🤖 Generated with [Claude Code](https://claude.com/claude-code)