### PR TITLE
feat: opt-in directory data updates

### DIFF
--- a/README.md
+++ b/README.md
@@ -12,7 +12,7 @@ After install, the app must keep working without further server contact. Concret
 
 - **All user-authored state** (groups, notes, tags, settings) lives in the user's browser (`relationships.db` in OPFS). Production's `deploy/server.py` does not expose `/api/groups` or `/api/settings` — there are no per-user resources on the server, no per-user storage to back up, no multi-tenant model to defend.
 - **Reads of contact data** run against the locally-cached `fellows.db` (OPFS) and the IndexedDB fallback cache. A stale session or an offline server must not lock the user out of data they've already downloaded — see [`docs/email_gate.md`](docs/email_gate.md) invariant 10.
-- **Server contact is bounded to two purposes only:** (1) the magic-link gate that authorizes a download, and (2) fetching new bundle / DB bytes on update. Anything else added server-side needs a strong justification against this constraint.
+- **Server contact is bounded to two purposes only:** (1) the magic-link gate that authorizes a download, and (2) fetching new bundle / DB bytes when the user opts in to an update (app-shell updates auto-prompt via the *New version available — Reload* banner; directory-data updates are user-initiated from the About page — see [`docs/users_manual.md` § Updates](docs/users_manual.md#updates)). Anything else added server-side needs a strong justification against this constraint.
 
 What this rules out, even if individually convenient: cross-device sync, server-side backups of `relationships.db`, an "edit once, see it everywhere" share feature, real-time collaboration, an admin console showing other users' groups, telemetry beyond the unauthenticated client-error sink. If a feature requires per-user state on the server, it doesn't belong in this app.
 

--- a/app/static/app.js
+++ b/app/static/app.js
@@ -151,6 +151,11 @@
       bootMarks[name] = _bootMs();
     }
   }
+  // Expose for e2e tests that need to wait for a specific boot phase
+  // (notably `get_full_done` — knowing that the boot path's second
+  // route() call has fired prevents test assertions from racing with
+  // an About-page re-render). Read-only by convention.
+  window.__bootMarks = bootMarks;
   // Captures the very start of script execution; everything else is
   // relative to this. Helpful when a boot stalls before pickDataProvider
   // even runs (e.g., long script-parse, blocked dependency fetch).
@@ -404,6 +409,281 @@
       if (document.hidden) return;
       checkForServerUpdate();
     }, UPDATE_CHECK_INTERVAL_MS);
+  }
+
+  // Companion to checkForServerUpdate — checks whether the bundled
+  // fellows.db has changed since the local sidecar was last written.
+  // Always uses /build-meta.json:fellows_db_sha as the truth value;
+  // the worker handles the local read. Independent of app-shell SHA
+  // so the two flows can succeed/fail individually.
+  // plans/opt_in_directory_data_updates.md.
+  //
+  // Returns a Promise resolving to { status, serverSha?, localSha?, fetchedAt?, error? }.
+  // `status`:
+  //   'update-available' — local fellows.db differs from server
+  //   'up-to-date'       — SHAs match
+  //   'no-local-data'    — worker has no fellows.db (cold-start case)
+  //   'unsupported'      — running on a provider that can't compare
+  //                        (api+idb fallback, no-OPFS browser)
+  //   'worker-stale'     — page is on a newer build than the worker
+  //                        (transient SW upgrade race; worker doesn't
+  //                        know the new RPC). Resolves on reload.
+  //   'error'            — server unreachable or worker errored
+  function checkForDirectoryDataUpdate() {
+    if (!dataProvider || typeof dataProvider._compareFellowsDbSha !== 'function') {
+      return Promise.resolve({ status: 'unsupported' });
+    }
+    return fetch('/build-meta.json', { cache: 'no-store', credentials: 'same-origin' })
+      .then(function (r) {
+        if (!r.ok) throw new Error('HTTP ' + r.status);
+        return r.json();
+      })
+      .then(function (meta) {
+        var serverSha = (meta && typeof meta.fellows_db_sha === 'string' && meta.fellows_db_sha)
+          ? meta.fellows_db_sha : null;
+        return dataProvider._compareFellowsDbSha({ serverSha: serverSha }).then(function (cmp) {
+          if (!cmp.hasFellowsDb) {
+            return {
+              status: 'no-local-data',
+              serverSha: serverSha,
+              localSha: cmp.localSha,
+              fetchedAt: cmp.fetchedAt
+            };
+          }
+          if (cmp.dataUpdateAvailable === true) {
+            return {
+              status: 'update-available',
+              serverSha: serverSha,
+              localSha: cmp.localSha,
+              fetchedAt: cmp.fetchedAt
+            };
+          }
+          if (cmp.dataUpdateAvailable === false) {
+            return {
+              status: 'up-to-date',
+              serverSha: serverSha,
+              localSha: cmp.localSha,
+              fetchedAt: cmp.fetchedAt
+            };
+          }
+          // dataUpdateAvailable === null (server didn't expose a SHA).
+          return {
+            status: 'error',
+            error: 'server did not report fellows_db_sha',
+            serverSha: serverSha,
+            localSha: cmp.localSha,
+            fetchedAt: cmp.fetchedAt
+          };
+        });
+      })
+      .catch(function (err) {
+        // Worker doesn't know the new RPC → page is newer than the
+        // worker bundle. Common during the SW upgrade race: page
+        // loaded the new shell, worker was spawned with the old shell
+        // still in cache. Reload spawns a fresh worker from the new
+        // cache and the check works.
+        var msg = (err && err.message) || String(err);
+        if (/unknown op:\s*compareFellowsDbSha/i.test(msg)) {
+          return { status: 'worker-stale', error: msg };
+        }
+        return { status: 'error', error: msg };
+      });
+  }
+
+  // Handler for the "Update directory data" button on the About page.
+  // Three-step flow per plans/opt_in_directory_data_updates.md:
+  //   1. previewFellowsDbSwap → fetch + validate, compute affected
+  //      members.
+  //   2. If affected.length > 0, render the confirm dialog;
+  //      Cancel → cancelFellowsDbSwap; Update anyway → step 3.
+  //      If affected.length === 0, apply silently (step 3).
+  //   3. applyFellowsDbSwap → atomic replace + meta update.
+  //   4. Refresh in-page directory state and the orphan set.
+  function handleUpdateDirectoryDataClick(checkResult, refreshBtn) {
+    var dataStatusEl = document.getElementById('about-data-status');
+    var dataActionEl = document.getElementById('about-data-action');
+    var lastCheckEl = document.getElementById('about-last-check');
+    function setBusy(msg) {
+      if (dataStatusEl) dataStatusEl.textContent = msg;
+      if (dataActionEl) dataActionEl.innerHTML = '';
+    }
+    function setDone(msg) {
+      if (dataStatusEl) dataStatusEl.textContent = msg;
+      if (dataActionEl) dataActionEl.innerHTML = '';
+      if (lastCheckEl) lastCheckEl.textContent = 'Last check: ' + new Date().toISOString();
+    }
+
+    if (!dataProvider || typeof dataProvider._previewFellowsDbSwap !== 'function') {
+      setDone('Directory data updates aren’t available in this browser.');
+      return;
+    }
+    var serverSha = checkResult && checkResult.serverSha;
+    setBusy('Checking impact…');
+
+    dataProvider._previewFellowsDbSwap({ serverSha: serverSha })
+      .then(function (preview) {
+        var affected = (preview && preview.affectedGroups) || [];
+        if (!affected.length) {
+          // No group impact — apply silently.
+          return applyDirectoryUpdate(preview.stagingId);
+        }
+        return new Promise(function (resolve) {
+          openDirectoryUpdateDialog(affected, {
+            onCancel: function () {
+              dataProvider._cancelFellowsDbSwap({ stagingId: preview.stagingId })
+                .catch(function () {});
+              setDone('Update cancelled. Your directory data is unchanged.');
+              resolve();
+            },
+            onConfirm: function () {
+              applyDirectoryUpdate(preview.stagingId).then(resolve, resolve);
+            }
+          });
+        });
+      })
+      .catch(function (err) {
+        if (err && err.versionMismatch) {
+          setDone('Reload the app first (a newer version is available), then try again.');
+          return;
+        }
+        var reason = (err && err.message) || String(err);
+        setDone('Could not stage update: ' + reason);
+      });
+
+    function applyDirectoryUpdate(stagingId) {
+      setBusy('Applying update…');
+      return dataProvider._applyFellowsDbSwap({ stagingId: stagingId })
+        .then(function () {
+          // Re-render the directory in place — getList + getFull rebuild
+          // the in-memory cache. Cheap; ~hundreds of rows.
+          return reloadDirectoryAfterDataSwap()
+            .catch(function () { /* surfaced via toast below if it matters */ });
+        })
+        .then(function () {
+          // Refresh orphan set against the freshly-imported fellows.db
+          // so group detail views flag any rows that became orphaned by
+          // the swap.
+          if (typeof dataProvider._findOrphanedGroupMembers === 'function') {
+            return dataProvider._findOrphanedGroupMembers().then(function (res) {
+              setOrphanedRecordIdsFromList(res && res.orphans);
+            }).catch(function () {});
+          }
+        })
+        .then(function () {
+          setDone('Directory data updated.');
+        })
+        .catch(function (err) {
+          var reason = (err && err.message) || String(err);
+          setDone('Update failed: ' + reason + '. Try again.');
+        });
+    }
+  }
+
+  // Reload directory data after a swap. Re-uses the existing getList +
+  // getFull pipeline so the rail / search / detail views all see the
+  // new rows. Resolves once renderDirectory has run with the new data.
+  // Skips re-routing the current view if the user is on About — About
+  // doesn't render fellow data, and a re-render would wipe the status
+  // text the apply handler is about to set.
+  function reloadDirectoryAfterDataSwap() {
+    if (!dataProvider || typeof dataProvider.getList !== 'function') return Promise.resolve();
+    return dataProvider.getList().then(function (data) {
+      list = Array.isArray(data) ? data : [];
+      renderDirectory();
+      return dataProvider.getFull();
+    }).then(function (full) {
+      if (Array.isArray(full)) {
+        fullFellowsCache = full;
+        fellowsBySlug = new Map();
+        full.forEach(function (f) {
+          if (f.slug) fellowsBySlug.set(f.slug, f);
+          if (f.record_id) fellowsBySlug.set(f.record_id, f);
+        });
+      }
+      // Re-route data-rendering views (group detail, fellow detail,
+      // visual directory) so the new bytes show through. Skip when
+      // the user is on a non-data view (About, Settings) — re-rendering
+      // those would clobber the just-applied status text and add
+      // nothing useful.
+      var hash = String(window.location.hash || '');
+      var skipReroute = hash.indexOf('#/about') === 0 || hash.indexOf('#/settings') === 0;
+      if (!skipReroute) {
+        try { route(); } catch (e) {}
+      }
+    });
+  }
+
+  // Build a one-shot modal listing the affected members. Cleans itself
+  // up on close. No bespoke markup in index.html — this dialog is
+  // unique to the update flow and is created on demand.
+  function openDirectoryUpdateDialog(affected, callbacks) {
+    var existing = document.getElementById('directory-update-dialog');
+    if (existing && existing.parentNode) existing.parentNode.removeChild(existing);
+
+    var dialog = document.createElement('div');
+    dialog.id = 'directory-update-dialog';
+    dialog.className = 'directory-update-dialog';
+    dialog.setAttribute('role', 'dialog');
+    dialog.setAttribute('aria-modal', 'true');
+    dialog.setAttribute('aria-labelledby', 'directory-update-dialog-title');
+
+    var listHtml = '';
+    for (var i = 0; i < affected.length; i++) {
+      var item = affected[i];
+      var name = item.name || ('record_id ' + item.recordId);
+      var groupNames = (item.groups || []).map(function (g) { return '‘' + g.name + '’'; });
+      listHtml += '<li><strong>' + escapeHtml(name) + '</strong> — in ' +
+        escapeHtml(groupNames.join(', ')) + '</li>';
+    }
+
+    dialog.innerHTML =
+      '<div class="directory-update-dialog-inner" role="document">' +
+        '<h2 id="directory-update-dialog-title" class="directory-update-dialog-title">Update directory data?</h2>' +
+        '<p>This update removes <strong>' + affected.length + ' fellow' +
+          (affected.length === 1 ? '' : 's') + '</strong> from your saved groups:</p>' +
+        '<ul class="directory-update-dialog-list">' + listHtml + '</ul>' +
+        '<p>After the update they will no longer appear in those groups. ' +
+        'Their entries will be flagged as &lsquo;Profile no longer available&rsquo; ' +
+        'so you can review and remove them.</p>' +
+        '<div class="directory-update-dialog-actions">' +
+          '<button type="button" class="directory-update-dialog-cancel" id="directory-update-dialog-cancel">Cancel</button>' +
+          '<button type="button" class="directory-update-dialog-confirm" id="directory-update-dialog-confirm">Update anyway</button>' +
+        '</div>' +
+      '</div>';
+
+    document.body.appendChild(dialog);
+
+    function close() {
+      if (dialog.parentNode) dialog.parentNode.removeChild(dialog);
+      document.removeEventListener('keydown', onKey);
+    }
+    function onKey(e) {
+      if (e.key === 'Escape') {
+        close();
+        if (callbacks && callbacks.onCancel) callbacks.onCancel();
+      }
+    }
+    document.addEventListener('keydown', onKey);
+
+    document.getElementById('directory-update-dialog-cancel').addEventListener('click', function () {
+      close();
+      if (callbacks && callbacks.onCancel) callbacks.onCancel();
+    });
+    document.getElementById('directory-update-dialog-confirm').addEventListener('click', function () {
+      close();
+      if (callbacks && callbacks.onConfirm) callbacks.onConfirm();
+    });
+    // Click outside the inner panel closes (cancel-equivalent).
+    dialog.addEventListener('click', function (e) {
+      if (e.target === dialog) {
+        close();
+        if (callbacks && callbacks.onCancel) callbacks.onCancel();
+      }
+    });
+    // Focus the cancel button by default — destructive action requires
+    // explicit confirm.
+    var cancelBtn = document.getElementById('directory-update-dialog-cancel');
+    if (cancelBtn) try { cancelBtn.focus(); } catch (e) {}
   }
 
   function logSwLifecycle(event, detail) {
@@ -2919,7 +3199,31 @@
       // Read-only view of fellows.db.meta.json. Powers the About-page
       // "Last update check" line and the diag panel's meta block. Pure
       // read; does not trigger a fetch.
-      _getFellowsDbMeta: function () { return rpc.call('getFellowsDbMeta'); }
+      _getFellowsDbMeta: function () { return rpc.call('getFellowsDbMeta'); },
+      // Opt-in directory-data update RPCs
+      // (plans/opt_in_directory_data_updates.md). Compare is a cheap
+      // sidecar read; preview fetches + validates + stages; apply
+      // promotes; cancel discards. None of them are version-gated —
+      // reads are always safe, and apply requires a stagingId minted in
+      // the same worker session so a stale page can't accidentally
+      // commit a swap.
+      _compareFellowsDbSha: function (args) {
+        return rpc.call('compareFellowsDbSha', args || {});
+      },
+      _previewFellowsDbSwap: function (args) {
+        return refuseIfVersionSkew('previewFellowsDbSwap') ||
+          rpc.call('previewFellowsDbSwap', args || {});
+      },
+      _applyFellowsDbSwap: function (args) {
+        return refuseIfVersionSkew('applyFellowsDbSwap') ||
+          rpc.call('applyFellowsDbSwap', args || {});
+      },
+      _cancelFellowsDbSwap: function (args) {
+        return rpc.call('cancelFellowsDbSwap', args || {});
+      },
+      _findOrphanedGroupMembers: function () {
+        return rpc.call('findOrphanedGroupMembers');
+      }
     };
   }
 
@@ -3907,6 +4211,63 @@
     }).catch(function () { /* ignore */ });
   }
 
+  // Set of record_ids known to be missing from the live fellows.db. Populated
+  // by the boot soft-scan and refreshed after applyFellowsDbSwap, so group
+  // detail rendering can flag rows whose underlying fellow is no longer in
+  // the directory. Empty when no scan has run, when there are no orphans,
+  // or when the api+idb fallback is in use (worker required to query).
+  var orphanedRecordIds = Object.create(null);
+
+  function setOrphanedRecordIdsFromList(orphans) {
+    orphanedRecordIds = Object.create(null);
+    if (!Array.isArray(orphans)) return;
+    for (var i = 0; i < orphans.length; i++) {
+      var rid = orphans[i] && orphans[i].recordId;
+      if (rid) orphanedRecordIds[rid] = true;
+    }
+  }
+
+  function isOrphanedRecordId(rid) {
+    return !!(rid && orphanedRecordIds[rid]);
+  }
+
+  // One-shot post-PR-#113 orphan scan. Catches group_members whose
+  // record_id is no longer in fellows.db — possible if the user got an
+  // auto-refresh under the old policy. Toast fires once; the
+  // orphan_scan_done setting prevents repeats. Group detail surfaces the
+  // orphan rows via isOrphanedRecordId regardless.
+  // plans/opt_in_directory_data_updates.md.
+  function maybeRunOrphanSoftScan() {
+    if (!dataProvider) return;
+    if (typeof dataProvider._findOrphanedGroupMembers !== 'function') return;
+    if (typeof dataProvider.getSetting !== 'function') return;
+    Promise.resolve(dataProvider.getSetting('orphan_scan_done')).then(function (done) {
+      if (done === '1') {
+        // Already scanned in a previous boot. Still refresh the in-memory
+        // set so group detail flags any orphans that are present, but no
+        // toast.
+        return dataProvider._findOrphanedGroupMembers().then(function (res) {
+          setOrphanedRecordIdsFromList(res && res.orphans);
+        });
+      }
+      return dataProvider._findOrphanedGroupMembers().then(function (res) {
+        var orphans = (res && res.orphans) || [];
+        setOrphanedRecordIdsFromList(orphans);
+        if (orphans.length) {
+          try {
+            showToast('Some group members are no longer in the directory. ' +
+              'See group details for review.', 8000);
+          } catch (e) {}
+        }
+        if (typeof dataProvider.setSetting === 'function') {
+          return dataProvider.setSetting('orphan_scan_done', '1').catch(function () {});
+        }
+      });
+    }).catch(function (e) {
+      bootDebugPush('orphan soft scan failed: ' + (e && e.message || e));
+    });
+  }
+
   function fellowHasEmail(f) {
     if (f.has_contact_email === true || f.has_contact_email === 1) return true;
     return !!(f.contact_email && String(f.contact_email).trim());
@@ -4795,25 +5156,38 @@
     aboutHtml += 'For support, request to join the github repository or just ask on one of the fellows channels.</p>';
     aboutHtml += '<p class="about-support">Having trouble with the app? Contact the EHF Communications Working Group.</p>';
     aboutHtml += '<p class="about-users-manual"><a href="https://github.com/richbodo/fellows_local_db/blob/main/docs/users_manual.md" target="_blank" rel="noopener">User Guide</a> \u2014 how to install, browse, save groups, export, and manage settings.</p>';
-    aboutHtml += '<p class="about-update-check">';
-    aboutHtml += '<button type="button" id="about-check-updates" class="about-check-updates-btn">Check for updates</button>';
-    aboutHtml += '<span id="about-update-status" class="about-update-status" role="status" aria-live="polite"></span>';
-    aboutHtml += '</p>';
-    // Persistent record of when the worker last reached the server for
-    // directory data. Populated async from fellows.db.meta.json. Useful
-    // when a user reports stale data — the line answers "is the
-    // distribution channel actually working for me?" without sending
-    // them into the diagnostics panel. Phase 4 of
-    // plans/local_first_worker_architecture.md.
-    aboutHtml += '<p class="about-last-update" id="about-last-update"></p>';
+    // Two-row update status block. App and Directory data are
+    // independently versioned (build/build_pwa.py emits both `git_sha`
+    // and `fellows_db_sha` into /build-meta.json); the user can act on
+    // either without affecting the other.
+    // plans/opt_in_directory_data_updates.md.
     var serverLabel = bootBuildMeta.git_sha
       ? bootBuildMeta.git_sha + (bootBuildMeta.built_at ? ' · ' + bootBuildMeta.built_at : '')
       : (bootBuildMeta.built_at || 'unknown');
-    aboutHtml += '<p class="about-build">';
-    aboutHtml += '<span class="about-build-label">Build</span> ';
+    aboutHtml += '<div class="about-update-block">';
+    aboutHtml += '<div class="about-update-row" id="about-app-row">';
+    aboutHtml += '<div class="about-update-row-label">App</div>';
+    aboutHtml += '<div class="about-update-row-status" id="about-app-status" role="status" aria-live="polite">';
     aboutHtml += '<code class="about-build-value">app: ' + escapeHtml(FELLOWS_UI_DIAG) + '</code> ';
     aboutHtml += '<code class="about-build-value">server: ' + escapeHtml(serverLabel) + '</code>';
+    aboutHtml += '</div>';
+    aboutHtml += '<div class="about-update-row-action" id="about-app-action"></div>';
+    aboutHtml += '</div>';
+    aboutHtml += '<div class="about-update-row" id="about-data-row">';
+    aboutHtml += '<div class="about-update-row-label">Directory data</div>';
+    aboutHtml += '<div class="about-update-row-status" id="about-data-status" role="status" aria-live="polite">Click "Check for updates" to compare with the server.</div>';
+    aboutHtml += '<div class="about-update-row-action" id="about-data-action"></div>';
+    aboutHtml += '</div>';
+    aboutHtml += '<p class="about-update-check">';
+    aboutHtml += '<button type="button" id="about-check-updates" class="about-check-updates-btn">Check for updates</button>';
+    aboutHtml += '<span id="about-last-check" class="about-update-status"></span>';
     aboutHtml += '</p>';
+    // Persistent record of when fellows.db was last fetched (or last
+    // failed). Populated async from fellows.db.meta.json. Useful when a
+    // user reports stale data — answers "is the distribution channel
+    // actually working for me?" without sending them into the
+    // diagnostics panel.
+    aboutHtml += '<p class="about-last-update" id="about-last-update"></p>';
     aboutHtml += '<p class="about-repo"><a href="https://github.com/richbodo/fellows_local_db" target="_blank" rel="noopener">';
     aboutHtml += '<svg class="github-icon" viewBox="0 0 16 16" width="20" height="20" aria-hidden="true"><path fill="currentColor" d="M8 0C3.58 0 0 3.58 0 8c0 3.54 2.29 6.53 5.47 7.59.4.07.55-.17.55-.38 0-.19-.01-.82-.01-1.49-2.01.37-2.53-.49-2.69-.94-.09-.23-.48-.94-.82-1.13-.28-.15-.68-.52-.01-.53.63-.01 1.08.58 1.23.82.72 1.21 1.87.87 2.33.66.07-.52.28-.87.51-1.07-1.78-.2-3.64-.89-3.64-3.95 0-.87.31-1.59.82-2.15-.08-.2-.36-1.02.08-2.12 0 0 .67-.21 2.2.82.64-.18 1.32-.27 2-.27.68 0 1.36.09 2 .27 1.53-1.04 2.2-.82 2.2-.82.44 1.1.16 1.92.08 2.12.51.56.82 1.27.82 2.15 0 3.07-1.87 3.75-3.65 3.95.29.25.54.73.54 1.48 0 1.07-.01 1.93-.01 2.2 0 .21.15.46.55.38A8.013 8.013 0 0016 8c0-4.42-3.58-8-8-8z"/></svg>';
     aboutHtml += ' richbodo/fellows_local_db</a></p>';
@@ -4852,27 +5226,95 @@
       }).catch(function () { /* non-fatal — leave line empty */ });
     })();
 
-    // Wire the "Check for updates" button. Shares the same checker used by
-    // the hourly poll so the user-visible status stays consistent with what
-    // triggers the sw-update-banner.
+    // Wire the "Check for updates" button. Drives the app-shell check
+    // (existing checkForServerUpdate, which raises the SW reload banner
+    // on drift) AND the directory-data check in parallel; each result
+    // populates its own status row independently.
+    // plans/opt_in_directory_data_updates.md.
     (function wireUpdateCheckButton() {
       var btn = document.getElementById('about-check-updates');
-      var statusEl = document.getElementById('about-update-status');
-      if (!btn || !statusEl) return;
+      var lastCheckEl = document.getElementById('about-last-check');
+      var appStatusEl = document.getElementById('about-app-status');
+      var appActionEl = document.getElementById('about-app-action');
+      var dataStatusEl = document.getElementById('about-data-status');
+      var dataActionEl = document.getElementById('about-data-action');
+      if (!btn) return;
+
+      function paintAppRow(res) {
+        if (!appStatusEl) return;
+        var serverLabel = bootBuildMeta.git_sha
+          ? bootBuildMeta.git_sha + (bootBuildMeta.built_at ? ' \u00b7 ' + bootBuildMeta.built_at : '')
+          : (bootBuildMeta.built_at || 'unknown');
+        var build = '<code class="about-build-value">app: ' + escapeHtml(FELLOWS_UI_DIAG) + '</code> ' +
+          '<code class="about-build-value">server: ' + escapeHtml(serverLabel) + '</code>';
+        var statusText, actionHtml = '';
+        if (res.status === 'update-available') {
+          statusText = ' \u2014 App update available';
+          actionHtml = '<button type="button" class="about-update-action-btn" id="about-app-update-btn">Reload to apply</button>';
+        } else if (res.status === 'up-to-date') {
+          statusText = ' \u2014 up to date';
+        } else if (res.status === 'no-boot-snapshot') {
+          statusText = ' \u2014 version recorded; future checks will compare against this build.';
+        } else {
+          statusText = ' \u2014 Couldn\u2019t check (offline?)';
+        }
+        appStatusEl.innerHTML = build + statusText;
+        if (appActionEl) appActionEl.innerHTML = actionHtml;
+        var appBtn = document.getElementById('about-app-update-btn');
+        if (appBtn) {
+          appBtn.addEventListener('click', function () { window.location.reload(); });
+        }
+      }
+
+      function paintDataRow(res) {
+        if (!dataStatusEl) return;
+        var statusText = '', actionHtml = '';
+        if (res.status === 'unsupported') {
+          statusText = 'Directory data updates aren\u2019t available in this browser.';
+        } else if (res.status === 'no-local-data') {
+          statusText = 'No local directory data \u2014 reload to download.';
+        } else if (res.status === 'worker-stale') {
+          // Transient SW-upgrade race: the page is on a newer build
+          // than the worker, so the new compareFellowsDbSha RPC isn't
+          // recognized. Reloading spawns a fresh worker from the now-
+          // current shell cache and the check works.
+          statusText = 'Reload the app to enable update checks.';
+          actionHtml = '<button type="button" class="about-update-action-btn" id="about-data-reload-btn">Reload</button>';
+        } else if (res.status === 'update-available') {
+          statusText = 'Directory Data update available';
+          actionHtml = '<button type="button" class="about-update-action-btn" id="about-data-update-btn">Update directory data</button>';
+        } else if (res.status === 'up-to-date') {
+          var snap = res.fetchedAt ? ' (snapshot from ' + escapeHtml(String(res.fetchedAt)) + ')' : '';
+          statusText = 'up to date' + snap;
+        } else {
+          statusText = 'Couldn\u2019t check (offline?)';
+        }
+        dataStatusEl.textContent = statusText;
+        if (dataActionEl) dataActionEl.innerHTML = actionHtml;
+        var dataBtn = document.getElementById('about-data-update-btn');
+        if (dataBtn) {
+          dataBtn.addEventListener('click', function () {
+            handleUpdateDirectoryDataClick(res, btn);
+          });
+        }
+        var reloadBtn = document.getElementById('about-data-reload-btn');
+        if (reloadBtn) {
+          reloadBtn.addEventListener('click', function () { window.location.reload(); });
+        }
+      }
+
       btn.addEventListener('click', function () {
         btn.disabled = true;
-        statusEl.textContent = 'Checking\u2026';
-        checkForServerUpdate().then(function (res) {
+        if (lastCheckEl) lastCheckEl.textContent = 'Checking\u2026';
+        if (appStatusEl) appStatusEl.textContent = 'Checking\u2026';
+        if (appActionEl) appActionEl.innerHTML = '';
+        if (dataStatusEl) dataStatusEl.textContent = 'Checking\u2026';
+        if (dataActionEl) dataActionEl.innerHTML = '';
+        Promise.all([checkForServerUpdate(), checkForDirectoryDataUpdate()]).then(function (results) {
           btn.disabled = false;
-          if (res.status === 'update-available') {
-            statusEl.textContent = 'New version available \u2014 reload to apply.';
-          } else if (res.status === 'up-to-date') {
-            statusEl.textContent = 'You\u2019re on the latest version.';
-          } else if (res.status === 'no-boot-snapshot') {
-            statusEl.textContent = 'Version recorded \u2014 future checks will compare against this build.';
-          } else {
-            statusEl.textContent = 'Unable to reach the server right now. Try again later.';
-          }
+          paintAppRow(results[0] || { status: 'error' });
+          paintDataRow(results[1] || { status: 'error' });
+          if (lastCheckEl) lastCheckEl.textContent = 'Last check: ' + new Date().toISOString();
         });
       });
     })();
@@ -5624,6 +6066,25 @@
         members.forEach(function (m) {
           var rid = m.record_id || '';
           var fellow = fellowsBySlug.get(rid);
+          // Orphan = explicitly flagged by the orphan scan, OR not found
+          // in the in-memory cache (defensive — the scan may not have run
+          // yet on this boot, e.g. on the api+idb fallback). The latter
+          // never produces false positives in worker mode because
+          // fellowsBySlug is populated from the same fellows.db the
+          // worker uses to validate group_members.
+          var orphaned = isOrphanedRecordId(rid) || (rid && !fellow);
+          if (orphaned) {
+            html += '<tr class="group-detail-member-orphan" data-record-id="' +
+              escapeHtml(rid) + '"><td>' +
+              '<span class="group-detail-orphan-icon" aria-hidden="true">?</span>' +
+              '<span class="group-detail-orphan-text">Profile no longer available' +
+              ' <code class="group-detail-orphan-rid">(record_id: ' +
+              escapeHtml(rid) + ')</code></span>' +
+              '<button type="button" class="group-detail-orphan-remove" data-record-id="' +
+              escapeHtml(rid) + '">Remove</button>' +
+              '</td></tr>';
+            return;
+          }
           var slug = fellow && fellow.slug ? fellow.slug : '';
           var href = slug ? '#/fellow/' + encodeURIComponent(slug) : '#';
           html += '<tr><td><a href="' + escapeHtml(href) + '">' +
@@ -6814,6 +7275,42 @@
         startInlineGroupRename(group);
       });
     }
+
+    // Wire per-row "Remove" buttons on orphan rows (members whose
+    // record_id is no longer in the live fellows.db). Calls updateGroup
+    // with the rid removed, then re-renders the page so the row drops
+    // out and counts refresh.
+    // plans/opt_in_directory_data_updates.md.
+    var orphanRemoveBtns = detailEl.querySelectorAll('.group-detail-orphan-remove');
+    if (orphanRemoveBtns && orphanRemoveBtns.length) {
+      Array.prototype.forEach.call(orphanRemoveBtns, function (btn) {
+        btn.addEventListener('click', function () {
+          var rid = btn.getAttribute('data-record-id');
+          if (!rid) return;
+          var remaining = (group.members || [])
+            .map(function (m) { return m.record_id; })
+            .filter(function (id) { return id && id !== rid; });
+          btn.disabled = true;
+          btn.textContent = 'Removing…';
+          dataProvider.updateGroup(group.id, { fellow_record_ids: remaining })
+            .then(function () {
+              // Drop from in-memory orphan set so subsequent renders
+              // don't re-flag (the rid is gone from group_members now,
+              // but the worker scan still considers it orphaned —
+              // remove it locally to keep state coherent until the next
+              // boot scan).
+              if (orphanedRecordIds[rid]) delete orphanedRecordIds[rid];
+              renderGroupDetailPage(group.id);
+            })
+            .catch(function (err) {
+              btn.disabled = false;
+              btn.textContent = 'Remove';
+              showToast('Could not remove: ' +
+                ((err && err.message) || 'unknown error'));
+            });
+        });
+      });
+    }
   }
 
   /** Inline rename for the group name (pencil ✎ next to the title on the
@@ -7656,6 +8153,11 @@
         // Start the hourly server-build-drift check. Idempotent; only
         // arms the interval when running as an installed PWA.
         startUpdateCheckPoll();
+        // One-shot soft scan for group members orphaned by past
+        // auto-refreshes (PR #113 era). Surfaces a toast once if any
+        // exist; sets relationships.settings.orphan_scan_done so it
+        // never repeats. plans/opt_in_directory_data_updates.md.
+        maybeRunOrphanSoftScan();
       })
       .catch(function (err) {
         // Only reached when the API refused us AND no local cache could
@@ -7860,29 +8362,25 @@
           '/schema=' + handle.init.schemaVersion + '; reads still work, writes refused'
         );
       }
-      var hadFellowsDbBefore = !!(handle.init && handle.init.hasFellowsDb);
-      // Wait for the boot /build-meta.json fetch so the worker can
-      // SHA-compare. If it never resolved (offline at boot, server 5xx),
-      // we fall through with serverSha=null and the worker preserves its
-      // P1-era no-op-on-returning-visit contract.
+      // Boot path is install-only by policy
+      // (plans/opt_in_directory_data_updates.md). The worker only fetches
+      // /fellows.db when there's nothing on disk yet (cold start /
+      // post–Reset Everything). Returning visitors keep whatever bytes
+      // they have, regardless of SHA — refresh is a user-driven action
+      // surfaced through the About-page "Update directory data" button.
+      // Pass serverSha purely for the worker's trace; it isn't consulted
+      // for the install-only branch.
       var metaPromise = bootBuildMetaPromise || Promise.resolve(bootBuildMeta);
       return metaPromise.then(function (meta) {
         var serverSha = (meta && typeof meta.fellows_db_sha === 'string' && meta.fellows_db_sha)
           ? meta.fellows_db_sha : null;
-        return provider._ensureFellowsDb({ serverSha: serverSha });
+        return provider._ensureFellowsDb({ serverSha: serverSha, mode: 'install-only' });
       })
         .then(function (res) {
           bootDebugPush(
             'ensureFellowsDb: hasFellowsDb=' + (res && res.hasFellowsDb) +
             ' refreshed=' + (res && res.refreshed)
           );
-          // Silent SHA-keyed refresh of an already-installed DB → small
-          // toast so the user knows they're seeing newer data. Cold-start
-          // imports skip the toast: the page renders the directory for
-          // the first time, no "updated" claim makes sense.
-          if (res && res.refreshed && hadFellowsDbBefore) {
-            try { showToast('Directory updated'); } catch (e) {}
-          }
           return provider;
         })
         .catch(function (e) {

--- a/app/static/styles.css
+++ b/app/static/styles.css
@@ -1350,12 +1350,140 @@ h1 {
   font-size: 0.95rem;
 }
 
+.about-update-block {
+  margin: 1rem 0 0.75rem;
+  padding: 0.75rem 1rem;
+  border: 1px solid var(--border, #d8d2e8);
+  border-radius: 6px;
+  background: var(--surface-soft, #f7f4fb);
+}
+
+.about-update-row {
+  display: grid;
+  grid-template-columns: 110px 1fr auto;
+  align-items: baseline;
+  gap: 0.75rem;
+  padding: 0.4rem 0;
+}
+
+.about-update-row + .about-update-row {
+  border-top: 1px solid var(--border, #d8d2e8);
+}
+
+.about-update-row-label {
+  font-weight: 600;
+  font-size: 0.95rem;
+  color: #333;
+}
+
+.about-update-row-status {
+  font-size: 0.9rem;
+  color: #5a5a5a;
+  word-break: break-word;
+}
+
+.about-update-row-action:empty {
+  display: none;
+}
+
+.about-update-action-btn {
+  background: var(--accent, #6b3aa0);
+  color: #fff;
+  border: 1px solid var(--accent, #6b3aa0);
+  border-radius: 4px;
+  padding: 0.35rem 0.75rem;
+  font: inherit;
+  font-size: 0.9rem;
+  cursor: pointer;
+  white-space: nowrap;
+}
+
+.about-update-action-btn:hover:not(:disabled) {
+  background: var(--accent-hover, #58308a);
+}
+
+.about-update-action-btn:disabled {
+  opacity: 0.6;
+  cursor: default;
+}
+
 .about-update-check {
   margin-top: 0.75rem;
   display: flex;
   align-items: center;
   gap: 0.75rem;
   flex-wrap: wrap;
+}
+
+.directory-update-dialog {
+  position: fixed;
+  inset: 0;
+  background: rgba(0, 0, 0, 0.45);
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  z-index: 1000;
+  padding: 1rem;
+}
+
+.directory-update-dialog-inner {
+  background: #fff;
+  border-radius: 8px;
+  max-width: 520px;
+  width: 100%;
+  max-height: 80vh;
+  overflow-y: auto;
+  padding: 1.25rem 1.5rem;
+  box-shadow: 0 8px 32px rgba(0, 0, 0, 0.25);
+}
+
+.directory-update-dialog-title {
+  margin: 0 0 0.75rem;
+  font-size: 1.15rem;
+}
+
+.directory-update-dialog-list {
+  margin: 0.5rem 0;
+  padding-left: 1.25rem;
+}
+
+.directory-update-dialog-list li {
+  margin: 0.25rem 0;
+}
+
+.directory-update-dialog-actions {
+  display: flex;
+  justify-content: flex-end;
+  gap: 0.5rem;
+  margin-top: 1rem;
+}
+
+.directory-update-dialog-cancel,
+.directory-update-dialog-confirm {
+  padding: 0.4rem 0.85rem;
+  border-radius: 4px;
+  font: inherit;
+  cursor: pointer;
+}
+
+.directory-update-dialog-cancel {
+  background: #fff;
+  color: #333;
+  border: 1px solid #bbb;
+}
+
+.directory-update-dialog-cancel:hover {
+  background: #f4f4f4;
+}
+
+.directory-update-dialog-confirm {
+  background: var(--accent, #6b3aa0);
+  color: #fff;
+  border: 1px solid var(--accent, #6b3aa0);
+}
+
+.directory-update-dialog-confirm:hover {
+  background: var(--accent-hover, #58308a);
 }
 
 .about-check-updates-btn {
@@ -1879,6 +2007,59 @@ h1 {
 .group-detail-members a {
   color: #0066cc;
   text-decoration: underline;
+}
+
+.group-detail-member-orphan td {
+  color: #777;
+  font-style: italic;
+  display: flex;
+  align-items: center;
+  gap: 0.5rem;
+}
+
+.group-detail-orphan-icon {
+  display: inline-flex;
+  align-items: center;
+  justify-content: center;
+  width: 1.25rem;
+  height: 1.25rem;
+  border-radius: 50%;
+  background: #ddd;
+  color: #555;
+  font-style: normal;
+  font-weight: 600;
+  font-size: 0.85rem;
+}
+
+.group-detail-orphan-text {
+  flex: 1;
+}
+
+.group-detail-orphan-rid {
+  font-style: normal;
+  color: #999;
+  font-size: 0.85em;
+}
+
+.group-detail-orphan-remove {
+  background: #fff;
+  color: #b34;
+  border: 1px solid #d99;
+  border-radius: 3px;
+  padding: 0.2rem 0.6rem;
+  font: inherit;
+  font-size: 0.85rem;
+  font-style: normal;
+  cursor: pointer;
+}
+
+.group-detail-orphan-remove:hover:not(:disabled) {
+  background: #fdf2f2;
+}
+
+.group-detail-orphan-remove:disabled {
+  opacity: 0.6;
+  cursor: default;
 }
 
 /* =========================================================================

--- a/app/static/vendor/sqlite-worker.js
+++ b/app/static/vendor/sqlite-worker.js
@@ -158,6 +158,13 @@ var RELATIONSHIPS_DB_SLOT = '/relationships.db';
 var FELLOWS_DB_SLOT = '/fellows.db';
 var RESTORE_STAGING_SLOT = '/relationships.db.restore-staging';
 var FELLOWS_STAGING_SLOT = '/fellows.db.staging';
+// Distinct from FELLOWS_STAGING_SLOT — the boot-path ensureFellowsDb
+// staging slot is short-lived (open, validate, swap, close in one tick)
+// while the user-driven swap can sit pending across the confirm dialog.
+// Using separate slots avoids any chance of one path stomping the other,
+// even though under the opt-in policy ensureFellowsDb only fires at cold
+// start.
+var FELLOWS_SWAP_STAGING_SLOT = '/fellows.db.swap-staging';
 var FELLOWS_META_FILE = 'fellows.db.meta.json';
 
 var REQUIRED_RESTORE_TABLES = ['groups', 'group_members', 'fellow_tags', 'fellow_notes', 'settings'];
@@ -169,6 +176,12 @@ var poolUtil = null;
 var relDb = null;
 var fellowsDb = null;
 var bootTrace = [];
+
+// User-driven directory-data update, between previewFellowsDbSwap and
+// applyFellowsDbSwap / cancelFellowsDbSwap. Holds the SHA + an opaque
+// stagingId that the page must echo back. Bytes live in the staging
+// slot, not in JS memory.
+var pendingFellowsDbSwap = null;
 
 function trace(msg) { bootTrace.push(new Date().toISOString() + ' ' + String(msg)); }
 
@@ -955,21 +968,24 @@ handlers.getStats = async function () {
   };
 };
 
-// ----- ensureFellowsDb (page-driven cold-start fetch + SHA-keyed refresh) ---
-// Page calls this exactly once per session, only after the gate decision
-// tree resolves to directory mode. Phase 3 semantics:
+// ----- ensureFellowsDb (page-driven cold-start fetch — opt-in policy) ------
+// Page calls this on every boot, only after the gate decision tree
+// resolves to directory mode. The boot path is install-only by design
+// (plans/opt_in_directory_data_updates.md): on a returning visitor with
+// fellows.db already on disk, the worker never auto-fetches, regardless
+// of SHA. The user has to explicitly request a refresh via the About
+// page → previewFellowsDbSwap → applyFellowsDbSwap RPCs.
 //
-//   - args.serverSha is the `fellows_db_sha` from /build-meta.json. Optional
-//     — pages that can't reach build-meta or older callers omit it.
-//   - hasFellowsDb=true AND serverSha matches local meta.sha → no-op.
-//     The directory keeps using whatever bytes are already on disk.
-//   - hasFellowsDb=true AND serverSha differs (or serverSha provided but
-//     local meta.sha is null — covers visitors upgrading from P1) →
-//     fetch, validate, atomically replace.
-//   - hasFellowsDb=true AND serverSha not provided → no-op (matches the
-//     P1-era contract for any caller that doesn't know about SHAs yet).
-//   - hasFellowsDb=false → fetch unconditionally; the comparison is moot
-//     because we have nothing local to keep.
+//   - args.mode: 'install-only' (default) — fetch only when fellowsDb
+//     is not open (cold start, post-Reset Everything). Returns the
+//     existing handle untouched otherwise. SHA is ignored in this mode
+//     beyond an informational trace.
+//   - args.mode: 'refresh' — pre-PR-#113 behavior, kept for the
+//     applyFellowsDbSwap RPC's internal use only. Fetch + validate +
+//     atomic replace + meta update. `args.serverSha`, if provided, is
+//     stamped into the trace; the actual SHA written to meta is the
+//     digest of the bytes we received.
+//   - Unknown / missing mode coerces to 'install-only'.
 //
 // On fetch / validation failure, `meta.last_failure_at` and
 // `last_failure_reason` are recorded; the previously-live fellows.db
@@ -990,24 +1006,14 @@ async function _writeMetaFailure(reason) {
   return existing;
 }
 
-handlers.ensureFellowsDb = async function (args) {
-  args = args || {};
-  var serverSha = (typeof args.serverSha === 'string' && args.serverSha) ? args.serverSha : null;
-  var localMeta = await readFellowsMeta();
-  var localSha = (localMeta && typeof localMeta.sha === 'string') ? localMeta.sha : null;
-
-  // Returning visitor with up-to-date bytes: no fetch, no re-import.
-  if (fellowsDb && serverSha && localSha && serverSha === localSha) {
-    return { hasFellowsDb: true, refreshed: false, meta: localMeta };
-  }
-  // Returning visitor with no SHA-comparison input: preserve P1-era contract.
-  if (fellowsDb && !serverSha) {
-    return { hasFellowsDb: true, refreshed: false, meta: localMeta || null };
-  }
-
-  var refreshKind = fellowsDb ? 'refresh' : 'cold-start';
-  trace('ensureFellowsDb: ' + refreshKind + ' fetch /fellows.db'
-    + (serverSha ? ' (serverSha=' + serverSha.slice(0, 12) + '…)' : ''));
+// Fetch /fellows.db, validate, atomically replace the live slot, write
+// meta. Throws on any failure with a code-tagged Error; on throw the
+// previously-live fellowsDb stays open and meta records the failure.
+// Used by both ensureFellowsDb's cold-start branch and (via raw bytes
+// already on disk) applyFellowsDbSwap.
+async function _fetchValidateAndImportFellowsDb(serverShaHint, kind) {
+  trace('fellows.db ' + kind + ': fetch /fellows.db'
+    + (serverShaHint ? ' (serverSha=' + serverShaHint.slice(0, 12) + '…)' : ''));
 
   var resp;
   try {
@@ -1063,8 +1069,8 @@ handlers.ensureFellowsDb = async function (args) {
   if (verifyDb) { try { verifyDb.close(); } catch (e3) {} }
 
   // Compute the digest of what we actually got. This is the value that
-  // ends up in meta.sha — not args.serverSha — so a server that lies
-  // about its SHA can't desync the local copy.
+  // ends up in meta.sha — not the hint — so a server that lies about
+  // its SHA can't desync the local copy.
   var fetchedSha = await _sha256Hex(bytes);
 
   // Promote staging → live slot. importDb requires the live slot's SAH
@@ -1075,7 +1081,7 @@ handlers.ensureFellowsDb = async function (args) {
   }
   poolUtil.importDb(FELLOWS_DB_SLOT, bytes);
   fellowsDb = new poolUtil.OpfsSAHPoolDb(FELLOWS_DB_SLOT);
-  trace('ensureFellowsDb: imported ' + bytes.byteLength + ' bytes, sha=' + fetchedSha.slice(0, 12) + '…');
+  trace('fellows.db ' + kind + ': imported ' + bytes.byteLength + ' bytes, sha=' + fetchedSha.slice(0, 12) + '…');
 
   var newMeta = {
     sha: fetchedSha,
@@ -1084,8 +1090,318 @@ handlers.ensureFellowsDb = async function (args) {
     last_failure_reason: null
   };
   try { await writeFellowsMeta(newMeta); }
-  catch (we) { trace('ensureFellowsDb: meta write failed: ' + (we && we.message || we)); }
-  return { hasFellowsDb: true, refreshed: true, meta: newMeta };
+  catch (we) { trace('fellows.db ' + kind + ': meta write failed: ' + (we && we.message || we)); }
+  return { bytes: bytes, sha: fetchedSha, meta: newMeta };
+}
+
+handlers.ensureFellowsDb = async function (args) {
+  args = args || {};
+  var mode = args.mode === 'refresh' ? 'refresh' : 'install-only';
+  var serverSha = (typeof args.serverSha === 'string' && args.serverSha) ? args.serverSha : null;
+  var localMeta = await readFellowsMeta();
+
+  // Install-only is the boot-path policy under
+  // plans/opt_in_directory_data_updates.md: never auto-refresh a
+  // returning visitor's fellows.db, regardless of SHA. The user opts
+  // in via previewFellowsDbSwap → applyFellowsDbSwap.
+  if (mode === 'install-only' && fellowsDb) {
+    return { hasFellowsDb: true, refreshed: false, meta: localMeta || null };
+  }
+
+  // Cold-start (no local fellows.db) under either mode: fetch.
+  // Refresh under either condition: fetch.
+  var kind = fellowsDb ? 'refresh' : 'cold-start';
+  var imported = await _fetchValidateAndImportFellowsDb(serverSha, kind);
+  return { hasFellowsDb: true, refreshed: true, meta: imported.meta };
+};
+
+// ----- Opt-in directory-data update flow ------------------------------------
+// plans/opt_in_directory_data_updates.md. Flow:
+//   1. compareFellowsDbSha({serverSha}) → quick read of meta.sha vs server.
+//   2. previewFellowsDbSwap({serverSha}) → fetch + validate + write to
+//      swap-staging slot. Compute affected group members. Return.
+//   3. applyFellowsDbSwap({stagingId}) → promote staging → live slot.
+//      OR cancelFellowsDbSwap({stagingId}) → discard.
+//
+// The staging slot persists between (2) and (3) so the dialog can sit
+// open without holding bytes in JS memory. `pendingFellowsDbSwap` holds
+// the metadata + an opaque id the page must echo back; a stale id
+// (page reloaded, worker restarted) makes apply 400.
+
+function _newStagingId() {
+  // 16 hex chars from crypto.getRandomValues — opaque, unguessable enough
+  // for a same-process correlation handle.
+  var arr = new Uint8Array(8);
+  crypto.getRandomValues(arr);
+  var hex = '';
+  for (var i = 0; i < arr.length; i++) {
+    var b = arr[i];
+    hex += (b < 16 ? '0' : '') + b.toString(16);
+  }
+  return hex;
+}
+
+function _clearSwapStagingSlot() {
+  if (!poolUtil) return;
+  try {
+    if (typeof poolUtil.unlink === 'function') {
+      poolUtil.unlink(FELLOWS_SWAP_STAGING_SLOT);
+    }
+  } catch (e) { /* slot may not exist; non-fatal */ }
+}
+
+handlers.compareFellowsDbSha = async function (args) {
+  args = args || {};
+  var serverSha = (typeof args.serverSha === 'string' && args.serverSha) ? args.serverSha : null;
+  var meta = await readFellowsMeta();
+  var localSha = (meta && typeof meta.sha === 'string') ? meta.sha : null;
+  // dataUpdateAvailable is only true when we have a local DB AND a
+  // local SHA AND a server SHA AND they differ. Cold-start (no local
+  // DB) is not an "update" — that's the install path. Server unreachable
+  // (serverSha null) returns null so the UI can show "couldn't check"
+  // distinctly from "up to date".
+  var dataUpdateAvailable = false;
+  if (!serverSha) {
+    dataUpdateAvailable = null;
+  } else if (fellowsDb && localSha) {
+    dataUpdateAvailable = (localSha !== serverSha);
+  }
+  return {
+    hasFellowsDb: !!fellowsDb,
+    localSha: localSha,
+    serverSha: serverSha,
+    fetchedAt: (meta && meta.fetched_at) || null,
+    dataUpdateAvailable: dataUpdateAvailable
+  };
+};
+
+handlers.previewFellowsDbSwap = async function (args) {
+  args = args || {};
+  var serverSha = (typeof args.serverSha === 'string' && args.serverSha) ? args.serverSha : null;
+  if (!fellowsDb) {
+    var nerr = new Error('No local fellows.db to swap from');
+    nerr.code = 'no_local_fellows_db';
+    throw nerr;
+  }
+  // A previous pending swap is implicitly discarded: we only support one
+  // outstanding swap at a time. Later attempts re-fetch.
+  if (pendingFellowsDbSwap) {
+    _clearSwapStagingSlot();
+    pendingFellowsDbSwap = null;
+  }
+
+  // Fetch into the swap-staging slot. Reuse the validation path by writing
+  // to the existing staging slot first, but copy into the swap-staging
+  // slot afterwards so the boot-path slot stays free for any future
+  // ensureFellowsDb call.
+  trace('previewFellowsDbSwap: fetch /fellows.db'
+    + (serverSha ? ' (serverSha=' + serverSha.slice(0, 12) + '…)' : ''));
+  var resp;
+  try {
+    resp = await fetch('/fellows.db', { credentials: 'include', cache: 'no-store' });
+  } catch (e) {
+    var nferr = new Error('Network fetch /fellows.db failed: ' + (e && e.message || e));
+    nferr.code = 'fellows_db_fetch_network';
+    throw nferr;
+  }
+  if (!resp.ok) {
+    var herr = new Error('GET /fellows.db returned HTTP ' + resp.status);
+    herr.code = 'fellows_db_fetch_http';
+    herr.httpStatus = resp.status;
+    throw herr;
+  }
+  var buf = await resp.arrayBuffer();
+  var bytes = new Uint8Array(buf);
+  if (!bytes.byteLength) {
+    var eerr = new Error('Empty /fellows.db response');
+    eerr.code = 'fellows_db_fetch_empty';
+    throw eerr;
+  }
+
+  // Validate by importing into the swap-staging slot directly and running
+  // PRAGMA quick_check + a fellows-table sanity probe.
+  var stagingDb = null;
+  var fetchedSha;
+  var stagedIdSet; // map: record_ids present in the staged fellows.db
+  try {
+    poolUtil.importDb(FELLOWS_SWAP_STAGING_SLOT, bytes);
+    stagingDb = new poolUtil.OpfsSAHPoolDb(FELLOWS_SWAP_STAGING_SLOT);
+    var qc = dbSelectOne(stagingDb, 'PRAGMA quick_check', null);
+    var qcResult = qc && (qc.quick_check || qc['quick_check']);
+    if (qcResult !== 'ok') {
+      throw new Error('quick_check failed: ' + (qcResult || 'unknown'));
+    }
+    // Smoke-check the schema. A zero-row DB is technically valid SQLite
+    // but would silently orphan every existing group member; reject it.
+    var totalRow = dbSelectOne(stagingDb, 'SELECT COUNT(*) AS n FROM fellows', null);
+    if (!totalRow || !totalRow.n) {
+      throw new Error('staged fellows.db has zero rows');
+    }
+    fetchedSha = await _sha256Hex(bytes);
+
+    // Compute affected group members: every record_id in group_members
+    // that has no matching record in the staged fellows.db. We need
+    // (a) the set of record_ids in the staged DB (b) every (member,
+    // group) pair from relationships.db (c) human-readable names from
+    // the *live* fellows.db so the dialog can show "Alice Smith" not
+    // a record_id.
+    var stagedIdsRows = dbSelectAll(stagingDb, 'SELECT record_id FROM fellows', null);
+    stagedIdSet = {};
+    for (var i = 0; i < stagedIdsRows.length; i++) stagedIdSet[stagedIdsRows[i].record_id] = true;
+  } catch (verr) {
+    if (stagingDb) { try { stagingDb.close(); } catch (e2) {} }
+    _clearSwapStagingSlot();
+    var ierr = new Error('Validation of staged fellows.db failed: ' + (verr && verr.message || verr));
+    ierr.code = 'fellows_db_invalid';
+    throw ierr;
+  }
+  try { stagingDb.close(); } catch (e3) {}
+
+  // Resolve affected members from the page's perspective. Read
+  // group_members + group names from relationships.db, drop any whose
+  // record_id is in the staged set, then look up display names in the
+  // *live* fellows.db.
+  var affected = []; // [{ recordId, name, groups: [{id, name}] }]
+  if (relDb) {
+    var memberRows = dbSelectAll(
+      relDb,
+      'SELECT gm.fellow_record_id AS rid, gm.group_id AS gid, g.name AS gname ' +
+        'FROM group_members gm JOIN groups g ON g.id = gm.group_id',
+      null
+    );
+    var byRid = {};
+    for (var m = 0; m < memberRows.length; m++) {
+      var row = memberRows[m];
+      if (stagedIdSet[row.rid]) continue; // still present after swap
+      if (!byRid[row.rid]) byRid[row.rid] = { recordId: row.rid, name: null, groups: [] };
+      byRid[row.rid].groups.push({ id: row.gid, name: row.gname });
+    }
+    var ridKeys = Object.keys(byRid);
+    if (ridKeys.length && fellowsDb) {
+      // Resolve names from the live DB. Bind one at a time — the count is
+      // expected to be small (members lost between consecutive deploys).
+      for (var rk = 0; rk < ridKeys.length; rk++) {
+        var rid = ridKeys[rk];
+        var nrow = dbSelectOne(fellowsDb, 'SELECT name FROM fellows WHERE record_id = ?', [rid]);
+        byRid[rid].name = (nrow && nrow.name) || null;
+        affected.push(byRid[rid]);
+      }
+      affected.sort(function (a, b) {
+        var an = (a.name || '').toLowerCase();
+        var bn = (b.name || '').toLowerCase();
+        return an < bn ? -1 : an > bn ? 1 : 0;
+      });
+    }
+  }
+
+  var stagingId = _newStagingId();
+  pendingFellowsDbSwap = {
+    stagingId: stagingId,
+    sha: fetchedSha,
+    fetchedAt: new Date().toISOString(),
+    serverShaHint: serverSha
+  };
+  trace('previewFellowsDbSwap: staged sha=' + fetchedSha.slice(0, 12) +
+    '… affectedMembers=' + affected.length + ' stagingId=' + stagingId);
+
+  return {
+    stagingId: stagingId,
+    newSha: fetchedSha,
+    affectedGroups: affected
+  };
+};
+
+handlers.applyFellowsDbSwap = async function (args) {
+  args = args || {};
+  var stagingId = args.stagingId;
+  if (!pendingFellowsDbSwap || !stagingId || pendingFellowsDbSwap.stagingId !== stagingId) {
+    var serr = new Error('No matching pending swap (stagingId mismatch or expired)');
+    serr.code = 'staging_id_mismatch';
+    throw serr;
+  }
+  var pending = pendingFellowsDbSwap;
+  // Read bytes back from the staging slot. exportFile returns a fresh
+  // Uint8Array; importDb-into-live releases the SAH after we close the
+  // current live handle.
+  var bytes;
+  try {
+    bytes = poolUtil.exportFile(FELLOWS_SWAP_STAGING_SLOT);
+  } catch (e) {
+    pendingFellowsDbSwap = null;
+    _clearSwapStagingSlot();
+    var rerr = new Error('Could not read staged bytes: ' + (e && e.message || e));
+    rerr.code = 'staging_export_failed';
+    throw rerr;
+  }
+  if (!bytes || !bytes.byteLength) {
+    pendingFellowsDbSwap = null;
+    _clearSwapStagingSlot();
+    var berr = new Error('Staged bytes are empty');
+    berr.code = 'staging_empty';
+    throw berr;
+  }
+  if (fellowsDb) {
+    try { fellowsDb.close(); } catch (e2) {}
+    fellowsDb = null;
+  }
+  poolUtil.importDb(FELLOWS_DB_SLOT, bytes);
+  fellowsDb = new poolUtil.OpfsSAHPoolDb(FELLOWS_DB_SLOT);
+  var newMeta = {
+    sha: pending.sha,
+    fetched_at: pending.fetchedAt,
+    last_failure_at: null,
+    last_failure_reason: null
+  };
+  try { await writeFellowsMeta(newMeta); }
+  catch (we) { trace('applyFellowsDbSwap: meta write failed: ' + (we && we.message || we)); }
+  pendingFellowsDbSwap = null;
+  _clearSwapStagingSlot();
+  trace('applyFellowsDbSwap: live slot promoted to sha=' + pending.sha.slice(0, 12) + '…');
+  return { ok: true, newSha: pending.sha, meta: newMeta };
+};
+
+handlers.cancelFellowsDbSwap = async function (args) {
+  args = args || {};
+  var stagingId = args.stagingId;
+  // Be lenient on cancel — if the page sends a stale id, just clear
+  // anyway. The intent ("don't apply the staged update") is unambiguous.
+  if (pendingFellowsDbSwap && stagingId && pendingFellowsDbSwap.stagingId !== stagingId) {
+    trace('cancelFellowsDbSwap: stagingId mismatch — clearing pending anyway');
+  }
+  pendingFellowsDbSwap = null;
+  _clearSwapStagingSlot();
+  return { ok: true };
+};
+
+// Soft scan invoked once on first boot of the new code (gated by the
+// `orphan_scan_done` setting on the page side). Returns the same shape
+// as previewFellowsDbSwap.affectedGroups so the same UI patterns apply.
+handlers.findOrphanedGroupMembers = async function () {
+  if (!relDb || !fellowsDb) return { orphans: [] };
+  var memberRows = dbSelectAll(
+    relDb,
+    'SELECT gm.fellow_record_id AS rid, gm.group_id AS gid, g.name AS gname ' +
+      'FROM group_members gm JOIN groups g ON g.id = gm.group_id',
+    null
+  );
+  if (!memberRows.length) return { orphans: [] };
+  var fellowRows = dbSelectAll(fellowsDb, 'SELECT record_id FROM fellows', null);
+  var existing = {};
+  for (var i = 0; i < fellowRows.length; i++) existing[fellowRows[i].record_id] = true;
+  var byRid = {};
+  for (var j = 0; j < memberRows.length; j++) {
+    var r = memberRows[j];
+    if (existing[r.rid]) continue;
+    if (!byRid[r.rid]) byRid[r.rid] = { recordId: r.rid, name: null, groups: [] };
+    byRid[r.rid].groups.push({ id: r.gid, name: r.gname });
+  }
+  var orphans = [];
+  var keys = Object.keys(byRid);
+  for (var k = 0; k < keys.length; k++) orphans.push(byRid[keys[k]]);
+  orphans.sort(function (a, b) {
+    return a.recordId < b.recordId ? -1 : a.recordId > b.recordId ? 1 : 0;
+  });
+  return { orphans: orphans };
 };
 
 // ----- Diagnostics ----------------------------------------------------------

--- a/docs/Architecture.md
+++ b/docs/Architecture.md
@@ -73,9 +73,15 @@ User-authored data (groups, tags, notes, settings) lives in
 Cross-DB joins (worker-internal) use SQLite `ATTACH DATABASE ... ?mode=ro`,
 which keeps contact data read-only at the SQLite level. `relationships.db`
 is durable across both app updates and Clear App Cache; `fellows.db`
-is re-imported only when its server-reported content SHA differs from
-the SHA recorded in OPFS-side `fellows.db.meta.json` — equal SHA means
-no fetch and no re-import (Phase 3 of the local-first worker plan).
+is re-imported **on user request** when its server-reported content SHA
+differs from the SHA recorded in OPFS-side `fellows.db.meta.json` —
+the boot path is install-only and never auto-refreshes a returning
+visitor. The user-driven swap path lives on the About page (*Update
+directory data*) and is gated by a pre-swap impact preview that lists
+any group members who would no longer have a profile after the
+update. See `plans/opt_in_directory_data_updates.md` for the policy
+and `plans/local_first_worker_architecture.md` for the underlying
+SHA-keyed-refresh mechanism (now wrapped behind the opt-in UI).
 
 In the browser this lives in OPFS (`sqlite3.wasm` + `relationships.db`
 + `fellows.db` + `fellows.db.meta.json`) in **both** standalone PWA mode

--- a/docs/persistence_and_upgrades.md
+++ b/docs/persistence_and_upgrades.md
@@ -16,8 +16,8 @@ layer (per [Architecture.md § Worker-owned OPFS](Architecture.md#worker-owned-o
 | Cache API `fellows-app-shell-vN` | service worker | HTML, JS, CSS, SW, manifest, icons, sqlite3.wasm, `vendor/sqlite-worker.js` | Yes — every CACHE_VERSION bump | Yes |
 | Cache API `fellows-images-v1` | service worker | Profile photos | No (separate cache name) — re-fetched as needed | Yes |
 | IndexedDB `fellows-local-db` | main (retired in Phase 6) | Offline-fallback full fellow rows | Regenerated on every successful boot | Yes |
-| OPFS `fellows.db` | worker | Imported Knack contact data | **Re-imported** when `fellows.db.meta.json:sha` differs from `build-meta.json:fellows_db_sha` (Phase 3); otherwise reused | **No** (gap; see "Open questions") |
-| OPFS `fellows.db.meta.json` | worker | `{sha, fetched_at, last_failure_at, last_failure_reason}` — the freshness sidecar that gates re-import of `fellows.db`. Sibling of `fellows.db` at the OPFS root, outside the SAH-pool dir, so a `relationships.db` restore can't desync it. | Updated after each successful re-import; otherwise untouched | **No** |
+| OPFS `fellows.db` | worker | Imported Knack contact data | **Re-imported on user request** via the About-page *Update directory data* button when `fellows.db.meta.json:sha` differs from `build-meta.json:fellows_db_sha`. Boot path is install-only and never auto-refreshes a returning visitor (`plans/opt_in_directory_data_updates.md`). | **No** (gap; see "Open questions") |
+| OPFS `fellows.db.meta.json` | worker | `{sha, fetched_at, last_failure_at, last_failure_reason}` — the freshness sidecar that records what's locally installed. Sibling of `fellows.db` at the OPFS root, outside the SAH-pool dir, so a `relationships.db` restore can't desync it. | Updated after each successful user-driven re-import; otherwise untouched | **No** |
 | OPFS `relationships.db` | worker | Groups, group members, fellow_tags, fellow_notes, settings — all user-authored | **Never** — that's the whole point of this file | **No** |
 | OPFS `relationships.db.bak.<ISO>` | worker | Snapshots of `relationships.db`, rotated to keep newest 5 | Auto-created on every boot when the most recent backup is more than 1 hour old (debounced); pruned to 5 newest | **No** (preserved alongside `relationships.db` for recovery) |
 | localStorage `fellows_authenticated_once` | main | "this origin has authenticated at least once" marker | Untouched | **Preserved by name** in `clearAllAppData` |
@@ -70,25 +70,67 @@ floors and triage policy.
 5. `app.js` shows the "New version available — Reload" banner.
 6. User clicks Reload. New SW activates. Old shell cache deleted.
    Controlled tabs auto-navigate (see `sw.js`'s activate handler).
-7. Fresh `app.js` runs against fresh shell against fresh `fellows.db`.
+7. Fresh `app.js` runs against fresh shell against the **same**
+   `fellows.db` already on disk. App-shell updates do not refresh
+   directory data — see *Directory data update flow* below.
 
 What survives the reload, end-to-end:
 - The session cookie (still valid until its 7-day TTL).
 - `fellows_authenticated_once` (the URL-just-works marker).
 - `relationships.db` (the user's groups, tags, notes, and settings).
+- `fellows.db` (the on-device fellow-data snapshot — unchanged unless
+  the user opts in to a directory data update).
 - The image cache.
 - All localStorage keys (drafts, filter prefs, etc.).
 
 What gets replaced (intentionally):
 - App shell HTML, JS, CSS, SW, manifest, and `vendor/sqlite-worker.js`
   (precached together; CACHE_VERSION-busted as one unit).
-- `fellows.db` in OPFS, **only when** `build-meta.json:fellows_db_sha`
-  differs from the locally-recorded `fellows.db.meta.json:sha` — the
-  worker's `ensureFellowsDb` op runs an atomic staging-slot import on
-  mismatch and updates the sidecar. Two consecutive boots against an
-  unchanged server produce zero `/fellows.db` requests.
 - IndexedDB cache (regenerated on next successful `getList`; retired
   in Phase 6 per [`plans/local_first_worker_architecture.md`](../plans/local_first_worker_architecture.md#phase-6--retire-indexeddb)).
+
+## Directory data update flow
+
+Independent of app-shell updates. The data on the device is treated as
+an installed snapshot — see [`plans/opt_in_directory_data_updates.md`](../plans/opt_in_directory_data_updates.md)
+for the full rationale.
+
+1. About page → **Check for updates** fetches `/build-meta.json` and
+   asks the worker to compare its `fellows_db_sha` to the local
+   `fellows.db.meta.json:sha`.
+2. If they match → row reads *up to date*; nothing to do.
+3. If they differ → row reads *Directory Data update available* with
+   an **Update directory data** button.
+4. Clicking the button calls `previewFellowsDbSwap` — the worker
+   fetches the new bytes, validates them in `/fellows.db.swap-staging`,
+   and computes which `group_members.fellow_record_id`s would no
+   longer have a profile after the swap.
+5. If any members would be affected, a confirm dialog lists them by
+   name and group. **Cancel** discards the staged bytes. **Update
+   anyway** commits the swap.
+6. If no members are affected, the swap commits silently and the
+   directory re-renders against the new bytes.
+7. After commit, `applyFellowsDbSwap` writes the new `meta.sha` and
+   refreshes the in-memory orphan set so group detail flags any new
+   orphans.
+
+The boot path never auto-fetches or auto-imports a returning
+visitor's `fellows.db` — that was the pre-2026-05 policy and is
+explicitly retired. Only cold-start (no local fellows.db) or the
+About-page button trigger a fetch.
+
+### Orphan members (post-swap)
+
+A `group_members` row whose `record_id` is no longer in
+`fellows.db` renders in group detail as **Profile no longer
+available (record_id: …)** with a per-row **Remove** button. Data
+isn't auto-removed — the user decides.
+
+A one-shot **soft scan** runs on first boot of the opt-in build to
+catch members orphaned by past auto-refreshes (PR #113 era). It
+fires a single toast pointing the user at group detail; the
+`relationships.settings.orphan_scan_done = "1"` marker prevents
+re-toasting.
 
 ## Auto-backup of `relationships.db`
 

--- a/docs/users_manual.md
+++ b/docs/users_manual.md
@@ -240,15 +240,33 @@ file or a recent auto-backup.](images/users_manual/11_settings.png)
 ## About
 
 `#/about` shows fellowship statistics (totals, breakdowns by region /
-cohort / fellow type) and the build line — handy when reporting a bug.
-**Check for updates** forces a service-worker refresh.
+cohort / fellow type) plus a two-line update status block:
 
-A line under the **Check for updates** button shows when the app last
-successfully refreshed fellow data from the server, e.g.
-*"Last update check: 2026-05-04T18:22:07Z — succeeded."* If the most
-recent attempt failed, it reads *"Last update attempt: … — failed: …"*.
-Useful when a fellow asks "am I seeing the latest data?" — the answer
-is right there.
+- **App** — the build label running in this tab.
+- **Directory data** — when fellows.db was last fetched.
+
+Click **Check for updates** to ask the server about both. Each row
+updates independently:
+
+- *up to date* — nothing to do.
+- *App update available* — a newer app version is on the server. A
+  **Reload to apply** button appears next to the row; clicking it is
+  the same as clicking the *New version available* banner.
+- *Directory Data update available* — the bundled fellow data on the
+  server differs from the snapshot on this device. An **Update
+  directory data** button appears. See *Updating directory data*
+  below.
+- *Couldn't check (offline?)* — the server didn't respond. Try again
+  when you're online.
+- *Reload the app to enable update checks* — appears briefly right
+  after an app update if the previous service worker was still running
+  when the page loaded. A single reload spawns a fresh background
+  worker and the check works.
+
+A line below the block shows when fellow data was last fetched (or
+the most recent failure), e.g. *"Last update check: 2026-05-04T18:22:07Z
+— succeeded."* — useful when a fellow asks "am I seeing the latest
+data?".
 
 ![About page.](images/users_manual/12_about_page.png)
 
@@ -256,9 +274,55 @@ is right there.
 
 ## Updates
 
-The app checks for new versions automatically — at every launch, and
-once an hour while open. When one's available a banner reads
-*"New version available — Reload."* Click Reload.
+The app handles two kinds of updates separately. Both are surfaced on
+the **About** page; you can click **Check for updates** at any time to
+re-check.
+
+### App updates
+
+The app shell (UI, layout, fixes) auto-checks for new versions — at
+every launch, and once an hour while open. When one's available a
+banner reads *"New version available — Reload."* Click Reload. The
+About page shows the same state alongside an inline **Reload to
+apply** button.
+
+Reloading replaces only the app. Your saved groups, notes, settings,
+and the fellow data on this device are untouched.
+
+### Directory data updates
+
+The fellow data on this device — names, profiles, contact info — is a
+snapshot. **By design it does not change automatically.** Once
+installed, the directory you see is yours: a fellow's profile won't
+shift mid-session, and your saved groups will keep referring to the
+same people.
+
+When the server's snapshot differs from yours, the About page's
+*Directory data* row shows **Directory Data update available** and an
+**Update directory data** button.
+
+Before applying the update, the app checks whether any of your saved
+group members would disappear from the new snapshot. If so, a confirm
+dialog lists them by name and group, e.g.:
+
+> *This update removes 2 fellows from your saved groups:*
+> *• Alice Smith — in 'NZ Mentors', 'Investors'*
+> *• Bob Jones   — in 'NZ Mentors'*
+>
+> *After the update they will no longer appear in those groups.
+> Their entries will be flagged as 'Profile no longer available' so
+> you can review and remove them.*
+>
+> *[Cancel] [Update anyway]*
+
+If no members would disappear, the update applies silently and the
+status flips to *Directory data updated.*
+
+After an update, members whose profile is no longer in the directory
+render in group detail as **Profile no longer available (record_id:
+…)** with a per-row **Remove** button. The data isn't lost — it's just
+no longer in the active snapshot. You can leave the row in place
+(harmless) or click **Remove** to drop it from the group.
 
 ---
 
@@ -270,7 +334,7 @@ Two reset paths if the app gets weird. Try the gentle one first.
 |---|---|---|
 | Wipes the cache, signs you out | ✓ | ✓ |
 | Wipes saved groups, notes, tags, settings | — | ✓ |
-| Re-downloads fellow data on next launch | ✓ | ✓ |
+| Wipes the on-device fellow data snapshot | — | ✓ |
 | Lands you at | the install landing | the email gate |
 
 - **Phone / tablet** — top-right **⋮** kebab → either option.
@@ -315,11 +379,12 @@ settings. No login, no server round-trip on each click. Photos that
 finished caching are available; the rest show a placeholder until you
 get a chance to fetch them.
 
-If you ever wonder whether the app has reached the server recently —
-to pick up new fellows, fixes, or a refreshed profile — the **About**
-page shows the timestamp of the last successful refresh under
-**Check for updates**. If your session has expired, visit `/?gate=1`
-for a new magic link.
+If you ever wonder whether the app has reached the server recently,
+the **About** page shows the timestamp of the last successful fetch
+under **Check for updates**. Picking up new fellows, fixes, or a
+refreshed profile is opt-in — see *Updates → Directory data updates*
+above. If your session has expired, visit `/?gate=1` for a new magic
+link.
 
 ---
 

--- a/plans/local_first_worker_architecture.md
+++ b/plans/local_first_worker_architecture.md
@@ -154,6 +154,17 @@ Out of scope: versioned `fellows.db` (next phase); IDB retirement (Phase 6).
 
 ### Phase 3 — Versioned, atomic `fellows.db` updates
 
+> **Policy supersession (2026-05).** Phase 3's silent-on-boot refresh
+> shipped in PR #113 and was superseded by an opt-in policy a few weeks
+> later — see [`plans/opt_in_directory_data_updates.md`](opt_in_directory_data_updates.md).
+> The fetch / validate / atomic-swap mechanism described below is
+> unchanged; only the **trigger** moved from boot-time SHA mismatch to
+> a user click on the About page's *Update directory data* button.
+> The boot path is now install-only. The "Directory updated" toast
+> described in this section was removed in the same change. Read this
+> phase as the underlying machinery; read the opt-in plan for the
+> current user-facing policy.
+
 Stop re-importing `fellows.db` on every boot. Metadata is **worker-owned**, stored as a sibling OPFS file — explicitly not in `relationships.settings`, so a `relationships.db` restore can't desync `fellows.db` freshness.
 
 Scope:

--- a/plans/opt_in_directory_data_updates.md
+++ b/plans/opt_in_directory_data_updates.md
@@ -1,0 +1,430 @@
+# Opt-in directory data updates
+
+## Why
+
+`fellows.db` is a frozen archive. EHF's old directory has been shut down,
+the canonical Knack source is gone (`docs/data_provenance.md`), and the
+PWA's job from here on is "let fellows keep using the snapshot they were
+given." In that world, silently re-importing `fellows.db` mid-session is
+the wrong default:
+
+- A user's profile view, search results, or saved-group member list can
+  change underneath them without any acknowledgement.
+- Group members reference fellows by `record_id` with no FK across DBs;
+  if a record disappears in a future snapshot, the corresponding
+  `group_members` row stays in OPFS but the INNER JOIN against the new
+  `fellows.db` silently drops the member from every UI surface. The user
+  loses context with no way to know it happened.
+- The app's stated stance ("install once, works forever";
+  `email_gate.md` invariant 10) treats the local copy as authoritative.
+  Auto-refresh quietly contradicted that.
+
+PR #113 (Phase 3 of `local_first_worker_architecture.md`) shipped a
+silent SHA-keyed refresh + a `'Directory updated'` toast. The
+mechanism is correct; the policy was wrong for this product. This plan
+reverses the policy without disturbing the mechanism.
+
+App-shell updates (bug fixes, UI improvements) keep their existing
+auto-detect + reload-banner flow. The two have always been
+independently versioned in `/build-meta.json` (`git_sha` for the shell,
+`fellows_db_sha` for the data); we just expose that independence to the
+user.
+
+## Goals
+
+1. **Directory data updates are opt-in.** The worker never re-imports
+   `fellows.db` on its own after the first install. The user has to ask.
+2. **Update availability is discoverable.** The About page shows two
+   independent status lines (App / Directory data) and a single
+   ceremonial "Check for updates" button that refreshes both.
+3. **Group integrity is protected at update time.** Before swapping
+   `fellows.db`, the worker computes which `group_members.record_id`s
+   would no longer resolve and surfaces them in a confirm dialog.
+4. **Past silent updates don't leave hidden damage.** A one-time soft
+   scan on first boot of the new code surfaces orphaned group members
+   that earlier auto-refreshes may have already created.
+5. **Cold-start still works.** A fresh install (post–Reset Everything,
+   or first-time visitor) still fetches `fellows.db` automatically as
+   part of boot. "Opt-in" applies to *re-imports*, not initial install.
+
+## Non-goals
+
+- **No schema change to `relationships.db`.** Denormalizing
+  `name`/`slug` into `group_members` would make groups robust to any
+  future record removal but is deferred — Knack is shut down, frozen
+  data is the steady state, and the diff dialog + soft scan cover the
+  realistic risk. Revisit if data churn ever happens.
+- **No silent removal of orphaned `group_members` rows.** The soft scan
+  surfaces them; the user decides what to do.
+- **No new server endpoint.** `/build-meta.json:fellows_db_sha` is
+  already the freshness signal we need.
+- **No change to the SW shell update path.** The "New version
+  available — Reload" banner stays. The two flows are intentionally
+  distinct.
+- **No image-cache versioning work.** Profile images live in
+  `fellows-images-v1` and are fetched lazily; they tag along with shell
+  updates. Out of scope here.
+
+## Product behavior
+
+### About page
+
+A single button — **Check for updates** — runs both checks in
+parallel and renders two independent status lines:
+
+```
+App
+  app: 2026-05-06-b4403be — up to date
+  [no action]
+
+Directory data
+  Snapshot from 2026-04-08 — up to date
+  [no action]
+
+[Check for updates]   Last check: 2026-05-06T12:34Z
+```
+
+When something is available:
+
+```
+App
+  app: 2026-05-06-b4403be → 2026-05-15-c0ffee1
+  App update available  [Reload to apply]
+
+Directory data
+  Snapshot from 2026-04-08 → 2026-05-15
+  Directory Data update available  [Update directory data]
+
+[Check for updates]   Last check: 2026-05-15T09:00Z
+```
+
+Status-line text constants (literal):
+
+- `"App update available"` — when `git_sha` differs.
+- `"Directory Data update available"` — when `fellows_db_sha` differs
+  from the locally-recorded sidecar SHA.
+- `"up to date"` — otherwise.
+- `"Couldn't check (offline?)"` — when `/build-meta.json` is
+  unreachable.
+
+The existing single-line status (`#about-update-status`) is removed in
+favor of the two-block layout. The "Last update check" line
+(`#about-last-update`) becomes "Last check" — the timestamp the
+About-page button last successfully reached the server.
+
+### Update directory data — confirm dialog
+
+Clicking **Update directory data** triggers a worker preview. If no
+group would lose members, apply silently and replace the status line
+with `"Directory data updated."` (no toast — the user just acted, the
+status block is the acknowledgement).
+
+If members would disappear, render a confirm dialog:
+
+```
+Update directory data?
+
+This update removes 2 fellows from your saved groups:
+
+  • Alice Smith — in 'NZ Mentors', 'Investors'
+  • Bob Jones   — in 'NZ Mentors'
+
+After the update they will no longer appear in those groups.
+Their entries will be flagged as 'Profile no longer available' so
+you can review and remove them.
+
+[Cancel]   [Update anyway]
+```
+
+`Cancel` discards the staged bytes. `Update anyway` commits the swap
+and writes the orphan list to a new `fellow_orphans` synthetic source
+(see § Orphan surfacing below).
+
+### Orphan surfacing
+
+In group detail and edit views, a member row whose `record_id` is not
+present in the current `fellows.db` renders as:
+
+```
+[?]   Profile no longer available  (record_id: rec_abc123)   [Remove]
+```
+
+Compact, non-blocking, never auto-removed. The user gets a one-click
+"Remove" affordance per row. No bulk-remove — too easy to misclick.
+
+This row is also what the soft scan (next section) surfaces.
+
+### Soft scan for pre-existing orphans
+
+On first boot of the new code, the page asks the worker to enumerate
+`group_members` rows whose `record_id` is not present in the current
+`fellows.db`. If any exist:
+
+- Set a one-shot `relationships.settings.orphan_scan_done = "1"`.
+- Show a single non-blocking toast on the boot the scan first runs:
+  `"Some group members are no longer in the directory. See group details for review."`
+- The orphan rows surface using the same UI pattern above.
+
+If `orphan_scan_done` is already set, skip — the scan has run before.
+This handles the case where users were on PR #113 and got auto-updates
+that already created orphans.
+
+## Implementation
+
+### Worker (`app/static/vendor/sqlite-worker.js`)
+
+**`ensureFellowsDb` policy split** — gate the existing
+fetch-and-import on a new `mode` arg, defaulting to `install-only`:
+
+| `mode`         | When called                            | Behavior |
+|----------------|----------------------------------------|----------|
+| `install-only` | Boot, every page load                  | If `hasFellowsDb`, no-op. Else fetch + import (cold-start). |
+| `refresh`      | User-clicks "Update directory data"   | Current Phase 3 behavior: fetch, validate, import, swap, update sidecar. |
+
+The `serverSha` arg stays — `install-only` ignores it (other than for
+trace logs); `refresh` uses it as the expected target SHA.
+
+The page's boot flow today does:
+
+```js
+provider._ensureFellowsDb({ serverSha });
+```
+
+It changes to:
+
+```js
+provider._ensureFellowsDb({ serverSha, mode: 'install-only' });
+```
+
+and the post-handler `'Directory updated'` toast disappears.
+
+**New RPC: `compareFellowsDbSha({ serverSha }) → { hasFellowsDb, localSha, dataUpdateAvailable }`**
+
+Cheap. Reads `fellows.db.meta.json` (already exposed via
+`_getFellowsDbMeta`, factor out the read), compares to `serverSha`,
+returns the comparison without touching the network. The page calls
+this as part of "Check for updates."
+
+**New RPC: `previewFellowsDbSwap({ serverSha }) → { affectedGroups, newSnapshotDate, stagingId }`**
+
+1. Fetch `/fellows.db` and validate (same path `refresh` uses).
+2. Write the bytes to a new temp SAH slot
+   (`fellows.db.swap-staging`), parallel to the existing
+   `relationships.db.restore-staging` pattern.
+3. ATTACH the staging slot, the live `fellows.db`, and `relationships.db`.
+4. Run:
+   ```sql
+   SELECT gm.fellow_record_id, COALESCE(f_old.name, '?') AS name,
+          GROUP_CONCAT(g.name, '|') AS group_names
+   FROM relationships.group_members gm
+   JOIN relationships.groups g ON g.id = gm.group_id
+   LEFT JOIN fellows_old.fellows f_old ON f_old.record_id = gm.fellow_record_id
+   LEFT JOIN fellows_new.fellows f_new ON f_new.record_id = gm.fellow_record_id
+   WHERE f_new.record_id IS NULL
+   GROUP BY gm.fellow_record_id
+   ORDER BY name;
+   ```
+5. Return the affected list + an opaque `stagingId`. Don't commit yet.
+
+**New RPC: `applyFellowsDbSwap({ stagingId }) → { ok, newSha }`**
+
+Atomic-rename the staging slot into place via the existing
+`poolUtil.importDb('fellows.db', bytes)` path the current `refresh`
+uses, update the meta sidecar. If `stagingId` doesn't match (user took
+too long, or the page reloaded), 400 — the page retries the preview.
+
+**New RPC: `findOrphanedGroupMembers() → { orphans: [{ recordId, groupIds }] }`**
+
+Used by the soft scan and by the group-detail render path (so a stale
+orphan row stays accurate after a "Remove" action elsewhere). Pure
+read.
+
+The existing `ensureFellowsDb` `serverSha` param and meta sidecar
+shape stay. Bump the worker handshake doc comment to note the policy
+change but **do not** bump `WORKER_RPC_VERSION` — request/response
+shapes haven't changed for existing RPCs, only added new ones.
+
+### Page (`app/static/app.js`)
+
+**Boot path**
+
+In `pickDataProvider()`:
+- Drop the `'Directory updated'` toast at line 7884.
+- Pass `mode: 'install-only'` to `_ensureFellowsDb`.
+- After successful directory render, call `findOrphanedGroupMembers()`
+  iff `relationships.settings.orphan_scan_done` is unset; show the
+  one-shot toast if any are returned; set the marker either way.
+
+**About page**
+
+Replace the single-status block (`renderAboutPage` ~line 4798) with
+the two-block layout from § Product behavior. New IDs:
+
+- `#about-app-status` (App line)
+- `#about-data-status` (Directory data line)
+- `#about-update-data-btn` (rendered only when data update available)
+- The existing `#about-check-updates` button stays — it now drives
+  both checks.
+
+The existing `checkForServerUpdate()` helper handles the app-shell
+half. Add a parallel `checkForDataUpdate()` that calls
+`compareFellowsDbSha` against the freshly-fetched
+`/build-meta.json:fellows_db_sha`. The button click runs
+`Promise.all([checkForServerUpdate(), checkForDataUpdate()])` and
+populates both lines.
+
+**Update flow**
+
+`#about-update-data-btn` click:
+1. Disable button, status → `"Checking impact…"`.
+2. `previewFellowsDbSwap({ serverSha })`.
+3. If `affectedGroups.length === 0`, call `applyFellowsDbSwap` directly
+   with status updates.
+4. Else render the confirm dialog (existing modal helper). Confirm →
+   `applyFellowsDbSwap`; cancel → discard the staging bytes via a new
+   `cancelFellowsDbSwap({ stagingId })` RPC and restore the previous
+   status.
+5. On apply success, reload the directory list in-place
+   (`bootDirectoryAsApp`'s data-only refresh path) so users see the
+   new data without a full page reload.
+
+**Group rendering**
+
+In group-detail render (`renderGroupDetail` and the visual directory),
+detect rows where the worker returned no fellow data for the
+`record_id` and substitute the orphan row:
+
+```
+[?]   Profile no longer available  (record_id: <id>)   [Remove]
+```
+
+`Remove` calls the existing group-edit RPC to drop that
+`fellow_record_id` from the group's member set.
+
+### Build / server
+
+No changes. `/build-meta.json:fellows_db_sha` is already emitted by
+both `build/build_pwa.py` and `app/server.py`.
+
+### Settings
+
+Add one new setting key in `relationships.settings`:
+
+| Key | Value | Purpose |
+|---|---|---|
+| `orphan_scan_done` | `"1"` | Marker that the one-time post-PR-113 orphan scan ran. |
+
+Set on first successful scan completion (regardless of whether orphans
+were found). Cleared by Reset Everything along with the rest of OPFS.
+
+### Tests
+
+E2E (Playwright, `tests/e2e/`):
+
+- **`test_directory_data_update_flow.py`** (new):
+  - Two boots with the same SHA produce zero `/fellows.db` requests
+    (regression on auto-refresh removal).
+  - Boot with mismatched SHA also produces zero `/fellows.db`
+    requests (proves opt-in).
+  - Click "Check for updates" with a mismatched SHA → "Directory Data
+    update available" appears.
+  - Click "Update directory data" with no group impact → directory
+    re-renders, toast-free, status flips to up-to-date.
+  - Click with group impact → confirm dialog appears with the right
+    members, Cancel discards, Update anyway commits.
+- **`test_orphan_soft_scan.py`** (new):
+  - Seed `relationships.db` with a `group_members` row pointing at a
+    `record_id` not in `fellows.db`. Boot. Toast appears once.
+    Reload. Toast does not reappear (`orphan_scan_done` is set).
+    Group detail shows the orphan row with Remove affordance.
+- **`test_versioned_fellows_db.py`** (existing, amend):
+  - Update the assertions: a SHA mismatch no longer triggers a
+    `/fellows.db` fetch on its own. Add a clicks-the-button case for
+    the new flow.
+
+Unit (worker-driven via `window.__dataProvider`):
+
+- `compareFellowsDbSha` correctness across (no local DB / matching /
+  mismatched / serverSha-null) cases.
+- `previewFellowsDbSwap` returns the right affected members across
+  (no groups / groups with no overlap / groups with overlap / groups
+  with multiple overlaps in same group) cases.
+- `applyFellowsDbSwap` rejects an invalid `stagingId`.
+- `findOrphanedGroupMembers` returns expected rows for seeded fixtures.
+
+## Migration
+
+No schema migration. The change is policy-only on the worker side and
+purely additive on the page side (new RPCs, new UI, removed toast +
+removed auto-refresh policy).
+
+What existing users see on the boot of the new code:
+
+1. App shell update banner appears (new `git_sha`). They click Reload
+   in their own time — nothing different about that flow.
+2. After reload, no data refresh happens automatically. Their
+   currently-installed snapshot stays.
+3. If they had pre-existing orphans from PR #113 auto-refreshes, the
+   one-time scan toast fires once and those rows are visible in their
+   group details.
+4. Next time they visit About and click "Check for updates", they see
+   the two-line status. If a data update is available, they decide
+   whether to apply it.
+
+## Doc updates
+
+Same PR:
+
+- `docs/users_manual.md` — rewrite **Updates** and **About** sections.
+  Describe the two-line status, the **Update directory data** button,
+  and the orphan-row UI. Keep the existing app-update reload-banner
+  paragraph; add a parallel paragraph for directory-data updates that
+  emphasizes opt-in. New screenshot of the About status block when an
+  update is available.
+- `docs/Architecture.md § Persistence and upgrades` — change
+  "**Re-imported** when `fellows.db.meta.json:sha` differs from
+  `build-meta.json:fellows_db_sha`" to "**Re-imported on user request**
+  when the SHAs differ; never automatically after the first install."
+- `docs/persistence_and_upgrades.md` — same edit in the storage-layer
+  table; add a row for `relationships.settings.orphan_scan_done`.
+- `plans/local_first_worker_architecture.md` — append a short note at
+  the top of Phase 3 (or in the "open questions" tail): "The silent
+  SHA-keyed refresh shipped here was superseded by opt-in updates;
+  see `plans/opt_in_directory_data_updates.md`. The fetch/import
+  mechanism is unchanged; only the trigger moved from boot to a user
+  click."
+- `README.md § Design Stance` — minor edit. Current bullet 2 is
+  "Server contact is bounded to two purposes only: (1) the magic-link
+  gate that authorizes a download, and (2) fetching new bundle / DB
+  bytes on update." Tighten "on update" to "when the user opts in to
+  an update" so the README matches the new default.
+
+## Rollout sequence
+
+1. **Worker changes** (mode split, new RPCs, new staging slot).
+   Self-contained; existing call sites still work because
+   `install-only` is the default new behavior and old callers don't
+   pass `mode`.
+2. **Page changes** (drop toast, switch to `install-only`, About-page
+   UI, confirm dialog, orphan row, soft scan).
+3. **Doc updates** in the same PR. Per CLAUDE.md, UI/UX changes ship
+   with the user-manual update.
+4. **Tests** as above. The existing `test_versioned_fellows_db.py`
+   needs amending so its assertions reflect the new policy — leaving
+   it untouched would land green and miss the regression.
+
+One PR, but I'd structure the diff as three logical commits (worker /
+page+UI / docs+tests) so review is easy.
+
+## Open follow-ups (not this plan)
+
+- Denormalize `name` + `slug` into `group_members` (schema bump on
+  `relationships.db`, 1 → 2). Makes groups fully durable against
+  record removal even without a diff dialog. Defer until / unless
+  data ever actually changes.
+- "Restore previous directory snapshot" — symmetrical to the
+  `relationships.db` restore feature. Cheap to add post-hoc since the
+  worker already knows how to atomically swap `fellows.db` slots; would
+  need a sidecar of recent snapshots in OPFS, similar to the
+  `relationships.db.bak.<ISO>` rotation. Probably overbuild for a
+  frozen-data app, but the door is open.

--- a/tests/e2e/conftest.py
+++ b/tests/e2e/conftest.py
@@ -186,14 +186,16 @@ class WorkerDataHelper:
         async () => {
           var dp = window.__dataProvider;
           if (!dp) return { groups_deleted: 0, settings_cleared: 0 };
-          // Drain any in-flight boot writes (reconcileHasEmailFilterOnBoot,
-          // reconcileSelfEmailOnBoot). Both fire on bootDirectoryAsApp and
-          // are fire-and-forget; we poll up to 1s for has_email_only to
-          // appear (it's the marker that reconcile has executed at least
-          // once on this page load).
+          // Drain any in-flight boot writes that are fire-and-forget
+          // (reconcileHasEmailFilterOnBoot, reconcileSelfEmailOnBoot,
+          // maybeRunOrphanSoftScan). Each writes a setting after boot.
+          // We poll up to 1s for has_email_only AND orphan_scan_done
+          // to land; if either is still missing after 1s the wipe
+          // proceeds anyway — the test just inherits the leaked key.
           for (var attempt = 0; attempt < 20; attempt++) {
             var probe = await dp.getSetting('has_email_only');
-            if (probe === '0' || probe === '1') break;
+            var orphan = await dp.getSetting('orphan_scan_done');
+            if ((probe === '0' || probe === '1') && orphan === '1') break;
             await new Promise(function (r) { setTimeout(r, 50); });
           }
           var groups = await dp.listGroups();

--- a/tests/e2e/test_directory_data_update_flow.py
+++ b/tests/e2e/test_directory_data_update_flow.py
@@ -1,0 +1,310 @@
+"""E2E for the opt-in directory data update flow.
+
+plans/opt_in_directory_data_updates.md. The boot path is install-only —
+covered by test_versioned_fellows_db.py:test_install_only_does_not_refetch_on_sha_mismatch.
+This file covers the user-driven path:
+
+  1. Click "Check for updates" with a mismatched fellows_db_sha →
+     "Directory Data update available" appears + the action button
+     surfaces.
+  2. Click "Update directory data" with NO group impact → silent apply,
+     status flips to "Directory data updated.", no dialog rendered.
+  3. Click with group impact → confirm dialog lists affected members.
+     Cancel restores the previous status (no swap). Update anyway
+     completes the swap and refreshes the directory in place.
+"""
+from __future__ import annotations
+
+import json
+
+from playwright.sync_api import expect
+
+from conftest import _STANDALONE_DISPLAY_INIT
+
+
+BUILD_META_PATH = "**/build-meta.json"
+
+
+def _route_build_meta(context, *, git_sha="boot-sha", fellows_db_sha=None):
+    payload = {"git_sha": git_sha, "built_at": "2026-05-06T00:00:00Z"}
+    if fellows_db_sha is not None:
+        payload["fellows_db_sha"] = fellows_db_sha
+    body = json.dumps(payload)
+
+    def _fulfill(route):
+        route.fulfill(
+            status=200,
+            content_type="application/json",
+            body=body,
+            headers={"Cache-Control": "no-cache"},
+        )
+
+    context.route(BUILD_META_PATH, _fulfill)
+
+
+def _make_standalone_page(context):
+    page = context.new_page()
+    page.add_init_script(_STANDALONE_DISPLAY_INIT)
+    return page
+
+
+def _wait_for_worker_ready(page, timeout_ms=15000):
+    """Wait for the worker provider to be live (kind='worker' on
+    window.__dataProvider).
+
+    We deliberately use a sync predicate rather than awaiting getList
+    inside the predicate. Playwright's wait_for_function with an
+    async predicate runs in an isolation that, in our app, leaves
+    `window.__dataProvider` not reachable from subsequent
+    `page.evaluate` calls — even though the value was "live" at the
+    moment the predicate resolved. Sync predicate sidesteps that.
+    """
+    page.wait_for_function(
+        "() => window.__dataProvider && window.__dataProvider.kind === 'worker'",
+        timeout=timeout_ms,
+    )
+
+
+def _boot_then_about(page, base_url):
+    """Boot the directory at `/`, wait for boot's second route() (the
+    one triggered after getFull completes) to land, THEN navigate to
+    /#/about.
+
+    Why: bootDirectoryAsApp calls route() twice — after getList and
+    after getFull. If we navigate to /#/about before getFull settles,
+    the second route() re-renders About from scratch and wipes the
+    Checking…/status text the click handler is about to set. Waiting
+    for `window.__bootMarks.get_full_done` proves the boot's second
+    route() has fired against `/`; the subsequent hashchange to
+    /#/about then runs route() once and stays put.
+    """
+    page.goto(base_url + "/", wait_until="domcontentloaded")
+    _wait_for_worker_ready(page)
+    page.wait_for_function(
+        "() => window.__bootMarks && window.__bootMarks.get_full_done != null",
+        timeout=15000,
+    )
+    page.goto(base_url + "/#/about", wait_until="domcontentloaded")
+    page.wait_for_selector("#about-check-updates", timeout=5000)
+
+
+def test_check_updates_surfaces_directory_data_button(context, base_url_fixture):
+    """Mock /build-meta.json to report a fake fellows_db_sha. Clicking
+    "Check for updates" should populate the Directory data row with
+    "Directory Data update available" and surface the action button."""
+    page = _make_standalone_page(context)
+    try:
+        # Boot with no fellows_db_sha so the cold-start ensureFellowsDb
+        # writes the real digest into meta sidecar; we'll then drift the
+        # mock's reported SHA so compare reports an update available.
+        _route_build_meta(context, git_sha="boot-sha")
+        _boot_then_about(page, base_url_fixture)
+
+        # Now drift: re-arm the mock with a deliberately different SHA.
+        context.unroute(BUILD_META_PATH)
+        _route_build_meta(context, git_sha="boot-sha", fellows_db_sha="f" * 64)
+
+        page.locator("#about-check-updates").click()
+        data_status = page.locator("#about-data-status")
+        expect(data_status).to_contain_text("Directory Data update available", timeout=5000)
+        expect(page.locator("#about-data-update-btn")).to_be_visible()
+    finally:
+        context.unroute(BUILD_META_PATH)
+        page.close()
+
+
+def test_apply_with_no_group_impact_succeeds_silently(context, base_url_fixture):
+    """No groups → no impact → no dialog. The swap commits and the
+    status flips to "Directory data updated." """
+    page = _make_standalone_page(context)
+    try:
+        _route_build_meta(context, git_sha="boot-sha")
+        _boot_then_about(page, base_url_fixture)
+
+        context.unroute(BUILD_META_PATH)
+        _route_build_meta(context, git_sha="boot-sha", fellows_db_sha="f" * 64)
+
+        page.locator("#about-check-updates").click()
+        expect(page.locator("#about-data-update-btn")).to_be_visible(timeout=5000)
+        page.locator("#about-data-update-btn").click()
+
+        data_status = page.locator("#about-data-status")
+        expect(data_status).to_contain_text("Directory data updated", timeout=10000)
+        # No dialog should have been rendered (no impact).
+        expect(page.locator("#directory-update-dialog")).to_have_count(0)
+    finally:
+        context.unroute(BUILD_META_PATH)
+        page.close()
+
+
+def test_apply_with_group_impact_shows_dialog_and_can_cancel(context, base_url_fixture):
+    """Seed a group with a synthetic record_id that's not in fellows.db,
+    so the preview reports it as affected. The dialog lists it; Cancel
+    leaves the directory unchanged."""
+    page = _make_standalone_page(context)
+    try:
+        _route_build_meta(context, git_sha="boot-sha")
+        _boot_then_about(page, base_url_fixture)
+
+        # Seed a group with a synthetic member rid that won't appear in
+        # the staged fellows.db. The worker will flag it as affected
+        # during preview.
+        page.evaluate(
+            """
+            async () => {
+              const dp = window.__dataProvider;
+              await dp.createGroup({
+                name: 'opt-in-canary',
+                note: '',
+                fellow_record_ids: ['rec_synthetic_orphan_xyz']
+              });
+            }
+            """
+        )
+
+        context.unroute(BUILD_META_PATH)
+        _route_build_meta(context, git_sha="boot-sha", fellows_db_sha="f" * 64)
+
+        page.locator("#about-check-updates").click()
+        expect(page.locator("#about-data-update-btn")).to_be_visible(timeout=5000)
+        page.locator("#about-data-update-btn").click()
+
+        # Dialog renders, lists the affected member.
+        dialog = page.locator("#directory-update-dialog")
+        expect(dialog).to_be_visible(timeout=10000)
+        expect(dialog).to_contain_text("opt-in-canary")
+        expect(dialog).to_contain_text("rec_synthetic_orphan_xyz")
+
+        # Cancel — dialog dismissed, status reflects the cancel, no swap.
+        page.locator("#directory-update-dialog-cancel").click()
+        expect(dialog).to_have_count(0)
+        expect(page.locator("#about-data-status")).to_contain_text(
+            "Update cancelled", timeout=5000
+        )
+
+        # Verify the canary group still references the orphan rid (no
+        # swap happened, so the group_members row is unchanged).
+        group_check = page.evaluate(
+            """
+            async () => {
+              const groups = await window.__dataProvider.listGroups();
+              const canary = groups.find((g) => g.name === 'opt-in-canary');
+              if (!canary) return { found: false };
+              const detail = await window.__dataProvider.getGroup(canary.id);
+              return {
+                found: true,
+                memberRids: (detail.members || []).map((m) => m.record_id)
+              };
+            }
+            """
+        )
+        assert group_check["found"], "canary group should still exist after cancel"
+        assert "rec_synthetic_orphan_xyz" in group_check["memberRids"], (
+            f"cancelled swap must leave group_members untouched; got {group_check}"
+        )
+    finally:
+        context.unroute(BUILD_META_PATH)
+        page.close()
+
+
+def test_stale_worker_surfaces_reload_affordance(context, base_url_fixture):
+    """When the page is on a newer build than the worker (the SW-upgrade
+    race), `compareFellowsDbSha` rejects with 'unknown op: ...'. The UI
+    must surface a clear "Reload the app to enable update checks" prompt
+    with a Reload button — not the generic "Couldn't check (offline?)".
+
+    Simulated by monkey-patching the provider method to throw the same
+    error shape the worker dispatcher emits for unknown ops.
+    """
+    page = _make_standalone_page(context)
+    try:
+        _route_build_meta(context, git_sha="boot-sha")
+        _boot_then_about(page, base_url_fixture)
+
+        context.unroute(BUILD_META_PATH)
+        _route_build_meta(context, git_sha="boot-sha", fellows_db_sha="f" * 64)
+
+        # Pretend the worker is older than this page: the new RPC is
+        # registered on the page-side provider (so the early
+        # 'unsupported' branch in checkForDirectoryDataUpdate doesn't
+        # fire), but calling it rejects exactly the way an old
+        # worker's dispatcher would.
+        page.evaluate(
+            """
+            () => {
+              window.__dataProvider._compareFellowsDbSha = function () {
+                return Promise.reject(new Error('unknown op: compareFellowsDbSha'));
+              };
+            }
+            """
+        )
+
+        page.locator("#about-check-updates").click()
+        data_status = page.locator("#about-data-status")
+        expect(data_status).to_contain_text(
+            "Reload the app to enable update checks", timeout=5000
+        )
+        expect(page.locator("#about-data-reload-btn")).to_be_visible()
+    finally:
+        context.unroute(BUILD_META_PATH)
+        page.close()
+
+
+def test_apply_with_group_impact_confirm_completes_swap(context, base_url_fixture):
+    """Same setup as the cancel test, but confirm the swap. After
+    apply, the directory data is refreshed and the status confirms the
+    update."""
+    page = _make_standalone_page(context)
+    try:
+        _route_build_meta(context, git_sha="boot-sha")
+        _boot_then_about(page, base_url_fixture)
+
+        page.evaluate(
+            """
+            async () => {
+              const dp = window.__dataProvider;
+              await dp.createGroup({
+                name: 'opt-in-confirm-canary',
+                note: '',
+                fellow_record_ids: ['rec_synthetic_orphan_xyz_confirm']
+              });
+            }
+            """
+        )
+
+        context.unroute(BUILD_META_PATH)
+        _route_build_meta(context, git_sha="boot-sha", fellows_db_sha="f" * 64)
+
+        page.locator("#about-check-updates").click()
+        expect(page.locator("#about-data-update-btn")).to_be_visible(timeout=5000)
+        page.locator("#about-data-update-btn").click()
+        expect(page.locator("#directory-update-dialog")).to_be_visible(timeout=10000)
+        page.locator("#directory-update-dialog-confirm").click()
+
+        expect(page.locator("#about-data-status")).to_contain_text(
+            "Directory data updated", timeout=10000
+        )
+        # The orphan rid is still in group_members (we don't auto-prune;
+        # the user removes it via the orphan row UI).
+        group_check = page.evaluate(
+            """
+            async () => {
+              const groups = await window.__dataProvider.listGroups();
+              const canary = groups.find((g) => g.name === 'opt-in-confirm-canary');
+              if (!canary) return { found: false };
+              const detail = await window.__dataProvider.getGroup(canary.id);
+              return {
+                found: true,
+                memberRids: (detail.members || []).map((m) => m.record_id)
+              };
+            }
+            """
+        )
+        assert group_check["found"]
+        assert "rec_synthetic_orphan_xyz_confirm" in group_check["memberRids"], (
+            f"orphan rid should remain in group_members until user removes it; "
+            f"got {group_check}"
+        )
+    finally:
+        context.unroute(BUILD_META_PATH)
+        page.close()

--- a/tests/e2e/test_orphan_soft_scan.py
+++ b/tests/e2e/test_orphan_soft_scan.py
@@ -1,0 +1,175 @@
+"""E2E for the post-PR-#113 orphan soft scan + orphan row UI.
+
+plans/opt_in_directory_data_updates.md. The soft scan runs once per
+profile (gated by `relationships.settings.orphan_scan_done`) to surface
+any group_members rows whose record_id is no longer in fellows.db. A
+toast fires once; subsequent boots skip it. The orphan row in group
+detail renders with a per-row Remove affordance regardless of whether
+the toast has been shown.
+"""
+from __future__ import annotations
+
+from playwright.sync_api import expect
+
+from conftest import _STANDALONE_DISPLAY_INIT
+
+
+def _make_standalone_page(context):
+    page = context.new_page()
+    page.add_init_script(_STANDALONE_DISPLAY_INIT)
+    return page
+
+
+def _wait_for_worker_ready(page, timeout_ms=15000):
+    """Wait for worker provider live (kind='worker'). Sync predicate —
+    async predicates have a quirk in this codebase that leaves
+    `window.__dataProvider` unreachable from later page.evaluate calls.
+    """
+    page.wait_for_function(
+        "() => window.__dataProvider && window.__dataProvider.kind === 'worker'",
+        timeout=timeout_ms,
+    )
+    # Wait for boot path's getFull to settle (its second route() call
+    # is what would otherwise re-render and clobber click-handler state).
+    page.wait_for_function(
+        "() => window.__bootMarks && window.__bootMarks.get_full_done != null",
+        timeout=timeout_ms,
+    )
+
+
+def _seed_orphan_group(page, group_name, orphan_rid):
+    """Create a group whose only member is a record_id that does not
+    exist in fellows.db. The soft scan + group-detail render flag this
+    as an orphan."""
+    page.evaluate(
+        """
+        async (args) => {
+          const dp = window.__dataProvider;
+          await dp.createGroup({
+            name: args.name,
+            note: '',
+            fellow_record_ids: [args.rid]
+          });
+        }
+        """,
+        {"name": group_name, "rid": orphan_rid},
+    )
+
+
+def test_soft_scan_fires_toast_once_and_marks_done(context, base_url_fixture):
+    """First boot with an orphan present: toast appears and the
+    `orphan_scan_done` setting flips to '1'. Subsequent reload does
+    not re-show the toast."""
+    page = _make_standalone_page(context)
+    try:
+        page.goto(base_url_fixture + "/", wait_until="domcontentloaded")
+        _wait_for_worker_ready(page)
+        # Wait for the boot soft scan to complete so we don't race with
+        # it when clearing the marker. The boot scan always sets the
+        # marker (whether or not orphans were found) — once we see '1'
+        # the boot scan is definitely done.
+        # NB: poll via repeated sync page.evaluate. wait_for_function
+        # with an async predicate has a quirk in this codebase (see
+        # _wait_for_worker_ready) that breaks subsequent evaluates.
+        deadline_ms = 10_000
+        elapsed = 0
+        while elapsed < deadline_ms:
+            val = page.evaluate("() => window.__dataProvider.getSetting('orphan_scan_done')")
+            if val == "1":
+                break
+            page.wait_for_timeout(200)
+            elapsed += 200
+        assert val == "1", f"boot soft scan did not set marker within {deadline_ms}ms"
+
+        # Seed an orphan group + clear the marker so the next boot's
+        # scan re-runs against the now-orphan-bearing relationships.db.
+        page.evaluate(
+            """
+            async () => {
+              const dp = window.__dataProvider;
+              await dp.createGroup({
+                name: 'orphan-toast-canary',
+                note: '',
+                fellow_record_ids: ['rec_orphan_for_toast_scan']
+              });
+              await dp.setSetting('orphan_scan_done', '');
+            }
+            """
+        )
+
+        page.reload(wait_until="domcontentloaded")
+        _wait_for_worker_ready(page)
+
+        toast = page.locator("#app-toast")
+        expect(toast).to_be_visible(timeout=10000)
+        expect(toast).to_contain_text("no longer in the directory")
+
+        # Marker is set after the scan runs.
+        marker = page.evaluate("() => window.__dataProvider.getSetting('orphan_scan_done')")
+        assert marker == "1", f"orphan_scan_done should be set after scan; got {marker!r}"
+
+        # Reload again — marker prevents the toast from re-firing.
+        # Wait long enough that a fresh toast would have been visible.
+        page.reload(wait_until="domcontentloaded")
+        _wait_for_worker_ready(page)
+        page.wait_for_timeout(500)
+        # Either the toast element doesn't exist yet (no toast was
+        # triggered this boot), or it exists but is not visible.
+        toast_count = page.locator("#app-toast.app-toast--visible").count()
+        assert toast_count == 0, (
+            f"orphan toast should not re-appear after marker is set; got count={toast_count}"
+        )
+    finally:
+        page.close()
+
+
+def test_orphan_row_renders_with_remove_affordance(context, base_url_fixture):
+    """Group detail flags orphan members and offers a Remove button.
+    Clicking Remove drops the row from group_members and re-renders."""
+    page = _make_standalone_page(context)
+    try:
+        page.goto(base_url_fixture + "/", wait_until="domcontentloaded")
+        _wait_for_worker_ready(page)
+
+        _seed_orphan_group(
+            page, group_name="orphan-row-canary", orphan_rid="rec_orphan_for_row_render"
+        )
+        # Look up the group ID and navigate.
+        group_id = page.evaluate(
+            """
+            async () => {
+              const groups = await window.__dataProvider.listGroups();
+              const g = groups.find((x) => x.name === 'orphan-row-canary');
+              return g ? g.id : null;
+            }
+            """
+        )
+        assert group_id is not None, "seeded group should be visible via listGroups"
+        page.goto(base_url_fixture + "/#/groups/" + str(group_id), wait_until="domcontentloaded")
+
+        orphan_row = page.locator(".group-detail-member-orphan")
+        expect(orphan_row).to_be_visible(timeout=5000)
+        expect(orphan_row).to_contain_text("Profile no longer available")
+        expect(orphan_row).to_contain_text("rec_orphan_for_row_render")
+
+        remove_btn = page.locator(".group-detail-orphan-remove")
+        expect(remove_btn).to_be_visible()
+        remove_btn.click()
+
+        # After the remove call settles + the page re-renders, the orphan
+        # row is gone and the group has zero members.
+        expect(page.locator(".group-detail-member-orphan")).to_have_count(0, timeout=10000)
+        members = page.evaluate(
+            """
+            async (gid) => {
+              const detail = await window.__dataProvider.getGroup(gid);
+              return (detail.members || []).map((m) => m.record_id);
+            }
+            """,
+            group_id,
+        )
+        assert members == [], (
+            f"Remove should drop the rid from group_members; got {members}"
+        )
+    finally:
+        page.close()

--- a/tests/e2e/test_update_check.py
+++ b/tests/e2e/test_update_check.py
@@ -1,9 +1,12 @@
 """E2E tests: About-page "Check for updates" button + server-drift banner.
 
-Exercises the Phase-2 update check: a boot snapshot of ``/build-meta.json``
-is compared against the latest value each time the user clicks the button
-(and, in production, once an hour). When the server git_sha has changed,
-the shared ``#sw-update-banner`` is surfaced so the user can reload.
+Exercises the two-row update status block on About. A single button
+drives both the app-shell check (existing checkForServerUpdate, which
+raises the SW reload banner on `git_sha` drift) and the directory-data
+check (compareFellowsDbSha). Each row populates its own status text and
+optional action button independently.
+
+plans/opt_in_directory_data_updates.md.
 """
 import json
 
@@ -16,11 +19,14 @@ from conftest import _STANDALONE_DISPLAY_INIT
 BUILD_META_PATH = "**/build-meta.json"
 
 
-def _route_build_meta(context, git_sha, built_at="2026-04-20T00:00:00Z"):
+def _route_build_meta(context, git_sha, fellows_db_sha=None, built_at="2026-04-20T00:00:00Z"):
     # NB: use context.route (not page.route) — page.route only fires for the
     # first matching request in our Playwright version; the boot fetch and the
     # button-click fetch both need to be mocked.
-    body = json.dumps({"git_sha": git_sha, "built_at": built_at})
+    payload = {"git_sha": git_sha, "built_at": built_at}
+    if fellows_db_sha is not None:
+        payload["fellows_db_sha"] = fellows_db_sha
+    body = json.dumps(payload)
 
     def _fulfill(route):
         route.fulfill(
@@ -53,8 +59,9 @@ class TestAboutUpdateCheck:
             btn = page.locator("#about-check-updates")
             expect(btn).to_be_visible()
             btn.click()
-            status = page.locator("#about-update-status")
-            expect(status).to_contain_text("latest version", timeout=5000)
+            # App row shows "up to date" when git_sha matches.
+            app_status = page.locator("#about-app-status")
+            expect(app_status).to_contain_text("up to date", timeout=5000)
             expect(page.locator("#sw-update-banner")).to_be_hidden()
         finally:
             context.unroute(BUILD_META_PATH)
@@ -72,8 +79,10 @@ class TestAboutUpdateCheck:
             _route_build_meta(context, git_sha="xyz999")
 
             page.locator("#about-check-updates").click()
-            status = page.locator("#about-update-status")
-            expect(status).to_contain_text("New version available", timeout=5000)
+            app_status = page.locator("#about-app-status")
+            expect(app_status).to_contain_text("App update available", timeout=5000)
+            # The Reload affordance lives in the action cell.
+            expect(page.locator("#about-app-update-btn")).to_be_visible()
             expect(page.locator("#sw-update-banner")).to_be_visible()
         finally:
             context.unroute(BUILD_META_PATH)
@@ -94,8 +103,8 @@ class TestAboutUpdateCheck:
             )
 
             page.locator("#about-check-updates").click()
-            status = page.locator("#about-update-status")
-            expect(status).to_contain_text("Unable to reach", timeout=5000)
+            app_status = page.locator("#about-app-status")
+            expect(app_status).to_contain_text("Couldn", timeout=5000)
             expect(page.locator("#sw-update-banner")).to_be_hidden()
         finally:
             context.unroute(BUILD_META_PATH)

--- a/tests/e2e/test_versioned_fellows_db.py
+++ b/tests/e2e/test_versioned_fellows_db.py
@@ -1,17 +1,23 @@
-"""E2E for Phase 3 versioned, atomic fellows.db updates.
+"""E2E for the fellows.db install + opt-in refresh primitives.
 
-Phase 3 of plans/local_first_worker_architecture.md: the worker stops
-re-importing fellows.db on every boot. The page reads `fellows_db_sha`
-from /build-meta.json and passes it to the worker's `ensureFellowsDb`;
-the worker compares against the SHA recorded in OPFS-side
-`fellows.db.meta.json` and fetches only on mismatch.
+Originally Phase 3 of plans/local_first_worker_architecture.md ("SHA-keyed
+refresh"). plans/opt_in_directory_data_updates.md narrowed the policy:
+the boot path is install-only (never auto-refreshes a returning
+visitor), and the user-driven "Update directory data" button on the
+About page is the only way an installed fellows.db ever gets replaced.
+The worker primitive (`ensureFellowsDb({mode: 'refresh'})`) still exists
+and is what `applyFellowsDbSwap` builds on; this file pins that
+primitive's behavior. The boot-path policy is covered by
+`test_directory_data_update_flow.py`.
 
-This file covers the four runtime-falsifiable acceptance criteria:
+This file covers four runtime-falsifiable acceptance criteria:
 
-  1. Two consecutive returning boots with the same fellows_db_sha
-     produce zero GET /fellows.db requests on the second boot.
-  2. Bumping fellows_db_sha (via /build-meta.json mock) triggers exactly
-     one GET /fellows.db; meta.sha rotates to the freshly-computed digest.
+  1. Two consecutive returning boots produce zero GET /fellows.db
+     requests on the second boot — install-only is the default.
+  2. ensureFellowsDb({mode: 'refresh'}) triggers exactly one GET
+     /fellows.db; meta.sha rotates to the freshly-computed digest.
+     This is the primitive applyFellowsDbSwap leans on — preserving
+     it keeps the user-driven swap path testable.
   3. A failed refresh (network error or non-2xx) leaves the previously
      live fellows.db intact and writes meta.last_failure_* — the
      directory keeps rendering against the cached bytes.
@@ -117,9 +123,14 @@ def test_matching_sha_makes_no_second_fetch(standalone_page, base_url_fixture):
     )
 
 
-def test_changed_sha_triggers_one_refetch(standalone_page, base_url_fixture):
-    """Bumping fellows_db_sha rotates meta.sha to the actual fetched digest
-    and produces exactly one GET /fellows.db on the next ensureFellowsDb."""
+def test_explicit_refresh_triggers_one_refetch(standalone_page, base_url_fixture):
+    """ensureFellowsDb({mode: 'refresh'}) rotates meta.sha to the actual
+    fetched digest and produces exactly one GET /fellows.db.
+
+    This is the worker primitive applyFellowsDbSwap builds on — it must
+    keep working under direct invocation even though boot-path callers
+    now always use mode='install-only'. plans/opt_in_directory_data_updates.md.
+    """
     page = standalone_page
 
     # Boot once normally so OPFS has a fellows.db + meta installed.
@@ -130,8 +141,8 @@ def test_changed_sha_triggers_one_refetch(standalone_page, base_url_fixture):
     )
     real_sha = meta_before["sha"]
 
-    # Now drive a refresh by passing a different serverSha to the worker.
-    # The worker treats this as "server has new bytes" and re-fetches.
+    # Drive an explicit refresh — install-only would no-op even with a
+    # different serverSha, so we have to opt in via mode='refresh'.
     requests: list[str] = []
     page.on(
         "request",
@@ -139,16 +150,16 @@ def test_changed_sha_triggers_one_refetch(standalone_page, base_url_fixture):
     )
     fake_server_sha = "f" * 64  # syntactically a SHA-256 hex but not a real digest
     result = page.evaluate(
-        "(sha) => window.__dataProvider._ensureFellowsDb({ serverSha: sha })",
+        "(sha) => window.__dataProvider._ensureFellowsDb({ serverSha: sha, mode: 'refresh' })",
         fake_server_sha,
     )
 
     assert result.get("refreshed") is True, (
-        f"SHA mismatch should trigger a refresh; got result={result}"
+        f"explicit refresh should re-import; got result={result}"
     )
     fetched = [r for r in requests if r.endswith("/fellows.db")]
     assert len(fetched) == 1, (
-        f"changed SHA must produce exactly one GET /fellows.db; got {fetched}"
+        f"explicit refresh must produce exactly one GET /fellows.db; got {fetched}"
     )
     # meta.sha is the digest the worker computed over the fetched bytes —
     # not the serverSha the page passed in. The dev server returns the
@@ -157,6 +168,56 @@ def test_changed_sha_triggers_one_refetch(standalone_page, base_url_fixture):
         f"meta.sha must reflect the digest of fetched bytes (server-returned sha "
         f"{real_sha}), not the serverSha the page passed in ({fake_server_sha}); "
         f"got {result['meta']['sha']}"
+    )
+
+
+def test_install_only_does_not_refetch_on_sha_mismatch(standalone_page, base_url_fixture):
+    """Install-only is a hard policy: even if the page hands the worker a
+    different serverSha, no fetch happens when fellowsDb is already open.
+
+    This is the boot-path contract — without it, every reload after a
+    deploy would silently re-import fellows.db and the user could see
+    profile data change underneath them. plans/opt_in_directory_data_updates.md.
+    """
+    page = standalone_page
+
+    # Cold-start boot.
+    page.goto(base_url_fixture + "/", wait_until="domcontentloaded")
+    meta_before = _wait_for_first_ensure(page)
+    assert meta_before and meta_before.get("sha")
+    sha_before = meta_before["sha"]
+
+    requests: list[str] = []
+    page.on(
+        "request",
+        lambda req: requests.append(req.url) if req.url.endswith("/fellows.db") else None,
+    )
+    fake_server_sha = "f" * 64
+    # Default mode (no `mode` arg) coerces to 'install-only'; explicit
+    # mode='install-only' is the same. Either way: no fetch, no refresh.
+    for mode_arg in (None, "install-only"):
+        if mode_arg is None:
+            result = page.evaluate(
+                "(sha) => window.__dataProvider._ensureFellowsDb({ serverSha: sha })",
+                fake_server_sha,
+            )
+        else:
+            result = page.evaluate(
+                "(args) => window.__dataProvider._ensureFellowsDb(args)",
+                {"serverSha": fake_server_sha, "mode": mode_arg},
+            )
+        assert result.get("refreshed") is False, (
+            f"install-only with SHA mismatch must NOT refresh "
+            f"(mode={mode_arg!r}); got result={result}"
+        )
+        assert result["meta"]["sha"] == sha_before, (
+            f"install-only no-op must leave meta.sha unchanged; "
+            f"before={sha_before} after={result['meta']['sha']}"
+        )
+    fetched = [r for r in requests if r.endswith("/fellows.db")]
+    assert len(fetched) == 0, (
+        f"install-only must produce zero GET /fellows.db requests "
+        f"regardless of SHA; got {fetched}"
     )
 
 
@@ -190,7 +251,8 @@ def test_failed_refresh_preserves_previous_db_and_records_failure(
             async () => {
               try {
                 const res = await window.__dataProvider._ensureFellowsDb({
-                  serverSha: 'f'.repeat(64)
+                  serverSha: 'f'.repeat(64),
+                  mode: 'refresh'
                 });
                 return { ok: true, res };
               } catch (e) {


### PR DESCRIPTION
## Summary

Reverses the auto-refresh policy for `fellows.db`. The boot path is now **install-only**: a returning visitor's directory snapshot never changes underneath them. App-shell updates keep their existing auto-prompt + reload-banner flow; *directory data* updates are user-initiated from the About page.

The mechanism (SHA-keyed fetch / validate / atomic-swap) is unchanged from PR #113 — only the trigger moved from boot-time SHA mismatch to a user click. Plan: [`plans/opt_in_directory_data_updates.md`](https://github.com/richbodo/fellows_local_db/blob/feat/opt-in-directory-data-updates/plans/opt_in_directory_data_updates.md).

### What's new

- **Two-row update status block on About** — App row + Directory data row, single ceremonial *Check for updates* button drives both.
- **Update directory data** button surfaces only when an update is available. Before swapping, the worker computes which `group_members.fellow_record_id`s would no longer have a profile and surfaces a confirm dialog naming them. Cancel discards the staged bytes.
- **Orphan rows in group detail** — members whose record_id is missing from the live `fellows.db` render as *Profile no longer available (record_id: …)* with a per-row Remove. Soft scan on first boot of the new code surfaces a single toast for orphans created by past auto-refreshes (PR #113 era).
- **Stale-worker reload affordance** — during the SW upgrade race (page on new build, worker still on old bundle), the directory check now surfaces *Reload the app to enable update checks* with a Reload button instead of the misleading *Couldn't check (offline?)*.

### Worker (commit 1)

`ensureFellowsDb({mode})` split: `'install-only'` is the new default and the boot policy; `'refresh'` is what `applyFellowsDbSwap` builds on. Five new RPCs back the user-driven flow: `compareFellowsDbSha`, `previewFellowsDbSwap`, `applyFellowsDbSwap`, `cancelFellowsDbSwap`, `findOrphanedGroupMembers`. `WORKER_RPC_VERSION` unchanged (additive only).

### Page + UI (commit 2)

About-page rewrite, confirm dialog, orphan rendering, soft-scan helper, boot-path policy switch. Stale-worker detection in `checkForDirectoryDataUpdate` catches `unknown op` and surfaces the Reload prompt. `window.__bootMarks` exposed for e2e wait helpers.

### Docs + tests (commit 3)

users_manual.md *Updates* + *About* sections rewritten. Architecture.md, persistence_and_upgrades.md, README.md tightened. Phase 3 of `local_first_worker_architecture.md` annotated with a supersession note. Five new e2e cases in `test_directory_data_update_flow.py` (incl. the stale-worker reload affordance), two in `test_orphan_soft_scan.py`, plus amendments to `test_versioned_fellows_db.py` and `test_update_check.py` for the new API and IDs.

## Test plan

- [x] `just test-fast` — 63 passed
- [x] `just test-e2e` — 169 passed, 12 skipped (mobile-only screenshot tests skipped by existing fixture gates), 0 failed
- [ ] **Manual smoke after merge + deploy:**
  - [ ] Visit `/#/about`, confirm two-row status block renders with build labels.
  - [ ] Click *Check for updates* — both rows populate; with no server change, both read *up to date*.
  - [ ] Roll a fresh `fellows.db` (e.g., `just db-rebuild` then `just deploy`); on a returning visitor's app, confirm boot does NOT auto-refresh and that *Check for updates* now surfaces *Directory Data update available* + the action button.
  - [ ] Click *Update directory data* with no impacted groups — silent apply, status flips to *Directory data updated.*.
  - [ ] Repeat with a group whose member is being removed — confirm dialog names the member, *Cancel* preserves group_members, *Update anyway* completes.
  - [ ] Verify the orphan row + Remove button on group detail.
  - [ ] After deploy, on a tab that was open mid-deploy, expect the stale-worker reload prompt on the directory data row; click Reload, then *Check for updates* should work.

## Follow-ups (out of scope)

- Denormalize `name` / `slug` into `group_members` so groups are durable against record removal even without the diff dialog. Schema bump on `relationships.db` (1 → 2). Defer until / unless data ever actually changes.
- Restore-previous-snapshot for `fellows.db`, parallel to the existing `relationships.db` backup rotation.

🤖 Generated with [Claude Code](https://claude.com/claude-code)