### PR TITLE
feat: surface boot phases and a 20s watchdog recovery panel

### DIFF
--- a/app/static/app.js
+++ b/app/static/app.js
@@ -10,6 +10,9 @@
   var loadingPanelEl = document.getElementById('loading-panel');
   var bootErrorPanelEl = document.getElementById('boot-error-panel');
   var bootErrorPreEl = document.getElementById('boot-error-pre');
+  var bootStuckPanelEl = document.getElementById('boot-stuck-panel');
+  var bootStuckLastMarkEl = document.getElementById('boot-stuck-last-mark');
+  var bootStuckElapsedEl = document.getElementById('boot-stuck-elapsed-secs');
   var authErrorPanelEl = document.getElementById('auth-error-panel');
   var authErrorPreEl = document.getElementById('auth-error-pre');
   var appWrapEl = document.getElementById('app-wrap');
@@ -1651,6 +1654,112 @@
     }
   }
 
+  // Boot watchdog. The bootDirectoryAsApp Promise chain has no built-in
+  // timeout: if the worker init resolves (we've already got an 8 s timeout
+  // there) but a subsequent RPC like _ensureFellowsDb or getList hangs —
+  // an OPFS contention edge case, an unresponsive cached fellows.db, an
+  // SW that won't deliver a network response — the user just sees
+  // "Loading…" forever. The watchdog fires after BOOT_WATCHDOG_MS to
+  // surface that state with actionable recovery affordances rather than
+  // letting the user guess.
+  //
+  // Cleared on bootMark('get_list_done') (the first moment the directory
+  // is known-renderable) and on .catch in bootDirectoryAsApp (different
+  // failure path; showBootFailure already has the user covered).
+  //
+  // The ?wd=<ms> URL parameter overrides the timer for e2e tests; bounded
+  // to a sane range so it can't be abused into an infinite loop or a
+  // pathological 0-delay.
+  var BOOT_WATCHDOG_MS = (function () {
+    try {
+      var raw = new URLSearchParams(location.search).get('wd');
+      var n = raw == null ? null : parseInt(raw, 10);
+      if (n != null && isFinite(n) && n >= 100 && n <= 60000) return n;
+    } catch (e) {}
+    return 20000;
+  })();
+  var bootWatchdog = {
+    state: 'idle',     // idle → pending → cleared|fired
+    startedAt: null,
+    lastMark: null,
+    timerId: null,
+    elapsedMs: null
+  };
+  // Exposed for e2e tests that need to assert the watchdog has fired or
+  // not without re-implementing the timer logic. Read-only by convention.
+  window.__bootWatchdog = bootWatchdog;
+
+  // Returns the most recent bootMark name (insertion order in bootMarks).
+  // bootMark is idempotent so insertion order is the order phases first
+  // completed; the last-inserted key is therefore "the latest phase that
+  // finished" — the load-bearing context for the recovery panel.
+  function lastCompletedBootMark() {
+    var keys = Object.keys(bootMarks);
+    return keys.length ? keys[keys.length - 1] : null;
+  }
+
+  function startBootWatchdog() {
+    if (bootWatchdog.state !== 'idle') return;
+    bootWatchdog.state = 'pending';
+    bootWatchdog.startedAt = _bootMs();
+    bootWatchdog.timerId = setTimeout(function () {
+      if (bootWatchdog.state !== 'pending') return;
+      bootWatchdog.state = 'fired';
+      bootWatchdog.lastMark = lastCompletedBootMark();
+      bootWatchdog.elapsedMs = _bootMs() - bootWatchdog.startedAt;
+      bootDebugPush(
+        'boot watchdog: stuck after ' + BOOT_WATCHDOG_MS +
+        'ms; last mark=' + (bootWatchdog.lastMark || '(none)')
+      );
+      // Telemetry so the operator sees stuck-boot rates in journald
+      // without depending on the user clicking Send report. Cardinality
+      // bounded to one event per page load by the state machine.
+      try {
+        reportWorkerEvent('boot_stuck', String(bootWatchdog.lastMark || 'unknown'));
+      } catch (e) {}
+      showBootStuck(bootWatchdog.lastMark);
+    }, BOOT_WATCHDOG_MS);
+  }
+
+  function clearBootWatchdog(reason) {
+    if (bootWatchdog.state !== 'pending') return;
+    bootWatchdog.state = 'cleared';
+    bootWatchdog.lastMark = lastCompletedBootMark();
+    bootWatchdog.elapsedMs = bootWatchdog.startedAt != null
+      ? _bootMs() - bootWatchdog.startedAt
+      : null;
+    if (bootWatchdog.timerId != null) {
+      clearTimeout(bootWatchdog.timerId);
+      bootWatchdog.timerId = null;
+    }
+    bootDebugPush(
+      'boot watchdog: cleared (' + (reason || 'unspecified') +
+      ') at last mark=' + (bootWatchdog.lastMark || '(none)') +
+      ' elapsed=' + (bootWatchdog.elapsedMs != null ? bootWatchdog.elapsedMs + 'ms' : '?')
+    );
+  }
+
+  function showBootStuck(lastMark) {
+    if (loadingEl) loadingEl.classList.add('hidden');
+    if (bootStuckLastMarkEl) {
+      bootStuckLastMarkEl.textContent = lastMark || 'starting up';
+    }
+    if (bootStuckElapsedEl) {
+      bootStuckElapsedEl.textContent = String(Math.round(BOOT_WATCHDOG_MS / 1000));
+    }
+    if (bootStuckPanelEl) bootStuckPanelEl.classList.remove('hidden');
+    // Capture a snapshot of the boot trace into the bug-report ring so
+    // the Send-report button (sync-only path) carries enough context
+    // without an awaitable diagnostics probe — the reason we ended up
+    // here is precisely that async probes can hang.
+    pushBugReportError(
+      'boot',
+      'boot_stuck',
+      'last_mark=' + String(lastMark || 'unknown') +
+      ' elapsed=' + BOOT_WATCHDOG_MS + 'ms'
+    );
+  }
+
   function clearCookiesBestEffort() {
     var cookiePairs = (document.cookie || '').split(';');
     cookiePairs.forEach(function (cookie) {
@@ -2636,6 +2745,7 @@
       'bug-report-button-install',
       'bug-report-button-gate',
       'bug-report-button-boot-error',
+      'bug-report-button-boot-stuck',
       'bug-report-button-auth-error'
     ];
     ids.forEach(function (id) {
@@ -2647,6 +2757,31 @@
         openBugReportDialog({ syncOnly: syncOnly });
       });
     });
+  }
+
+  // Wires the Reload and Clear-App-Cache buttons inside the boot-stuck
+  // recovery panel. Both delegate to existing global affordances rather
+  // than duplicating logic — Reload is a plain location.reload(), and
+  // Clear App Cache routes through the global #clear-app-cache-button
+  // so the click is indistinguishable from the user pressing the same
+  // button at the bottom of the page (single source of truth for the
+  // confirm dialog + clearAllAppData re-entrancy guards).
+  function initBootStuckPanelButtons() {
+    var reloadBtn = document.getElementById('boot-stuck-reload-button');
+    if (reloadBtn) {
+      reloadBtn.addEventListener('click', function (ev) {
+        ev.preventDefault();
+        window.location.reload();
+      });
+    }
+    var clearBtn = document.getElementById('boot-stuck-clear-cache-button');
+    if (clearBtn) {
+      clearBtn.addEventListener('click', function (ev) {
+        ev.preventDefault();
+        var globalBtn = document.getElementById('clear-app-cache-button');
+        if (globalBtn) globalBtn.click();
+      });
+    }
   }
 
   // ===== Mobile shell: appbar + tabs + kebab sheet =======================
@@ -7976,6 +8111,7 @@
   initResetEverythingButton();
   initDiagnosticsPanel();
   initBugReportButtons();
+  initBootStuckPanelButtons();
   initKebabSheet();
   initComposerFab();
   initGroupCardSheet();
@@ -7991,6 +8127,19 @@
     if (loadingEl) {
       loadingEl.classList.remove('hidden');
     }
+    // Replace the static "Loading…" with a phase that conveys "we've
+    // started." The next two checkpoints (Setting up local database… /
+    // Loading directory…) update as the boot chain progresses, so a
+    // user looking at a stuck tab can at least tell which phase
+    // stalled. The watchdog uses bootMarks (not these strings) for
+    // its lastMark report; the user-facing strings can drift without
+    // affecting telemetry.
+    setSetupStatus('Starting up…');
+    // Start the boot watchdog. Cleared on get_list_done (success) or in
+    // the .catch (failure path that already has its own panel). Only
+    // armed in directory boot; the email-gate / install-landing paths
+    // settle synchronously and don't need a hang surface.
+    startBootWatchdog();
     // Restore the in-progress group draft (members + auto-title state)
     // before any rendering so the rail and markers come up consistent.
     loadGroupDraft();
@@ -8052,6 +8201,14 @@
       });
     }
 
+    // pickDataProvider is the slow part of cold-start boot: worker spawn,
+    // OPFS attach, optional fellows.db fetch + import. Surface the phase
+    // to the user so a tab that takes 10+ s on a fresh install isn't
+    // indistinguishable from a hung one. The SW cache-progress handler
+    // above will overwrite this transiently with byte counts when the
+    // shell precache is populating; that's intentional — bytes are
+    // more concrete than a label.
+    setSetupStatus('Setting up local database…');
     pickDataProvider()
       .then(function (provider) {
         dataProvider = provider;
@@ -8077,7 +8234,7 @@
         // ehf_has_email_only from localStorage-only into the durable
         // relationships.settings store on first post-PR-D boot.
         reconcileHasEmailFilterOnBoot();
-        setSetupStatus('Loading…');
+        setSetupStatus('Loading directory…');
         return provider.getList().catch(function (err) {
           if (isAuthFailure(err)) return tryListFromCache(err);
           throw err;
@@ -8085,6 +8242,7 @@
       })
       .then(function (data) {
         bootMark('get_list_done');
+        clearBootWatchdog('get_list_done');
         bootDebugPush(
           'getList: OK count=' + (Array.isArray(data) ? data.length : typeof data) +
           (offlineOnlyMode ? ' (from cache)' : '')
@@ -8160,6 +8318,12 @@
         maybeRunOrphanSoftScan();
       })
       .catch(function (err) {
+        // Either branch below settles the boot one way or another, so the
+        // watchdog is no longer load-bearing — clear it before we route
+        // the user. Without this clear, a slow .catch path could trip
+        // the watchdog after we've already shown the gate or boot-error
+        // panel, double-rendering recovery affordances.
+        clearBootWatchdog('boot_failure');
         // Only reached when the API refused us AND no local cache could
         // answer. In browser-tab-acting-as-app mode, hand off to the
         // email gate quietly. Otherwise show the boot-failure panel.

--- a/app/static/index.html
+++ b/app/static/index.html
@@ -273,6 +273,25 @@
         >Send this report to the maintainer</button>
       </p>
     </div>
+    <div id="boot-stuck-panel" class="boot-error-panel hidden" role="alert">
+      <p class="boot-error-lead"><strong>This is taking longer than expected.</strong></p>
+      <p class="boot-error-hint">
+        The directory hasn't finished loading after <span id="boot-stuck-elapsed-secs">20</span> seconds.
+        The last step that completed was <code id="boot-stuck-last-mark">starting up</code>.
+        That usually means a stuck service worker, a slow or unresponsive database, or a transient network issue.
+      </p>
+      <p class="boot-error-actions">
+        <button type="button" id="boot-stuck-reload-button" class="bug-report-inline-button">Reload</button>
+        <button type="button" id="boot-stuck-clear-cache-button" class="bug-report-inline-button">Clear App Cache &amp; Reload</button>
+        <button
+          type="button"
+          id="bug-report-button-boot-stuck"
+          class="bug-report-inline-button"
+          data-bug-report-context="boot-stuck"
+          data-sync-only="1"
+        >Send report to the maintainer</button>
+      </p>
+    </div>
   </div>
   <div id="auth-error-panel" class="auth-error-panel hidden" role="alert">
     <p class="boot-error-lead"><strong>Authentication check failed.</strong></p>

--- a/docs/email_gate.md
+++ b/docs/email_gate.md
@@ -158,7 +158,7 @@ What the maintainer can read in journald:
 - **Route** — the URL hash route the user was on, with these substitutions: query string dropped (`?…`), `#/fellow/<slug>` redacted to `#/fellow/<redacted>`, `#/unlock/<token>` redacted to `#/unlock/<token>` placeholder (token leak would grant a session).
 - **Display mode** — `"standalone"` (installed PWA) or `"browser-tab"`. Other values dropped.
 - **Online flag** — `Boolean(navigator.onLine)`.
-- **Events** (up to 20) — each has a `kind` from a fixed allow-list (`http`, `sw`, `window.error`, `unhandledrejection`, `console.error`), an optional ISO `ts` (length-capped, not parsed), a `msg` (up to 500 chars, with email + slug + token redaction applied), and an optional `extra` (up to 200 chars, same redaction). Unknown kinds are silently dropped.
+- **Events** (up to 20) — each has a `kind` from a fixed allow-list (`http`, `sw`, `window.error`, `unhandledrejection`, `console.error`, `install`, `worker`), an optional ISO `ts` (length-capped, not parsed), a `msg` (up to 500 chars, with email + slug + token redaction applied), and an optional `extra` (up to 200 chars, same redaction). Unknown kinds are silently dropped.
 - **`lastSubmitHashPrefix`** — only if it matches `^[0-9a-f]{12}$`. This is `sha256(email).slice(0,12)` from a prior gate submit; it's the same join key the server already logs as `email_hash_prefix` in `event=send_unlock_email`. Not reversible to an email at this length, but stable enough to grep journald and find the matching send attempt.
 - **`client_ip_prefix`** — first 12 hex of `sha256(client_ip)`. The raw IP is *never* logged. The hash is stable enough that two reports from the same client cluster together; opaque enough that a journald audit doesn't expose a per-fellow source map.
 
@@ -223,6 +223,19 @@ just prod-stats '7 days ago'   # weekly view
 ```
 
 `just prod-stats` parses these events out of journald and renders an `Install funnel:` section under `Client error reports`. Each row counts events by `msg`; `outcome_*` rows include a per-platform breakdown from `extra` (typically `web` for Chrome/Edge/Android Chrome). The section is hidden when there's no install activity in the window. See `scripts/prod_stats.py:_print_install_funnel` for the renderer.
+
+#### `kind=worker` events
+
+Spawn / init outcomes for the dedicated SQLite worker (`vendor/sqlite-worker.js`), used to triage cold-start failures and stuck-boot reports. One event per worker spawn outcome plus, after the boot watchdog ships, one event per stuck boot. Cardinality is bounded — the worker spawns at most twice per page load (warm + at most one re-spawn), and `boot_stuck` fires at most once.
+
+| `msg` | Fired when |
+|---|---|
+| `spawn_ok` | Warm worker `init` RPC succeeded. `extra` carries `rpc=<n> schema=<n> opfsCapable=<bool> hasFellowsDb=<bool> hasRelDb=<bool>`. |
+| `spawn_failed` | Worker construction or `init` RPC failed (timeout, OPFS init error, etc.). `extra` carries the truncated error message. |
+| `ownership_conflict` | Worker init refused because another tab already holds the OPFS SAH-pool. Signals that "this app is already open in another tab" panel was shown. |
+| `boot_stuck` | `bootDirectoryAsApp` did not reach `get_list_done` within `BOOT_WATCHDOG_MS` (20 s default). `extra` carries the last completed `bootMark` name (`script_start`, `pick_provider_start`, `worker_init_done`, `provider_ready`, …) — this is the load-bearing diagnostic. The recovery panel surfaces the same name to the user. |
+
+Operator query: `journalctl -u fellows-pwa | grep '"kind": "worker"'`. Pair `boot_stuck` events with the user's `ua` and `lastSubmitHashPrefix` (if any) to find the matching session and reproduce.
 
 ### Anti-abuse posture
 

--- a/docs/users_manual.md
+++ b/docs/users_manual.md
@@ -348,6 +348,24 @@ A confirm dialog spells out what's lost before it runs. In-progress
 group drafts are lost in either reset (drafts are unsaved by
 definition).
 
+### When the directory hangs at "Loading…"
+
+Rare, but it can happen — usually a stuck service worker or an
+unresponsive local database after a deploy. After about 20 seconds of
+no progress the app replaces the loading message with a recovery
+panel that names the last completed phase and gives you three options:
+
+- **Reload** — try again with a fresh page load. Fixes most stuck
+  service-worker cases on its own.
+- **Clear App Cache & Reload** — same as the red button at the
+  bottom of the page. Wipes the shell cache and signs you out, but
+  keeps your saved groups and the on-device fellow data.
+- **Send report to the maintainer** — opens the bug-report dialog
+  pre-filled with the boot trace so we can see where it stalled.
+
+Try Reload first; if that doesn't help, Clear App Cache. Send the
+report if both fail — that's the case where we want to hear about it.
+
 ---
 
 ## Reporting a bug

--- a/tests/e2e/test_boot_watchdog.py
+++ b/tests/e2e/test_boot_watchdog.py
@@ -1,0 +1,113 @@
+"""E2E: boot watchdog surfaces a recovery panel when boot stalls.
+
+The watchdog catches the gap between worker init success and getList
+success — the blind spot we hit on 2026-05-06 when use-in-tab booted
+into an indefinite "Loading…" with no actionable feedback. With the
+watchdog, a stalled boot flips to a panel that names the last
+completed phase and offers Reload / Clear App Cache / Send report.
+
+The ?wd=<ms> URL override shortens BOOT_WATCHDOG_MS so these tests
+finish in well under a second.
+"""
+from __future__ import annotations
+
+import pytest
+from playwright.sync_api import expect
+
+
+class TestBootWatchdog:
+    def test_watchdog_fires_and_shows_recovery_panel_when_boot_hangs(
+        self, page, base_url_fixture
+    ):
+        """Block the two endpoints bootDirectoryAsApp ultimately needs:
+        - /fellows.db (worker cold-start fetch via _ensureFellowsDb)
+        - /api/fellows (api+idb fallback when worker unavailable)
+
+        With both blocked, the boot chain stalls. The shortened
+        watchdog fires and the panel appears.
+        """
+
+        def _hang(route):
+            # Returning without calling continue/fulfill/abort holds
+            # the request pending. The watchdog fires well before any
+            # network timeout.
+            pass
+
+        page.route("**/api/fellows*", _hang)
+        page.route("**/fellows.db", _hang)
+
+        page.goto(base_url_fixture + "/?wd=300", wait_until="domcontentloaded")
+
+        # The recovery panel should become visible inside #loading-panel
+        # within a couple of seconds (300 ms timer + ~hundred ms render).
+        page.wait_for_selector("#boot-stuck-panel:not(.hidden)", timeout=5000)
+        expect(page.locator("#boot-stuck-panel")).to_be_visible()
+
+        # The watchdog state machine should have transitioned to fired,
+        # not cleared. (cleared would mean get_list_done resolved despite
+        # our route block — would indicate a routing miss.)
+        state = page.evaluate("(window.__bootWatchdog || {}).state")
+        assert state == "fired", (
+            f"watchdog should have fired with both critical fetches blocked; got: {state}"
+        )
+
+        # Last-mark text should be populated. We don't assert a specific
+        # mark name because the exact phase that completes before the
+        # block depends on whether the worker init won the race against
+        # the watchdog — both 'script_start' and 'pick_provider_start'
+        # are valid here. The load-bearing assertion is that the user
+        # gets *some* phase name, not 'unknown'.
+        last_mark = page.locator("#boot-stuck-last-mark").inner_text()
+        assert last_mark, "last-mark element should not be empty"
+        assert last_mark != "unknown"
+
+        # The three recovery affordances must be present and clickable.
+        expect(page.locator("#boot-stuck-reload-button")).to_be_visible()
+        expect(page.locator("#boot-stuck-clear-cache-button")).to_be_visible()
+        expect(page.locator("#bug-report-button-boot-stuck")).to_be_visible()
+
+    def test_watchdog_does_not_fire_on_normal_boot(self, page, base_url_fixture):
+        """Negative case: a healthy boot should leave the watchdog in
+        'cleared' state and never reveal the recovery panel. Catches
+        the regression where the watchdog fires too eagerly (e.g. the
+        clear path fails to wire up).
+        """
+        page.goto(base_url_fixture + "/", wait_until="domcontentloaded")
+        page.locator("#loading").wait_for(state="hidden", timeout=10000)
+
+        expect(page.locator("#app-wrap")).to_be_visible()
+        expect(page.locator("#boot-stuck-panel")).to_be_hidden()
+
+        state = page.evaluate("(window.__bootWatchdog || {}).state")
+        assert state == "cleared", (
+            f"watchdog should have cleared on a healthy boot; got: {state}"
+        )
+
+    def test_reload_button_in_recovery_panel_reloads_the_page(
+        self, page, base_url_fixture
+    ):
+        """The Reload button must actually trigger a page navigation.
+        Wired via window.location.reload() in initBootStuckPanelButtons.
+        """
+
+        def _hang(route):
+            pass
+
+        page.route("**/api/fellows*", _hang)
+        page.route("**/fellows.db", _hang)
+
+        page.goto(base_url_fixture + "/?wd=300", wait_until="domcontentloaded")
+        page.wait_for_selector("#boot-stuck-panel:not(.hidden)", timeout=5000)
+
+        # Drop the route blocks so the reload can succeed and we can
+        # observe the new page settled.
+        page.unroute("**/api/fellows*")
+        page.unroute("**/fellows.db")
+
+        with page.expect_navigation(timeout=10000):
+            page.click("#boot-stuck-reload-button")
+
+        # After reload the panel should be hidden again. Boot doesn't
+        # need to fully complete for this assertion — the panel state
+        # is per-page-load, so a fresh navigation alone is the proof.
+        expect(page.locator("#boot-stuck-panel")).to_be_hidden()


### PR DESCRIPTION
## Summary

- Replaces the inert "Loading…" with phase-aware status: **Starting up…** → **Setting up local database…** → **Loading directory…**, wired into `bootDirectoryAsApp` at the points that bound the slow phases.
- Adds a 20-second boot watchdog. If `bootMark('get_list_done')` doesn't fire in time, `#boot-stuck-panel` replaces the loading text with the last completed phase name and three actions: **Reload**, **Clear App Cache & Reload**, **Send report to maintainer**.
- Emits a `kind=worker, msg=boot_stuck` telemetry event with the last-mark name, so operators see stuck-boot rates in journald without depending on user reports.
- `?wd=<ms>` URL param shortens the watchdog for e2e tests (clamped to [100, 60000]).
- New `window.__bootWatchdog` exposure for tests; documented in `email_gate.md` § kind=worker events.

Background and motivation: 2026-05-06 hang report — boot rendered the shell, then sat at "Loading…" forever after the user clicked "Use the directory in this tab" on the install landing. The PR #118 fix (warm worker survives install-landing) addresses the most likely root cause; this PR is defense in depth so the next hang from any layer at least gives the user a productive next step.

## Test plan

- [x] `just test-fast` — 63 passed
- [x] `just test-e2e` (full) — 173 passed, 12 skipped
- [x] New `tests/e2e/test_boot_watchdog.py`:
  - `test_watchdog_fires_and_shows_recovery_panel_when_boot_hangs` — blocks `/api/fellows*` and `/fellows.db` with `page.route` no-op handlers, asserts the panel, the state machine in `fired`, the last-mark text, and the three action buttons.
  - `test_watchdog_does_not_fire_on_normal_boot` — negative case; healthy boot leaves the watchdog in `cleared` and the panel hidden.
  - `test_reload_button_in_recovery_panel_reloads_the_page` — happy-path verification of the in-panel Reload affordance.

## Manual QA for the maintainer

After deploy:

1. Open https://fellows.globaldonut.com/?wd=300 with DevTools' **Network → Offline** toggled on (or block `/api/fellows*` and `/fellows.db`). Within ~1 s the recovery panel should appear with the last completed phase named.
2. Click **Reload** in the panel — page should refresh.
3. Click **Send report to the maintainer** (in another stuck-boot session) — bug-report dialog should pre-fill with the boot trace including the `boot_stuck` ring entry.
4. After a few real stuck-boot incidents (or a synthetic one), `journalctl -u fellows-pwa | grep '"kind": "worker"' | grep boot_stuck` should show the events with `extra` carrying the last-mark name.

## Docs

- `docs/users_manual.md` — short subsection under *Clearing app data* explaining the recovery panel.
- `docs/email_gate.md` — adds `worker` to the documented `kind` allow-list (was already in the server-side `ALLOWED_EVENT_KINDS`; doc had drifted) and adds a new *kind=worker events* table covering `spawn_ok`, `spawn_failed`, `ownership_conflict`, `boot_stuck`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)