### PR TITLE
fix(e2e): gate-fallback tests + Phase 2 local-first-boot coverage

### DIFF
--- a/tests/e2e/test_bug_report.py
+++ b/tests/e2e/test_bug_report.py
@@ -192,21 +192,27 @@ class TestBugReportHttpCapture:
     ):
         page = context.new_page()
         # Marker set: shouldActAsApp() returns true → bootDirectoryAsApp.
-        # Post-cutover the worker tries /fellows.db first; route both that
-        # and /api/fellows + /api/auth/status to push the boot through to
-        # the email-gate fallback where the bug-report button lives.
+        # Post-P1 cutover, /api/fellows is only fetched on the api+idb
+        # fallback path — which is triggered when the worker's
+        # ensureFellowsDb gets a 401/403. So:
+        #   /fellows.db → 401 (worker fetch; needs context.route since
+        #     page.route doesn't intercept Web Worker requests)
+        #   /api/fellows* → 404 (the error captured for the bug report)
+        #   /api/auth/status → 503 (so startBrowserUx falls through to
+        #     the quiet email-gate fallback where the bug-report button
+        #     on the gate is reachable)
         page.add_init_script(
             "window.localStorage.setItem('fellows_authenticated_once', '1');"
         )
-        page.route(
+        context.route(
             "**/fellows.db",
-            lambda r: r.fulfill(status=404, body="Not Found"),
+            lambda r: r.fulfill(status=401, body="unauthorized"),
         )
-        page.route(
+        context.route(
             "**/api/fellows*",
             lambda r: r.fulfill(status=404, body="Not Found"),
         )
-        page.route(
+        context.route(
             "**/api/auth/status",
             lambda r: r.fulfill(status=503, body="auth check unavailable"),
         )

--- a/tests/e2e/test_email_gate.py
+++ b/tests/e2e/test_email_gate.py
@@ -177,15 +177,21 @@ class TestEmailGate:
         # fallback's /api/fellows, and the auth-status check. All must
         # fail for this test to exercise the "everything 5xx with
         # marker" safety net.
-        page.route(
+        #
+        # /fellows.db is fetched by the dedicated worker (not the page),
+        # so context.route is required — page.route does not intercept
+        # Web Worker requests. The other two are page-fetched and would
+        # also work with page.route, but using context.route for all
+        # three keeps the mock setup uniform.
+        context.route(
             "**/fellows.db",
             lambda r: r.fulfill(status=503, body="service unavailable"),
         )
-        page.route(
+        context.route(
             "**/api/fellows*",
             lambda r: r.fulfill(status=503, body="service unavailable"),
         )
-        page.route(
+        context.route(
             AUTH_STATUS_PATH,
             lambda r: r.fulfill(status=503, body="service unavailable"),
         )

--- a/tests/e2e/test_local_first_boot.py
+++ b/tests/e2e/test_local_first_boot.py
@@ -1,0 +1,169 @@
+"""E2E: Phase 2 acceptance — local-first boot with the network down.
+
+Plan: ``plans/local_first_worker_architecture.md`` § Phase 2.
+
+The post-P1 architecture stores ``fellows.db`` and ``relationships.db`` in
+OPFS, owned by the dedicated worker. After a successful first boot a
+returning visit's worker init opens the local files without making any
+HTTP request — directory + groups render from local state regardless of
+what ``/fellows.db`` and ``/api/fellows*`` are doing.
+
+This test covers the L4 + L5 invariants by:
+
+1. Letting the first boot complete normally (worker downloads fellows.db,
+   the helper seeds a relationship via the worker RPC).
+2. Closing the page, then arming context routes so ``/fellows.db`` 503s
+   and ``/api/fellows*`` 401s — the catastrophic-server case.
+3. Opening a second page in the same browser context (so OPFS persists).
+   Directory and the seeded group must still render; the build badge
+   shows the offline marker; the email gate / auth-error panels stay
+   hidden.
+"""
+import importlib.util
+import os
+import sys
+
+import pytest
+from playwright.sync_api import expect
+
+# Load the e2e-suite conftest directly. The natural ``from conftest import``
+# resolves to whichever conftest pytest registered first in the session,
+# which is ``tests/e2e/mobile/conftest.py`` when the mobile tree is
+# collected before this file. Loading by absolute path avoids that
+# ordering quirk without depending on collection order.
+_E2E_CONFTEST_PATH = os.path.join(os.path.dirname(os.path.abspath(__file__)), "conftest.py")
+_spec = importlib.util.spec_from_file_location("_e2e_conftest", _E2E_CONFTEST_PATH)
+_e2e_conftest = importlib.util.module_from_spec(_spec)
+_spec.loader.exec_module(_e2e_conftest)
+_STANDALONE_DISPLAY_INIT = _e2e_conftest._STANDALONE_DISPLAY_INIT
+WorkerDataHelper = _e2e_conftest.WorkerDataHelper
+
+
+FELLOWS_DB = "**/fellows.db"
+API_FELLOWS = "**/api/fellows**"
+
+
+def _make_standalone_page(context):
+    page = context.new_page()
+    page.add_init_script(_STANDALONE_DISPLAY_INIT)
+    page.add_init_script(
+        "window.localStorage.setItem('fellows_authenticated_once', '1');"
+    )
+    return page
+
+
+class TestLocalFirstBoot:
+    """L4 + L5: local DBs render before any /api/fellows* or /fellows.db request."""
+
+    def test_returning_visit_renders_from_local_opfs_when_network_down(
+        self, context, base_url_fixture
+    ):
+        # ----- First boot: prime OPFS -----
+        page1 = _make_standalone_page(context)
+        try:
+            page1.goto(base_url_fixture + "/", wait_until="domcontentloaded")
+            helper = WorkerDataHelper(page1)
+            kind = helper.wait()
+            assert kind == "worker", (
+                f"Expected worker-backed dataProvider for first boot, got {kind!r}. "
+                "Without a worker provider this test can't validate local-first behavior."
+            )
+            # Reset relationships state and seed one group so we can
+            # later assert it survived a network-down second boot.
+            helper.wipe_relationships()
+            full = helper.get_full_fellows()
+            assert isinstance(full, list) and len(full) >= 2, (
+                "Expected at least 2 fellows in the local fellows.db after first boot."
+            )
+            seed_ids = [full[0]["record_id"], full[1]["record_id"]]
+            seed_group = helper.create_group(
+                "Local-first canary", fellow_record_ids=seed_ids
+            )
+            assert seed_group["id"], "create_group did not return an id"
+            # Confirm directory is rendering from the worker-owned
+            # fellows.db (the L4 happy path) before we shut everything
+            # down.
+            page1.locator("#directory").wait_for(state="visible", timeout=5000)
+        finally:
+            page1.close()
+
+        # ----- Second boot: network is gone, OPFS persists -----
+        # Routes registered AFTER the first boot completes; OPFS state
+        # carries over inside the browser context so the worker's init
+        # finds fellows.db + relationships.db without any HTTP traffic.
+        context.route(
+            FELLOWS_DB,
+            lambda r: r.fulfill(status=503, body="service unavailable"),
+        )
+        context.route(
+            API_FELLOWS,
+            lambda r: r.fulfill(status=401, body="session expired"),
+        )
+        # Track whether either protected endpoint was contacted —
+        # invariant L4 says local DBs render before any such request.
+        contacted = []
+
+        def _track(req):
+            url = req.url
+            if "/fellows.db" in url or "/api/fellows" in url:
+                contacted.append(url)
+
+        page2 = _make_standalone_page(context)
+        page2.on("request", _track)
+        try:
+            page2.goto(base_url_fixture + "/", wait_until="domcontentloaded")
+            page2.locator("#loading").wait_for(state="hidden", timeout=10000)
+            # Directory rendered from worker-owned local fellows.db.
+            directory = page2.locator("#directory")
+            directory.wait_for(state="visible", timeout=5000)
+
+            # Provider stayed worker-backed (no fall-through to api+idb).
+            kind2 = page2.evaluate(
+                "() => (window.__dataProvider && window.__dataProvider.kind) || null"
+            )
+            assert kind2 == "worker", (
+                f"Expected worker provider on second boot, got {kind2!r}. "
+                "Local-first means OPFS persistence is enough; the worker "
+                "must not fall back to api+idb just because the network is down."
+            )
+
+            # Seeded group survived and is reachable through the same RPC
+            # path the live UI uses.
+            helper2 = WorkerDataHelper(page2)
+            groups = helper2.list_groups()
+            names = [g["name"] for g in (groups or [])]
+            assert "Local-first canary" in names, (
+                f"Expected the seeded group to survive into the second boot, got {names!r}."
+            )
+
+            # Email-gate / install-landing / auth-error panels all stay
+            # hidden — this is decidedly NOT a degraded-UX boot.
+            expect(page2.locator("#install-gate-private")).to_be_hidden()
+            expect(page2.locator("#install-landing")).to_be_hidden()
+            expect(page2.locator("#auth-error-panel")).to_be_hidden()
+
+            # L4 ground-truth: no protected-endpoint request was issued
+            # before the directory rendered. /fellows.db must not be
+            # fetched at all (the worker's init is network-free; there's
+            # no version-keyed refresh until Phase 3). /api/fellows* may
+            # be optionally re-fetched in the future as a freshness top-up,
+            # but Phase 1's worker provider serves getList/getFull from
+            # local OPFS exclusively, so no /api/fellows traffic should
+            # appear here either.
+            assert not any("/fellows.db" in u for u in contacted), (
+                f"L4 violation: /fellows.db was fetched on a returning visit with "
+                f"local OPFS primed: {contacted!r}"
+            )
+            assert not any("/api/fellows" in u for u in contacted), (
+                f"Worker provider should serve directory data from local OPFS, "
+                f"not from /api/fellows: {contacted!r}"
+            )
+        finally:
+            try:
+                helper2 = WorkerDataHelper(page2)
+                helper2.wipe_relationships()
+            except Exception:
+                pass
+            context.unroute(FELLOWS_DB)
+            context.unroute(API_FELLOWS)
+            page2.close()


### PR DESCRIPTION
## Summary

- Two e2e tests (`test_marker_set_api_unreachable_falls_back_to_gate`, `test_404_on_api_fellows_appears_in_bug_report_body`) were consistently failing post-P1 because `page.route` doesn't intercept Web Worker fetches — so the worker downloaded the real `/fellows.db` and the directory rendered instead of the gate. Switched to `context.route`; in the bug-report case also flipped `/fellows.db` from 404 → 401 so the api+idb fallback path is actually triggered (it's the only path that fetches `/api/fellows` post-P1).
- New `tests/e2e/test_local_first_boot.py` covers Phase 2 acceptance per `plans/local_first_worker_architecture.md` § Phase 5: two-page lifecycle inside one context — first page primes OPFS, second page boots with `/fellows.db` 503'd and `/api/fellows*` 401'd. Asserts directory still renders, provider stays `worker`, seeded group survives, and **no request to `/fellows.db` or `/api/fellows*` is issued during boot** (the L4 / L5 invariants).
- Test count: **337 passing → 341 passing, 0 failing.** No production code touched.

## Why this matters

The gate-fallback tests were the canary for "stale session + everything offline" — invariant 10 of `email_gate.md`, the "install once, works forever" promise. Pre-fix they were silently passing-by-accident on the unintended route bypass; post-P1 they were just failing. Fixing them confirms the invariant holds end-to-end with the worker as canonical owner.

The local-first-boot test is the missing Phase 2 acceptance gate. Without it, the L4 ("render local before any /api/fellows* or /fellows.db request") and L5 ("/fellows.db 5xx never blocks relationships ops") invariants had no automated coverage.

## Root cause writeup

`page.route()` does not intercept fetches issued from inside a Web Worker; only `context.route()` does. The two failing tests stubbed `**/fellows.db` with `page.route(...)` — but in the post-P1 architecture that fetch comes from `vendor/sqlite-worker.js`, not the page. The worker downloaded the real DB from the dev server, ensureFellowsDb resolved successfully, the directory rendered with 515 rows, and `#install-gate-private` stayed hidden the entire 15s timeout window.

A debug script confirmed the diagnosis: with `page.route` the trace showed `getList: OK count=515`; with `context.route` ensureFellowsDb correctly threw with `httpStatus=503`, the bootDirectoryAsApp.catch handed off to startBrowserUx, /api/auth/status 503'd, and `initEmailGate` rendered the gate.

## Test plan

- [x] `just test` → 341 passed, 12 skipped, 0 failed (was 337/12/3)
- [x] `pytest tests/e2e/test_email_gate.py::TestEmailGate::test_marker_set_api_unreachable_falls_back_to_gate -v` passes
- [x] `pytest tests/e2e/test_bug_report.py::TestBugReportHttpCapture::test_404_on_api_fellows_appears_in_bug_report_body -v` passes
- [x] `pytest tests/e2e/test_local_first_boot.py -v` passes both standalone and alongside `tests/e2e/mobile/` (the importlib trick avoids `conftest`-shadowing on collection order)

## Manual QA for the maintainer

None — this is test-only. The follow-up cleanup (stale doc-state banners + missing "fellow data unavailable" group-detail hint) is tracked in #111.

🤖 Generated with [Claude Code](https://claude.com/claude-code)