### PR TITLE
fix(settings): expose OPFS-init failure instead of hiding backup/restore

### DIFF
--- a/app/static/app.js
+++ b/app/static/app.js
@@ -1156,7 +1156,14 @@
   // HTML string. Caller decides which container to drop it into.
   // `feature` is what the user was trying to do — "groups", "this group",
   // "settings", "save this group". Used in the headline only.
-  function renderLocalDataUnavailablePanel(feature) {
+  // `opts.runtimeFailure` (optional) means the OPFS path *should* have
+  // worked on this browser version but failed at runtime (e.g. the page
+  // loaded before the dev server picked up COOP/COEP, or a transient
+  // sqlite-wasm glitch). When set AND the detected version meets the
+  // floor, we render a different copy that doesn't tell a Chrome-130
+  // user to upgrade Chrome.
+  function renderLocalDataUnavailablePanel(feature, opts) {
+    opts = opts || {};
     var b = detectBrowserSupport();
     var label = feature || 'this feature';
     var browserHuman =
@@ -1168,8 +1175,32 @@
       b.name === 'samsung' ? 'Samsung Internet' :
       'your browser';
     var versionTxt = b.versionString ? (' ' + b.versionString) : '';
+    // "Version meets the floor we ship for": if both numbers are known
+    // and version >= minVersion. Used to decide whether the "you need a
+    // newer browser" copy applies, or whether the runtime-failure copy
+    // is a better fit.
+    var versionLooksOk =
+      b.version != null && b.minVersion != null && b.version >= b.minVersion;
     var detailLines = [];
-    if (b.onIos) {
+    if (opts.runtimeFailure && versionLooksOk) {
+      // Browser is recent enough on paper. Most likely cause: the page
+      // loaded before the server sent the cross-origin-isolation headers
+      // OPFS-SAH-Pool needs (Cross-Origin-Opener-Policy: same-origin +
+      // Cross-Origin-Embedder-Policy: require-corp). A hard reload almost
+      // always fixes it. If not, Diagnostics has the boot trace.
+      detailLines.push(
+        'You\'re running ' + browserHuman + versionTxt + ', which is recent enough — ' +
+        'so this is unusual. The local-storage layer (OPFS) didn\'t initialize on this load. ' +
+        'The most common cause is the page loading before the server finished sending the ' +
+        'cross-origin-isolation headers OPFS needs.'
+      );
+      detailLines.push(
+        'Try a <b>hard reload</b>: <kbd>Cmd-Shift-R</kbd> on macOS, ' +
+        '<kbd>Ctrl-Shift-R</kbd> on Windows/Linux. ' +
+        'If that doesn\'t fix it, open <b>Diagnostics</b> (lower-left button) and copy the boot trace — ' +
+        'the OPFS gates section shows exactly which capability check failed.'
+      );
+    } else if (b.onIos) {
       // iOS forces every browser engine to WebKit, so the only fix is to
       // upgrade iOS itself (iOS 16.4+ ships Safari 16.4+).
       detailLines.push(
@@ -1237,14 +1268,21 @@
       );
     }
     var detailHtml = detailLines.map(function (l) { return '<p>' + l + '</p>'; }).join('');
+    var isRuntime = !!(opts.runtimeFailure && versionLooksOk);
+    var headline = isRuntime
+      ? 'Can\'t open ' + escapeHtml(label) + ' right now'
+      : 'Can\'t open ' + escapeHtml(label) + ' on this browser';
+    var lede = isRuntime
+      ? 'Saved groups and per-device settings live in your browser\'s local storage (OPFS). ' +
+        'On this load, that storage didn\'t initialize — so the rest of the app works, but ' +
+        escapeHtml(label) + ' can\'t until it does.'
+      : 'Saved groups and per-device settings live in your browser\'s local storage. ' +
+        'On this device, that storage isn\'t available — so the rest of the app works, but ' +
+        escapeHtml(label) + ' can\'t.';
     return (
       '<div class="local-data-unavailable">' +
-        '<h3>Can\'t open ' + escapeHtml(label) + ' on this browser</h3>' +
-        '<p class="local-data-unavailable-lede">' +
-          'Saved groups and per-device settings live in your browser\'s local storage. ' +
-          'On this device, that storage isn\'t available — so the rest of the app works, but ' +
-          escapeHtml(label) + ' can\'t.' +
-        '</p>' +
+        '<h3>' + headline + '</h3>' +
+        '<p class="local-data-unavailable-lede">' + lede + '</p>' +
         detailHtml +
         '<p class="local-data-unavailable-foot">' +
           'If none of these options work for you, please reach out — we\'re happy to help.' +
@@ -6138,18 +6176,28 @@
     var exportSection = document.getElementById('settings-export-section');
 
     // Backup + restore both depend on the OPFS-backed sqlite provider —
-    // the API provider has no live relationships.db to export or
-    // overwrite. Hide both sections up front when we're on the API
-    // provider (typical on dev localhost without the SAH-pool VFS, or
-    // any browser that fell back to API mode). PR #84's behavior was
-    // to hide the export section only on click rejection; this matches
-    // it for both sections at render time so users don't see broken
-    // affordances. The localDataUnavailable click-rejection paths
-    // below remain for paranoia / late provider downgrades.
+    // the API provider (dev fallback) operates on a server-side
+    // relationships.db that isn't the user's data, and prod doesn't
+    // serve those routes at all. So when we're on the API provider we
+    // can't honor a click on "Download my user data" or "Restore from
+    // a file"; PR #84 hid the export section on click rejection and
+    // PR #92 hid both sections proactively at render time. That avoided
+    // broken affordances but turned the failure silent — a user who
+    // arrived hoping to restore got an email field and no explanation.
+    // Now: render the existing local-data-unavailable panel into the
+    // export section (covering "backup and restore" together), hide
+    // the restore section, and let the panel tell the user what to do.
+    // The late `localDataUnavailable` click-handler paths below remain
+    // for paranoia / late provider downgrades.
     var localPersistenceAvailable = !!(dataProvider && dataProvider.kind === 'sqlite');
     if (!localPersistenceAvailable) {
       var preExport = document.getElementById('settings-export-section');
-      if (preExport) preExport.style.display = 'none';
+      if (preExport) {
+        preExport.innerHTML = renderLocalDataUnavailablePanel(
+          'backup and restore',
+          { runtimeFailure: true }
+        );
+      }
       var preRestore = document.getElementById('settings-restore-section');
       if (preRestore) preRestore.style.display = 'none';
     }

--- a/tests/e2e/test_settings.py
+++ b/tests/e2e/test_settings.py
@@ -141,16 +141,19 @@ class TestSettingsPage:
         addr = page.locator("#export-self-email-addr")
         expect(addr).to_have_value("rich@example.com")
 
-    def test_userdata_sections_in_dom_and_hidden_in_api_mode(
+    def test_userdata_sections_in_dom_and_exposed_in_api_mode(
         self, standalone_page, base_url_fixture
     ):
         """The Settings page emits both the "Your saved data" (PR #84) and
-        "Restore from backup" (PR #88) sections in the DOM. Their *visibility*
+        "Restore from backup" (PR #88) sections in the DOM. Their *content*
         depends on the data provider:
-        - OPFS-backed sqlite provider → both sections visible.
-        - API provider → both sections hidden up front, because there's no
-          live relationships.db to export or overwrite (PR #88's fix to the
-          silent-fail Download bug).
+        - OPFS-backed sqlite provider → original markup (Download button +
+          Restore picker + recent-backups list).
+        - API provider → the export section is replaced by the
+          local-data-unavailable panel (PR-this), and the restore section
+          is hidden. This keeps the failure visible to the user with the
+          existing browser-aware copy ("Try a hard reload, open Diagnostics,
+          …") instead of silently disappearing both sections.
 
         Dev e2e runs in API-provider mode (Playwright's chromium does not
         expose `FileSystemFileHandle.prototype.createSyncAccessHandle` on the
@@ -161,20 +164,31 @@ class TestSettingsPage:
         _wait_for_directory(page)
         export_section = page.locator("#settings-export-section")
         restore_section = page.locator("#settings-restore-section")
-        # Both sections must be in the DOM (so OPFS-mode users see them).
+        # Both sections must be in the DOM (so OPFS-mode users get them
+        # back when the provider is sqlite — same gate from PR #92).
         expect(export_section).to_have_count(1)
         expect(restore_section).to_have_count(1)
-        # Markup details that don't depend on visibility.
-        expect(page.locator("#settings-download-userdata")).to_have_count(1)
-        expect(page.locator("#settings-restore-pick")).to_have_count(1)
-        file_input = page.locator("#settings-restore-file")
-        expect(file_input).to_have_count(1)
-        accept = file_input.get_attribute("accept") or ""
-        assert ".db" in accept and ".sqlite" in accept
-        # In dev (API provider), proactive hide kicks in.
-        assert export_section.evaluate("el => el.style.display") == "none", (
-            "expected export section hidden in API-provider mode"
-        )
+        # In dev (API provider), the export section is replaced by the
+        # unavailable-panel, and the restore section is hidden.
+        panel = export_section.locator(".local-data-unavailable")
+        expect(panel).to_have_count(1)
+        # The panel headline ends with either "right now" (runtime-failure
+        # branch — Playwright's chromium reports as Chrome >= 102) or
+        # "on this browser" (browser-too-old branch). Either way it's a
+        # visible, user-readable message — the bug we're fixing was
+        # silent disappearance, not the specific copy.
+        headline = panel.locator("h3").inner_text()
+        assert "backup and restore" in headline.lower(), headline
+        # Restore section stays hidden so the panel is the single source
+        # of "what's wrong + what to do."
         assert restore_section.evaluate("el => el.style.display") == "none", (
             "expected restore section hidden in API-provider mode"
         )
+        # The download button is gone (its containing section was overwritten
+        # by the panel). The restore-pick button still exists in the DOM
+        # because the restore section is hidden via display:none rather than
+        # rewritten — but it isn't reachable from the user's perspective
+        # because its parent section is hidden, so the panel is the only
+        # thing they actually see.
+        expect(page.locator("#settings-download-userdata")).to_have_count(0)
+        expect(page.locator("#settings-restore-pick")).not_to_be_visible()


### PR DESCRIPTION
## Summary

PR #92 hid the export + restore sections proactively when the OPFS-backed sqlite provider didn't come up — avoiding broken affordances but turning the failure silent. A user who came to Settings to restore a backup got an email field and no explanation. This PR makes the failure visible.

The fix reuses the existing `renderLocalDataUnavailablePanel` (already used by the groups views on the same `localDataUnavailable` rejection). The export section's content is replaced by the panel; the restore section is hidden so the panel covers "backup and restore" together.

## Two pieces

### 1. `renderLocalDataUnavailablePanel(feature, opts)`

New optional `opts.runtimeFailure` flag. When set AND the detected browser version meets the floor (Chrome 102+, Edge 102+, Safari 16.4+, Firefox 111+), the panel emits a different copy: it doesn't tell a Chrome-130 user to upgrade Chrome. Instead:

> "You're running Chrome 130, which is recent enough — so this is unusual. The local-storage layer (OPFS) didn't initialize on this load. The most common cause is the page loading before the server finished sending the cross-origin-isolation headers OPFS needs. Try a hard reload: Cmd-Shift-R on macOS … If that doesn't fix it, open Diagnostics (lower-left button) and copy the boot trace …"

Headline + lede also flip to *"right now"* / *"didn't initialize on this load"* so the panel reads as a transient runtime issue rather than a permanent capability gap.

When the version is below the floor (or unknown), `opts.runtimeFailure` is ignored and the existing browser-too-old copy applies — which is the correct root cause.

### 2. `renderSettingsPage` proactive-hide → expose-via-panel

The block at `app.js:6149` that previously did
```js
if (preExport)  preExport.style.display  = 'none';
if (preRestore) preRestore.style.display = 'none';
```
now does:
```js
if (preExport)  preExport.innerHTML = renderLocalDataUnavailablePanel('backup and restore', { runtimeFailure: true });
if (preRestore) preRestore.style.display = 'none';
```

The late `localDataUnavailable` click-handler paths below remain for paranoia / late provider downgrades but should be unreachable in the proactive case.

## Why this matters

The case that triggered this PR: a user opened `localhost:8765/#/settings` in incognito Chrome on the current build, saw only the email field, and asked "I know backup/restore was worked on at some point, why don't I see it?" The OPFS-init path failed in that tab (likely the page loaded before the server picked up the COOP/COEP headers — the most common dev-side cause), PR #92's proactive-hide kicked in, and the user got no signal that anything had even tried to render. The user's framing: *"silent failure isn't a good look when a user is trying to restore — we need to intercept and expose that kind of error."*

This PR does that. It does not address the OPFS-init failure itself; that's a separate triage best done from the boot trace. But now the user has the boot trace pointed at, instead of an empty page.

## Test plan

- [x] `node --check app/static/app.js` — JS parses.
- [x] `just test-fast` — 80 passed.
- [x] `just test-e2e` — 139 passed.
- [x] `tests/e2e/test_settings.py::test_userdata_sections_in_dom_and_exposed_in_api_mode` rewritten (was `_hidden_in_api_mode`) to assert the panel is rendered, the headline names "backup and restore", and the restore section is hidden. Passes.
- [ ] Manual on dev: open `#/settings` in incognito Chrome (where OPFS typically falls back), confirm the panel renders with the "recent enough — try a hard reload" branch and the restore section is hidden.
- [ ] Manual on prod after deploy: same panel appears for any user whose browser falls below the OPFS floor (Safari 16.3 etc.), using the existing browser-too-old copy.

🤖 Generated with [Claude Code](https://claude.com/claude-code)