### PR TITLE
diag(opfs): expose dataProvider + capability gates + boot trace

### DIFF
--- a/app/static/app.js
+++ b/app/static/app.js
@@ -1279,11 +1279,47 @@
       : 'Saved groups and per-device settings live in your browser\'s local storage. ' +
         'On this device, that storage isn\'t available — so the rest of the app works, but ' +
         escapeHtml(label) + ' can\'t.';
+    // On the runtime-failure path, embed the OPFS gates + boot trace
+    // inline so the user (and the maintainer triaging) can see the
+    // actual reason without clicking elsewhere. Collapsed by default
+    // so the panel stays scannable; always present when isRuntime.
+    var traceHtml = '';
+    if (isRuntime) {
+      var traceParts = [];
+      try {
+        traceParts.push('Provider chosen: ' +
+          (dataProvider && dataProvider.kind ? dataProvider.kind : '(none yet)'));
+      } catch (e) {}
+      try {
+        traceParts.push('OPFS capability gates:');
+        traceParts.push(describeOpfsGates());
+      } catch (e) {
+        traceParts.push('(could not read gates: ' + String(e && e.message || e) + ')');
+      }
+      try {
+        if (bootDebugLines && bootDebugLines.length) {
+          traceParts.push('');
+          traceParts.push('Boot trace (chronological):');
+          traceParts.push(bootDebugLines.join('\n'));
+        } else {
+          traceParts.push('');
+          traceParts.push('Boot trace: (empty — nothing recorded yet)');
+        }
+      } catch (e) {
+        traceParts.push('Boot trace error: ' + String(e && e.message || e));
+      }
+      traceHtml =
+        '<details class="local-data-unavailable-trace">' +
+          '<summary>Show what failed (boot trace)</summary>' +
+          '<pre>' + escapeHtml(traceParts.join('\n')) + '</pre>' +
+        '</details>';
+    }
     return (
       '<div class="local-data-unavailable">' +
         '<h3>' + headline + '</h3>' +
         '<p class="local-data-unavailable-lede">' + lede + '</p>' +
         detailHtml +
+        traceHtml +
         '<p class="local-data-unavailable-foot">' +
           'If none of these options work for you, please reach out — we\'re happy to help.' +
         '</p>' +
@@ -1876,6 +1912,43 @@
         String((document.cookie || '').length)
     );
     lines.push('');
+    // OPFS / sqlite-wasm boot state. The Settings page hides backup/restore
+    // when this fell through to API mode; this section answers "and why?".
+    // Showing it before SW state because it's the first place we look when
+    // a "no backup section" report comes in.
+    lines.push('--- OPFS / sqlite-wasm boot state ---');
+    try {
+      lines.push('dataProvider.kind: ' +
+        (dataProvider && dataProvider.kind ? dataProvider.kind : '(none — boot incomplete)'));
+    } catch (e) {
+      lines.push('dataProvider.kind: (unavailable: ' + String(e && e.message || e) + ')');
+    }
+    try {
+      lines.push('directoryDataSource: ' +
+        (typeof directoryDataSource !== 'undefined' ? directoryDataSource : '(unset)'));
+    } catch (e) {}
+    try {
+      lines.push('OPFS capability gates:');
+      var gateLines = describeOpfsGates().split('\n');
+      for (var gi = 0; gi < gateLines.length; gi++) {
+        lines.push('  ' + gateLines[gi]);
+      }
+    } catch (e) {
+      lines.push('OPFS capability gates: (error — ' + String(e && e.message || e) + ')');
+    }
+    try {
+      if (bootDebugLines && bootDebugLines.length) {
+        lines.push('Boot trace (chronological, ' + bootDebugLines.length + ' lines):');
+        for (var bli = 0; bli < bootDebugLines.length; bli++) {
+          lines.push('  ' + bootDebugLines[bli]);
+        }
+      } else {
+        lines.push('Boot trace: (empty — boot has not run, or trace not yet captured)');
+      }
+    } catch (e) {
+      lines.push('Boot trace: (error — ' + String(e && e.message || e) + ')');
+    }
+    lines.push('');
     if ('serviceWorker' in navigator) {
       try {
         var regs = await navigator.serviceWorker.getRegistrations();
@@ -2167,6 +2240,29 @@
     try {
       lines.push('directoryDataSource: ' +
         (typeof directoryDataSource !== 'undefined' ? directoryDataSource : '(unset)'));
+    } catch (e) {}
+    // OPFS / sqlite-wasm boot state. Critical for triaging
+    // "backup/restore section says 'OPFS didn't initialize' — but why?".
+    // Without these the bug-report tells us the failure was visible to
+    // the user but not which gate failed or what the SAH-pool threw.
+    try {
+      lines.push(
+        'dataProvider: ' +
+          (dataProvider && dataProvider.kind ? dataProvider.kind : '(none)')
+      );
+    } catch (e) {}
+    try {
+      lines.push('opfs gates: ' + describeOpfsGates().replace(/\n/g, ' | '));
+    } catch (e) {}
+    try {
+      if (bootDebugLines && bootDebugLines.length) {
+        lines.push('boot trace (' + bootDebugLines.length + ' lines):');
+        for (var bdi = 0; bdi < bootDebugLines.length; bdi++) {
+          lines.push('  ' + bootDebugLines[bdi]);
+        }
+      } else {
+        lines.push('boot trace: (empty — boot has not run, or trace not yet captured)');
+      }
     } catch (e) {}
     if (lastSubmitInfo.emailHashPrefix && lastSubmitInfo.submittedAt) {
       // Join key into deploy/server.py's event=send_unlock_email log.

--- a/app/static/styles.css
+++ b/app/static/styles.css
@@ -2848,6 +2848,32 @@ a.group-action-btn--primary {
   color: #6a5800;
 }
 
+.local-data-unavailable-trace {
+  margin: 0.75rem 0 0;
+  font-size: 0.85rem;
+}
+
+.local-data-unavailable-trace > summary {
+  cursor: pointer;
+  color: #6a5800;
+  user-select: none;
+}
+
+.local-data-unavailable-trace > pre {
+  margin: 0.5rem 0 0;
+  padding: 0.5rem 0.75rem;
+  background: #fff3c7;
+  border: 1px solid #e7c873;
+  border-radius: 4px;
+  font-family: ui-monospace, SFMono-Regular, Menlo, Monaco, Consolas, monospace;
+  font-size: 0.8rem;
+  line-height: 1.4;
+  white-space: pre-wrap;
+  word-break: break-word;
+  max-height: 18rem;
+  overflow: auto;
+}
+
 /* =========================================================================
  * Mobile redesign — Phase 3 step 2: shell chrome (appbar, tab nav, kebab
  * bottom-sheet) and focus-mode-by-default at the mobile breakpoint.

--- a/tests/e2e/test_settings.py
+++ b/tests/e2e/test_settings.py
@@ -192,3 +192,17 @@ class TestSettingsPage:
         # thing they actually see.
         expect(page.locator("#settings-download-userdata")).to_have_count(0)
         expect(page.locator("#settings-restore-pick")).not_to_be_visible()
+        # When the panel is in runtime-failure mode (which it is in dev e2e —
+        # Chrome reports as supported but the SAH-pool can't install on the
+        # main thread), it embeds a <details> with the boot trace + OPFS
+        # gates inline so the maintainer doesn't need to ask the user to
+        # also click the Diagnostics button.
+        trace = panel.locator("details.local-data-unavailable-trace")
+        expect(trace).to_have_count(1)
+        # The pre block carries the gate output. We use text_content (not
+        # inner_text) because the <details> is collapsed by default —
+        # inner_text would return '' until a click. We don't assert
+        # specific text; the gate values vary per environment.
+        trace_text = trace.locator("pre").text_content() or ""
+        assert len(trace_text.strip()) > 0, "expected non-empty boot trace"
+        assert "opfs" in trace_text.lower(), trace_text


### PR DESCRIPTION
## Summary

PR #95 made the OPFS-init failure visible in Settings, but didn't expose **why**. A user reported "no amount of cache clearing or reloading helps" on Chrome 147, plus a diagnostics dump that omitted every OPFS-related field — `dataProvider.kind`, the gate states, and the `bootDebugLines` trace were all collected internally but never rendered anywhere a user could see.

This PR is pure instrumentation: it plumbs that data through three surfaces so the next failure report comes pre-loaded with the diagnosis.

## What's new

### 1. Diagnostics panel + "additional diagnostics" block
`collectDiagnosticsText` gains a leading **"OPFS / sqlite-wasm boot state"** section:
```
--- OPFS / sqlite-wasm boot state ---
dataProvider.kind: api
directoryDataSource: api
OPFS capability gates:
  standalone display-mode: false (informational; not a gate)
  globalThis.sqlite3InitModule: function
  navigator.storage: present
  navigator.storage.getDirectory: function
  isSecureContext: true
  navigator.onLine: true
  shouldTryOpfsProvider(): true
Boot trace (chronological, N lines):
  2026-05-03T08:46:48.123Z pickDataProvider: start
  …
  2026-05-03T08:46:48.456Z OPFS path failed → API fallback: <error here>
```

### 2. Bug-report header (short diagnostic block)
`buildBugReportSyncBody` gains inline `dataProvider:`, `opfs gates:`, and `boot trace:` lines so the maintainer sees the diagnosis without scrolling into "additional diagnostics".

### 3. The unavailable panel
`renderLocalDataUnavailablePanel`, when `runtimeFailure: true`, appends a collapsible `<details>` with the same gate output + boot trace inline. The user (and us, when they screenshot the panel) sees the failure reason without clicking elsewhere. Styled as a small monospaced pre with a "Show what failed (boot trace)" summary; collapsed by default so the panel stays scannable.

## Why no fix yet

This PR is *instrumentation only*. It doesn't fix any underlying init failure — it makes "the section is hidden, what now?" answerable from a single screenshot.

I investigated the SAH-Pool lock hypothesis (`vendor/sqlite3.js:11448–11688`):

- Lock granularity is per-file. `acquireAccessHandles` iterates every file in OPFS `.opaque/` and calls `createSyncAccessHandle()` on each; any single throw aborts init with no retry.
- `installOpfsSAHPoolVfs` caches failure promises and returns the cached rejection on subsequent calls within a load unless `forceReinitIfPreviouslyFailed: true` is passed (we don't).
- There IS a built-in recovery path — `OpfsSAHPoolUtil.removeVfs()` deletes `.opaque/` recursively — but it's circular: the pool needs to be running to call it.

**Critically**, the reporting user's diagnostics show `last_seen_sha.txt: (none)`. That sentinel is written by `maybeBackupRelationshipsDb` after a successful first SAH-pool init. Its absence means the pool has **never** succeeded on that device — not a "locked after working" pattern. So lock recovery isn't the root cause. Narrowed-down suspects: a gate failure (unlikely on Chrome 147 + localhost), the `apiVersionCheck` in `sqlite3.js:11934` throwing, or a first-call `acquireAccessHandles` on a brand-new `.opaque/` throwing for an unrelated reason.

The boot trace this PR exposes will tell us which. Next PR (after we see real boot trace data): the actual fix.

## Test plan

- [x] `node --check app/static/app.js`.
- [x] `just test-e2e settings` — 9 passed; new assertion verifies `details.local-data-unavailable-trace > pre` is non-empty and mentions OPFS.
- [x] `just test-e2e` — 139 passed; mobile screenshot snapshots for `#/settings` still match (the `<details>` is collapsed by default so the visible layout is unchanged).
- [ ] Manual verification on the reporting user's Chrome 147 build: open `#/settings`, expand the new "Show what failed" details, paste the gate states + boot trace.

🤖 Generated with [Claude Code](https://claude.com/claude-code)