### PR TITLE
fix(images): stop accumulating ?v= entries in fellows-images-v1

### DIFF
--- a/app/static/app.js
+++ b/app/static/app.js
@@ -449,10 +449,18 @@
     function next() {
       var f = queue.shift();
       if (!f) return null;
-      // Same cache-busting suffix as <img src> in renderDetail — keeps the
-      // prewarm and the on-demand render aligned so we hit one cache entry.
-      var jpgUrl = '/images/' + encodeURIComponent(f.slug) + '.jpg?v=' + encodeURIComponent(FELLOWS_UI_DIAG);
-      var pngUrl = '/images/' + encodeURIComponent(f.slug) + '.png?v=' + encodeURIComponent(FELLOWS_UI_DIAG);
+      // No cache-bust query: profile photos for a given slug are
+      // immutable and the URL must stay stable across deploys. A `?v=`
+      // suffix tied to the build label produces a fresh cache key on
+      // every deploy and never evicts the old one — fellows-images-v1
+      // grew to 725 entries across 508 fellows in production before
+      // this fix. Recovery from a previously-404'd photo lags the
+      // deploy by up to a few minutes (browser HTTP cache TTL on the
+      // 404), which is acceptable for ~hundreds of mostly-static
+      // photos. The SW activate handler also sweeps any legacy `?v=`
+      // entries left over from before this change.
+      var jpgUrl = '/images/' + encodeURIComponent(f.slug) + '.jpg';
+      var pngUrl = '/images/' + encodeURIComponent(f.slug) + '.png';
       // Try .jpg first. If 404 / not-ok, fall back to .png — some fellows
       // have only a .png on disk (they uploaded a PNG on Knack), and
       // without this fallback the prewarm never caches them. Mirrors the
@@ -4053,12 +4061,13 @@
     if (demo) leftTop += '<p class="detail-demographics">' + escapeHtml(demo) + '</p>';
     var hasImage = fellow.has_image === 1 || fellow.has_image === true;
     if (hasImage && slug) {
-      // Cache-bust against stale 404s from before a fellow's photo existed.
-      // The HTTP cache has a long max-age for 200 images (good), but if a
-      // browser cached a 404 during a gap, it would persist for days. Adding
-      // ?v=<version> to the URL forces a fresh cache key on every release
-      // so a recovered image surfaces immediately after deploy.
-      var imgUrl = '/images/' + escapeHtml(slug) + '.jpg?v=' + escapeHtml(FELLOWS_UI_DIAG);
+      // Stable URL across deploys — see prewarmProfileImages for why we
+      // don't append ?v=<build_label>. A fellow whose photo was 404 on
+      // a prior visit will keep showing the placeholder until the
+      // browser's HTTP cache TTL on that 404 expires; for ~hundreds of
+      // mostly-static photos that lag is acceptable, and the alternative
+      // accumulates cache entries on every deploy without bound.
+      var imgUrl = '/images/' + escapeHtml(slug) + '.jpg';
       leftTop +=
         '<div class="profile-image-wrap profile-image-wrap--loading" data-slug="' + escapeHtml(slug) + '">' +
           '<img class="profile-image" data-slug="' + escapeHtml(slug) + '" src="' + imgUrl + '" alt="' + escapeHtml(name) + '">' +
@@ -4212,7 +4221,7 @@
           function () {
             var s = img.getAttribute('data-slug');
             if (s && img.src.indexOf('.png') === -1) {
-              img.src = '/images/' + s + '.png?v=' + FELLOWS_UI_DIAG;
+              img.src = '/images/' + s + '.png';
               img.addEventListener('load', markLoaded, { once: true });
               img.addEventListener('error', markPending, { once: true });
             } else {
@@ -5769,7 +5778,7 @@
         var slug = m.slug;
         var imgSrc;
         if (m.has_image && slug) {
-          imgSrc = '/images/' + encodeURIComponent(slug) + '.jpg?v=' + escapeHtml(FELLOWS_UI_DIAG);
+          imgSrc = '/images/' + encodeURIComponent(slug) + '.jpg';
         } else {
           imgSrc = PORTRAIT_SVG_PLACEHOLDER;
         }
@@ -5817,7 +5826,7 @@
     var slug = m.slug;
     var imgSrc;
     if (m.has_image && slug) {
-      imgSrc = '/images/' + encodeURIComponent(slug) + '.jpg?v=' + escapeHtml(FELLOWS_UI_DIAG);
+      imgSrc = '/images/' + encodeURIComponent(slug) + '.jpg';
     } else {
       imgSrc = PORTRAIT_SVG_PLACEHOLDER;
     }

--- a/app/static/sw.js
+++ b/app/static/sw.js
@@ -75,6 +75,37 @@ self.addEventListener('activate', (event) => {
         (err) => ({ key: k, ok: false, error: String(err && err.message || err) })
       ))
     );
+    // One-time sweep of legacy /images/<slug>.<ext>?v=<build_label>
+    // entries. The cache-bust query was retired in this commit; until
+    // every installed user activates the new SW, fellows-images-v1
+    // continues holding stale duplicates from past deploys (725 / 508
+    // ratio observed in production before the fix). No-op once the
+    // sweep has run on a given install — new images land at bare URLs
+    // and the legacy entries will all have been removed. Safe to leave
+    // here permanently.
+    let imagesPurged = 0;
+    try {
+      if (keys.indexOf(IMAGES_CACHE) !== -1) {
+        const imageCache = await caches.open(IMAGES_CACHE);
+        const reqs = await imageCache.keys();
+        for (const req of reqs) {
+          // Match any /images/* entry carrying a query string. The only
+          // query that ever appeared on these URLs was ?v=<build_label>;
+          // matching on '?' keeps the predicate simple and resilient if
+          // the form ever varied.
+          if (req.url.indexOf('/images/') !== -1 && req.url.indexOf('?') !== -1) {
+            const ok = await imageCache.delete(req);
+            if (ok) imagesPurged += 1;
+          }
+        }
+      }
+    } catch (e) {
+      // Non-fatal — quota / private mode / corrupted cache. Activate
+      // must still complete so the new app shell takes over.
+      try {
+        console.warn('[sw] activate: image cache-bust sweep failed', e);
+      } catch (_) {}
+    }
     await self.clients.claim();
     // Tell the page what we did, regardless of whether anything was
     // deleted. Page logs this to bootDebugLines via the existing SW
@@ -84,13 +115,14 @@ self.addEventListener('activate', (event) => {
       type: 'sw-activate-pruned',
       activatedAt: new Date().toISOString(),
       currentCache: APP_SHELL_CACHE,
-      deletions: deletions
+      deletions: deletions,
+      imagesPurged: imagesPurged
     });
     // Also console-log so an operator with DevTools open sees it
     // even if the page-side log channel is disconnected.
     try {
       console.log('[sw] activate: current=', APP_SHELL_CACHE,
-        'deletions=', deletions);
+        'deletions=', deletions, 'imagesPurged=', imagesPurged);
     } catch (e) {}
     // Burn-down: only force-reload controlled windows when we're replacing a
     // prior shell cache. Rescues tabs stuck on stale in-memory app.js from a

--- a/tests/e2e/test_image_cache_no_bust.py
+++ b/tests/e2e/test_image_cache_no_bust.py
@@ -1,0 +1,247 @@
+"""Regression: image URLs must not carry a `?v=<build_label>` query.
+
+In production we observed `fellows-images-v1` growing to 725 entries
+across only 508 fellows-with-photos — a 1.43× overcount caused by a
+cache-bust suffix that produced a fresh cache key on every deploy
+without ever evicting the prior key. The image cache is intentionally
+*not* busted on shell-version bumps (sw.js:10 — `fellows-images-v1`),
+which is the right call for ~34 MB of mostly-static assets; the URL
+suffix defeated that intent.
+
+This file pins the fix:
+
+  1. Image fetches initiated by the prewarm and the on-demand detail
+     render carry no query string.
+  2. The image cache, after a render, contains no `?` URLs.
+
+Together they guarantee a stable cache key per fellow across deploys.
+"""
+from __future__ import annotations
+
+import re
+
+import pytest
+
+
+def _wait_for_provider_and_fellows_db(page, timeout_ms: int = 10000) -> None:
+    """Block until the worker has opened fellows.db. The worker init is
+    network-free post-Phase-1 (L4a); the page must drive
+    `ensureFellowsDb` before any `getList` / `getOne` call. Same pattern
+    as tests/e2e/test_versioned_fellows_db.py:_wait_for_first_ensure.
+    """
+    page.evaluate(
+        """
+        async (timeoutMs) => {
+          // Get the canonical server SHA so the probe is idempotent
+          // with whatever the boot is doing.
+          let serverSha = null;
+          try {
+            const r = await fetch('/build-meta.json', { cache: 'no-store' });
+            if (r.ok) {
+              const meta = await r.json();
+              serverSha = (typeof meta.fellows_db_sha === 'string') ? meta.fellows_db_sha : null;
+            }
+          } catch (e) {}
+          const deadline = Date.now() + timeoutMs;
+          while (Date.now() < deadline) {
+            if (window.__dataProvider && typeof window.__dataProvider.getList === 'function') {
+              try {
+                const res = await window.__dataProvider._ensureFellowsDb({ serverSha: serverSha });
+                if (res && res.hasFellowsDb) return;
+              } catch (e) {}
+            }
+            await new Promise((r) => setTimeout(r, 100));
+          }
+          throw new Error('worker did not settle with fellows.db open within ' + timeoutMs + 'ms');
+        }
+        """,
+        timeout_ms,
+    )
+
+
+def _first_with_image_slug(page) -> str:
+    """Find a slug whose fellow has has_image=true. Required because the
+    detail-render path only emits an /images/<slug>.jpg request when
+    the fellow actually uploaded a photo; picking the first slug
+    blindly hits a placeholder and the assertion finds nothing.
+    """
+    return page.evaluate(
+        """
+        async () => {
+          const dp = window.__dataProvider;
+          const list = await dp.getList();
+          for (const row of list) {
+            if (row && row.slug) {
+              const f = await dp.getOne(row.slug);
+              if (f && (f.has_image === 1 || f.has_image === true)) return row.slug;
+            }
+          }
+          throw new Error('no fellow with has_image found');
+        }
+        """
+    )
+
+
+def test_image_urls_have_no_cache_bust_query(standalone_page, base_url_fixture):
+    """Capture every /images/* request the page makes during boot +
+    detail render. None should carry a `?v=…` query — the bug was the
+    `?v=<FELLOWS_UI_DIAG>` suffix on every image URL.
+    """
+    page = standalone_page
+    image_requests: list[str] = []
+    page.on(
+        "request",
+        lambda req: image_requests.append(req.url) if "/images/" in req.url else None,
+    )
+
+    page.goto(base_url_fixture + "/", wait_until="domcontentloaded")
+    _wait_for_provider_and_fellows_db(page)
+
+    slug = _first_with_image_slug(page)
+    page.goto(base_url_fixture + "/#/fellow/" + slug, wait_until="domcontentloaded")
+    # Wait for the <img> to settle — either loaded or in error fallback.
+    page.wait_for_function(
+        """
+        () => {
+          const imgs = document.querySelectorAll('img.profile-image');
+          if (!imgs.length) return false;
+          return Array.from(imgs).every((img) => img.complete);
+        }
+        """,
+        timeout=10000,
+    )
+
+    # The page makes many image requests during boot (prewarm) and detail
+    # render. Every one of them must be a bare URL.
+    assert image_requests, (
+        "expected at least one /images/* request during boot + detail render; "
+        "got none — fixture may be misconfigured"
+    )
+    bad = [u for u in image_requests if "?" in u]
+    assert not bad, (
+        "image URLs must not carry a query string — every `?v=...` produces a "
+        "fresh cache key on each deploy and never evicts the old one. "
+        "Offending URLs:\n  " + "\n  ".join(bad[:10])
+    )
+
+
+def test_image_cache_holds_no_bust_query_entries(standalone_page, base_url_fixture):
+    """After the page renders a profile detail, fellows-images-v1 must
+    contain only bare-URL entries. Catches the symptom directly: if the
+    prewarm or any other image fetch ever re-introduces `?v=`, the
+    cache will record it and this assertion will trip."""
+    page = standalone_page
+    page.goto(base_url_fixture + "/", wait_until="domcontentloaded")
+    _wait_for_provider_and_fellows_db(page)
+    slug = _first_with_image_slug(page)
+    page.goto(base_url_fixture + "/#/fellow/" + slug, wait_until="domcontentloaded")
+    page.wait_for_function(
+        """
+        () => {
+          const imgs = document.querySelectorAll('img.profile-image');
+          if (!imgs.length) return false;
+          return Array.from(imgs).every((img) => img.complete);
+        }
+        """,
+        timeout=10000,
+    )
+
+    # Inspect the cache contents directly. The SW writes to
+    # fellows-images-v1 via cacheFirstInto; entry count > 0 proves the
+    # path is exercised, and the no-`?` predicate proves no entry slipped
+    # in with a query string.
+    bad_urls = page.evaluate(
+        """
+        async () => {
+          if (!('caches' in self)) return null;
+          const keys = await caches.keys();
+          if (keys.indexOf('fellows-images-v1') === -1) return [];
+          const cache = await caches.open('fellows-images-v1');
+          const reqs = await cache.keys();
+          return reqs.map((r) => r.url).filter((u) => u.indexOf('?') !== -1);
+        }
+        """
+    )
+    if bad_urls is None:
+        pytest.skip("Cache API unavailable in this browser context")
+    assert bad_urls == [], (
+        "fellows-images-v1 must not contain any URLs with a query string. "
+        "Offending entries:\n  " + "\n  ".join(bad_urls[:10])
+    )
+
+
+def test_sw_activate_sweeps_legacy_bust_entries(standalone_page, base_url_fixture):
+    """Pre-populate fellows-images-v1 with a synthetic `?v=…` entry,
+    then force the SW to re-activate. The activate handler's one-time
+    sweep must remove the legacy entry while leaving bare-URL entries
+    intact.
+
+    We can't trigger a real SW upgrade from the test (the SW only
+    activates when its bytes change), so we open the cache directly,
+    insert the entries, and then call `unregister()` + reload to get
+    a fresh install→activate cycle on the same context.
+    """
+    page = standalone_page
+    page.goto(base_url_fixture + "/", wait_until="domcontentloaded")
+
+    # Wait for SW to be controlling — otherwise the cache might not
+    # have been opened yet by anything.
+    page.wait_for_function(
+        "() => navigator.serviceWorker && navigator.serviceWorker.controller",
+        timeout=10000,
+    )
+
+    # Seed two entries: one legacy (with ?v=), one bare. Use a
+    # synthetic Response so we don't depend on a real /images endpoint.
+    page.evaluate(
+        """
+        async () => {
+          const cache = await caches.open('fellows-images-v1');
+          const ok = new Response(new Blob(['x']), { status: 200 });
+          await cache.put('/images/test-slug.jpg?v=2026-04-01-deadbeef', ok.clone());
+          await cache.put('/images/test-slug-bare.jpg', ok.clone());
+        }
+        """
+    )
+
+    # Force the SW to re-install + re-activate. unregister() drops the
+    # registration; the next navigation triggers install handlers,
+    # which on this codebase culminate in the activate sweep.
+    page.evaluate(
+        """
+        async () => {
+          const regs = await navigator.serviceWorker.getRegistrations();
+          await Promise.all(regs.map((r) => r.unregister()));
+        }
+        """
+    )
+    page.reload(wait_until="domcontentloaded")
+    page.wait_for_function(
+        "() => navigator.serviceWorker && navigator.serviceWorker.controller",
+        timeout=10000,
+    )
+
+    # The bare entry should still be there; the `?v=` entry should be gone.
+    state = page.evaluate(
+        """
+        async () => {
+          const cache = await caches.open('fellows-images-v1');
+          const reqs = await cache.keys();
+          const urls = reqs.map((r) => r.url);
+          return {
+            hasBare: urls.some((u) => u.endsWith('/images/test-slug-bare.jpg')),
+            hasBust: urls.some((u) => u.indexOf('/images/test-slug.jpg?') !== -1),
+            allWithBust: urls.filter((u) => u.indexOf('?') !== -1)
+          };
+        }
+        """
+    )
+    assert state["hasBust"] is False, (
+        "SW activate sweep should have removed the legacy ?v= entry from "
+        "fellows-images-v1; remaining query-string entries: "
+        + str(state["allWithBust"])
+    )
+    assert state["hasBare"] is True, (
+        "SW activate sweep must not touch bare-URL entries; lost the seeded "
+        "test-slug-bare.jpg"
+    )


### PR DESCRIPTION
## Summary

The About-page diag line *"Profile photos cached locally: 725 / 508"* surfaced a real bug: `fellows-images-v1` was holding stale duplicates from past deploys. Root cause was a `?v=<FELLOWS_UI_DIAG>` cache-bust query on every image URL — each deploy created fresh cache keys without evicting the prior ones. `725 / 508 ≈ 1.43` is what you'd expect after a couple of build-label rotations.

- **Drop the query string** from all six image URL builders (`app.js`: prewarm, renderDetail, the 404→PNG fallback, visual-directory grid, contact modal). URLs now stable across deploys.
- **One-time SW-activate sweep** (`sw.js`) deletes any `/images/*` entry with a `?` in the URL. No-op for fresh installs; for already-installed users, drains the legacy bloat on the next deploy. Stays in place permanently — cheaper than tracking when it's safe to remove.
- **Tradeoff:** a fellow whose photo gets added between deploys may see the placeholder for a few extra minutes (until the browser's HTTP cache TTL on the prior 404 expires). Acceptable for ~hundreds of mostly-static photos; the unbounded cache growth was worse.

Independent of #115 (Phase 4) — different files, no merge conflict.

## Manual QA — for the maintainer

- [ ] **Counter behaves post-deploy.** After ship, visit the prod About page. The first reload after the SW updates should show `Profile photos cached locally: 0 / 508` (or whatever subset the prewarm has reached). On subsequent visits it should grow but never exceed 508. Confirms the sweep ran.
- [ ] **DevTools → Application → Cache Storage → fellows-images-v1.** No entries with `?` in the URL.
- [ ] **Render a fellow detail.** Photo loads as expected; no `?v=` in the Network panel for `/images/...` requests.
- [ ] **404 recovery still works (manual).** If a fellow's photo is recovered server-side, a fresh visit (or hard reload) eventually surfaces the photo. Not regression-testable inline; mention here for awareness.

## Test plan

- [x] `just test` — 357 passed / 12 skipped (+3 new tests; no regressions)
- [x] `tests/e2e/test_image_cache_no_bust.py` — 3 tests:
  - image fetches initiated by boot path carry no query string
  - `fellows-images-v1` holds no `?` URLs after a render
  - SW activate sweep removes seeded `?v=` entries while preserving bare-URL entries

🤖 Generated with [Claude Code](https://claude.com/claude-code)