### PR TITLE
ci: drop claude-code-plugins; use v1 action's auto-mode

### DIFF
--- a/.github/workflows/claude-code-review.yml
+++ b/.github/workflows/claude-code-review.yml
@@ -36,9 +36,14 @@ jobs:
         uses: anthropics/claude-code-action@v1
         with:
           claude_code_oauth_token: ${{ secrets.CLAUDE_CODE_OAUTH_TOKEN }}
-          plugin_marketplaces: 'https://github.com/anthropics/claude-code.git'
-          plugins: 'code-review@claude-code-plugins'
-          prompt: '/code-review:code-review ${{ github.repository }}/pull/${{ github.event.pull_request.number }}'
+          prompt: |
+            Review this pull request. Focus on:
+            - Correctness and likely bugs
+            - Security issues (especially around auth, SQL, OPFS access)
+            - Performance and unnecessary complexity
+            - Test coverage gaps
+            Be concise. If the PR looks good, say so briefly.
+          claude_args: "--model claude-opus-4-7"
           # See https://github.com/anthropics/claude-code-action/blob/main/docs/usage.md
           # or https://code.claude.com/docs/en/cli-reference for available options
 


### PR DESCRIPTION
## Summary
- Drops `plugin_marketplaces` + `plugins: 'code-review@claude-code-plugins'` from the Claude review workflow.
- Replaces the `/code-review:code-review` slash-command prompt with a plain review prompt.
- Pins `claude_args: "--model claude-opus-4-7"`.

## Why
The plugin path recurringly produced empty results: the job exits 0 after several minutes of real work but no comment ever lands on the PR — matches [anthropics/claude-code-action#1087](https://github.com/anthropics/claude-code-action/issues/1087).

Latest failed run on `fix/post-p102-review-fixes` ([run 25316338412](https://github.com/richbodo/fellows_local_db/actions/runs/25316338412)) confirmed it:

```
"subtype": "success",
"is_error": false,
"duration_ms": 218515,
"num_turns": 13,
"total_cost_usd": 1.3373143,
"permission_denials_count": 3
```

…followed by `No buffered inline comments` from the post-comments step. The plugin tried to shell out (likely `gh pr comment`) under the action's default no-Bash posture, got denied 3×, and produced nothing for the action to post.

## Why this fix works
The v1 action's auto-detected `agent` mode (`Auto-detected mode: agent for event: pull_request` in the logs) handles GitHub comment posting via its own TypeScript handlers — no `Bash(gh:*)` shell-out needed. Same OAuth token, same `permissions:` block, just a simpler call shape.

## Test plan
- [ ] Merge to `main` (CI workflow changes only take effect once on the default branch for `pull_request` triggers).
- [ ] Open a follow-up trivial PR (e.g. a docs typo) and confirm a Claude review comment lands within ~5 min.
- [ ] If denials recur, check the run tail for `permission_denials_count` and inspect what tool was denied — likely points at a hook (`.claude/hooks/pre_tool_use.py`) or a tool the new prompt tried to use.

🤖 Generated with [Claude Code](https://claude.com/claude-code)