### PR TITLE
diag(opfs): probe sqlite-wasm's five OPFS APIs individually

### DIFF
--- a/app/static/app.js
+++ b/app/static/app.js
@@ -1582,8 +1582,28 @@
         (navigator.storage && typeof navigator.storage.getDirectory)
     );
     lines.push('isSecureContext: ' + globalThis.isSecureContext);
+    lines.push('crossOriginIsolated: ' + (typeof globalThis.crossOriginIsolated !== 'undefined' ? globalThis.crossOriginIsolated : '(unset)'));
     lines.push('navigator.onLine: ' + navigator.onLine);
     lines.push('shouldTryOpfsProvider(): ' + shouldTryOpfsProvider());
+    // sqlite-wasm's installOpfsSAHPoolVfs has a stricter check than ours:
+    // it requires all of FileSystemHandle / FileSystemDirectoryHandle /
+    // FileSystemFileHandle / FileSystemFileHandle.prototype.createSyncAccessHandle
+    // (vendor/sqlite3.js:11971-11977). When any are missing it throws
+    // "Missing required OPFS APIs." with no breakdown of which one. Probe
+    // them individually so the boot trace pins the actual gap.
+    lines.push('--- sqlite-wasm SAH-pool API surface ---');
+    lines.push('FileSystemHandle: ' + typeof globalThis.FileSystemHandle);
+    lines.push('FileSystemDirectoryHandle: ' + typeof globalThis.FileSystemDirectoryHandle);
+    lines.push('FileSystemFileHandle: ' + typeof globalThis.FileSystemFileHandle);
+    var sahType = '(FileSystemFileHandle missing)';
+    try {
+      sahType = globalThis.FileSystemFileHandle
+        ? typeof globalThis.FileSystemFileHandle.prototype.createSyncAccessHandle
+        : '(FileSystemFileHandle missing)';
+    } catch (e) {
+      sahType = '(probe threw: ' + (e && e.message || e) + ')';
+    }
+    lines.push('FileSystemFileHandle.prototype.createSyncAccessHandle: ' + sahType);
     return lines.join('\n');
   }
 


### PR DESCRIPTION
## Summary

PR #96 surfaced the boot trace and the user immediately got actionable data:

> `OPFS path failed → API fallback: Missing required OPFS APIs.`

That's not the SAH-pool-lock pattern I'd suggested (`NoModificationAllowedError`); it's the upstream pre-flight at `vendor/sqlite3.js:11971-11977` rejecting because one of **five** required APIs is falsy:

```js
if (!globalThis.FileSystemHandle ||
    !globalThis.FileSystemDirectoryHandle ||
    !globalThis.FileSystemFileHandle ||
    !globalThis.FileSystemFileHandle.prototype.createSyncAccessHandle ||
    !navigator?.storage?.getDirectory) {
  return Promise.reject(new Error("Missing required OPFS APIs."));
}
```

Our `shouldTryOpfsProvider()` only checks the last one, which passed (the user's gates show `navigator.storage.getDirectory: function`). So we know one of the other four is the gap, but the upstream gate doesn't break it out.

This PR adds per-API probes to `describeOpfsGates()` so the next reload pinpoints the gap. New section in the boot trace / diagnostics / panel `<details>`:

```
--- sqlite-wasm SAH-pool API surface ---
FileSystemHandle: function
FileSystemDirectoryHandle: function
FileSystemFileHandle: function
FileSystemFileHandle.prototype.createSyncAccessHandle: function
```

(or `undefined` for whichever is the culprit.) Also adds explicit `crossOriginIsolated:` to the gates section — was inferable from `isSecureContext` + COOP/COEP, but the explicit value is the SharedArrayBuffer gate.

## Hypothesis going in

`FileSystemFileHandle.prototype.createSyncAccessHandle` was Worker-only until Chrome 121 (Dec 2023). On Chrome 147 main thread it should exist — if it's `function`, we look elsewhere; if it's `undefined`, we know the issue is main-thread availability and the fix likely involves moving SAH-pool init into a dedicated Worker.

## Test plan

- [x] `node --check app/static/app.js`.
- [x] `just test-e2e` — 139 passed; mobile snapshot tests for `#/settings` still pass (the new lines live in the collapsed `<details>`; visible layout unchanged).
- [ ] Manual on the reporting user's Chrome: reload, expand "Show what failed" in the panel, paste the five new API-surface lines. That's the data we need to design the actual fix.

🤖 Generated with [Claude Code](https://claude.com/claude-code)