### PR TITLE
fix(ui+email): prominent +/✕ icons, visual-directory link, EHF Directory From name

### DIFF
--- a/app/static/app.js
+++ b/app/static/app.js
@@ -3594,7 +3594,8 @@
       mark.dataset.recordId = rid;
       mark.setAttribute('aria-pressed', on ? 'true' : 'false');
       mark.title = on ? 'remove from group' : 'add to group';
-      mark.textContent = on ? '✓' : '+';
+      mark.setAttribute('aria-label', on ? 'remove from group' : 'add to group');
+      mark.textContent = on ? '✕' : '+';
       mark.addEventListener('click', function (ev) {
         // Marker is inside the row but must NOT trigger row navigation.
         ev.stopPropagation();
@@ -3706,9 +3707,13 @@
     var demo = [fellow.gender_pronouns, fellow.ethnicity].filter(Boolean).join(' | ');
     leftTop += '<h2 class="detail-name">' + escapeHtml(name);
     if (rid) {
-      leftTop += ' <a href="#" class="detail-add-to-group" data-record-id="' +
-        escapeHtml(rid) + '">' +
-        (inDraft ? 'remove from group' : 'add to group') +
+      var addLabel = inDraft ? 'remove from group' : 'add to group';
+      leftTop += ' <a href="#" class="detail-add-to-group' +
+        (inDraft ? ' detail-add-to-group--on' : '') +
+        '" data-record-id="' + escapeHtml(rid) + '"' +
+        ' role="button" aria-pressed="' + (inDraft ? 'true' : 'false') + '"' +
+        ' aria-label="' + addLabel + '" title="' + addLabel + '">' +
+        (inDraft ? '✕' : '+') +
         '</a>';
     }
     leftTop += '</h2>';
@@ -4047,8 +4052,9 @@
 
   function setMarkerEl(markEl, on) {
     if (!markEl) return;
-    markEl.textContent = on ? '✓' : '+';
+    markEl.textContent = on ? '✕' : '+';
     markEl.title = on ? 'remove from group' : 'add to group';
+    markEl.setAttribute('aria-label', on ? 'remove from group' : 'add to group');
     markEl.setAttribute('aria-pressed', on ? 'true' : 'false');
     if (on) {
       markEl.classList.add('dir-mark--on');
@@ -4073,7 +4079,13 @@
     if (!link) return;
     var rid = link.dataset.recordId;
     var on = !!(rid && groupDraft.members.has(rid));
-    link.textContent = on ? 'remove from group' : 'add to group';
+    var label = on ? 'remove from group' : 'add to group';
+    link.textContent = on ? '✕' : '+';
+    link.title = label;
+    link.setAttribute('aria-label', label);
+    link.setAttribute('aria-pressed', on ? 'true' : 'false');
+    if (on) link.classList.add('detail-add-to-group--on');
+    else link.classList.remove('detail-add-to-group--on');
   }
 
   function toggleDraftMember(rid, name) {
@@ -5073,6 +5085,10 @@
           '<a href="#" class="group-detail-title-edit" id="group-detail-title-edit" role="button" ' +
             'aria-label="Rename group" title="Rename group">✎</a>' +
         '</h2>' +
+        '<p class="group-detail-visual-link-row">' +
+          '<a href="#/groups/' + escapeHtml(String(group.id)) +
+            '/directory" class="group-detail-visual-link">view as visual directory</a>' +
+        '</p>' +
         '<p class="group-detail-meta">' +
           escapeHtml(String(memberCount)) + memberWord +
           ' · created ' + escapeHtml((group.created_at || '').slice(0, 10)) +

--- a/app/static/styles.css
+++ b/app/static/styles.css
@@ -1578,17 +1578,17 @@ h1 {
 }
 
 .dir-mark {
-  flex: 0 0 18px;
-  width: 18px;
-  height: 18px;
+  flex: 0 0 24px;
+  width: 24px;
+  height: 24px;
   padding: 0;
-  font-size: 0.95rem;
+  font-size: 1.25rem;
   line-height: 1;
   font-weight: 700;
   background: transparent;
   border: 0;
   cursor: pointer;
-  color: #bbb;
+  color: #555;
   text-align: center;
   font-family: inherit;
 }
@@ -1636,20 +1636,33 @@ h1 {
   user-select: none;
 }
 
-/* "add to group" / "remove from group" link beside the detail-card name. */
+/* + / ✕ icon-toggle beside the detail-card name. Same affordance as the
+ * directory list .dir-mark, sized larger so it reads as prominent next
+ * to the H2 heading. */
 .detail-add-to-group {
-  display: inline-block;
+  display: inline-flex;
+  align-items: center;
+  justify-content: center;
+  width: 2rem;
+  height: 2rem;
   margin-left: 0.5rem;
-  font-size: 0.85rem;
-  font-weight: 400;
-  color: #0066cc;
-  text-decoration: underline;
+  font-size: 1.8rem;
+  font-weight: 700;
+  line-height: 1;
+  color: #555;
+  text-decoration: none;
   vertical-align: middle;
   cursor: pointer;
+  border-radius: 4px;
 }
 
 .detail-add-to-group:hover {
-  color: #004499;
+  color: var(--accent);
+  text-decoration: none;
+}
+
+.detail-add-to-group--on {
+  color: var(--accent);
 }
 
 /* Mobile: stack the rail below the detail (existing 700px breakpoint
@@ -1799,6 +1812,17 @@ h1 {
 }
 
 .group-detail-breadcrumb a {
+  color: #0066cc;
+  text-decoration: underline;
+}
+
+.group-detail-visual-link-row {
+  margin: 0 0 0.6rem 0;
+  font-size: 0.85rem;
+  color: #555;
+}
+
+.group-detail-visual-link {
   color: #0066cc;
   text-decoration: underline;
 }

--- a/deploy/magic_link_auth.py
+++ b/deploy/magic_link_auth.py
@@ -158,16 +158,20 @@ def install_recently_allowed(token_issued_at: Optional[float], now: Optional[flo
     return (now - token_issued_at) < INSTALL_WINDOW
 
 
-DEFAULT_MAIL_FROM = "admin@fellows.globaldonut.com"
+DEFAULT_MAIL_FROM = "EHF Directory <admin@fellows.globaldonut.com>"
 
 
 def build_postmark_body(to_email: str, magic_url: str) -> dict:
     """Construct the Postmark /email payload. Pure function; no network.
 
-    From address defaults to admin@fellows.globaldonut.com. Override via
-    FELLOWS_MAIL_FROM. Reply-To is taken from FELLOWS_REPLY_TO when set —
-    useful when admin@ doesn't route to a human mailbox yet and replies
-    should land with the operator directly.
+    From defaults to ``EHF Directory <admin@fellows.globaldonut.com>``.
+    Postmark validates the address part against the verified Sender
+    Signature / domain; the display name is what fellows actually see in
+    their inbox (``admin`` alone reads as spam-adjacent). Override via
+    FELLOWS_MAIL_FROM — pass either a bare address or the same
+    ``Display Name <addr>`` shape. Reply-To is taken from
+    FELLOWS_REPLY_TO when set — useful when admin@ doesn't route to a
+    human mailbox yet and replies should land with the operator directly.
     """
     from_addr = os.environ.get("FELLOWS_MAIL_FROM", DEFAULT_MAIL_FROM).strip()
     reply_to = os.environ.get("FELLOWS_REPLY_TO", "").strip()

--- a/docs/email_system_management.md
+++ b/docs/email_system_management.md
@@ -12,7 +12,7 @@ Environment variables used in this section:
 |---|---|
 | `FELLOWS_SESSION_SECRET` | Long random signing key. Generate with `python -c "import secrets; print(secrets.token_urlsafe(48))"`. |
 | `FELLOWS_POSTMARK_TOKEN` | Postmark Server API token from the server's settings page. |
-| `FELLOWS_MAIL_FROM` | Sender address that users see on the magic-link email. Defaults to `admin@fellows.globaldonut.com` — must be a verified Sender Signature (or an address on a domain-verified domain) in Postmark. **Do not use `noreply@` addresses** — Postmark actively refuses them and they hurt your sender reputation. |
+| `FELLOWS_MAIL_FROM` | Sender that users see on the magic-link email. Defaults to `EHF Directory <admin@fellows.globaldonut.com>` — the display name (`EHF Directory`) is what shows in the inbox; the address part must be a verified Sender Signature (or an address on a domain-verified domain) in Postmark. Pass either a bare address or the same `Display Name <addr>` shape. **Do not use `noreply@` addresses** — Postmark actively refuses them and they hurt your sender reputation. |
 | `FELLOWS_REPLY_TO` | Optional. When set, becomes the `Reply-To` header. Use this to route replies to a real operator mailbox (e.g. `richbodo+fellows@gmail.com`) while `admin@fellows.globaldonut.com` is the visible sender. When unset, replies go to `FELLOWS_MAIL_FROM`. |
 | `FELLOWS_PUBLIC_ORIGIN` | Public HTTPS origin for the deployed app, for example `https://fellows.globaldonut.com`. Used to build the magic-link URL in the email body. |
 
@@ -108,7 +108,7 @@ If you do want the address to appear in Postmark's Signatures list (so the dashb
 ssh -p 52221 rsb@fellows.globaldonut.com
 sudo nano /etc/fellows/fellows-pwa.env
 # Edit:
-#   FELLOWS_MAIL_FROM=admin@fellows.globaldonut.com
+#   FELLOWS_MAIL_FROM=EHF Directory <admin@fellows.globaldonut.com>
 #   FELLOWS_REPLY_TO=richbodo+fellows@gmail.com   # or any mailbox you check
 sudo systemctl restart fellows-pwa
 ```
@@ -124,7 +124,7 @@ just prod-env           # confirms the change landed (values shown raw — copy/
 
 1. Open `https://fellows.globaldonut.com/?gate=1` in a fresh incognito window (forces the email gate even if you already have a session cookie).
 2. Submit a known-allowlisted address.
-3. Check the inbox — the `From:` header should read `admin@fellows.globaldonut.com`. If you click Reply, your MUA should pre-fill `FELLOWS_REPLY_TO`.
+3. Check the inbox — the sender column should show `EHF Directory` and the `From:` header should read `EHF Directory <admin@fellows.globaldonut.com>`. If you click Reply, your MUA should pre-fill `FELLOWS_REPLY_TO`.
 4. From your laptop:
    ```bash
    just email-debug '10 minutes ago'

--- a/docs/users_manual.md
+++ b/docs/users_manual.md
@@ -94,8 +94,9 @@ fellows match.](images/users_manual/01_directory_search.png)
 screenshot; the app renders them normally.](images/users_manual/04_fellow_detail.png)
 
 Click a name (in the directory or any group) to open the profile. The
-**← →** arrows step through the directory alphabetically. **add to
-group** drops the fellow into your current selection (see Groups below).
+**← →** arrows step through the directory alphabetically. The **+**
+beside the name drops the fellow into your current selection (see
+Groups below); once added it flips to **✕** — tap again to remove.
 
 ---
 
@@ -111,7 +112,7 @@ App Cache**.
 The directory page is where you build groups.
 
 1. Search or filter.
-2. Tap **+** beside a fellow.
+2. Tap **+** beside a fellow (it flips to **✕** once they're in the draft).
 3. Run another search — your selection persists.
 4. Name the group and click **Create new group**.
 
@@ -149,6 +150,8 @@ and an action bar.
 
 - **Rename** — pencil ✎ next to the title.
 - **Note** — auto-saves on edit.
+- **view as visual directory** — small text link below the title opens
+  the yearbook-style portrait grid for the same group (see below).
 - **Delete** — kebab → *Delete*; confirms before removing. Only the
   group is deleted; fellows themselves are untouched.
 

--- a/tests/e2e/test_groups_compose.py
+++ b/tests/e2e/test_groups_compose.py
@@ -2,7 +2,7 @@
 
 Pins the user-visible contract:
 - Right rail is present on the directory page.
-- +/✓ markers next to every fellow toggle draft membership; click does
+- +/✕ markers next to every fellow toggle draft membership; click does
   not navigate the row.
 - Picked fellows appear as chips in the rail; create button enables.
 - Title field auto-follows the search until the user types, then flips
@@ -53,7 +53,7 @@ class TestGroupComposer:
         expect(mark).to_have_text("+")
         expect(mark).to_have_attribute("aria-pressed", "false")
         mark.click()
-        expect(mark).to_have_text("✓")
+        expect(mark).to_have_text("✕")
         expect(mark).to_have_attribute("aria-pressed", "true")
         expect(mark).to_have_class(re.compile(r"\bdir-mark--on\b"))
         chip = page.locator("#group-rail-members .group-rail-member-name").first
@@ -61,7 +61,7 @@ class TestGroupComposer:
         expect(page.locator("#group-rail-create")).to_be_enabled()
 
     def test_marker_click_does_not_navigate_row(self, worker_data, base_url_fixture):
-        """The +/✓ click is intercepted via stopPropagation; URL hash stays put."""
+        """The +/✕ click is intercepted via stopPropagation; URL hash stays put."""
         page = worker_data.page
         _wait_for_directory(page)
         starting_url = page.url
@@ -76,7 +76,7 @@ class TestGroupComposer:
         row = _aaron_row(page)
         mark = row.locator(".dir-mark")
         mark.click()
-        expect(mark).to_have_text("✓")
+        expect(mark).to_have_text("✕")
         # Chip × removes; marker flips back.
         page.locator("#group-rail-members .group-rail-member-remove").first.click()
         expect(mark).to_have_text("+")
@@ -114,7 +114,7 @@ class TestGroupComposer:
         worker_data.wait()
         _wait_for_directory(page)
         # Marker comes up already on; chip restored from localStorage.
-        expect(_aaron_row(page).locator(".dir-mark")).to_have_text("✓")
+        expect(_aaron_row(page).locator(".dir-mark")).to_have_text("✕")
         expect(page.locator("#group-rail-members .group-rail-member-name").first).to_have_text(
             "Aaron Bird"
         )

--- a/tests/e2e/test_groups_edit.py
+++ b/tests/e2e/test_groups_edit.py
@@ -5,7 +5,7 @@ Pins:
   banner appears, rail flips to "editing group" / "Done editing",
   members are pre-selected, has-email filter is unchecked, search is
   cleared.
-- Toggling +/✓ in edit mode auto-saves via the worker updateGroup RPC;
+- Toggling +/✕ in edit mode auto-saves via the worker updateGroup RPC;
   the group's membership reflects the change immediately.
 - Done editing navigates to #/groups/<id>; banner hides; rail returns
   to compose mode.
@@ -241,7 +241,7 @@ class TestComposeDraftSurvivesEdit:
         expect(page.locator("#group-rail-title")).to_have_value("My in-progress group")
         chip = page.locator("#group-rail-members .group-rail-member-name").first
         expect(chip).to_have_text("Aaron Bird")
-        expect(_aaron_row(page).locator(".dir-mark")).to_have_text("✓")
+        expect(_aaron_row(page).locator(".dir-mark")).to_have_text("✕")
 
 
 class TestReloadDuringEdit:

--- a/tests/test_magic_link_auth.py
+++ b/tests/test_magic_link_auth.py
@@ -175,12 +175,13 @@ def test_gated_paths():
     assert ml.is_protected_data_path("/images/foo.jpg")
 
 
-def test_build_postmark_body_default_sender_is_admin(monkeypatch):
-    """Default FELLOWS_MAIL_FROM is admin@… (no-reply retired per Postmark guidance)."""
+def test_build_postmark_body_default_sender_is_ehf_directory(monkeypatch):
+    """Default From carries the ``EHF Directory`` display name so the inbox
+    shows a recognizable sender rather than bare ``admin@``."""
     monkeypatch.delenv("FELLOWS_MAIL_FROM", raising=False)
     monkeypatch.delenv("FELLOWS_REPLY_TO", raising=False)
     body = ml.build_postmark_body("user@example.com", "https://fellows.globaldonut.com/#/unlock/tok")
-    assert body["From"] == "admin@fellows.globaldonut.com"
+    assert body["From"] == "EHF Directory <admin@fellows.globaldonut.com>"
     assert body["To"] == "user@example.com"
     assert body["MessageStream"] == "outbound"
     assert "expires in 30 minutes" in body["Subject"]
@@ -192,10 +193,10 @@ def test_build_postmark_body_default_sender_is_admin(monkeypatch):
 
 def test_build_postmark_body_reply_to_env_wins(monkeypatch):
     """FELLOWS_REPLY_TO becomes the ReplyTo header when set."""
-    monkeypatch.setenv("FELLOWS_MAIL_FROM", "admin@fellows.globaldonut.com")
+    monkeypatch.setenv("FELLOWS_MAIL_FROM", "EHF Directory <admin@fellows.globaldonut.com>")
     monkeypatch.setenv("FELLOWS_REPLY_TO", "richbodo+fellows@gmail.com")
     body = ml.build_postmark_body("u@x.com", "https://example/#/unlock/tok")
-    assert body["From"] == "admin@fellows.globaldonut.com"
+    assert body["From"] == "EHF Directory <admin@fellows.globaldonut.com>"
     assert body["ReplyTo"] == "richbodo+fellows@gmail.com"
 
 


### PR DESCRIPTION
## Summary

- **Issue #103** — directory `+` markers grow from 18px / `0.95rem` / `#bbb` to **24px / `1.25rem` / `#555`**, in-group glyph swaps `✓ → ✕`, and the fellow-detail "add to group" / "remove from group" text link is replaced with the same `+`/`✕` icon-toggle sized at 2rem / 1.8rem so it reads prominently next to the H2 name.
- **Issue #104** — small *view as visual directory* link sits just below the group title on the group text detail page (in its own line, not buried in the breadcrumb).
- **Email From name** — `DEFAULT_MAIL_FROM` is now `EHF Directory <admin@fellows.globaldonut.com>` so the inbox shows a recognizable sender rather than bare `admin@`. Postmark validates the address part; the display name is cosmetic. `FELLOWS_MAIL_FROM` override still accepts either a bare address or the `Display Name <addr>` shape.

Tests + docs updated to match (`tests/e2e/test_groups_compose.py`, `tests/e2e/test_groups_edit.py`, `tests/test_magic_link_auth.py`, `docs/users_manual.md`, `docs/email_system_management.md`).

Closes #103, closes #104.

## Test plan

Automated (already green locally):
- [x] `pytest tests/test_magic_link_auth.py` — 15 passed (including new EHF Directory default-From assertion).
- [x] `pytest tests/e2e/test_groups_compose.py tests/e2e/test_groups_edit.py tests/e2e/test_groups_detail.py` — 25 passed (icon glyph + visual-directory link).
- [x] `just test-fast` — 63 passed.

Manual QA for the maintainer (browser):
- [ ] Reload the dev app at `http://localhost:8765/` and hard-refresh (Cmd-Shift-R). Confirm the directory `+` reads more prominent and tapping it flips to `✕`.
- [ ] Open a fellow detail (`#/fellow/<slug>`): confirm the icon next to the name is the larger `+` / `✕` button, not the old underlined text link, and that tapping it round-trips correctly.
- [ ] Open a group's text detail page (`#/groups/<id>`): confirm a small *view as visual directory* link sits just below the title and navigates to `#/groups/<id>/directory`.
- [ ] After deploy, send yourself a magic link from `?gate=1`: confirm the inbox sender column reads **EHF Directory** (Gmail, Apple Mail) and the `From:` header is `EHF Directory <admin@fellows.globaldonut.com>`. No ops change required — Postmark already accepts the bare-address default; the display name is added at the message layer.
- [ ] (Optional) Refresh `tests/e2e/mobile/__snapshots__/directory--*.png` if you want the snapshots to match the larger marker — they passed today because the harness isn't pixel-diffing, but a refresh pass would tighten them.

🤖 Generated with [Claude Code](https://claude.com/claude-code)