### PR TITLE
chore(build): stamp build label from git SHA at build time, drop just bump

### DIFF
--- a/README.md
+++ b/README.md
@@ -311,18 +311,17 @@ After PRs merge to `main`, deploy with:
 
 ```bash
 git checkout main && git pull         # confirm merges are local
-just bump [<label>]                   # one chore(version): commit on main
-git push                              # push the bump to origin/main
-just ship                             # build → test → deploy → smoke (refuses if you forgot to bump)
+just ship                             # build → test → deploy → smoke
 just whats-running                    # confirm prod's git SHA matches local HEAD
 ```
 
-A few rules of thumb:
+That's the whole flow. The build label (`<YYYY-MM-DD>-<short-sha>`) is stamped into `FELLOWS_UI_DIAG` and `CACHE_VERSION` automatically by `build/build_pwa.py` from the current `git HEAD`, so every deploy gets a unique label tied to the code being shipped — no separate bump step, no `chore(version):` commit.
 
-- **Bump on `main`, not on a PR branch.** The bump is a deploy marker, not a PR marker. Bumping on a feature branch creates noise (every PR carries its own bump, only the last-merged wins) and obscures the deploy boundary in `main`'s history. The exception is PR #80's own bump infrastructure — the very first deploy after that merged needs `just bump initial` once, then the normal rubric.
-- **The label is optional but useful.** `just bump groups-fab` produces `2026-05-02-<sha>-groups-fab`, which reads more memorably in the build badge than a bare timestamp + SHA.
+A few notes:
+
+- **The dev server stamps the same label.** `python app/server.py` (and `just serve`) substitutes the placeholder when serving `app.js` and `sw.js`, using the current `git HEAD` short SHA. So the build badge in dev shows the live source SHA. If you see the literal `__FELLOWS_UI_DIAG__` in the badge, something is wrong with the substitution path — likely a stale `deploy/dist/` served raw or an unbuilt bundle in front of you.
 - **Test on prod, not localhost, when the change touches auth or session state.** The dev server returns `authEnabled: false` and skips the email gate entirely — checks like "Clear App Cache lands me at the gate" don't reproduce locally. The Playwright e2e suite (`just test-e2e ...`) mocks the prod auth path; `https://fellows.globaldonut.com` is the real verification.
-- **Hotfix override.** `BUMP_GUARD=skip just deploy` bypasses the bump guard for a fix that can't wait. The in-app version label stays behind one deploy until you bump and re-ship.
+- **What's deployed lives in the response, not in `git log`.** Use `just drift` to compare prod's `X-Fellows-Build` / `build_label` to local main, and `just whats-running` for the local + prod snapshot.
 
 ## Local Dev Notes
 

--- a/app/server.py
+++ b/app/server.py
@@ -11,7 +11,6 @@ Then open http://localhost:8765/
 import json
 import re
 import sqlite3
-import subprocess
 import sys
 import urllib.parse
 from datetime import datetime, timezone
@@ -32,9 +31,16 @@ if str(REPO_ROOT) not in sys.path:
 _DEPLOY_DIR = str(REPO_ROOT / "deploy")
 if _DEPLOY_DIR not in sys.path:
     sys.path.insert(0, _DEPLOY_DIR)
+# build/ exposes the build-label substitution helpers shared with prod's
+# build_pwa.py — keeps dev and dist identical on what gets stamped into
+# app.js / sw.js.
+_BUILD_DIR = str(REPO_ROOT / "build")
+if _BUILD_DIR not in sys.path:
+    sys.path.insert(0, _BUILD_DIR)
 
 from app import relationships  # noqa: E402  (after sys.path manipulation)
 import client_error_sanitizer as ces  # noqa: E402
+import build_pwa as _build_pwa  # noqa: E402  (build-label helpers)
 DB_PATH = APP_DIR / "fellows.db"
 STATIC_DIR = APP_DIR / "static"
 IMAGES_DIR = APP_DIR / "fellow_profile_images_by_name"
@@ -43,37 +49,26 @@ IMAGES_DIR_FALLBACK = REPO_ROOT / "final_fellows_set" / "fellow_profile_images_b
 PORT = 8765
 
 
-def _dev_build_meta() -> dict:
+def _dev_build_meta(label: str) -> dict:
     """Synthesize a build-meta blob for the dev server.
 
     Mirrors the shape of `deploy/dist/build-meta.json` (written by
     `build/build_pwa.py`) so the PWA's drift-check, diagnostics panel,
-    and build badge work identically in dev. The `git_sha` reflects
-    the currently checked-out commit when the server was started;
-    `built_at` is the server start time.
+    and build badge work identically in dev. The `git_sha` half of
+    `label` reflects the currently checked-out commit when the server
+    was started; `built_at` is the server start time.
     """
-    git_sha = None
-    try:
-        r = subprocess.run(
-            ["git", "rev-parse", "--short", "HEAD"],
-            cwd=str(REPO_ROOT),
-            capture_output=True,
-            text=True,
-            timeout=5,
-            check=False,
-        )
-        if r.returncode == 0 and (r.stdout or "").strip():
-            git_sha = (r.stdout or "").strip()
-    except (OSError, subprocess.SubprocessError):
-        pass
+    sha = label.rsplit("-", 1)[-1] if label else None
     return {
         "built_at": datetime.now(timezone.utc).strftime("%Y-%m-%dT%H:%M:%SZ"),
-        "git_sha": git_sha,
+        "git_sha": sha,
+        "build_label": label,
         "generator": "app/server.py (dev)",
     }
 
 
-BUILD_META: dict = _dev_build_meta()
+BUILD_LABEL: str = _build_pwa.compute_build_label(REPO_ROOT)
+BUILD_META: dict = _dev_build_meta(BUILD_LABEL)
 
 # Columns in fellows table (exclude extra_json for row dict)
 FELLOW_COLUMNS = [
@@ -752,6 +747,17 @@ class Handler(BaseHTTPRequestHandler):
         except OSError:
             self.send_error_404()
             return
+        # Build-label substitution mirrors what build/build_pwa.py does
+        # for deploy/dist/. Source has '__FELLOWS_UI_DIAG__' /
+        # '__CACHE_VERSION__' placeholders so dev and dist agree on the
+        # same substitution path; replacing here keeps the build badge,
+        # SW cache name, and image cache-bust query string consistent
+        # with the current git HEAD without a hand-maintained chore(version)
+        # commit.
+        if file_path.name in ("app.js", "sw.js"):
+            text = data.decode("utf-8")
+            stamped = _build_pwa.substitute_build_label(text, BUILD_LABEL)
+            data = stamped.encode("utf-8")
         self.send_response(200)
         self.send_header("Content-Type", ctype)
         self.send_header("Content-Length", str(len(data)))

--- a/app/static/app.js
+++ b/app/static/app.js
@@ -161,8 +161,16 @@
   };
   /** Bump on every meaningful UI / diagnostics change. Rendered in the
    *  always-visible build badge so a dev can tell at a glance which app.js
-   *  is actually running vs what the server was deployed with. */
-  var FELLOWS_UI_DIAG = '2026-05-02-6a74fa5-initial';
+   *  is actually running vs what the server was deployed with.
+   *
+   *  '__FELLOWS_UI_DIAG__' is a build-time placeholder.
+   *  build/build_pwa.py replaces it with `<YYYY-MM-DD>-<short-sha>` when
+   *  assembling deploy/dist/; the dev server in app/server.py does the
+   *  same substitution when serving /app.js. If you see the literal
+   *  placeholder in the running app, the bundle wasn't built — you're
+   *  either looking at raw source or hit a build step that didn't run.
+   *  See docs/DevOps.md. */
+  var FELLOWS_UI_DIAG = '__FELLOWS_UI_DIAG__';
 
   // Persistent marker: "this origin has been authenticated successfully at
   // least once." Preserved across clearAllAppData. Used by startBrowserUx's

--- a/app/static/sw.js
+++ b/app/static/sw.js
@@ -1,4 +1,10 @@
-const CACHE_VERSION = 'v15';
+// CACHE_VERSION + the FELLOWS_UI_DIAG constant in app.js are placeholders
+// substituted at build time by build/build_pwa.py (and at request time by
+// the dev server in app/server.py) with the current git short SHA. So
+// every build/deploy gets a unique cache name and visible build label
+// without needing a hand-maintained chore(version) commit on main. See
+// docs/DevOps.md for the routine deploy flow.
+const CACHE_VERSION = '__CACHE_VERSION__';
 const APP_SHELL_CACHE = `fellows-app-shell-${CACHE_VERSION}`;
 // Separate cache so shell-version bumps don't evict the ~34 MB of profile images.
 const IMAGES_CACHE = 'fellows-images-v1';

--- a/build/build_pwa.py
+++ b/build/build_pwa.py
@@ -21,26 +21,80 @@ DB_SRC = REPO_ROOT / "app" / "fellows.db"
 IMAGES_SRC = REPO_ROOT / "app" / "fellow_profile_images_by_name"
 IMAGES_FALLBACK = REPO_ROOT / "final_fellows_set" / "fellow_profile_images_by_name"
 
+# Source-tracked placeholders in app/static/app.js and app/static/sw.js,
+# substituted at build time (here) and at request time (app/server.py for
+# dev). Format of the substituted value: <YYYY-MM-DD>-<short-sha>. Both
+# substitutions use compute_build_label() below so dev and prod agree on
+# what the badge shows.
+PLACEHOLDER_UI_DIAG = "__FELLOWS_UI_DIAG__"
+PLACEHOLDER_CACHE_VERSION = "__CACHE_VERSION__"
 
-def write_build_meta(dest: Path) -> None:
-    """Fingerprint for deploy debugging (client vs server bundle drift)."""
-    git_sha = None
+
+def get_short_sha(repo_root: Path = REPO_ROOT) -> str | None:
+    """Current git short SHA, or None if git isn't available."""
     try:
         r = subprocess.run(
             ["git", "rev-parse", "--short", "HEAD"],
-            cwd=str(REPO_ROOT),
+            cwd=str(repo_root),
             capture_output=True,
             text=True,
             timeout=5,
             check=False,
         )
         if r.returncode == 0 and (r.stdout or "").strip():
-            git_sha = (r.stdout or "").strip()
+            return (r.stdout or "").strip()
     except (OSError, subprocess.SubprocessError):
         pass
+    return None
+
+
+def compute_build_label(repo_root: Path = REPO_ROOT) -> str:
+    """`<YYYY-MM-DD>-<short-sha>` — what gets baked into the bundle.
+
+    Falls back to `<YYYY-MM-DD>-unknown` if git isn't reachable so the
+    placeholder never survives substitution. The SHA piece is what makes
+    each build uniquely identifiable; the date piece is for human eyes
+    on the build badge.
+    """
+    today = datetime.now(timezone.utc).strftime("%Y-%m-%d")
+    sha = get_short_sha(repo_root) or "unknown"
+    return f"{today}-{sha}"
+
+
+def substitute_build_label(text: str, label: str) -> str:
+    """Replace both PWA placeholders with `label`. Pure function — same
+    text in dev and dist as long as the label matches."""
+    return text.replace(PLACEHOLDER_UI_DIAG, label).replace(
+        PLACEHOLDER_CACHE_VERSION, label
+    )
+
+
+def stamp_static_assets(dist_dir: Path, label: str) -> None:
+    """Substitute `__FELLOWS_UI_DIAG__` and `__CACHE_VERSION__` in the
+    two files that carry them. No-op if the placeholders aren't present
+    (e.g., a partial rebuild on already-stamped output)."""
+    for relpath in ("app.js", "sw.js"):
+        target = dist_dir / relpath
+        if not target.is_file():
+            continue
+        original = target.read_text(encoding="utf-8")
+        stamped = substitute_build_label(original, label)
+        if stamped != original:
+            target.write_text(stamped, encoding="utf-8")
+
+
+def write_build_meta(dest: Path, label: str) -> None:
+    """Fingerprint for deploy debugging (client vs server bundle drift).
+
+    The git_sha here matches the SHA-half of the build label so a single
+    server response can be cross-referenced against a single source
+    revision. built_at is UTC, ISO-8601, second-resolution.
+    """
+    sha = label.rsplit("-", 1)[-1] if label else None
     meta = {
         "built_at": datetime.now(timezone.utc).strftime("%Y-%m-%dT%H:%M:%SZ"),
-        "git_sha": git_sha,
+        "git_sha": sha,
+        "build_label": label,
         "generator": "build/build_pwa.py",
     }
     dest.write_text(json.dumps(meta, indent=2) + "\n", encoding="utf-8")
@@ -79,7 +133,9 @@ def main() -> int:
     if DIST_DIR.exists():
         shutil.rmtree(DIST_DIR)
     shutil.copytree(STATIC_DIR, DIST_DIR)
-    write_build_meta(DIST_DIR / "build-meta.json")
+    label = compute_build_label()
+    stamp_static_assets(DIST_DIR, label)
+    write_build_meta(DIST_DIR / "build-meta.json", label)
     if DB_SRC.is_file():
         shutil.copy2(DB_SRC, DIST_DIR / "fellows.db")
         write_allowed_email_hashes(DB_SRC, DIST_DIR / "allowed_emails.json")
@@ -93,7 +149,7 @@ def main() -> int:
             if p.is_file() and p.suffix.lower() in (".jpg", ".jpeg", ".png", ".gif", ".webp"):
                 shutil.copy2(p, dest / p.name)
     nfiles = sum(1 for p in DIST_DIR.rglob("*") if p.is_file())
-    print(f"Wrote {DIST_DIR} ({nfiles} files)")
+    print(f"Wrote {DIST_DIR} ({nfiles} files)  build_label={label}")
     return 0
 
 

--- a/docs/DevOps.md
+++ b/docs/DevOps.md
@@ -106,16 +106,28 @@ Adhoc commands that don't need root require `ANSIBLE_BECOME=false` (because beco
 
 ## Routine operations
 
-From the repo root:
+The standard "ship current main to prod" flow is one command:
 
 ```bash
-just deploy             # most common: build + push + restart + HTTPS smoke
-just ship               # test-fast → deploy (safest daily push)
-just ship-fast          # deploy-fast + smoke (reuse existing deploy/dist/)
-just deploy-check       # Ansible --check mode: what would change, no writes
+git checkout main && git pull         # confirm merges are local
+just ship                             # build + test + deploy + smoke (one shot)
+just whats-running                    # confirm prod's git_sha matches HEAD
 ```
 
-Under the hood these call `./scripts/deploy_pwa.sh --ask-become-pass`, which runs the `ansible/deploy_pwa.yml` playbook. Equivalent manual form:
+`just ship` runs `test-fast` → `deploy`, and `just deploy` itself runs the full ansible playbook (build → rsync → restart → HTTPS smoke). The build step (`build/build_pwa.py`) stamps the current `git rev-parse --short HEAD` into the `FELLOWS_UI_DIAG` and `CACHE_VERSION` placeholders in `app/static/app.js` and `app/static/sw.js` as it copies them to `deploy/dist/`. Format: `<YYYY-MM-DD>-<short-sha>`. Result: every deploy carries a unique label tied to the code being shipped — no manual bump step, no `chore(version):` commits cluttering `main`.
+
+What's deployed lives in the response, not in `git log`. Use `just drift` for the local-vs-prod SHA comparison (reads `/build-meta.json` on prod) and `just whats-running` for a side-by-side snapshot.
+
+The other deploy recipes:
+
+```bash
+just deploy             # build + ansible + smoke (no test step)
+just deploy-fast        # ansible + smoke, reusing the existing deploy/dist/
+just ship-fast          # deploy-fast + smoke (skip rebuild AND tests)
+just deploy-check       # ansible --check mode: what would change, no writes
+```
+
+Under the hood `just deploy` calls `./scripts/deploy_pwa.sh --ask-become-pass`, which runs the `ansible/deploy_pwa.yml` playbook. Equivalent manual form:
 
 ```bash
 python build/build_pwa.py

--- a/docs/justfile.md
+++ b/docs/justfile.md
@@ -104,27 +104,24 @@ Export them or inline: `FELLOWS_BASE_URL=https://staging.example.com just smoke`
 
 ### build
 
-- **`build`** — assemble `deploy/dist/` (runs `build/build_pwa.py`).
-- **`build-meta`** — print `deploy/dist/build-meta.json` (timestamp + git sha
-  of the last build). Useful to pair with `drift`.
-- **`bump [LABEL]`** — bump `CACHE_VERSION` (sw.js) and `FELLOWS_UI_DIAG`
-  (app.js) in lock-step, then commit with a `chore(version):` prefix. The
-  diag string becomes `<YYYY-MM-DD>-<short-sha>[-<LABEL>]`. Run before
-  `just deploy` so the in-app build label matches the code being shipped.
-  Requires a clean working tree (the bump commit is just the version
-  files). The `_bump-guard` (gated on `deploy` and `deploy-fast`) finds
-  the bump commit via `git log --grep=^chore\(version\):`.
+- **`build`** — assemble `deploy/dist/` (runs `build/build_pwa.py`). The
+  build stamps the current `git rev-parse --short HEAD` into the
+  `__FELLOWS_UI_DIAG__` and `__CACHE_VERSION__` placeholders in
+  `app.js` and `sw.js` as it copies them. Format: `<YYYY-MM-DD>-<short-sha>`.
+  No manual bump step; every build label matches HEAD.
+- **`build-meta`** — print `deploy/dist/build-meta.json` (build_label,
+  git_sha, built_at). Useful to pair with `drift`.
 
 ### deploy
 
 - **`deploy`** — full prod deploy. Wraps `./scripts/deploy_pwa.sh --ask-become-pass`,
   which runs `ansible/deploy_pwa.yml`: build → rsync → restart → HTTPS smoke.
-  Refuses if HEAD has commits past the most recent `chore(version):` bump
-  (run `just bump` first). Bypass with `BUMP_GUARD=skip just deploy` for
-  hotfixes where you accept the in-app label staying behind.
+  No bump-guard step — the build label is auto-stamped from HEAD by the
+  `build` recipe inside the playbook.
 - **`deploy-fast`** — deploy without rebuilding `deploy/dist/` (sets
-  `fellows_skip_build=true`). Use when the bundle is already fresh. Same
-  bump guard as `deploy`.
+  `fellows_skip_build=true`). Re-pushes whatever was last stamped into
+  `deploy/dist/`; surprising if HEAD has moved since the last build.
+  Use after a manual `just build` when you want to skip the rebuild.
 - **`deploy-check`** — Ansible `--check` mode: reports what would change, but
   doesn't touch anything. Good before a risky deploy.
 - **`ship`** — **`test-fast` → `deploy`**. The full "build-test-deploy-test"
@@ -157,10 +154,11 @@ Export them or inline: `FELLOWS_BASE_URL=https://staging.example.com just smoke`
   this recipe just doesn't use it any more (the header value is the
   build timestamp; the SHA from `/build-meta.json` is more useful for
   side-by-side comparison with `git log`).
-- **`whats-running`** — full version report: local HEAD, on-disk
-  `CACHE_VERSION` + `FELLOWS_UI_DIAG`, the most recent `chore(version):`
-  commit and how many commits HEAD is past it, prod's `/build-meta.json`,
-  and a refresh cheat-sheet (Cmd-Shift-R bypasses the SW shell cache;
+- **`whats-running`** — local-vs-prod version snapshot: local HEAD,
+  the build label that the next `just build` would stamp into the bundle
+  (`<YYYY-MM-DD>-<short-sha>`), prod's `/build-meta.json` (build_label /
+  git_sha / built_at), and a drift line if HEAD is ahead of prod. Plus
+  a refresh cheat-sheet (Cmd-Shift-R bypasses the SW shell cache;
   Clear App Cache preserves OPFS; incognito is the nuclear baseline).
   Use when "is this the version I think it is?" comes up.
 - **`prod-logs [UNIT]`** — SSH + `journalctl -u UNIT -f`. Default unit
@@ -220,10 +218,10 @@ Export them or inline: `FELLOWS_BASE_URL=https://staging.example.com just smoke`
 - **Reset after dev-DB got weird**: `just reset` (stop, snapshot, canonical
   rebuild, start, open browser).
 - **Before merging to main**: `just test` (all tests, port-safe).
-- **Ship a PR to prod**: `just bump [<label>]` then `just ship` (the
-  bump guard refuses if you skip the bump). Bump is its own commit so
-  the in-app `app: …` build label always tracks the code that was
-  shipped — no more "which PR is this badge from?" guessing.
+- **Ship a PR to prod**: `git checkout main && git pull` then `just ship`.
+  The build step auto-stamps the current HEAD's short SHA into the
+  in-app `app: …` build label, so the badge always tracks the code being
+  shipped — no separate bump step.
 - **Check whether prod is current**: `just drift` (one-line diff) or
   `just whats-running` (full local + prod report with refresh tips).
 - **How is prod doing?** `just prod-stats` (last 24h of page loads,

--- a/justfile
+++ b/justfile
@@ -256,91 +256,24 @@ build:
 build-meta:
     @if [ -f deploy/dist/build-meta.json ]; then cat deploy/dist/build-meta.json; else echo "No deploy/dist/build-meta.json — run 'just build' first."; fi
 
-# Bump CACHE_VERSION (sw.js) and FELLOWS_UI_DIAG (app.js) and commit.
-#
-# The diag string becomes <YYYY-MM-DD>-<short-sha>[-<label>]. Examples:
-#   just bump                    -> '2026-05-02-7b5f548'
-#   just bump groups-fab         -> '2026-05-02-7b5f548-groups-fab'
-#
-# Requires a clean working tree so the bump commit is just the version
-# files. The bump commit message starts with 'chore(version):' so the
-# deploy guard can find it via git log --grep.
-#
-# Bump versions and commit so 'just deploy' will let you ship.
-[group('build')]
-bump label="":
-    #!/usr/bin/env bash
-    set -euo pipefail
-    if ! git diff --quiet || ! git diff --cached --quiet; then
-        echo "ERROR: working tree has uncommitted changes."
-        echo "Commit or stash first; 'just bump' should be its own commit."
-        exit 1
-    fi
-    sha=$(git rev-parse --short HEAD)
-    today=$(date +%Y-%m-%d)
-    label="{{label}}"
-    if [ -n "${label}" ]; then
-        new_diag="${today}-${sha}-${label}"
-    else
-        new_diag="${today}-${sha}"
-    fi
-    cur_n=$(grep -oE "CACHE_VERSION = 'v[0-9]+'" app/static/sw.js | grep -oE '[0-9]+' | head -1)
-    if [ -z "${cur_n}" ]; then
-        echo "ERROR: could not parse CACHE_VERSION from app/static/sw.js"
-        exit 1
-    fi
-    new_n=$((cur_n + 1))
-    new_cache="v${new_n}"
-    sed -i.bak -E "s|CACHE_VERSION = 'v[0-9]+'|CACHE_VERSION = '${new_cache}'|" app/static/sw.js
-    sed -i.bak -E "s|var FELLOWS_UI_DIAG = '[^']*'|var FELLOWS_UI_DIAG = '${new_diag}'|" app/static/app.js
-    rm -f app/static/sw.js.bak app/static/app.js.bak
-    grep -F "CACHE_VERSION = '${new_cache}'" app/static/sw.js >/dev/null || { echo "ERROR: sw.js bump did not apply"; exit 1; }
-    grep -F "FELLOWS_UI_DIAG = '${new_diag}'" app/static/app.js >/dev/null || { echo "ERROR: app.js bump did not apply"; exit 1; }
-    git add app/static/sw.js app/static/app.js
-    git commit -m "chore(version): bump to ${new_diag} (cache ${new_cache})"
-    echo
-    echo "Bumped to: ${new_diag}"
-    echo "         CACHE_VERSION = ${new_cache}"
-    echo "         FELLOWS_UI_DIAG = ${new_diag}"
-    echo "         commit $(git rev-parse --short HEAD)"
-    echo
-    echo "Push when ready:  git push"
-
-# Internal: refuse to deploy if HEAD has commits past the most recent
-# 'chore(version):' commit. Bypass with BUMP_GUARD=skip for emergencies
-# (e.g. a hotfix where you accept the version label staying behind).
-_bump-guard:
-    #!/usr/bin/env bash
-    set -uo pipefail
-    if [ "${BUMP_GUARD:-}" = "skip" ]; then
-        echo "WARN: bump guard skipped via BUMP_GUARD=skip"
-        exit 0
-    fi
-    bump=$(git log --grep='^chore(version):' -1 --format=%H 2>/dev/null || true)
-    if [ -z "${bump}" ]; then
-        echo "ERROR: no chore(version) commit found in history."
-        echo "Run:  just bump [<label>]"
-        echo "Override: BUMP_GUARD=skip just deploy"
-        exit 1
-    fi
-    n=$(git rev-list "${bump}..HEAD" --count)
-    if [ "${n}" -gt 0 ]; then
-        echo "ERROR: ${n} commit(s) on HEAD past last version bump (${bump:0:7})."
-        echo "Run:  just bump [<label>]   to bump versions to current HEAD."
-        echo "      just whats-running    to see drift detail."
-        echo "Override: BUMP_GUARD=skip just deploy"
-        exit 1
-    fi
-    echo "[bump-guard] OK: HEAD is the latest version bump."
-
 # Deploy to prod (build + ansible + HTTPS smoke, via ansible/deploy_pwa.yml).
+#
+# The build step (build/build_pwa.py) stamps the current git short SHA into
+# FELLOWS_UI_DIAG and CACHE_VERSION as it copies to deploy/dist/, so every
+# deploy automatically gets a unique label tied to HEAD — no manual bump
+# step. See docs/DevOps.md for the routine flow and `just whats-running`
+# for the local-vs-prod label snapshot.
 [group('deploy')]
-deploy: _bump-guard
+deploy:
     ./scripts/deploy_pwa.sh --ask-become-pass
 
 # Deploy, reusing existing deploy/dist/ (skips the build step).
+# Skips the rebuild, so the label baked into deploy/dist/ is whatever was
+# stamped on the last `just build` — usually fine for re-pushing the
+# same code, surprising if HEAD has moved. Run `just build` first if in
+# doubt, or use `just deploy` for the rebuild-then-push path.
 [group('deploy')]
-deploy-fast: _bump-guard
+deploy-fast:
     ansible-playbook ansible/deploy_pwa.yml --ask-become-pass --extra-vars "fellows_skip_build=true"
 
 # Ansible --check (dry run, no changes made).
@@ -401,24 +334,29 @@ whats-running:
     set -uo pipefail
     head_sha=$(git rev-parse --short HEAD)
     head_subject=$(git log -1 --format=%s HEAD)
-    cache_v=$(grep -oE "CACHE_VERSION = 'v[0-9]+'" app/static/sw.js | grep -oE 'v[0-9]+' | head -1)
-    diag=$(grep -E "var FELLOWS_UI_DIAG = '[^']*'" app/static/app.js | head -1 | sed -E "s|.*'([^']*)'.*|\\1|")
-    last_bump=$(git log --grep='^chore(version):' -1 --format='%h %ci %s' 2>/dev/null || echo "(none)")
-    drift_n=$(if [ -n "$(git log --grep='^chore(version):' -1 --format=%H 2>/dev/null)" ]; then git rev-list "$(git log --grep='^chore(version):' -1 --format=%H)..HEAD" --count; else echo "?"; fi)
+    today=$(date -u +%Y-%m-%d)
+    next_label="${today}-${head_sha}"
     echo "Local"
     echo "  HEAD:                ${head_sha} ${head_subject}"
-    echo "  CACHE_VERSION:       ${cache_v}"
-    echo "  FELLOWS_UI_DIAG:     ${diag}"
-    echo "  Last version bump:   ${last_bump}"
-    echo "  Commits past bump:   ${drift_n}"
+    echo "  Build label (next):  ${next_label}"
+    echo "                       (auto-stamped into FELLOWS_UI_DIAG + CACHE_VERSION"
+    echo "                        by build/build_pwa.py on the next 'just build' or 'just deploy')"
     echo
     echo "Prod ({{base_url}})"
     if curl -sf "{{base_url}}/build-meta.json" -o /tmp/_fellows_bm.json 2>/dev/null; then
         prod_sha=$(python3 -c "import json,sys; print(json.load(open('/tmp/_fellows_bm.json')).get('git_sha','?'))" 2>/dev/null || echo '?')
         prod_built=$(python3 -c "import json,sys; print(json.load(open('/tmp/_fellows_bm.json')).get('built_at','?'))" 2>/dev/null || echo '?')
+        prod_label=$(python3 -c "import json,sys; print(json.load(open('/tmp/_fellows_bm.json')).get('build_label','?'))" 2>/dev/null || echo '?')
+        echo "  build_label:         ${prod_label}"
         echo "  git_sha:             ${prod_sha}"
         echo "  built_at:            ${prod_built}"
         rm -f /tmp/_fellows_bm.json
+        if [ "${prod_sha}" != "?" ] && [ "${prod_sha}" != "${head_sha}" ]; then
+            commits_ahead=$(git rev-list "${prod_sha}..HEAD" --count 2>/dev/null || echo '?')
+            echo "  drift:               local HEAD is ${commits_ahead} commits ahead of prod"
+        elif [ "${prod_sha}" = "${head_sha}" ]; then
+            echo "  drift:               none — prod matches local HEAD"
+        fi
     else
         echo "  (could not fetch /build-meta.json)"
     fi


### PR DESCRIPTION
## Summary

Replaces source-tracked `CACHE_VERSION` + `FELLOWS_UI_DIAG` with build-time substitution. Every build/deploy now gets a unique label tied to `git HEAD` without a manual bump step. Drops the `chore(version):` commit pattern, the `just bump` recipe, and the `_bump-guard` — all of which were friction without adding much value at this scale (single maintainer, single server, no staging — what's deployed lives in the prod response, not in `git log`).

## Why

\`just deploy\` was rejecting with *"17 commit(s) on HEAD past last version bump"* — a guard only needed because someone has to manually update labels in source. The bump step wasn't documented in DevOps.md, and the conventional approach for an app this size is to compute the build identifier at build time from the SHA. This PR does that, removing the guard, the bump step, and the chore(version) commits in one motion.

## What changed

- **`app/static/sw.js`** — \`const CACHE_VERSION = 'v15'\` → \`'__CACHE_VERSION__'\`.
- **`app/static/app.js`** — \`var FELLOWS_UI_DIAG = '...'\` → \`'__FELLOWS_UI_DIAG__'\`.
- **`build/build_pwa.py`** — new \`compute_build_label()\` (returns \`<YYYY-MM-DD>-<short-sha>\`), \`substitute_build_label(text, label)\`, and \`stamp_static_assets(dist_dir, label)\`. \`main()\` calls them after \`shutil.copytree(STATIC_DIR, DIST_DIR)\`. \`write_build_meta\` now records the label alongside git_sha + built_at.
- **`app/server.py`** — imports the helpers from build/build_pwa.py and substitutes the placeholders in-flight when serving \`/app.js\` or \`/sw.js\`. Computes the label once at server-start; restart picks up new commits.
- **`justfile`** — drop \`bump\` and \`_bump-guard\`. Drop the \`_bump-guard\` dependency from \`deploy\` and \`deploy-fast\`. Rewrite \`whats-running\` to compute the next build label from current HEAD and surface the local-vs-prod drift line.
- **`README.md`** — rewrite "Shipping a change": \`git pull && just ship\` is the whole flow.
- **`docs/DevOps.md`** — rewrite "Routine operations" with the build-label story and a clear three-line standard flow.
- **`docs/justfile.md`** — update \`build\`, \`deploy\`, \`deploy-fast\`, \`whats-running\`, and the "Ship a PR to prod" sequence; remove the \`bump\` entry.

## How it works

\`build/build_pwa.py\` now:

1. Copies \`app/static/\` to \`deploy/dist/\`.
2. Computes \`label = f"{date}-{short_sha}"\` from the current git HEAD.
3. Replaces \`__FELLOWS_UI_DIAG__\` and \`__CACHE_VERSION__\` in the dist copies of \`app.js\` and \`sw.js\` with that label.
4. Writes \`build-meta.json\` with the label, the SHA, and the build timestamp.

\`app/server.py\` does the same substitution in-flight when serving \`app.js\` / \`sw.js\` in dev, using the same helper. So the dev build badge tracks the live source SHA without any rebuild step — restart the dev server to pick up new commits.

If you ever want a git-side audit trail of deploys, a post-deploy \`git tag deployed/<datetime>\` is a clean add-on. Intentionally not in this PR because prod's \`X-Fellows-Build\` header and \`/build-meta.json\` already answer "what's running."

## Test plan

- [x] \`python build/build_pwa.py\` produces a stamped bundle:
  \`Wrote .../deploy/dist (530 files)  build_label=2026-05-03-75463e6\`.
- [x] \`curl http://127.0.0.1:8765/sw.js\` and \`/app.js\` show the substituted constants in dev.
- [x] \`just whats-running\` shows the next build label and the drift line.
- [x] \`just test-e2e\` — 138/139 pass; the one failure is the pre-existing \`test_groups_index_lists_created_group\` cross-test-pollution flake acknowledged in PR #84 (passes in isolation).
- [ ] After merge, \`just ship\` against current main should be one command from clean checkout to prod with the badge showing the new label.

🤖 Generated with [Claude Code](https://claude.com/claude-code)