### PR TITLE
fix(opfs): sqlite-worker fallback for browsers missing main-thread createSyncAccessHandle

### DIFF
--- a/app/static/app.js
+++ b/app/static/app.js
@@ -3227,6 +3227,293 @@
     });
   }
 
+  // ===== Hybrid (API + worker) provider ====================================
+  //
+  // When main-thread SAH-pool init fails because Chrome's main thread strips
+  // FileSystemFileHandle.prototype.createSyncAccessHandle from the prototype
+  // (PR #95–#98 found this on a vanilla Chrome 147 install), we spin up
+  // app/static/sqlite-worker.js and run sqlite-wasm in worker scope. The
+  // worker exposes ONLY the relationships side of the data provider; the
+  // fellows directory continues to come from the API provider on the main
+  // thread, so we don't pay the cost of re-downloading fellows.db into the
+  // worker just to read it.
+  //
+  // Result: dataProvider.kind === 'api+worker' — directory methods come
+  // from the API provider unchanged, relationships/backup/restore come
+  // from the worker via RPC. Settings page treats this as
+  // "local persistence available" and renders the backup section.
+
+  function createSqliteWorkerRpc(worker) {
+    var nextId = 0;
+    var pending = new Map();
+    worker.onmessage = function (ev) {
+      var msg = ev.data || {};
+      var slot = pending.get(msg.id);
+      if (!slot) return;
+      pending.delete(msg.id);
+      if (msg.ok) {
+        slot.resolve(msg.result);
+      } else {
+        var err = new Error(msg.error || 'worker rpc error');
+        if (msg.errorName) err.name = msg.errorName;
+        if (msg.stack) err.workerStack = msg.stack;
+        slot.reject(err);
+      }
+    };
+    worker.onerror = function (ev) {
+      bootDebugPush('sqlite-worker error: ' + (ev && ev.message || 'unknown'));
+    };
+    return {
+      call: function (op, args, transferables) {
+        var id = ++nextId;
+        return new Promise(function (resolve, reject) {
+          pending.set(id, { resolve: resolve, reject: reject });
+          try {
+            worker.postMessage({ id: id, op: op, args: args }, transferables || []);
+          } catch (e) {
+            pending.delete(id);
+            reject(e);
+          }
+        });
+      },
+      terminate: function () { try { worker.terminate(); } catch (e) {} }
+    };
+  }
+
+  // Resolve member record_ids to {record_id, name} pairs using the
+  // main-thread fellowsBySlug cache. Worker-side getGroup returns
+  // members without names (worker has no fellows.db) — main thread
+  // attaches them here, the same way the existing main-thread sqlite
+  // provider does (attachMemberNames inside createSqliteDataProvider).
+  function attachMemberNamesFromCache(members) {
+    if (!Array.isArray(members)) return [];
+    var out = members.map(function (m) {
+      var rid = m && m.record_id;
+      var fellow = fellowsBySlug.get(rid);
+      return { record_id: rid, name: fellow ? fellow.name : rid };
+    });
+    out.sort(function (a, b) {
+      var an = (a.name || '').toLowerCase(), bn = (b.name || '').toLowerCase();
+      return an < bn ? -1 : (an > bn ? 1 : 0);
+    });
+    return out;
+  }
+
+  // Build the hybrid provider. Strategy: for every method, try API first;
+  // if API rejects with localDataUnavailable (the marker for "this server
+  // can't serve this route" — dev's app/server.py serves /api/groups but
+  // prod's deploy/server.py 404s it), fall through to the sqlite worker.
+  //
+  // - Directory methods (getList etc.): API works in both dev and prod, no
+  //   worker involvement.
+  // - Groups + settings: API in dev, worker in prod. The first failed call
+  //   in prod warms the API provider's groupsRouteSupported cache, so
+  //   subsequent calls fail fast (no network round-trip) and fall through
+  //   to the worker without overhead.
+  // - Backup/restore (exportRelationshipsBytes, importRelationshipsBytes,
+  //   etc.): no API equivalent in either dev OR prod, always rejects with
+  //   localDataUnavailable, always falls through to worker.
+  //
+  // The worker is spawned LAZILY — on first call that needs it, not at
+  // boot. Eager spawn was breaking Playwright e2e (worker init kept the
+  // page from networkidle for too long); lazy means tests that never
+  // touch backup/restore (or groups in prod) never spawn it. Real users
+  // pay a one-time ~1s init on first click of a worker-only feature.
+  function createHybridApiAndWorkerProvider(apiProvider) {
+    var rpcPromise = null;  // null = not started; Promise = pending or resolved
+    function getRpc() {
+      if (!rpcPromise) {
+        rpcPromise = (function () {
+          bootDebugPush('worker sqlite: lazy init starting');
+          var worker;
+          try { worker = new Worker('/vendor/sqlite-worker.js'); }
+          catch (ce) {
+            return Promise.reject(new Error('worker construction failed: ' + (ce && ce.message || ce)));
+          }
+          var rpc = createSqliteWorkerRpc(worker);
+          var sha = (bootBuildMeta && bootBuildMeta.git_sha) || null;
+          return rpc.call('init', { gitSha: sha }).then(function (initResult) {
+            bootDebugPush('worker sqlite: lazy init OK relDb=' + !!(initResult && initResult.relDbOpen));
+            if (initResult && initResult.trace && initResult.trace.length) {
+              bootDebugPush('--- begin worker trace ---');
+              for (var i = 0; i < initResult.trace.length; i++) {
+                bootDebugPush('  ' + initResult.trace[i]);
+              }
+              bootDebugPush('--- end worker trace ---');
+            }
+            return rpc;
+          }).catch(function (err) {
+            try { rpc.terminate(); } catch (e) {}
+            // Reset so a future call can retry — useful if the failure was
+            // transient (network blip, etc.).
+            rpcPromise = null;
+            bootDebugPush('worker sqlite: lazy init failed: ' + (err && err.message || err));
+            throw err;
+          });
+        })();
+      }
+      return rpcPromise;
+    }
+    function workerCall(op, args, transferables) {
+      return getRpc().then(function (rpc) { return rpc.call(op, args, transferables); });
+    }
+    // Try API first; on localDataUnavailable, fall through to worker.
+    // `apiThunk` is a closure that calls the API provider method; `workerOp`
+    // is the worker RPC name; `argsForWorker` (and `transferables`) get
+    // passed through to the worker if we fall through.
+    function apiOrWorker(apiThunk, workerOp, argsForWorker, transferables) {
+      return apiThunk().catch(function (err) {
+        if (err && err.localDataUnavailable) {
+          return workerCall(workerOp, argsForWorker, transferables);
+        }
+        throw err;
+      });
+    }
+    function withResolvedMembers(group) {
+      if (!group) return null;
+      group.members = attachMemberNamesFromCache(group.members || []);
+      return group;
+    }
+    return {
+      kind: 'api+worker',
+      // Directory — API only.
+      getList: apiProvider.getList.bind(apiProvider),
+      getFull: apiProvider.getFull.bind(apiProvider),
+      getOne: apiProvider.getOne.bind(apiProvider),
+      search: apiProvider.search.bind(apiProvider),
+      getStats: apiProvider.getStats.bind(apiProvider),
+      // Groups — API in dev, worker in prod. attachMemberNamesFromCache
+      // only runs on the worker fallback (API already returns names).
+      listGroups: function () {
+        return apiOrWorker(
+          function () { return apiProvider.listGroups(); },
+          'listGroups'
+        );
+      },
+      getGroup: function (id) {
+        return apiOrWorker(
+          function () { return apiProvider.getGroup(id); },
+          'getGroup',
+          { id: id }
+        ).then(function (g) {
+          // API returns members already with names; worker returns
+          // record_ids only. Detect by checking if any member already has
+          // a name, and skip if so.
+          if (!g || !g.members || !g.members.length) return g;
+          var first = g.members[0];
+          if (first && typeof first.name === 'string') return g;
+          g.members = attachMemberNamesFromCache(g.members);
+          return g;
+        });
+      },
+      createGroup: function (data) {
+        return apiOrWorker(
+          function () { return apiProvider.createGroup(data); },
+          'createGroup',
+          data
+        ).then(function (g) {
+          if (!g || !g.members || !g.members.length) return g;
+          var first = g.members[0];
+          if (first && typeof first.name === 'string') return g;
+          g.members = attachMemberNamesFromCache(g.members);
+          return g;
+        });
+      },
+      updateGroup: function (id, patch) {
+        return apiOrWorker(
+          function () { return apiProvider.updateGroup(id, patch); },
+          'updateGroup',
+          { id: id, patch: patch }
+        ).then(function (g) {
+          if (!g || !g.members || !g.members.length) return g;
+          var first = g.members[0];
+          if (first && typeof first.name === 'string') return g;
+          g.members = attachMemberNamesFromCache(g.members);
+          return g;
+        });
+      },
+      deleteGroup: function (id) {
+        return apiOrWorker(
+          function () { return apiProvider.deleteGroup(id); },
+          'deleteGroup',
+          { id: id }
+        );
+      },
+      // Settings — API in dev, worker in prod.
+      getSetting: function (key) {
+        return apiOrWorker(
+          function () { return apiProvider.getSetting(key); },
+          'getSetting',
+          { key: key }
+        );
+      },
+      getSettings: function () {
+        return apiOrWorker(
+          function () { return apiProvider.getSettings(); },
+          'getSettings'
+        );
+      },
+      setSetting: function (key, value) {
+        return apiOrWorker(
+          function () { return apiProvider.setSetting(key, value); },
+          'setSetting',
+          { key: key, value: value }
+        );
+      },
+      // Backup / restore — no API equivalent. The API thunks always
+      // reject with localDataUnavailable, so apiOrWorker always falls
+      // through to the worker.
+      exportRelationshipsBytes: function () {
+        return apiOrWorker(
+          function () { return apiProvider.exportRelationshipsBytes(); },
+          'exportRelationshipsBytes'
+        );
+      },
+      inspectRelationshipsBytes: function (bytes) {
+        return apiOrWorker(
+          function () { return apiProvider.inspectRelationshipsBytes(bytes); },
+          'inspectRelationshipsBytes',
+          { bytes: bytes },
+          [bytes.buffer]
+        );
+      },
+      countRelationships: function () {
+        return apiOrWorker(
+          function () { return apiProvider.countRelationships(); },
+          'countRelationships'
+        );
+      },
+      importRelationshipsBytes: function (bytes) {
+        return apiOrWorker(
+          function () { return apiProvider.importRelationshipsBytes(bytes); },
+          'importRelationshipsBytes',
+          { bytes: bytes },
+          [bytes.buffer]
+        );
+      },
+      listRelationshipsBackups: function () {
+        return apiOrWorker(
+          function () { return apiProvider.listRelationshipsBackups(); },
+          'listRelationshipsBackups'
+        );
+      },
+      restoreRelationshipsBackup: function (name) {
+        return apiOrWorker(
+          function () {
+            return apiProvider.restoreRelationshipsBackup
+              ? apiProvider.restoreRelationshipsBackup(name)
+              : Promise.reject(localDataUnavailableError('restore-backup'));
+          },
+          'restoreRelationshipsBackup',
+          { name: name }
+        );
+      },
+      // Diagnostics — pulls the worker's own boot trace. Only used by
+      // diagnostics / panel rendering; safe to spawn the worker here.
+      _getWorkerTrace: function () { return workerCall('getTrace'); }
+    };
+  }
+
   function pickDataProvider() {
     bootDebugPush('pickDataProvider: start');
     bootDebugPush('gates (one line): ' + describeOpfsGates().replace(/\n/g, ' | '));
@@ -3237,23 +3524,29 @@
     bootDebugPush('trying OPFS + sqlite-wasm');
     return initOpfsDataProvider().catch(function (e) {
       var errMsg = e && e.message ? e.message : String(e);
-      bootDebugPush('OPFS path failed → API fallback: ' + errMsg);
-      console.warn('Local SQLite / OPFS unavailable, using API:', e);
-      // If the failure was "Missing required OPFS APIs.", probe a worker
-      // to see whether the worker thread has the API the main thread
-      // lacks. We don't act on the result yet — this PR is data-gathering
-      // for the Worker-based fallback rewrite that follows. The probe
-      // result lands in the boot trace and renders inline in the panel.
+      bootDebugPush('main-thread OPFS path failed: ' + errMsg);
+      console.warn('Main-thread SQLite/OPFS unavailable:', e);
+      // Specific failure mode: main thread is missing
+      // FileSystemFileHandle.prototype.createSyncAccessHandle (or one of
+      // the other 4 sqlite-wasm pre-flight APIs). Workers expose those
+      // even when the main thread doesn't, so try the worker fallback.
       if (/Missing required OPFS APIs/.test(errMsg)) {
         return probeOpfsInWorker().then(function (probe) {
-          try {
-            bootDebugPush('worker probe: ' + JSON.stringify(probe));
-          } catch (jsonErr) {
-            bootDebugPush('worker probe: (could not serialize result)');
+          try { bootDebugPush('worker probe: ' + JSON.stringify(probe)); }
+          catch (jsonErr) { bootDebugPush('worker probe: (could not serialize)'); }
+          var workerHasSah = probe && probe.ok && probe.createSyncAccessHandle === 'function';
+          var apiProvider = createApiDataProvider();
+          if (!workerHasSah) {
+            bootDebugPush('worker probe says createSyncAccessHandle unavailable in worker too → API only');
+            return apiProvider;
           }
-          return createApiDataProvider();
+          // Hybrid provider — worker spawns lazily on first OPFS-required
+          // call, so plain directory navigation pays no worker cost.
+          bootDebugPush('worker probe positive → hybrid provider (lazy worker)');
+          return createHybridApiAndWorkerProvider(apiProvider);
         });
       }
+      bootDebugPush('OPFS path failed → API fallback: ' + errMsg);
       return createApiDataProvider();
     });
   }
@@ -6395,7 +6688,16 @@
     // the restore section, and let the panel tell the user what to do.
     // The late `localDataUnavailable` click-handler paths below remain
     // for paranoia / late provider downgrades.
-    var localPersistenceAvailable = !!(dataProvider && dataProvider.kind === 'sqlite');
+    // 'sqlite' = main-thread SAH-pool succeeded; 'api+worker' = main-thread
+    // SAH-pool failed but the dedicated sqlite-worker.js came up (PR-this).
+    // Both expose working backup/restore; only the plain 'api' fallback
+    // needs the unavailable-panel.
+    var localPersistenceAvailable = !!(
+      dataProvider && (
+        dataProvider.kind === 'sqlite' ||
+        dataProvider.kind === 'api+worker'
+      )
+    );
     if (!localPersistenceAvailable) {
       var preExport = document.getElementById('settings-export-section');
       if (preExport) {

--- a/app/static/sw.js
+++ b/app/static/sw.js
@@ -16,6 +16,7 @@ const APP_SHELL_ASSETS = [
   '/styles.css',
   '/app.js',
   '/sw.js',
+  '/vendor/sqlite-worker.js',
   '/manifest.webmanifest',
   '/icons/icon-192.png',
   '/icons/icon-512.png',

--- a/app/static/vendor/sqlite-worker.js
+++ b/app/static/vendor/sqlite-worker.js
@@ -1,0 +1,575 @@
+// EHF Fellows local DB — sqlite-wasm worker (relationships.db only).
+//
+// Runs sqlite-wasm + OPFS-SAH-Pool in dedicated-worker scope. Used as a
+// fallback when the main thread can't init SAH-pool because Chrome's
+// configuration strips FileSystemFileHandle.prototype.createSyncAccessHandle
+// from the main-thread prototype (PR #95–#98 found this on a vanilla
+// Chrome 147 install). Workers expose the API even when the main thread
+// hides it.
+//
+// Scope: relationships.db only. The fellows directory (read-only contact
+// data) keeps using the API provider on the main thread — no need to
+// re-download a ~1.5MB fellows.db into the worker just to read it.
+// The hybrid provider on the main thread (createHybridApiAndWorkerProvider
+// in app.js) routes fellows queries to API and relationships queries here.
+//
+// Protocol:
+//   main → worker: { id, op, args }
+//   worker → main: { id, ok: true,  result }
+//                  { id, ok: false, error, errorName?, stack? }
+//
+// First message must be op='init' with { gitSha }.
+
+'use strict';
+
+// Sibling import — this file lives in /vendor/ alongside sqlite3.js.
+// The relative path is what makes sqlite-wasm's scriptDirectory resolve
+// to /vendor/, so its internal locateFile('sqlite3.wasm') finds the
+// companion /vendor/sqlite3.wasm. (Earlier this worker lived at
+// /sqlite-worker.js and the wasm look-up resolved to /sqlite3.wasm — 404.)
+importScripts('./sqlite3.js');
+
+// ===== Constants (mirrored from app.js — keep in sync) ======================
+
+var RELATIONSHIPS_SCHEMA_SQL =
+  'CREATE TABLE IF NOT EXISTS groups (' +
+  '  id INTEGER PRIMARY KEY,' +
+  '  name TEXT NOT NULL,' +
+  '  note TEXT NOT NULL DEFAULT \'\',' +
+  '  created_at TEXT NOT NULL,' +
+  '  updated_at TEXT NOT NULL' +
+  ');' +
+  'CREATE TABLE IF NOT EXISTS group_members (' +
+  '  group_id INTEGER NOT NULL REFERENCES groups(id) ON DELETE CASCADE,' +
+  '  fellow_record_id TEXT NOT NULL,' +
+  '  PRIMARY KEY (group_id, fellow_record_id)' +
+  ');' +
+  'CREATE INDEX IF NOT EXISTS idx_group_members_group ON group_members(group_id);' +
+  'CREATE TABLE IF NOT EXISTS fellow_tags (' +
+  '  fellow_record_id TEXT NOT NULL,' +
+  '  tag TEXT NOT NULL,' +
+  '  created_at TEXT NOT NULL,' +
+  '  PRIMARY KEY (fellow_record_id, tag)' +
+  ');' +
+  'CREATE INDEX IF NOT EXISTS idx_fellow_tags_tag ON fellow_tags(tag);' +
+  'CREATE TABLE IF NOT EXISTS fellow_notes (' +
+  '  fellow_record_id TEXT PRIMARY KEY,' +
+  '  body TEXT NOT NULL,' +
+  '  updated_at TEXT NOT NULL' +
+  ');' +
+  'CREATE TABLE IF NOT EXISTS settings (' +
+  '  key TEXT PRIMARY KEY,' +
+  '  value TEXT' +
+  ');';
+
+var BACKUP_PREFIX = 'relationships.db.bak.';
+var BACKUP_SENTINEL = 'last_seen_sha.txt';
+var BACKUP_KEEP = 3;
+var RESTORE_STAGING_SLOT = 'relationships.db.restore-staging';
+var REQUIRED_RESTORE_TABLES = ['groups', 'group_members', 'fellow_tags', 'fellow_notes', 'settings'];
+
+// ===== State ================================================================
+
+var sqlite3 = null;
+var poolUtil = null;
+var relDb = null;
+var gitSha = null;
+var bootTrace = [];
+
+function trace(msg) { bootTrace.push(new Date().toISOString() + ' ' + String(msg)); }
+
+// ===== SQL helpers ==========================================================
+
+function dbSelectAll(db, sql, bind) {
+  var st = db.prepare(sql);
+  var out = [];
+  try {
+    if (bind !== undefined && bind !== null) st.bind(bind);
+    while (st.step()) out.push(st.get({}));
+  } finally { st.finalize(); }
+  return out;
+}
+
+function dbSelectOne(db, sql, bind) {
+  var rows = dbSelectAll(db, sql, bind);
+  return rows.length ? rows[0] : null;
+}
+
+function dbRun(db, sql, bind) {
+  var st = db.prepare(sql);
+  try {
+    if (bind !== undefined && bind !== null) st.bind(bind);
+    st.step();
+  } finally { st.finalize(); }
+}
+
+function bootstrapRelationshipsSchema(db) {
+  db.exec(RELATIONSHIPS_SCHEMA_SQL);
+  db.exec('PRAGMA user_version = 1');
+}
+
+function nowIsoSecond() {
+  return new Date().toISOString().replace(/\.\d+Z$/, 'Z');
+}
+
+function dedupeRecordIds(ids) {
+  var seen = {}, out = [];
+  if (!ids) return out;
+  for (var i = 0; i < ids.length; i++) {
+    var rid = ids[i];
+    if (typeof rid !== 'string') continue;
+    var s = rid.replace(/^\s+|\s+$/g, '');
+    if (!s || seen[s]) continue;
+    seen[s] = 1;
+    out.push(s);
+  }
+  return out;
+}
+
+// ===== OPFS root file helpers ===============================================
+
+async function _opfsRoot() { return await self.navigator.storage.getDirectory(); }
+
+async function _opfsReadText(name) {
+  try {
+    var root = await _opfsRoot();
+    var fh = await root.getFileHandle(name);
+    var f = await fh.getFile();
+    return await f.text();
+  } catch (e) { return null; }
+}
+
+async function _opfsWriteText(name, content) {
+  var root = await _opfsRoot();
+  var fh = await root.getFileHandle(name, { create: true });
+  var w = await fh.createWritable();
+  await w.write(content);
+  await w.close();
+}
+
+async function _opfsWriteBinary(name, bytes) {
+  var root = await _opfsRoot();
+  var fh = await root.getFileHandle(name, { create: true });
+  var w = await fh.createWritable();
+  await w.write(bytes);
+  await w.close();
+}
+
+async function _opfsReadBinary(name) {
+  var root = await _opfsRoot();
+  var fh = await root.getFileHandle(name);
+  var f = await fh.getFile();
+  return new Uint8Array(await f.arrayBuffer());
+}
+
+async function listRelationshipsBackups() {
+  try {
+    var root = await _opfsRoot();
+    var out = [];
+    for await (var entry of root.values()) {
+      if (entry.kind === 'file' && entry.name.indexOf(BACKUP_PREFIX) === 0) {
+        var f = await entry.getFile();
+        out.push({ name: entry.name, size: f.size, lastModified: f.lastModified });
+      }
+    }
+    out.sort(function (a, b) { return a.name < b.name ? -1 : a.name > b.name ? 1 : 0; });
+    return out;
+  } catch (e) { return []; }
+}
+
+async function _rotateRelationshipsBackups() {
+  var backups = await listRelationshipsBackups();
+  var root = await _opfsRoot();
+  while (backups.length > BACKUP_KEEP) {
+    var oldest = backups.shift();
+    try {
+      await root.removeEntry(oldest.name);
+      trace('backup: rotated out ' + oldest.name);
+    } catch (e) {
+      trace('backup: rotate removeEntry failed for ' + oldest.name);
+    }
+  }
+}
+
+async function maybeBackupRelationshipsDb() {
+  if (!gitSha) {
+    trace('backup: skipped (no build SHA)');
+    return { backedUp: false, reason: 'no SHA' };
+  }
+  var poolFiles = [];
+  try { poolFiles = poolUtil.getFileNames(); } catch (e) {}
+  var hasRelDb = poolFiles.indexOf('relationships.db') !== -1;
+  var prevSha = await _opfsReadText(BACKUP_SENTINEL);
+  if (!hasRelDb) {
+    try { await _opfsWriteText(BACKUP_SENTINEL, gitSha); } catch (e) {}
+    trace('backup: skipped (no relationships.db yet)');
+    return { backedUp: false, reason: 'first install' };
+  }
+  if (prevSha === gitSha) {
+    trace('backup: skipped (no SHA change)');
+    return { backedUp: false, reason: 'no SHA change' };
+  }
+  var bytes;
+  try { bytes = poolUtil.exportFile('relationships.db'); }
+  catch (e) {
+    trace('backup: exportFile failed: ' + (e && e.message || e));
+    return { backedUp: false, reason: 'export failed' };
+  }
+  if (!bytes || !bytes.byteLength) {
+    try { await _opfsWriteText(BACKUP_SENTINEL, gitSha); } catch (e) {}
+    return { backedUp: false, reason: 'empty file' };
+  }
+  var ts = new Date().toISOString().replace(/[:.]/g, '-');
+  var backupName = BACKUP_PREFIX + ts;
+  try { await _opfsWriteBinary(backupName, bytes); }
+  catch (e) {
+    trace('backup: write failed: ' + (e && e.message || e));
+    return { backedUp: false, reason: 'write failed' };
+  }
+  await _rotateRelationshipsBackups();
+  try { await _opfsWriteText(BACKUP_SENTINEL, gitSha); } catch (e) {}
+  trace(
+    'backup: wrote ' + backupName + ' (' + bytes.byteLength + ' bytes); ' +
+    'sentinel ' + (prevSha || '<none>') + ' → ' + gitSha
+  );
+  return { backedUp: true, name: backupName, size: bytes.byteLength };
+}
+
+async function snapshotRelationshipsDbToBackup() {
+  var poolFiles = [];
+  try { poolFiles = poolUtil.getFileNames(); } catch (e) {}
+  if (poolFiles.indexOf('relationships.db') === -1) {
+    return { backedUp: false, reason: 'no relationships.db' };
+  }
+  var bytes;
+  try { bytes = poolUtil.exportFile('relationships.db'); }
+  catch (e) { return { backedUp: false, reason: 'export failed: ' + (e && e.message || e) }; }
+  if (!bytes || !bytes.byteLength) return { backedUp: false, reason: 'empty file' };
+  var ts = new Date().toISOString().replace(/[:.]/g, '-');
+  var backupName = BACKUP_PREFIX + ts;
+  try { await _opfsWriteBinary(backupName, bytes); }
+  catch (e) { return { backedUp: false, reason: 'write failed: ' + (e && e.message || e) }; }
+  await _rotateRelationshipsBackups();
+  trace('snapshot: wrote ' + backupName + ' (' + bytes.byteLength + ' bytes)');
+  return { backedUp: true, name: backupName, size: bytes.byteLength };
+}
+
+async function inspectBytes(bytes) {
+  if (!poolUtil) return { valid: false, error: 'pool util unavailable' };
+  if (!bytes || !bytes.byteLength) return { valid: false, error: 'File is empty.' };
+  var hdr = 'SQLite format 3\0';
+  if (bytes.byteLength < hdr.length) {
+    return { valid: false, error: 'File is too small to be a SQLite database.' };
+  }
+  for (var i = 0; i < hdr.length; i++) {
+    if (bytes[i] !== hdr.charCodeAt(i)) {
+      return { valid: false, error: 'File does not look like a SQLite database.' };
+    }
+  }
+  var tmp = null;
+  try {
+    poolUtil.importDb(RESTORE_STAGING_SLOT, bytes);
+    tmp = new poolUtil.OpfsSAHPoolDb(RESTORE_STAGING_SLOT);
+    var qc = dbSelectOne(tmp, 'PRAGMA quick_check', null);
+    var qcResult = qc && (qc.quick_check || qc['quick_check']);
+    if (qcResult !== 'ok') {
+      return { valid: false, error: 'SQLite integrity check failed: ' + (qcResult || 'unknown') };
+    }
+    var tableRows = dbSelectAll(tmp, "SELECT name FROM sqlite_master WHERE type='table'", null);
+    var tableNames = tableRows.map(function (r) { return r.name; });
+    var missing = REQUIRED_RESTORE_TABLES.filter(function (t) { return tableNames.indexOf(t) === -1; });
+    if (missing.length) {
+      return {
+        valid: false,
+        error: 'File is missing expected tables: ' + missing.join(', ') +
+          '. Is this a relationships.db backup?'
+      };
+    }
+    return {
+      valid: true,
+      counts: {
+        groups: dbSelectOne(tmp, 'SELECT COUNT(*) AS n FROM groups', null).n,
+        members: dbSelectOne(tmp, 'SELECT COUNT(*) AS n FROM group_members', null).n,
+        tags: dbSelectOne(tmp, 'SELECT COUNT(*) AS n FROM fellow_tags', null).n,
+        notes: dbSelectOne(tmp, 'SELECT COUNT(*) AS n FROM fellow_notes', null).n,
+        settings: dbSelectOne(tmp, 'SELECT COUNT(*) AS n FROM settings', null).n
+      }
+    };
+  } catch (e) {
+    return { valid: false, error: (e && e.message) || String(e) };
+  } finally {
+    if (tmp) { try { tmp.close(); } catch (e2) {} }
+  }
+}
+
+// ===== RPC handlers =========================================================
+
+var handlers = {};
+
+handlers.init = async function (args) {
+  args = args || {};
+  gitSha = args.gitSha || null;
+  trace('init: starting');
+  if (typeof globalThis.sqlite3InitModule !== 'function') {
+    throw new Error('sqlite3InitModule missing in worker (vendor/sqlite3.js failed to load?)');
+  }
+  sqlite3 = await globalThis.sqlite3InitModule();
+  trace('sqlite3InitModule: OK');
+  if (typeof sqlite3.installOpfsSAHPoolVfs !== 'function') {
+    throw new Error('sqlite3.installOpfsSAHPoolVfs missing in worker build');
+  }
+  poolUtil = await sqlite3.installOpfsSAHPoolVfs();
+  trace('installOpfsSAHPoolVfs: OK');
+
+  // Auto-backup before opening relationships.db for app use, mirrors what
+  // the main-thread sqlite provider does on initOpfsDataProvider.
+  await maybeBackupRelationshipsDb();
+
+  try {
+    relDb = new poolUtil.OpfsSAHPoolDb('relationships.db');
+    bootstrapRelationshipsSchema(relDb);
+    trace('relationships.db: open + schema OK');
+  } catch (relErr) {
+    trace('relationships.db: open failed (' + (relErr && relErr.message || relErr) + ')');
+    relDb = null;
+  }
+
+  return {
+    ok: true,
+    relDbOpen: !!relDb,
+    poolFiles: (function () { try { return poolUtil.getFileNames(); } catch (e) { return []; } })(),
+    trace: bootTrace.slice()
+  };
+};
+
+// ----- Relationships (groups + settings) ------------------------------------
+
+handlers.listGroups = async function () {
+  if (!relDb) throw new Error('relationships db not open');
+  return dbSelectAll(
+    relDb,
+    'SELECT g.id, g.name, g.note, g.created_at, g.updated_at, ' +
+      'COUNT(gm.fellow_record_id) AS count ' +
+      'FROM groups g LEFT JOIN group_members gm ON gm.group_id = g.id ' +
+      'GROUP BY g.id ORDER BY g.updated_at DESC, g.id DESC',
+    null
+  );
+};
+
+handlers.getGroup = async function (args) {
+  if (!relDb) throw new Error('relationships db not open');
+  var id = args && args.id;
+  var row = dbSelectOne(relDb, 'SELECT * FROM groups WHERE id = ?', [id]);
+  if (!row) return null;
+  // Members come back as record_ids only; main thread resolves names from
+  // its in-memory cache (populated by getList/getFull). Mirrors how the
+  // main-thread sqlite provider does it (attachMemberNames in app.js).
+  var members = dbSelectAll(
+    relDb, 'SELECT fellow_record_id AS record_id FROM group_members WHERE group_id = ?', [id]
+  );
+  row.members = members;
+  return row;
+};
+
+handlers.createGroup = async function (data) {
+  if (!relDb) throw new Error('relationships db not open');
+  var name = data && data.name;
+  var note = (data && typeof data.note === 'string') ? data.note : '';
+  var ids = dedupeRecordIds(data && data.fellow_record_ids);
+  var now = nowIsoSecond();
+  relDb.exec('BEGIN');
+  try {
+    dbRun(relDb, 'INSERT INTO groups(name, note, created_at, updated_at) VALUES (?, ?, ?, ?)',
+          [name, note, now, now]);
+    var idRow = dbSelectOne(relDb, 'SELECT last_insert_rowid() AS id', null);
+    var gid = idRow && idRow.id;
+    for (var i = 0; i < ids.length; i++) {
+      dbRun(relDb, 'INSERT INTO group_members(group_id, fellow_record_id) VALUES (?, ?)', [gid, ids[i]]);
+    }
+    relDb.exec('COMMIT');
+    return await handlers.getGroup({ id: gid });
+  } catch (e) {
+    try { relDb.exec('ROLLBACK'); } catch (e2) {}
+    throw e;
+  }
+};
+
+handlers.updateGroup = async function (args) {
+  if (!relDb) throw new Error('relationships db not open');
+  var id = args && args.id;
+  var patch = (args && args.patch) || {};
+  var existing = dbSelectOne(relDb, 'SELECT 1 AS x FROM groups WHERE id = ?', [id]);
+  if (!existing) return null;
+  var sets = ['updated_at = ?'];
+  var params = [nowIsoSecond()];
+  if (typeof patch.name === 'string') { sets.push('name = ?'); params.push(patch.name); }
+  if (typeof patch.note === 'string') { sets.push('note = ?'); params.push(patch.note); }
+  params.push(id);
+  relDb.exec('BEGIN');
+  try {
+    dbRun(relDb, 'UPDATE groups SET ' + sets.join(', ') + ' WHERE id = ?', params);
+    if (Array.isArray(patch.fellow_record_ids)) {
+      dbRun(relDb, 'DELETE FROM group_members WHERE group_id = ?', [id]);
+      var ids = dedupeRecordIds(patch.fellow_record_ids);
+      for (var i = 0; i < ids.length; i++) {
+        dbRun(relDb, 'INSERT INTO group_members(group_id, fellow_record_id) VALUES (?, ?)', [id, ids[i]]);
+      }
+    }
+    relDb.exec('COMMIT');
+    return await handlers.getGroup({ id: id });
+  } catch (e) {
+    try { relDb.exec('ROLLBACK'); } catch (e2) {}
+    throw e;
+  }
+};
+
+handlers.deleteGroup = async function (args) {
+  if (!relDb) throw new Error('relationships db not open');
+  var id = args && args.id;
+  var existing = dbSelectOne(relDb, 'SELECT 1 AS x FROM groups WHERE id = ?', [id]);
+  if (!existing) return false;
+  dbRun(relDb, 'DELETE FROM groups WHERE id = ?', [id]);
+  return true;
+};
+
+handlers.getSetting = async function (args) {
+  if (!relDb) return null;
+  var row = dbSelectOne(relDb, 'SELECT value FROM settings WHERE key = ?', [args && args.key]);
+  return row ? row.value : null;
+};
+
+handlers.getSettings = async function () {
+  if (!relDb) return {};
+  var rows = dbSelectAll(relDb, 'SELECT key, value FROM settings', null);
+  var bag = {};
+  rows.forEach(function (r) { bag[r.key] = r.value; });
+  return bag;
+};
+
+handlers.setSetting = async function (args) {
+  if (!relDb) throw new Error('relationships db not open');
+  var key = args && args.key;
+  var value = args && args.value;
+  if (value === null || value === undefined || value === '') {
+    dbRun(relDb, 'DELETE FROM settings WHERE key = ?', [key]);
+  } else {
+    dbRun(
+      relDb,
+      'INSERT INTO settings(key, value) VALUES (?, ?) ON CONFLICT(key) DO UPDATE SET value = excluded.value',
+      [key, value]
+    );
+  }
+  return { key: key, value: value };
+};
+
+// ----- Backup / restore -----------------------------------------------------
+
+handlers.exportRelationshipsBytes = async function () {
+  if (!poolUtil) throw new Error('pool util unavailable');
+  return poolUtil.exportFile('relationships.db');
+};
+
+handlers.inspectRelationshipsBytes = async function (args) {
+  return inspectBytes(args && args.bytes);
+};
+
+handlers.countRelationships = async function () {
+  if (!relDb) return null;
+  return {
+    groups: dbSelectOne(relDb, 'SELECT COUNT(*) AS n FROM groups', null).n,
+    members: dbSelectOne(relDb, 'SELECT COUNT(*) AS n FROM group_members', null).n,
+    tags: dbSelectOne(relDb, 'SELECT COUNT(*) AS n FROM fellow_tags', null).n,
+    notes: dbSelectOne(relDb, 'SELECT COUNT(*) AS n FROM fellow_notes', null).n,
+    settings: dbSelectOne(relDb, 'SELECT COUNT(*) AS n FROM settings', null).n
+  };
+};
+
+handlers.importRelationshipsBytes = async function (args) {
+  if (!poolUtil) throw new Error('pool util unavailable');
+  var bytes = args && args.bytes;
+  var inspection = await inspectBytes(bytes);
+  if (!inspection.valid) {
+    var err = new Error(inspection.error || 'invalid relationships.db file');
+    err.invalidBackup = true;
+    throw err;
+  }
+  var snap = await snapshotRelationshipsDbToBackup();
+  if (relDb) {
+    try { relDb.close(); } catch (e) {}
+    relDb = null;
+  }
+  poolUtil.importDb('relationships.db', bytes);
+  relDb = new poolUtil.OpfsSAHPoolDb('relationships.db');
+  bootstrapRelationshipsSchema(relDb);
+  return {
+    counts: inspection.counts,
+    preRestoreSnapshot: snap && snap.backedUp ? snap.name : null
+  };
+};
+
+handlers.listRelationshipsBackups = async function () {
+  if (!poolUtil) return [];
+  var raw = await listRelationshipsBackups();
+  var out = [];
+  // Sequential — staging slot is shared across inspects.
+  for (var i = 0; i < raw.length; i++) {
+    var entry = raw[i];
+    try {
+      var bytes = await _opfsReadBinary(entry.name);
+      var insp = await inspectBytes(bytes);
+      out.push({
+        name: entry.name, size: entry.size, lastModified: entry.lastModified,
+        counts: insp.valid ? insp.counts : null,
+        invalid: !insp.valid,
+        error: insp.valid ? null : insp.error
+      });
+    } catch (e) {
+      out.push({
+        name: entry.name, size: entry.size, lastModified: entry.lastModified,
+        counts: null, invalid: true, error: (e && e.message) || String(e)
+      });
+    }
+  }
+  return out;
+};
+
+handlers.restoreRelationshipsBackup = async function (args) {
+  if (!poolUtil) throw new Error('pool util unavailable');
+  var name = args && args.name;
+  var backups = await listRelationshipsBackups();
+  var match = null;
+  for (var i = 0; i < backups.length; i++) {
+    if (backups[i].name === name) { match = backups[i]; break; }
+  }
+  if (!match) throw new Error('Backup not found: ' + name);
+  var bytes = await _opfsReadBinary(name);
+  return await handlers.importRelationshipsBytes({ bytes: bytes });
+};
+
+// Diagnostics — pulls the worker's own boot trace.
+handlers.getTrace = async function () { return bootTrace.slice(); };
+
+// ===== Dispatcher ===========================================================
+
+self.onmessage = async function (ev) {
+  var data = ev.data || {};
+  var id = data.id;
+  var op = data.op;
+  var args = data.args;
+  var handler = handlers[op];
+  if (!handler) {
+    self.postMessage({ id: id, ok: false, error: 'unknown op: ' + op });
+    return;
+  }
+  try {
+    var result = await handler(args);
+    self.postMessage({ id: id, ok: true, result: result });
+  } catch (e) {
+    self.postMessage({
+      id: id, ok: false,
+      error: (e && e.message) || String(e),
+      errorName: e && e.name,
+      stack: e && e.stack
+    });
+  }
+};

--- a/deploy/server.py
+++ b/deploy/server.py
@@ -482,8 +482,11 @@ class Handler(SimpleHTTPRequestHandler):
             self.send_header("Cache-Control", "no-cache")
         elif pl.endswith(".webmanifest") or pl.rsplit("/", 1)[-1] == "manifest.webmanifest":
             self.send_header("Cache-Control", "no-cache")
-        elif pl.rsplit("/", 1)[-1] in ("app.js", "styles.css"):
+        elif pl.rsplit("/", 1)[-1] in ("app.js", "styles.css") or pl.endswith("/vendor/sqlite-worker.js"):
             # App shell: must revalidate so browsers (and SW networkFirst) get auth UX updates.
+            # sqlite-worker.js is tightly versioned with app.js (same release cycle, same
+            # postMessage protocol) — keep it on the no-cache rail so a prod deploy can't
+            # leave a stale worker running against new app.js for up to 7 days.
             self.send_header("Cache-Control", "no-cache")
         elif pl.rsplit("/", 1)[-1] == "build-meta.json":
             self.send_header("Cache-Control", "no-cache")

--- a/tests/e2e/test_settings.py
+++ b/tests/e2e/test_settings.py
@@ -141,68 +141,76 @@ class TestSettingsPage:
         addr = page.locator("#export-self-email-addr")
         expect(addr).to_have_value("rich@example.com")
 
-    def test_userdata_sections_in_dom_and_exposed_in_api_mode(
+    def test_userdata_sections_in_dom_and_failure_is_never_silent(
         self, standalone_page, base_url_fixture
     ):
         """The Settings page emits both the "Your saved data" (PR #84) and
         "Restore from backup" (PR #88) sections in the DOM. Their *content*
-        depends on the data provider:
-        - OPFS-backed sqlite provider → original markup (Download button +
-          Restore picker + recent-backups list).
-        - API provider → the export section is replaced by the
-          local-data-unavailable panel (PR-this), and the restore section
-          is hidden. This keeps the failure visible to the user with the
-          existing browser-aware copy ("Try a hard reload, open Diagnostics,
-          …") instead of silently disappearing both sections.
+        depends on which backend the data provider picked:
 
-        Dev e2e runs in API-provider mode (Playwright's chromium does not
-        expose `FileSystemFileHandle.prototype.createSyncAccessHandle` on the
-        main thread, so the SAH-pool VFS can't install). The OPFS round-trip
-        is verified on prod manually — see issue #85 test plan."""
+        - main-thread sqlite ('sqlite') → original markup (Download +
+          Restore + recent-backups list).
+        - hybrid api+worker ('api+worker', this-PR) → SAME markup as
+          sqlite mode — backup actually works via the dedicated worker
+          even though the main thread couldn't install SAH-pool.
+        - plain API fallback ('api') → the export section is replaced by
+          the local-data-unavailable panel (PR #95), and the restore
+          section is hidden.
+
+        The shipped guarantee from PR #95 is that the failure is never
+        silent: a user who came to back up their data either sees a
+        working backup section OR sees an explanation of what's wrong.
+        This test asserts that invariant — exactly one of the two
+        renders, regardless of which backend Playwright's chromium ends
+        up with. (Playwright's chromium worker has historically had
+        FileSystemFileHandle.prototype.createSyncAccessHandle, so the
+        hybrid path is the expected outcome here, but tests shouldn't
+        couple to that detail.)"""
         page = standalone_page
         page.goto(f"{base_url_fixture}/#/settings", wait_until="domcontentloaded")
         _wait_for_directory(page)
         export_section = page.locator("#settings-export-section")
         restore_section = page.locator("#settings-restore-section")
-        # Both sections must be in the DOM (so OPFS-mode users get them
-        # back when the provider is sqlite — same gate from PR #92).
+        # Both sections must be in the DOM regardless of mode.
         expect(export_section).to_have_count(1)
         expect(restore_section).to_have_count(1)
-        # In dev (API provider), the export section is replaced by the
-        # unavailable-panel, and the restore section is hidden.
+        # Markup that doesn't depend on which mode we're in.
+        file_input = page.locator("#settings-restore-file")
+        expect(file_input).to_have_count(1)
+        accept = file_input.get_attribute("accept") or ""
+        assert ".db" in accept and ".sqlite" in accept
+
+        # The shipped guarantee: either backup works or we say why.
+        download_btn = page.locator("#settings-download-userdata")
         panel = export_section.locator(".local-data-unavailable")
-        expect(panel).to_have_count(1)
-        # The panel headline ends with either "right now" (runtime-failure
-        # branch — Playwright's chromium reports as Chrome >= 102) or
-        # "on this browser" (browser-too-old branch). Either way it's a
-        # visible, user-readable message — the bug we're fixing was
-        # silent disappearance, not the specific copy.
-        headline = panel.locator("h3").inner_text()
-        assert "backup and restore" in headline.lower(), headline
-        # Restore section stays hidden so the panel is the single source
-        # of "what's wrong + what to do."
-        assert restore_section.evaluate("el => el.style.display") == "none", (
-            "expected restore section hidden in API-provider mode"
+        button_visible = download_btn.count() == 1 and download_btn.is_visible()
+        panel_present = panel.count() == 1
+
+        assert button_visible or panel_present, (
+            "expected EITHER a working Download button (sqlite/hybrid mode) "
+            "OR the local-data-unavailable panel (api fallback) — got neither"
         )
-        # The download button is gone (its containing section was overwritten
-        # by the panel). The restore-pick button still exists in the DOM
-        # because the restore section is hidden via display:none rather than
-        # rewritten — but it isn't reachable from the user's perspective
-        # because its parent section is hidden, so the panel is the only
-        # thing they actually see.
-        expect(page.locator("#settings-download-userdata")).to_have_count(0)
-        expect(page.locator("#settings-restore-pick")).not_to_be_visible()
-        # When the panel is in runtime-failure mode (which it is in dev e2e —
-        # Chrome reports as supported but the SAH-pool can't install on the
-        # main thread), it embeds a <details> with the boot trace + OPFS
-        # gates inline so the maintainer doesn't need to ask the user to
-        # also click the Diagnostics button.
-        trace = panel.locator("details.local-data-unavailable-trace")
-        expect(trace).to_have_count(1)
-        # The pre block carries the gate output. We use text_content (not
-        # inner_text) because the <details> is collapsed by default —
-        # inner_text would return '' until a click. We don't assert
-        # specific text; the gate values vary per environment.
-        trace_text = trace.locator("pre").text_content() or ""
-        assert len(trace_text.strip()) > 0, "expected non-empty boot trace"
-        assert "opfs" in trace_text.lower(), trace_text
+        assert not (button_visible and panel_present), (
+            "didn't expect both the Download button AND the panel to render; "
+            "they're mutually exclusive states"
+        )
+
+        if panel_present:
+            # API-only fallback (no worker available). PR #95 invariants.
+            headline = panel.locator("h3").inner_text()
+            assert "backup and restore" in headline.lower(), headline
+            assert restore_section.evaluate("el => el.style.display") == "none", (
+                "panel mode should hide the restore section"
+            )
+            # PR #96 invariant — boot trace is embedded inline, not
+            # buried behind a Diagnostics click.
+            trace = panel.locator("details.local-data-unavailable-trace")
+            expect(trace).to_have_count(1)
+            trace_text = trace.locator("pre").text_content() or ""
+            assert len(trace_text.strip()) > 0, "expected non-empty boot trace"
+            assert "opfs" in trace_text.lower(), trace_text
+        else:
+            # sqlite or api+worker mode — backup section is real.
+            # Restore section visible, picker button present.
+            expect(restore_section).to_be_visible()
+            expect(page.locator("#settings-restore-pick")).to_be_visible()


### PR DESCRIPTION
## Summary

PR #95–#98 confirmed the diagnosis: vanilla Chrome 147 on Mac exposes `FileSystemFileHandle.prototype.createSyncAccessHandle` in **worker scope** but NOT on the main thread. SAH-pool init at `vendor/sqlite3.js:11974` therefore rejects with `"Missing required OPFS APIs."` and the user lands in API mode where backup/restore can't work. A fresh Chrome profile shows the same gap, ruling out extension/policy.

This PR makes backup/restore (and groups/settings in production) actually work for that user — and any other user whose Chrome strips the main-thread API.

## How

When main-thread SAH-pool fails AND the worker probe (PR #98) shows `createSyncAccessHandle: 'function'` in worker scope, run sqlite-wasm in a dedicated worker. The page becomes a thin RPC client.

### Hybrid `api+worker` provider

| Method | Backend | Notes |
|---|---|---|
| Directory (`getList`, `getFull`, `getOne`, `search`, `getStats`) | **API only** | No need to re-download fellows.db into the worker just to read it. |
| Groups + settings (`listGroups`, `createGroup`, `setSetting`, …) | **API → worker fallback** | Try API first; on `localDataUnavailable` (the marker for "this server can't serve this route"), fall through to worker. **Dev** hits API (route exists). **Prod** hits worker (route is 404; the API provider's `groupsRouteSupported` cache makes subsequent calls fail fast without a round-trip). |
| Backup / restore (`exportRelationshipsBytes`, `importRelationshipsBytes`, `listRelationshipsBackups`, …) | **Worker only** | No API equivalent ever exists in dev or prod, always falls through. |

### Lazy worker spawn

The worker is spawned **on first call that needs it**, not at boot. Eager spawn caused 5+ minutes of Playwright e2e and an OOM kill before this PR (worker init kept pages from `networkidle`, breaking detail-view tests). Lazy means tests/users that don't touch worker-only features pay no worker cost.

### `/vendor/` placement

`vendor/sqlite-worker.js` lives next to `sqlite3.js` so sqlite-wasm's `locateFile()` resolves `sqlite3.wasm` correctly. (Earlier the worker lived at `/sqlite-worker.js`, `scriptDirectory` was `/`, and the wasm fetch hit `/sqlite3.wasm` → 404.)

## Files

- **`app/static/vendor/sqlite-worker.js`** (new, ~480 lines) — sqlite-wasm RPC server. Imports `./sqlite3.js`, runs `installOpfsSAHPoolVfs` in worker scope, opens `relationships.db` (with auto-backup + schema bootstrap), handles RPC for groups/settings/backup/restore/OPFS-root file ops.
- **`app/static/app.js`** (+~250 lines) — `createSqliteWorkerRpc`, `createHybridApiAndWorkerProvider` with `apiOrWorker` fallback shim, lazy worker spawn, hybrid wiring in `pickDataProvider`. `attachMemberNamesFromCache` resolves member `record_id`s → names via `fellowsBySlug` for the worker path (worker has no fellows.db). Settings page treats `kind === 'api+worker'` as having local persistence.
- **`app/static/sw.js`** — adds `/vendor/sqlite-worker.js` to `APP_SHELL_ASSETS`.
- **`deploy/server.py`** — adds `/vendor/sqlite-worker.js` to the no-cache list so prod deploys can't strand a stale worker against a new `app.js` for up to 7 days.
- **`tests/e2e/test_settings.py`** — rewrites the PR #95 test to assert the user-visible invariant ("backup either works or the panel explains why") rather than coupling to a specific provider mode.

## Test plan

- [x] `node --check app/static/{app,vendor/sqlite-worker}.js`.
- [x] `just test-e2e` — 139 passed (was 137 failing 2 mid-iteration).
- [ ] **Manual on the reporting user's Chrome 147**: open `#/settings`, click *Restore from a file*. Should now show the file picker and complete the round-trip via the worker. Boot trace in the diagnostics dump should read `worker probe positive → hybrid provider (lazy worker)` followed by `worker sqlite: lazy init OK` on first method call.
- [ ] Manual on prod after deploy: groups page + settings page should both work for any user with the Chrome 147 config.

🤖 Generated with [Claude Code](https://claude.com/claude-code)