### PR TITLE
feat(p4): diagnostics panel meta block + drop connection banner

### DIFF
--- a/app/static/app.js
+++ b/app/static/app.js
@@ -13,7 +13,6 @@
   var authErrorPanelEl = document.getElementById('auth-error-panel');
   var authErrorPreEl = document.getElementById('auth-error-pre');
   var appWrapEl = document.getElementById('app-wrap');
-  var connectionBannerEl = document.getElementById('connection-banner');
   var directoryEl = document.getElementById('directory');
   var directoryListEl = document.getElementById('directory-list') || directoryEl;
   var searchInputEl = document.getElementById('search-input');
@@ -1911,6 +1910,34 @@
           lines.push('worker getOpfsInventory failed: ' + String(invErr && invErr.message || invErr));
         }
       }
+      // fellows.db.meta.json — the freshness sidecar that gates
+      // SHA-keyed re-import (Phase 3) and powers the About-page
+      // "Last update check" line (Phase 4). Same source-prefer pattern
+      // as the inventory call above.
+      var metaSource = null;
+      if (dataProvider && typeof dataProvider._getFellowsDbMeta === 'function') {
+        metaSource = dataProvider._getFellowsDbMeta();
+      } else if (warmWorker && warmWorker.rpc) {
+        metaSource = warmWorker.rpc.call('getFellowsDbMeta');
+      }
+      if (metaSource) {
+        try {
+          var meta = await metaSource;
+          if (meta && typeof meta === 'object') {
+            lines.push('fellows.db.meta.json (worker view):');
+            lines.push('  sha: ' + (meta.sha || '(unset)'));
+            lines.push('  fetched_at: ' + (meta.fetched_at || '(never)'));
+            lines.push('  last_failure_at: ' + (meta.last_failure_at || '(none)'));
+            if (meta.last_failure_reason) {
+              lines.push('  last_failure_reason: ' + meta.last_failure_reason);
+            }
+          } else {
+            lines.push('fellows.db.meta.json: (not yet written — cold start)');
+          }
+        } catch (metaErr) {
+          lines.push('worker getFellowsDbMeta failed: ' + String(metaErr && metaErr.message || metaErr));
+        }
+      }
     } else if (warmWorkerError) {
       var failTag = (warmWorkerError && warmWorkerError.code === 'OWNERSHIP_CONFLICT')
         ? 'FAILED [OWNERSHIP_CONFLICT — another tab/window holds OPFS]'
@@ -2651,7 +2678,6 @@
     if (installGatePrivateEl) installGatePrivateEl.classList.add('hidden');
     if (appWrapEl) appWrapEl.classList.add('hidden');
     setShellVisible(false);
-    if (connectionBannerEl) connectionBannerEl.classList.add('hidden');
     if (authErrorPanelEl) authErrorPanelEl.classList.remove('hidden');
     if (authErrorPreEl) authErrorPreEl.textContent = lines.join('\n');
   }
@@ -2881,7 +2907,11 @@
       // Diagnostics — pulls the worker's own boot trace + OPFS inventory.
       _getWorkerTrace: function () { return rpc.call('getTrace'); },
       _getOpfsInventory: function () { return rpc.call('getOpfsInventory'); },
-      _ensureFellowsDb: function (args) { return rpc.call('ensureFellowsDb', args || {}); }
+      _ensureFellowsDb: function (args) { return rpc.call('ensureFellowsDb', args || {}); },
+      // Read-only view of fellows.db.meta.json. Powers the About-page
+      // "Last update check" line and the diag panel's meta block. Pure
+      // read; does not trigger a fetch.
+      _getFellowsDbMeta: function () { return rpc.call('getFellowsDbMeta'); }
     };
   }
 
@@ -3424,7 +3454,6 @@
     setShellVisible(false);
     showLoading(false);
     showApp(false);
-    if (connectionBannerEl) connectionBannerEl.classList.add('hidden');
 
     if (authPayload) {
       showAuthDebugInstall(authPayload, httpStatus != null ? httpStatus : 200);
@@ -3569,7 +3598,6 @@
     setShellVisible(false);
     showLoading(false);
     showApp(false);
-    if (connectionBannerEl) connectionBannerEl.classList.add('hidden');
 
     setGateReasonBanner(reason);
 
@@ -4762,6 +4790,13 @@
     aboutHtml += '<button type="button" id="about-check-updates" class="about-check-updates-btn">Check for updates</button>';
     aboutHtml += '<span id="about-update-status" class="about-update-status" role="status" aria-live="polite"></span>';
     aboutHtml += '</p>';
+    // Persistent record of when the worker last reached the server for
+    // directory data. Populated async from fellows.db.meta.json. Useful
+    // when a user reports stale data — the line answers "is the
+    // distribution channel actually working for me?" without sending
+    // them into the diagnostics panel. Phase 4 of
+    // plans/local_first_worker_architecture.md.
+    aboutHtml += '<p class="about-last-update" id="about-last-update"></p>';
     var serverLabel = bootBuildMeta.git_sha
       ? bootBuildMeta.git_sha + (bootBuildMeta.built_at ? ' · ' + bootBuildMeta.built_at : '')
       : (bootBuildMeta.built_at || 'unknown');
@@ -4781,6 +4816,32 @@
     aboutHtml += '<div class="stats-grid" id="stats-grid"></div>';
     aboutHtml += '</div>';
     detailEl.innerHTML = aboutHtml;
+
+    // Populate the "Last update check" line from the worker's
+    // fellows.db.meta.json. Async + non-blocking: a missing/empty meta
+    // (cold-start) renders "No update checks recorded yet" and the page
+    // continues. If the dataProvider doesn't expose the meta RPC (api+idb
+    // fallback on no-OPFS browsers), leave the line empty — the meta
+    // doesn't exist in that path.
+    (function renderLastUpdateCheck() {
+      var el = document.getElementById('about-last-update');
+      if (!el) return;
+      if (!dataProvider || typeof dataProvider._getFellowsDbMeta !== 'function') return;
+      Promise.resolve(dataProvider._getFellowsDbMeta()).then(function (meta) {
+        if (!meta || (!meta.fetched_at && !meta.last_failure_at)) {
+          el.textContent = 'No update checks recorded yet.';
+          return;
+        }
+        var fetchedTs = meta.fetched_at ? new Date(meta.fetched_at).getTime() : 0;
+        var failedTs = meta.last_failure_at ? new Date(meta.last_failure_at).getTime() : 0;
+        if (failedTs > fetchedTs) {
+          var reason = meta.last_failure_reason || 'unknown reason';
+          el.textContent = 'Last update attempt: ' + meta.last_failure_at + ' — failed: ' + reason;
+        } else {
+          el.textContent = 'Last update check: ' + meta.fetched_at + ' — succeeded.';
+        }
+      }).catch(function () { /* non-fatal — leave line empty */ });
+    })();
 
     // Wire the "Check for updates" button. Shares the same checker used by
     // the hourly poll so the user-visible status stays consistent with what
@@ -7404,20 +7465,6 @@
     }
   }
 
-  function updateConnectionBanner() {
-    if (!connectionBannerEl) return;
-    if (navigator.onLine) {
-      connectionBannerEl.textContent = 'You are online.';
-      connectionBannerEl.classList.remove('hidden');
-      setTimeout(function () {
-        connectionBannerEl.classList.add('hidden');
-      }, 2000);
-    } else {
-      connectionBannerEl.textContent = 'You are offline. Showing cached data where available.';
-      connectionBannerEl.classList.remove('hidden');
-    }
-  }
-
   initSwReloadButton();
   initClearCacheButton();
   initResetEverythingButton();
@@ -7705,10 +7752,6 @@
     } else {
       initWindowAISearch();
     }
-
-    window.addEventListener('online', updateConnectionBanner);
-    window.addEventListener('offline', updateConnectionBanner);
-    updateConnectionBanner();
   }
 
   // Eagerly spawn the worker (init only — network-free per L4a) so OPFS

--- a/app/static/index.html
+++ b/app/static/index.html
@@ -240,7 +240,6 @@
       <a href="#/about" class="site-nav-link">About</a>
     </nav>
   </header>
-  <div id="connection-banner" class="connection-banner hidden" aria-live="polite"></div>
   <div id="edit-mode-banner" class="edit-mode-banner hidden" role="status" aria-live="polite">
     <span class="edit-mode-banner-text">
       <span aria-hidden="true">✎ </span><b>editing</b>

--- a/app/static/styles.css
+++ b/app/static/styles.css
@@ -400,16 +400,6 @@ body {
   background: #f4f4f4;
 }
 
-.connection-banner {
-  margin-top: 0.5rem;
-  padding: 0.4rem 0.6rem;
-  font-size: 0.85rem;
-  border-radius: 3px;
-  background: #fff3cd;
-  color: #664d03;
-  border: 1px solid #ffe69c;
-}
-
 .hidden {
   display: none;
 }
@@ -1390,6 +1380,16 @@ h1 {
 .about-update-status {
   font-size: 0.9rem;
   color: #5a5a5a;
+}
+
+.about-last-update {
+  margin: 0.25rem 0 0;
+  font-size: 0.85rem;
+  color: #5a5a5a;
+}
+
+.about-last-update:empty {
+  display: none;
 }
 
 /* =========================================================================

--- a/app/static/vendor/sqlite-worker.js
+++ b/app/static/vendor/sqlite-worker.js
@@ -1100,6 +1100,14 @@ handlers.getVersions = async function () {
   };
 };
 
+// Read-only view of fellows.db.meta.json for diagnostics + the About
+// page's "Last update check" line. Pure read — never triggers a fetch
+// or import; that's ensureFellowsDb's job. Returns null when the meta
+// file doesn't exist yet (cold-start before first ensureFellowsDb).
+handlers.getFellowsDbMeta = async function () {
+  return await readFellowsMeta();
+};
+
 // Reset Everything's nuclear path. Closes both DB handles, tears down the
 // SAH-pool VFS via removeVfs() (which releases every SAH and recursively
 // removes the pool's opaque storage dir), then sweeps sibling files we

--- a/docs/users_manual.md
+++ b/docs/users_manual.md
@@ -243,6 +243,13 @@ file or a recent auto-backup.](images/users_manual/11_settings.png)
 cohort / fellow type) and the build line — handy when reporting a bug.
 **Check for updates** forces a service-worker refresh.
 
+A line under the **Check for updates** button shows when the app last
+successfully refreshed fellow data from the server, e.g.
+*"Last update check: 2026-05-04T18:22:07Z — succeeded."* If the most
+recent attempt failed, it reads *"Last update attempt: … — failed: …"*.
+Useful when a fellow asks "am I seeing the latest data?" — the answer
+is right there.
+
 ![About page.](images/users_manual/12_about_page.png)
 
 ---
@@ -302,13 +309,17 @@ submit), the gate has its own diagnostics block:
 
 ## Offline
 
-Works fully offline once installed. Photos that finished caching are
-available; the rest show a placeholder until you're back online.
+The app is local-first by design. Once installed, it runs entirely on
+your device — fellow data, your saved groups, your notes, your
+settings. No login, no server round-trip on each click. Photos that
+finished caching are available; the rest show a placeholder until you
+get a chance to fetch them.
 
-If the server is unreachable or your session has expired, the app
-keeps running off the last cached load. The build badge at the top
-reads *"server: unreachable"* or *"server: offline · using cache."*
-For fresh data, visit `/?gate=1` for a new magic link.
+If you ever wonder whether the app has reached the server recently —
+to pick up new fellows, fixes, or a refreshed profile — the **About**
+page shows the timestamp of the last successful refresh under
+**Check for updates**. If your session has expired, visit `/?gate=1`
+for a new magic link.
 
 ---
 

--- a/plans/local_first_worker_architecture.md
+++ b/plans/local_first_worker_architecture.md
@@ -171,18 +171,37 @@ Acceptance:
 
 Out of scope: cross-version schema migration. The schema is single-version today; if it ever isn't, a separate plan covers it.
 
-### Phase 4 — Diagnostics
+### Phase 4 — Diagnostics + UI vocabulary cleanup
 
-Cheap wins; ship anytime after Phase 3.
+After Phases 1–3, the app has only one user-facing mode: local. The server is contacted opportunistically for build-meta and SHA-keyed `fellows.db` refresh, never for primary reads. This phase brings the UI vocabulary in line with that, and surfaces the persistent server-contact signal (`fellows.db.meta.json`) in the two places it's actually useful: the developer's diagnostics panel, and the user's About-page update check.
+
+The framing matters. To users, this is a desktop-app delivered by magic link — they install it, it runs, that's the model. Telling them "you're online" or "local-only mode" presumes a SaaS mental model the app was deliberately built to avoid. To developers, "is the server reachable right now?" is a less useful question than "when did the worker last successfully sync?" — the latter is persistent across sessions and is exactly what `fellows.db.meta.json` already records.
 
 Scope:
-- Diagnostics panel (`?diag=1`) shows: worker status (running / errored / version), worker `WORKER_RPC_VERSION` + `RELATIONSHIPS_SCHEMA_VERSION` vs page expected values, OPFS file inventory (per worker query), `persisted()` result with reason if false, contents of `fellows.db.meta.json` (last sha, last fetched_at, last_failure_*), build label of worker bundle (informational).
-- Build badge (already there) gains a tiny indicator when local-only mode is in effect.
+
+- **Drop the main-UI connection banner.** `#connection-banner` ("You are online." / "You are offline. Showing cached data where available.") is leftover from the api+idb era. Post-cutover it tells the user something they don't need to know and contradicts the desktop-app mental model. Delete the element from `index.html`, the `updateConnectionBanner` function + `connectionBannerEl` reference in `app.js`, the `online`/`offline` window listeners, the per-route hide calls, and the `.connection-banner` CSS rule.
+
+- **Surface "last server contact" on the About page.** That's the one place a user would ask the question — they're already there to check for updates. Add a passive line near the existing "Check for updates" control:
+  - `Last update check: <ISO timestamp> — succeeded` when `fetched_at` is the most recent event.
+  - `Last update attempt: <ISO timestamp> — failed: <reason>` when `last_failure_at` is more recent than `fetched_at`.
+  - `No update checks recorded yet` when the meta is empty.
+  - Source: `fellows.db.meta.json:fetched_at` / `last_failure_at` / `last_failure_reason`, read via a new worker RPC `getFellowsDbMeta` (thin wrapper over existing `readFellowsMeta()`).
+
+- **Render `fellows.db.meta.json` contents in the Diagnostics panel.** Same `getFellowsDbMeta` RPC; show the full blob (sha, fetched_at, last_failure_at, last_failure_reason). Developer-grade detail belongs here, not on About.
+
+- **Drop the build-badge "local-only mode" indicator from earlier drafts of this phase.** In a single-mode app there is no mode-change to indicate. The build badge keeps its build-label role; no new trigger is added. `setBuildBadgeOfflineOnly` is left untouched — it still fires harmlessly in the api+idb fallback path (browsers without OPFS) and is unrelated to the post-cutover happy path.
+
+- **The rest of the Phase 4 panel content shipped in Phase 1** (worker version handshake, OPFS inventory, `persisted()` state). Verify they still render correctly post-Phase-3; no new code needed there.
 
 Acceptance:
-- Diagnostics panel renders all of the above without main-thread OPFS access (everything is RPC-derived, except `persisted()` which is a `navigator.storage` call on the page).
 
-Out of scope: telemetry beyond the existing client-error sink.
+- Main-route DOM has no `connection-banner` element on any route. No `online`/`offline` window listeners remain.
+- About page shows the last-update-check line, populated from the worker meta.
+- Diagnostics panel shows the full `fellows.db.meta.json` contents — RPC-derived, no main-thread OPFS access.
+- `tests/e2e/test_diagnostics_panel.py` (new) opens `?diag=1`, captures the panel text, and asserts each Phase 4 section renders. Same file asserts the connection banner is absent from the directory route.
+- `docs/users_manual.md` reflects the About-page change (per CLAUDE.md: UI/UX changes ship with the doc update).
+
+Out of scope: telemetry beyond the existing client-error sink. Renaming or restyling the build badge. A real-time "server reachable now?" indicator — the persistent meta is sufficient.
 
 ### Phase 5 — Test infrastructure (paired with each phase)
 
@@ -350,9 +369,10 @@ Files touched by more than one phase. Use this to decide which phases can run in
 | File | P0 | P1 | P2 | P3 | P4 | P6 |
 |---|---|---|---|---|---|---|
 | `app/static/app.js` | | ✓ | ✓ | ✓ | ✓ | ✓ |
-| `app/static/vendor/sqlite-worker.js` | (probe op, reverted) | ✓ canonical | | ✓ meta + SHA refresh | | |
+| `app/static/vendor/sqlite-worker.js` | (probe op, reverted) | ✓ canonical | | ✓ meta + SHA refresh | ✓ `getFellowsDbMeta` RPC | |
 | `app/static/sw.js` | | | | ✓ runtime-cache exclusion | | |
-| `app/static/index.html` | | ✓ (preload, Q-B) | | | | |
+| `app/static/index.html` | | ✓ (preload, Q-B) | | | ✓ delete `connection-banner` element | |
+| `app/static/styles.css` | | | | | ✓ delete `.connection-banner` rule | |
 | `build/build_pwa.py` | | ✓ worker label sub | | ✓ `fellows_db_sha` | | |
 | `app/server.py` | | ✓ delete routes + worker label sub | | ✓ `fellows_db_sha` compute | | |
 | `deploy/server.py` | | | | ✓ `build-meta.json` field | | |
@@ -361,10 +381,11 @@ Files touched by more than one phase. Use this to decide which phases can run in
 | `docs/browser_support.md` | ✓ | ✓ small revision | | | | |
 | `docs/email_gate.md` | | | | | | ✓ invariant 10 |
 | `docs/debugging.md` | | ✓ "worker stuck on init" playbook | | | | |
+| `docs/users_manual.md` | | | | | ✓ About-page "Last update check" line | |
 | `CLAUDE.md` | ✓ | | | | | |
 | `tests/test_api.py` | | ✓ delete classes | | | | |
 | `tests/e2e/conftest.py` | | ✓ OPFS-state helper | | | | |
-| `tests/e2e/test_*.py` | | ✓ migrate 7 fixtures | ✓ new test file | ✓ new test file | | |
+| `tests/e2e/test_*.py` | | ✓ migrate 7 fixtures | ✓ new test file | ✓ new test file | ✓ new test file | |
 
 The hottest seams are `app/static/app.js` (every phase except P0) and `vendor/sqlite-worker.js` (P1 + P3). **Worktree branches off P1 will conflict heavily with branches off P2/P3/P4 if P1 isn't merged first.** Do not parallelize P1 with anything downstream.
 

--- a/tests/e2e/test_diagnostics_panel.py
+++ b/tests/e2e/test_diagnostics_panel.py
@@ -1,0 +1,193 @@
+"""E2E for Phase 4 of plans/local_first_worker_architecture.md.
+
+Two things this file pins:
+
+  1. The Diagnostics panel (`?diag=1`) renders every section the plan
+     calls for: worker spawn + version handshake, OPFS inventory,
+     `fellows.db.meta.json` block, persisted-storage state. All of it
+     is RPC-derived — there is no main-thread `getDirectory` call
+     during render.
+  2. The legacy "You are online." / "You are offline." connection
+     banner is gone. Post-cutover the app has only one mode (local),
+     so the banner contradicted the desktop-app mental model.
+
+These run against the dev server using the standalone-mode fixture,
+so the directory boot path is exercised end-to-end. The diag panel's
+`?diag=1` query auto-opens the panel and triggers `refresh()`, which
+calls `collectDiagnosticsText()` — same code path the user gets when
+they tap the diag toggle button.
+"""
+from __future__ import annotations
+
+import re
+
+import pytest
+
+
+def _wait_for_diag_text(page, timeout_ms: int = 10000) -> str:
+    """Wait until the diag <pre> has populated content. The panel renders
+    asynchronously: `refresh()` does network probes, awaits worker RPCs,
+    and only then writes the joined lines into <pre>. Polling against
+    the textContent length is the simplest "it's done" signal — the
+    final text is several KB, while a still-rendering panel is empty
+    or very short.
+    """
+    return page.evaluate(
+        """
+        async (timeoutMs) => {
+          const deadline = Date.now() + timeoutMs;
+          while (Date.now() < deadline) {
+            const pre = document.getElementById('diag-pre');
+            const text = pre ? (pre.textContent || '') : '';
+            // collectDiagnosticsText emits 80+ lines of dense info;
+            // 1 KB is a safe floor for "render finished".
+            if (text.length > 1000) return text;
+            await new Promise((r) => setTimeout(r, 100));
+          }
+          throw new Error('diag panel did not populate within ' + timeoutMs + 'ms');
+        }
+        """,
+        timeout_ms,
+    )
+
+
+def test_diag_panel_renders_all_phase4_sections(standalone_page, base_url_fixture):
+    """Open `?diag=1` and confirm every Phase 4 section is present.
+
+    Each section is identified by a stable substring from
+    collectDiagnosticsText so the test fails loudly if a section is
+    accidentally deleted in a future refactor.
+    """
+    page = standalone_page
+
+    # Cold boot — populates fellows.db.meta.json so the meta block has
+    # something real to render. Without an ensureFellowsDb call first
+    # the meta is null and we'd only verify the cold-start branch.
+    page.goto(base_url_fixture + "/?diag=1", wait_until="domcontentloaded")
+    page.evaluate(
+        """
+        async () => {
+          const deadline = Date.now() + 10000;
+          while (Date.now() < deadline) {
+            if (window.__dataProvider && window.__dataProvider.kind === 'worker') {
+              try {
+                const r = await fetch('/build-meta.json', { cache: 'no-store' });
+                const meta = r.ok ? await r.json() : null;
+                const sha = meta && typeof meta.fellows_db_sha === 'string'
+                  ? meta.fellows_db_sha : null;
+                const res = await window.__dataProvider._ensureFellowsDb({ serverSha: sha });
+                if (res && res.hasFellowsDb) return;
+              } catch (e) {}
+            }
+            await new Promise((r) => setTimeout(r, 100));
+          }
+          throw new Error('worker did not resolve ensureFellowsDb within 10s');
+        }
+        """
+    )
+
+    # The `?diag=1` URL flag auto-opens + refreshes the panel on boot.
+    # Refresh once more so the panel re-renders against the now-warm
+    # meta (the auto-open fires before our ensureFellowsDb above).
+    page.evaluate(
+        """
+        async () => {
+          const btn = document.getElementById('diag-refresh');
+          if (btn) btn.click();
+        }
+        """
+    )
+    text = _wait_for_diag_text(page)
+
+    # 1. Worker spawn + version handshake.
+    assert "worker spawn:" in text, f"missing worker spawn line; text head:\n{text[:500]}"
+    assert "worker version compatibility:" in text, "missing version compatibility line"
+    assert "worker capabilities:" in text, "missing worker capabilities line"
+
+    # 2. OPFS inventory (RPC-derived from the worker, not getDirectory on main).
+    assert "OPFS root entries (worker view):" in text, "missing OPFS root inventory"
+
+    # 3. fellows.db.meta.json block — Phase 4's primary new section.
+    assert "fellows.db.meta.json (worker view):" in text, "missing fellows.db.meta.json section"
+    # After a successful ensureFellowsDb, sha + fetched_at must be populated.
+    # The render uses `(unset)` / `(never)` placeholders when fields are missing —
+    # we want the populated path here.
+    assert re.search(r"sha:\s+[0-9a-f]{64}", text), (
+        f"meta.sha should render as a 64-char hex digest after a successful "
+        f"ensureFellowsDb; got snippet:\n{text}"
+    )
+    assert re.search(r"fetched_at:\s+\d{4}-\d{2}-\d{2}T", text), (
+        "meta.fetched_at should render an ISO timestamp after a successful "
+        "ensureFellowsDb"
+    )
+
+    # 4. persisted-storage state. May be null in a Playwright headless context
+    # (no user gesture for a quota prompt), but the line must render either way.
+    assert "navigator.storage.persist():" in text, "missing persist-storage line"
+
+    # 5. Build label of the worker bundle (informational).
+    assert re.search(r"build=\S+", text), "missing worker build label"
+
+
+def test_no_main_thread_opfs_during_diag_render(standalone_page, base_url_fixture):
+    """Phase 4 acceptance: the panel's render must be RPC-derived. The
+    main thread must not call `navigator.storage.getDirectory` while
+    populating the diag pre — that would re-introduce the dual-OPFS-owner
+    bug Phase 1 cut over to fix.
+
+    We instrument `navigator.storage.getDirectory` *before* navigation
+    so any call from page-side JS during boot or diag refresh
+    increments a counter we can read after the panel finishes rendering.
+    The worker's getDirectory call happens in a different realm and is
+    not affected.
+    """
+    page = standalone_page
+    page.add_init_script(
+        """
+        (() => {
+          if (!navigator.storage || !navigator.storage.getDirectory) return;
+          const orig = navigator.storage.getDirectory.bind(navigator.storage);
+          let count = 0;
+          navigator.storage.getDirectory = function () {
+            count++;
+            return orig.apply(this, arguments);
+          };
+          Object.defineProperty(window, '__getDirectoryCallCount', {
+            get: function () { return count; }
+          });
+        })();
+        """
+    )
+    page.goto(base_url_fixture + "/?diag=1", wait_until="domcontentloaded")
+    _wait_for_diag_text(page)
+
+    count = page.evaluate("() => window.__getDirectoryCallCount || 0")
+    assert count == 0, (
+        f"main-thread navigator.storage.getDirectory was called {count} time(s) "
+        f"during boot + diag render — Phase 1 invariant L1 says the worker is "
+        f"the only OPFS opener"
+    )
+
+
+def test_connection_banner_is_gone(standalone_page, base_url_fixture):
+    """The legacy `#connection-banner` element ("You are online.") was
+    leftover vocabulary from before the worker cutover. Phase 4 deletes
+    it. Pin its absence so the element doesn't get accidentally
+    re-introduced in a future copy/paste.
+    """
+    page = standalone_page
+    page.goto(base_url_fixture + "/", wait_until="domcontentloaded")
+
+    # Explicit check: the element must not exist in the DOM.
+    locator = page.locator("#connection-banner")
+    assert locator.count() == 0, (
+        "Phase 4 removed #connection-banner from the main UI; if you need to "
+        "re-introduce a server-status indicator, the About page is the right "
+        "place (see docs/users_manual.md and the renderLastUpdateCheck IIFE)."
+    )
+
+    # Defense in depth: the user-visible strings must not appear anywhere
+    # on the page either, in case the element is reborn under a new id.
+    body_text = page.evaluate("() => document.body.innerText || ''")
+    assert "You are online." not in body_text
+    assert "You are offline." not in body_text

--- a/tests/e2e/test_versioned_fellows_db.py
+++ b/tests/e2e/test_versioned_fellows_db.py
@@ -6,7 +6,7 @@ from /build-meta.json and passes it to the worker's `ensureFellowsDb`;
 the worker compares against the SHA recorded in OPFS-side
 `fellows.db.meta.json` and fetches only on mismatch.
 
-This file covers the three runtime-falsifiable acceptance criteria:
+This file covers the four runtime-falsifiable acceptance criteria:
 
   1. Two consecutive returning boots with the same fellows_db_sha
      produce zero GET /fellows.db requests on the second boot.
@@ -15,6 +15,10 @@ This file covers the three runtime-falsifiable acceptance criteria:
   3. A failed refresh (network error or non-2xx) leaves the previously
      live fellows.db intact and writes meta.last_failure_* — the
      directory keeps rendering against the cached bytes.
+  4. Restoring a relationships.db backup does not trigger a fellows.db
+     re-fetch on next boot — proves the freshness sidecar
+     (`fellows.db.meta.json`) lives outside the SAH-pool dir and is not
+     touched by the relationships.db swap (invariant L8).
 
 These run against the dev server (no auth gate) using the standalone-mode
 fixture so the directory boot path is exercised end-to-end. The SW's
@@ -224,4 +228,97 @@ def test_failed_refresh_preserves_previous_db_and_records_failure(
     rows = page.evaluate("() => window.__dataProvider.getList()")
     assert isinstance(rows, list) and len(rows) > 0, (
         f"directory must still render after a failed refresh; got {len(rows) if isinstance(rows, list) else rows}"
+    )
+
+
+def test_relationships_restore_does_not_refetch_fellows_db(
+    standalone_page, base_url_fixture
+):
+    """Restoring a relationships.db backup must not desync fellows.db
+    freshness — invariant L8 in the local-first worker plan.
+
+    The whole reason `fellows.db.meta.json` lives at the OPFS root
+    (sibling of the SAH-pool dir, not inside relationships.settings) is
+    so a relationships.db swap can't accidentally wipe or invalidate
+    the fellows.db freshness signal. This pins that decoupling: after
+    a real importRelationshipsBytes round-trip, a reload must produce
+    zero GET /fellows.db requests because meta.sha still matches.
+    """
+    page = standalone_page
+
+    # Cold-start boot to populate fellows.db + record its sha in meta.
+    page.goto(base_url_fixture + "/", wait_until="domcontentloaded")
+    meta_before = _wait_for_first_ensure(page)
+    assert meta_before and meta_before.get("sha"), (
+        f"first boot should populate meta.sha; got {meta_before}"
+    )
+    sha_before = meta_before["sha"]
+
+    # Capture pristine relationships.db bytes, mutate, then restore — all
+    # inside one page.evaluate so the Uint8Array stays in the same JS
+    # context. Mutation is what proves the import actually swapped the
+    # DB; if importRelationshipsBytes silently no-op'd, the test would
+    # still see groupsAfter > 0 and fail loudly.
+    restore_outcome = page.evaluate(
+        """
+        async () => {
+          const dp = window.__dataProvider;
+          // Drain reconcileHasEmailFilterOnBoot before exporting so the
+          // captured bytes reflect a settled relationships.db. Same
+          // reasoning as conftest.py's wipe_relationships helper.
+          for (let i = 0; i < 20; i++) {
+            const probe = await dp.getSetting('has_email_only');
+            if (probe === '0' || probe === '1') break;
+            await new Promise((r) => setTimeout(r, 50));
+          }
+          const originalBytes = await dp.exportRelationshipsBytes();
+          await dp.createGroup({
+            name: 'phase3-decouple-canary',
+            note: '',
+            fellow_record_ids: []
+          });
+          const groupsBefore = await dp.listGroups();
+          const importResult = await dp.importRelationshipsBytes(originalBytes);
+          const groupsAfter = await dp.listGroups();
+          return {
+            groupsBefore: (groupsBefore || []).length,
+            groupsAfter: (groupsAfter || []).length,
+            preRestoreSnapshot: importResult && importResult.preRestoreSnapshot
+              ? true
+              : false
+          };
+        }
+        """
+    )
+    assert restore_outcome["groupsBefore"] >= 1, (
+        f"createGroup mutation should be visible before the restore; "
+        f"got {restore_outcome}"
+    )
+    assert restore_outcome["groupsAfter"] == 0, (
+        f"importRelationshipsBytes must replace the live DB with the "
+        f"pristine bytes (canary group should be gone); got {restore_outcome}"
+    )
+    assert restore_outcome["preRestoreSnapshot"], (
+        f"import path should snapshot the pre-restore DB; got {restore_outcome}"
+    )
+
+    # Now reload. The relationships.db restore is committed to OPFS; on
+    # next boot the worker re-reads fellows.db.meta.json untouched and
+    # the SHA-keyed gate must skip the fetch.
+    requests: list[str] = []
+    page.on(
+        "request",
+        lambda req: requests.append(req.url) if req.url.endswith("/fellows.db") else None,
+    )
+    page.reload(wait_until="domcontentloaded")
+    meta_after = _wait_for_first_ensure(page)
+
+    assert meta_after and meta_after.get("sha") == sha_before, (
+        f"meta.sha must survive a relationships.db restore unchanged: "
+        f"before={sha_before} after_restore_reload={meta_after and meta_after.get('sha')}"
+    )
+    fetched = [r for r in requests if r.endswith("/fellows.db")]
+    assert len(fetched) == 0, (
+        f"a relationships.db restore must not trigger /fellows.db re-fetch "
+        f"on next boot; got {fetched}"
     )

--- a/tests/test_build_pwa.py
+++ b/tests/test_build_pwa.py
@@ -1,0 +1,89 @@
+"""Unit tests for build/build_pwa.py helpers.
+
+Phase 3 of plans/local_first_worker_architecture.md added
+`compute_fellows_db_sha` and the `write_build_meta` `fellows_db_sha`
+field. The worker side is exercised via tests/e2e/test_versioned_fellows_db.py;
+this module pins the Python helper's contract independently — equal
+SHA → no fetch hinges on both ends agreeing on `hashlib.sha256` over
+the raw file bytes.
+"""
+from __future__ import annotations
+
+import hashlib
+import json
+from pathlib import Path
+
+from build.build_pwa import compute_fellows_db_sha, write_build_meta
+
+
+def test_compute_fellows_db_sha_matches_hashlib(tmp_path: Path):
+    """SHA must match `hashlib.sha256` over the raw file bytes — same
+    invariant the worker assumes when comparing meta.sha to the
+    server-reported `fellows_db_sha`. If the helper ever switches to a
+    different digest or changes input encoding, this catches it before
+    every returning visitor's worker silently re-imports."""
+    db_path = tmp_path / "fellows.db"
+    payload = b"some bytes that look like a sqlite file"
+    db_path.write_bytes(payload)
+
+    assert compute_fellows_db_sha(db_path) == hashlib.sha256(payload).hexdigest()
+
+
+def test_compute_fellows_db_sha_handles_chunked_read(tmp_path: Path):
+    """Hash is computed by streaming 1-MiB chunks; verify a >1 MiB file
+    rolls up to the same digest as a one-shot hash. Guards against a
+    chunk-boundary bug that would only surface on real production-sized
+    fellows.db files."""
+    db_path = tmp_path / "fellows.db"
+    payload = b"a" * (3 * (1 << 20) + 137)  # 3 MiB + change → spans 4 chunks
+    db_path.write_bytes(payload)
+
+    assert compute_fellows_db_sha(db_path) == hashlib.sha256(payload).hexdigest()
+
+
+def test_compute_fellows_db_sha_returns_none_for_missing_file(tmp_path: Path):
+    """Returns None rather than raising; `write_build_meta` uses this to
+    decide whether to omit `fellows_db_sha` from the meta blob."""
+    assert compute_fellows_db_sha(tmp_path / "does-not-exist.db") is None
+
+
+def test_write_build_meta_omits_sha_when_db_path_is_none(tmp_path: Path):
+    """When the build does not point at a DB, `fellows_db_sha` must be
+    omitted entirely — not emitted as null. The worker treats absence
+    as 'no comparison available' and falls back to cold-start-only
+    behavior; a stray null would compare unequal to every real digest
+    and force a re-fetch on every boot."""
+    dest = tmp_path / "build-meta.json"
+    write_build_meta(dest, "2026-05-06-abcdef0", db_path=None)
+
+    meta = json.loads(dest.read_text())
+    assert "fellows_db_sha" not in meta
+    assert meta["build_label"] == "2026-05-06-abcdef0"
+    assert meta["git_sha"] == "abcdef0"
+    assert meta["generator"] == "build/build_pwa.py"
+
+
+def test_write_build_meta_omits_sha_when_db_file_is_missing(tmp_path: Path):
+    """db_path given but file doesn't exist → still treated as 'no
+    comparison available' rather than raising. A botched build that
+    points at a missing DB shouldn't crash meta-emission."""
+    dest = tmp_path / "build-meta.json"
+    write_build_meta(dest, "2026-05-06-abcdef0", db_path=tmp_path / "nope.db")
+
+    meta = json.loads(dest.read_text())
+    assert "fellows_db_sha" not in meta
+
+
+def test_write_build_meta_emits_sha_when_db_file_exists(tmp_path: Path):
+    """Happy path: real db_path → `fellows_db_sha` appears in the JSON
+    and matches `compute_fellows_db_sha` for the same bytes. End-to-end
+    proof that build-meta.json is wired through to the worker's gate."""
+    db_path = tmp_path / "fellows.db"
+    db_path.write_bytes(b"hello")
+    dest = tmp_path / "build-meta.json"
+
+    write_build_meta(dest, "2026-05-06-abcdef0", db_path=db_path)
+    meta = json.loads(dest.read_text())
+
+    assert meta["fellows_db_sha"] == hashlib.sha256(b"hello").hexdigest()
+    assert meta["fellows_db_sha"] == compute_fellows_db_sha(db_path)


### PR DESCRIPTION
## Summary

Phase 4 of `plans/local_first_worker_architecture.md`.

- **Surface `fellows.db.meta.json` where it's useful.** New `getFellowsDbMeta` worker RPC powers two consumers: the diagnostics panel renders the full meta blob (sha / fetched_at / last_failure_at / last_failure_reason); the About page shows a single passive line under "Check for updates" — *Last update check: \<ISO\> — succeeded.* or *Last update attempt: … — failed: \<reason\>.*
- **Delete the legacy connection banner.** "You are online." / "You are offline. Showing cached data where available." was vocabulary from the pre-cutover api+idb era. Post-Phase-3 the app has one mode (local), and the banner contradicted the desktop-app mental model. Element + function + listeners + per-route hide calls + CSS rule all removed.
- **Plan rewrite.** Phase 4 section and file-conflict table updated in the same PR to match the new scope (Diagnostics + UI vocabulary cleanup).
- **Phase 3 follow-up tests bundled.** Test-only, no production code: unit tests for `compute_fellows_db_sha` / `write_build_meta`, and a relationships-restore decoupling e2e that pins invariant L8.

Net: +354 passed (up from 344), 12 skipped (mobile screenshot fixtures, unrelated).

## Manual QA — for the maintainer

These verify behavior the e2e tests can't fully cover (the build-meta SHA flow on a real prod-style bundle, plus user-visible UI on the About page). All run locally:

- [ ] **About-page line populates.** `just serve`, open `http://localhost:8765/#/about`, confirm a "Last update check: …" line appears under the **Check for updates** button. After a cold-boot it should read `succeeded`. To exercise the failed branch, `just stop` then click **Check for updates** — the existing button status will say "Unable to reach the server", but the persistent line stays on the last successful timestamp until the next refresh attempt rotates it.
- [ ] **Diag panel renders the meta block.** Navigate to `http://localhost:8765/?diag=1`, confirm a `fellows.db.meta.json (worker view):` section with `sha`, `fetched_at`, `last_failure_at`, and (if applicable) `last_failure_reason` lines.
- [ ] **No connection banner on any route.** Reload the directory while toggling DevTools' offline mode — no "You are online." / "You are offline." banner should appear at the top of the page on any of `#/`, `#/about`, `#/groups`, `#/settings`.
- [ ] **Build badge unchanged.** Top-of-page `app: <SHA>` and `server: <SHA · timestamp>` still render correctly. Phase 4 doesn't touch the badge.
- [ ] **Prod smoke after deploy** (when ready): `just smoke`, then visit the prod About page and confirm the new line is populated from `fellows.db.meta.json` after the bundle SHA settles.

## Test plan

- [x] `just test` — 354 passed / 12 skipped
- [x] `tests/e2e/test_diagnostics_panel.py` — 3 new tests (panel sections present, no main-thread `getDirectory` during render, connection banner absent)
- [x] `tests/e2e/test_versioned_fellows_db.py::test_relationships_restore_does_not_refetch_fellows_db` — pins invariant L8
- [x] `tests/test_build_pwa.py` — 6 unit tests for `compute_fellows_db_sha` / `write_build_meta`

🤖 Generated with [Claude Code](https://claude.com/claude-code)