### PR TITLE
fix(sw): skip cache.put for non-GET requests

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -28,6 +28,9 @@ tests/e2e/mobile/current_state/
 .aider*
 .server.pid
 
+# Claude Code agent worktrees (per-agent isolated copies of the repo)
+.claude/worktrees/
+
 # Ansible local inventory (copy from inventory/hosts.ini.example)
 ansible/inventory/hosts.ini
 

--- a/app/static/sw.js
+++ b/app/static/sw.js
@@ -114,6 +114,20 @@ self.addEventListener('fetch', (event) => {
   event.respondWith(cacheFirstInto(request, APP_SHELL_CACHE));
 });
 
+// Cache API rejects PUT/POST/DELETE/PATCH at cache.put. Without this guard
+// the verify-token / send-unlock / client-errors / logout POSTs all fired
+// an unhandled rejection ("Failed to execute 'put' on 'Cache': Request
+// method 'POST' is unsupported") on every API call. The response was still
+// returned correctly, but the console flood made real errors hard to spot.
+// .catch() on the cache write covers quota / private-mode / corrupted-cache
+// cases the same way — cache misses are never fatal.
+function safeCachePut(cacheName, request, response) {
+  if (request.method !== 'GET') return;
+  caches.open(cacheName)
+    .then((cache) => cache.put(request, response))
+    .catch(() => { /* quota / private mode / etc. — non-fatal */ });
+}
+
 function cacheFirstInto(request, cacheName) {
   return caches.match(request).then((cached) => {
     if (cached) {
@@ -123,10 +137,7 @@ function cacheFirstInto(request, cacheName) {
       if (!response || response.status !== 200 || response.type !== 'basic') {
         return response;
       }
-      const responseToCache = response.clone();
-      caches.open(cacheName).then((cache) => {
-        cache.put(request, responseToCache);
-      });
+      safeCachePut(cacheName, request, response.clone());
       return response;
     });
   });
@@ -136,10 +147,7 @@ function networkFirst(request) {
   return fetch(request)
     .then((response) => {
       if (response && response.ok && response.status === 200) {
-        const responseClone = response.clone();
-        caches.open(APP_SHELL_CACHE).then((cache) => {
-          cache.put(request, responseClone);
-        });
+        safeCachePut(APP_SHELL_CACHE, request, response.clone());
       }
       return response;
     })

--- a/tests/e2e/test_sw_post_caching.py
+++ b/tests/e2e/test_sw_post_caching.py
@@ -1,0 +1,176 @@
+"""Regression: the service worker must not try to cache POST responses.
+
+Surfaced after PR #102 (Phase 1 cutover) hit prod: every 200-OK POST through
+networkFirst (verify-token, send-unlock, logout) flooded the console with
+`Uncaught (in promise) TypeError: Failed to execute 'put' on 'Cache':
+Request method 'POST' is unsupported`. The response was still returned to
+the page so functionality wasn't broken, but the noise made real errors
+invisible in field-report screenshots.
+
+Fix: gate `cache.put` on `request.method === 'GET'` and wrap in `.catch()`
+so future cache failures (quota, private mode) also stay quiet. See sw.js's
+`safeCachePut`.
+
+Testing approach: instrument `Cache.prototype.put` inside the SW context
+to record every put attempt with method + URL. Console-capture doesn't
+work because Playwright's `page.on('console')` doesn't surface SW errors,
+and the cache-state assertion alone can't distinguish the bug from the
+fix (cache.put throws either way for POST — bug attempts it, fix skips
+it). Recording attempts is the only way to see the difference from outside
+the SW.
+
+The bug only triggers when:
+  (a) response status is 200 (not 204), AND
+  (b) the SW is already installed and controlling the page.
+On prod, condition (b) was met because the user had visited before. The
+test reproduces (b) by warming the SW with a first navigation, then
+issuing the magic-link redirect.
+"""
+from __future__ import annotations
+
+import json
+from http.client import HTTPConnection
+from urllib.parse import urlparse
+
+import pytest
+
+
+# Patch installed into the SW's `self` to record every Cache.put attempt.
+# `self.__cachePutAttempts__` is read back via Worker.evaluate after the test
+# triggers the verify-token POST.
+_SW_INSTRUMENT = """
+() => {
+    if (self.__cachePutAttempts__) return; // idempotent
+    self.__cachePutAttempts__ = [];
+    const original = Cache.prototype.put;
+    Cache.prototype.put = function (req, res) {
+        const url = (req && typeof req === 'object' && req.url) ? req.url : String(req);
+        const method = (req && typeof req === 'object' && req.method) ? req.method : 'GET';
+        self.__cachePutAttempts__.push({method, url});
+        return original.call(this, req, res);
+    };
+}
+"""
+
+
+def _issue_token(deploy_server):
+    """Drive POST /api/send-unlock and return the issued token."""
+    parsed = urlparse(deploy_server["base_url"])
+    body = json.dumps({"email": deploy_server["test_email"]}).encode("utf-8")
+    conn = HTTPConnection(parsed.hostname, parsed.port, timeout=3)
+    conn.request(
+        "POST",
+        "/api/send-unlock",
+        body=body,
+        headers={
+            "Content-Type": "application/json",
+            "Content-Length": str(len(body)),
+        },
+    )
+    conn.getresponse().read()
+    conn.close()
+    assert deploy_server["sent"], "stubbed Postmark recorder never fired"
+    return deploy_server["sent"][-1]["url"].rsplit("/#/unlock/", 1)[-1]
+
+
+@pytest.fixture
+def deploy_clean_page_with_sw(context, deploy_server):
+    """Fresh page with cookies cleared AND the SW pre-installed +
+    instrumented to record cache.put attempts.
+
+    Cookie clear: a leftover session would short-circuit the verify-token
+    POST (auth_status returns authenticated:true and the page skips
+    redemption).
+    SW pre-install: an un-installed SW would let verify-token POST bypass
+    the SW entirely (the bug only triggers when the SW intercepts).
+    """
+    context.clear_cookies()
+    page = context.new_page()
+    state = deploy_server["auth_state"]
+    with state.lock:
+        state.tokens.clear()
+        state.rate_buckets.clear()
+    deploy_server["sent"].clear()
+
+    page.goto(deploy_server["base_url"] + "/?gate=1", wait_until="load")
+    page.wait_for_function(
+        "navigator.serviceWorker && navigator.serviceWorker.controller !== null",
+        timeout=10000,
+    )
+
+    # Find the registered SW worker and install the cache.put recorder.
+    sw_workers = [w for w in context.service_workers if "/sw.js" in w.url]
+    assert sw_workers, f"no /sw.js worker registered; got {[w.url for w in context.service_workers]}"
+    sw = sw_workers[-1]
+    sw.evaluate(_SW_INSTRUMENT)
+
+    try:
+        yield {"page": page, "sw": sw}
+    finally:
+        page.close()
+
+
+def _cache_put_attempts(sw):
+    return sw.evaluate("self.__cachePutAttempts__ || []")
+
+
+def test_sw_does_not_attempt_to_cache_post_responses(
+    deploy_clean_page_with_sw, deploy_server
+):
+    """The exact path that broke in prod: returning user clicks a magic
+    link, SW networkFirst intercepts the verify-token POST. Bug = SW
+    calls Cache.put with the POST request → TypeError. Fix = SW skips
+    the put for non-GET methods.
+    """
+    page = deploy_clean_page_with_sw["page"]
+    sw = deploy_clean_page_with_sw["sw"]
+
+    token = _issue_token(deploy_server)
+    page.goto(
+        f"{deploy_server['base_url']}/#/unlock/{token}", wait_until="load"
+    )
+    page.wait_for_selector("#install-landing:not(.hidden)", timeout=5000)
+    # Tick so any in-flight cache.put completes (or fails to even start).
+    page.wait_for_timeout(200)
+
+    attempts = _cache_put_attempts(sw)
+    post_attempts = [a for a in attempts if a.get("method") != "GET"]
+    assert not post_attempts, (
+        "SW called Cache.put with a non-GET request — the Cache API rejects "
+        "this with TypeError. networkFirst must guard cache.put on "
+        f"method=='GET'. Attempts: {post_attempts}"
+    )
+
+
+def test_verify_token_post_not_stored_in_any_cache(
+    deploy_clean_page_with_sw, deploy_server
+):
+    """Defensive belt-and-braces: even if some future code path tries to
+    cache a POST, no cache should contain a POST entry."""
+    page = deploy_clean_page_with_sw["page"]
+
+    token = _issue_token(deploy_server)
+    page.goto(
+        f"{deploy_server['base_url']}/#/unlock/{token}", wait_until="load"
+    )
+    page.wait_for_selector("#install-landing:not(.hidden)", timeout=5000)
+    page.wait_for_timeout(200)
+
+    cached_post_count = page.evaluate(
+        """async () => {
+            const names = await caches.keys();
+            let n = 0;
+            for (const name of names) {
+                const cache = await caches.open(name);
+                const reqs = await cache.keys();
+                for (const r of reqs) {
+                    if (r.url.indexOf('/api/verify-token') !== -1) n += 1;
+                }
+            }
+            return n;
+        }"""
+    )
+    assert cached_post_count == 0, (
+        f"POST /api/verify-token must never land in any cache; "
+        f"found {cached_post_count} entries"
+    )


### PR DESCRIPTION
## Summary

Service worker's `networkFirst` was calling `cache.put` on every 200-OK response, including POST. Cache API rejects PUT/POST/DELETE/PATCH at `cache.put`, so every API POST through the SW (`verify-token`, `send-unlock`, `logout`) fired an `Uncaught (in promise) TypeError: Failed to execute 'put' on 'Cache': Request method 'POST' is unsupported`. The response was still returned correctly so functionality wasn't broken, but the noise made real errors invisible in field-report screenshots — and on the post-PR-102 prod test it took several round-trips to triage what was actually a slow first-install SW activation.

## What landed

### `safeCachePut` helper, applied in both SW handlers

- Bails when `request.method !== 'GET'` so the Cache API never sees a POST.
- Wraps the open+put chain in `.catch()` so quota / private-mode / corrupted-cache failures stay quiet too. Cache misses are non-fatal in this code path; burying them in `console.error` would re-create the signal-vs-noise problem.

Both `networkFirst` and `cacheFirstInto` go through it. `cacheFirstInto` only ever sees GETs in practice, but a single helper means a future caller can't reintroduce the bug without going out of its way.

### Regression test (`tests/e2e/test_sw_post_caching.py`)

Two cases, both using the existing `deploy_server` session fixture (real magic-link round-trip with stubbed Postmark):

1. **`test_sw_does_not_attempt_to_cache_post_responses`** — instruments `Cache.prototype.put` inside the SW context via Playwright's `Worker.evaluate`, records every put attempt with method + URL, asserts no non-GET attempts after the verify-token POST.
2. **`test_verify_token_post_not_stored_in_any_cache`** — defensive belt-and-braces: even if some future code path tries to cache a POST, no cache contains a POST entry.

The fixture warms the SW with a first navigation before issuing the magic-link redirect — the bug only fires when the SW is already controlling the page (which is what made it a "returning visitor" bug in prod).

### Why instrument the SW directly

Three other approaches don't work:
- `page.on('console')` doesn't surface SW errors (different context in Playwright).
- The cache-state assertion alone can't distinguish bug-attempted-but-threw from fix-skipped (the entry isn't in the cache either way — `cache.put` throws before storing).
- Mocking via `page.route` to fake a 200 POST response doesn't work either (the bug only triggers when the SW is warm; in a single-navigation test, verify-token fires before the SW is installed).

Verified the test catches the bug: with `safeCachePut` reverted, `test_sw_does_not_attempt_to_cache_post_responses` fails with `Cache.put` attempts containing the `POST /api/verify-token` entry.

### Bonus: gitignore `.claude/worktrees/`

One-line addition. Claude Code's per-agent isolated worktree directories live there; full repo copies including the gitignored `app/fellows.db`. Spotted during `/prime` at session start.

## Test results

```
tests/e2e/test_sw_post_caching.py::test_sw_does_not_attempt_to_cache_post_responses[chromium] PASSED
tests/e2e/test_sw_post_caching.py::test_verify_token_post_not_stored_in_any_cache[chromium] PASSED

Full suite: 338 passed, 1 failed, 12 skipped, 1 deselected in 3:09
```

The 1 failure is `test_email_gate.py::test_marker_set_api_unreachable_falls_back_to_gate` — the same pre-existing Playwright/headless-Chromium timing issue called out as fix-forward in PR #102 / #105 descriptions. Same as the deselected `test_404_on_api_fellows_appears_in_bug_report_body`. No new regressions.

## Test plan (manual QA for the maintainer)

- [ ] Deploy this and re-run the post-PR-102 acceptance: open prod in a clean profile, sign in via magic link. Console should be free of the `Cache: Request method 'POST' is unsupported` flood. Repeat with a returning-visitor profile (where the SW is already warm) — same console-clean expectation.
- [ ] Open `?diag=1` after the magic-link redeem. The page should still render the install landing as before; this PR is pure noise reduction, no behavior change for end users.
- [ ] Optional: in DevTools Application → Service Workers, confirm the new `sw.js` activated (look for `safeCachePut` in the Sources panel).

## What this does NOT change

- The SW's actual caching behavior for GET responses — unchanged.
- The two pre-existing flaky e2e tests called out in PR #102 / #105.
- The cosmetic post-PR-102 noise tracked in #107 (image-prewarm `.png`-only fellow 404s, missing `vendor/sqlite3-opfs-async-proxy.js`). Both are functionally benign and bundled separately for one-PR-one-prod-test cadence.

Closes nothing directly; reduces console noise that was making #107 harder to read.

🤖 Generated with [Claude Code](https://claude.com/claude-code)