### PR TITLE
fix(auth): break standalone-PWA boot trap on session expiry (#125)

### DIFF
--- a/app/static/app.js
+++ b/app/static/app.js
@@ -2431,6 +2431,54 @@
         );
       });
     }
+    // Power-user escape hatch from any boot state — including the
+    // standalone-PWA auth-trap that motivated this button (issue #125).
+    // Standalone PWA windows have no URL bar, so a user whose session
+    // expired and whose IDB cache is empty can be stuck in a loop where
+    // every Clear App Cache reload returns to the same boot-error panel.
+    // Diagnostics is reachable from that state (it sits on top of the
+    // boot-error panel), and from here the user can sign out + force the
+    // gate UI in one click. Fires the same teardown as `clearCookiesBestEffort`
+    // + `POST /api/logout` does for the auth cookie, then navigates to
+    // `/?gate=1` which forces the email-gate render path regardless of
+    // localStorage markers (per email_gate.md invariant 7).
+    var forceGateBtn = document.getElementById('diag-force-gate');
+    if (forceGateBtn) {
+      forceGateBtn.addEventListener('click', function () {
+        var ok = window.confirm(
+          'Sign out of this device and reload to the email gate?\n\n' +
+          'Your saved groups, notes, and settings stay safe in local storage. ' +
+          'You will need to re-request a magic link to sign back in.'
+        );
+        if (!ok) return;
+        // Server clears the HttpOnly session cookie. Best-effort —
+        // a network failure here shouldn't block the recovery flow,
+        // because the gate UI itself doesn't require a cleared cookie
+        // (?gate=1 forces the gate render).
+        var logoutPromise;
+        try {
+          logoutPromise = fetch('/api/logout', {
+            method: 'POST',
+            credentials: 'same-origin',
+            headers: { 'Content-Type': 'application/json' },
+            body: '{}'
+          }).catch(function () { /* swallowed */ });
+        } catch (e) {
+          logoutPromise = Promise.resolve();
+        }
+        // Best-effort JS-visible cookie sweep for any non-HttpOnly
+        // residue. Then nuke localStorage so the gate boots clean — the
+        // `fellows_authenticated_once` marker would otherwise route a
+        // returning visitor straight back into the same trap on the
+        // browser-tab decision tree.
+        Promise.resolve(logoutPromise).then(function () {
+          try { clearCookiesBestEffort(); } catch (e) {}
+          try { localStorage.clear(); } catch (e) {}
+          try { sessionStorage.clear(); } catch (e) {}
+          window.location.replace('/?gate=1');
+        });
+      });
+    }
 
     try {
       if (new URLSearchParams(location.search).get('diag') === '1' && panel) {
@@ -3508,8 +3556,15 @@
   // `?gate=1` still bypasses both branches so a dev can always reach the
   // email gate explicitly.
   function shouldActAsApp() {
-    if (isStandaloneDisplayMode()) return true;
+    // `?gate=1` is the always-reachable dev escape hatch (email_gate.md
+    // invariant 7). Checked FIRST so it wins over standalone-mode short-
+    // circuit — without that ordering, a standalone PWA whose session has
+    // expired had no in-app path back to the gate (issue #125): every
+    // reload entered shouldActAsApp() → standalone short-circuit → true →
+    // bootDirectoryAsApp → 403 → boot-error panel, even when navigating
+    // to /?gate=1 from the diag panel's Force-email-gate button.
     if (parseGateOverride().force) return false;
+    if (isStandaloneDisplayMode()) return true;
     return hasAuthenticatedOnce();
   }
 
@@ -8340,12 +8395,40 @@
         // the watchdog after we've already shown the gate or boot-error
         // panel, double-rendering recovery affordances.
         clearBootWatchdog('boot_failure');
-        // Only reached when the API refused us AND no local cache could
-        // answer. In browser-tab-acting-as-app mode, hand off to the
-        // email gate quietly. Otherwise show the boot-failure panel.
-        if (!isStandaloneDisplayMode() && hasAuthenticatedOnce()) {
+        // Two routes hand off to startBrowserUx (which renders the email
+        // gate when /api/auth/status reports authenticated=false):
+        //
+        // 1. Browser-tab-acting-as-app + we've authenticated here before
+        //    (the original path; quiet handoff for returning visitors).
+        // 2. *Any* boot whose proximate cause is HTTP 401/403 — including
+        //    standalone PWAs whose 7-day session cookie expired. Without
+        //    this branch, standalone users were trapped: standalone mode
+        //    short-circuits shouldActAsApp() to true regardless of auth,
+        //    so every reload re-entered bootDirectoryAsApp, hit the same
+        //    403 from /fellows.db, and showed showBootFailure with no
+        //    in-app way to reach the gate (PWA windows have no URL bar).
+        //    Clear App Cache and Reset Everything both looped back into
+        //    the same trap. See issue #125.
+        var authFailure = err && (
+          err.httpStatus === 401 || err.httpStatus === 403 ||
+          err.status === 401 || err.status === 403
+        );
+        if ((!isStandaloneDisplayMode() && hasAuthenticatedOnce()) || authFailure) {
           bootDebugPush('as-app boot failed; handing off to startBrowserUx: ' +
             (err && err.message ? err.message : String(err)));
+          // Telemetry: distinguish the auth-failure handoff (the dominant
+          // cause in production once a fellow's session ages out) from
+          // generic boot failures so the operator can read incidence
+          // straight out of journald (`kind=worker, msg=boot_failed_auth`).
+          // Cardinality bounded to one event per page load.
+          if (authFailure) {
+            try {
+              reportWorkerEvent(
+                'boot_failed_auth',
+                'last_mark=' + String(lastCompletedBootMark() || 'unknown')
+              );
+            } catch (e) {}
+          }
           setShellVisible(false);
           if (loadingPanelEl) loadingPanelEl.classList.add('hidden');
           if (loadingEl) loadingEl.classList.add('hidden');

--- a/app/static/index.html
+++ b/app/static/index.html
@@ -77,6 +77,12 @@
       <span class="diag-panel-hint">Add <code>?diag=1</code> to URL to open on load</span>
       <button type="button" id="diag-refresh" class="diag-toolbar-btn">Refresh</button>
       <button type="button" id="diag-copy" class="diag-toolbar-btn" title="Copy all diagnostics to clipboard">Copy all</button>
+      <button
+        type="button"
+        id="diag-force-gate"
+        class="diag-toolbar-btn"
+        title="Sign out and reload to the email gate. Useful when a stuck boot has no other way back."
+      >Force email gate</button>
       <button type="button" id="diag-close" class="diag-toolbar-btn">Close</button>
     </div>
     <pre id="diag-pre" class="diag-pre"></pre>

--- a/tests/e2e/test_diagnostics_panel.py
+++ b/tests/e2e/test_diagnostics_panel.py
@@ -169,6 +169,58 @@ def test_no_main_thread_opfs_during_diag_render(standalone_page, base_url_fixtur
     )
 
 
+def test_force_email_gate_button_signs_out_and_navigates_to_gate(
+    standalone_page, base_url_fixture
+):
+    """The Force-email-gate diag button is the power-user escape hatch
+    from a stuck PWA boot (issue #125). On confirm it: (a) POSTs
+    /api/logout, (b) clears localStorage + sessionStorage, (c) replaces
+    location to /?gate=1. We assert the URL flip + the gate render —
+    the localStorage wipe is verified by re-reading the marker after
+    navigation (it must NOT survive, unlike Clear App Cache which
+    preserves fellows_authenticated_once by name).
+    """
+    page = standalone_page
+
+    # Boot normally with the panel open via ?diag=1 so the button is
+    # rendered + wired before we click it. Standalone display-mode is
+    # set by the fixture; the localhost dev passthrough boots the
+    # directory directly.
+    page.goto(base_url_fixture + "/?diag=1", wait_until="domcontentloaded")
+    page.locator("#loading").wait_for(state="hidden", timeout=10000)
+
+    # Pre-condition: the auth-once marker is set by a successful
+    # getList during normal boot. Confirms we have *something* in
+    # localStorage to verify the wipe behavior against.
+    assert page.evaluate("localStorage.getItem('fellows_authenticated_once')") == "1"
+
+    # Auto-accept the confirm dialog. The diag button uses window.confirm()
+    # so the user can't trigger this destructively by accident; the test
+    # bypasses the prompt by stubbing it.
+    page.evaluate("window.confirm = function () { return true; };")
+
+    # Click the button and wait for the navigation. location.replace
+    # fires a navigation event Playwright can hook.
+    with page.expect_navigation(timeout=8000):
+        page.click("#diag-force-gate")
+
+    # The new URL must end with /?gate=1 — the gate-override the email_gate.md
+    # decision tree treats as "force email gate UI regardless of cookie".
+    assert page.url.endswith("/?gate=1"), f"unexpected URL after force-gate: {page.url}"
+
+    # And the gate panel itself must render (the user has somewhere to go,
+    # not just a URL change).
+    page.locator("#install-gate-private").wait_for(state="visible", timeout=5000)
+
+    # localStorage must be wiped — otherwise a returning visit to a
+    # browser-tab decision tree could route back into the same trapped
+    # state via the auth-once marker.
+    marker = page.evaluate("localStorage.getItem('fellows_authenticated_once')")
+    assert marker is None, (
+        f"force-gate must clear fellows_authenticated_once; got: {marker!r}"
+    )
+
+
 def test_connection_banner_is_gone(standalone_page, base_url_fixture):
     """The legacy `#connection-banner` element ("You are online.") was
     leftover vocabulary from before the worker cutover. Phase 4 deletes

--- a/tests/e2e/test_offline_only_mode.py
+++ b/tests/e2e/test_offline_only_mode.py
@@ -142,6 +142,58 @@ class TestOfflineOnlyMode:
             context.unroute(API_FELLOWS)
             page.close()
 
+    def test_401_without_cached_data_in_standalone_pwa_falls_back_to_gate(self, context, base_url_fixture):
+        """Standalone PWA + 401 + no cache → must reach the email gate, not
+        the boot-error panel (issue #125). Pre-fix, the catch handler at
+        bootDirectoryAsApp's tail only handed off to startBrowserUx when
+        ``!isStandaloneDisplayMode() && hasAuthenticatedOnce()`` — which
+        was false in standalone mode, trapping users in a boot-error loop
+        with no in-app way back to the gate (PWA windows have no URL bar).
+        The fix extends the handoff to fire on any HTTP 401/403, regardless
+        of display mode.
+        """
+        page = _make_standalone_page(context)
+        # Mock /fellows.db and /api/fellows as 401 (expired session).
+        context.route(
+            FELLOWS_DB,
+            lambda r: r.fulfill(status=401, body="session expired"),
+        )
+        context.route(
+            API_FELLOWS,
+            lambda r: r.fulfill(status=401, body="session expired"),
+        )
+        # Mock /api/auth/status so startBrowserUx renders the gate (rather
+        # than the local-dev passthrough) once handoff fires.
+        context.route(
+            "**/api/auth/status",
+            lambda r: r.fulfill(
+                status=200,
+                content_type="application/json",
+                body=json.dumps({
+                    "authEnabled": True,
+                    "authenticated": False,
+                    "hasSessionCookie": False,
+                    "installRecentlyAllowed": False,
+                }),
+            ),
+        )
+        try:
+            page.goto(base_url_fixture + "/", wait_until="domcontentloaded")
+            # The fix routes the catch handler to startBrowserUx → email
+            # gate. The gate's load-bearing element is the private container.
+            page.locator("#install-gate-private").wait_for(state="visible", timeout=10000)
+            # Pre-fix, the boot-error panel would have rendered. Asserting
+            # both "gate visible" AND "boot-error panel hidden" pins the
+            # fix-branch decision against any future regression that flips
+            # back to the trap behavior.
+            expect(page.locator("#boot-error-panel")).to_be_hidden()
+            expect(page.locator("#auth-error-panel")).to_be_hidden()
+        finally:
+            context.unroute(FELLOWS_DB)
+            context.unroute(API_FELLOWS)
+            context.unroute("**/api/auth/status")
+            page.close()
+
     def test_401_without_cached_data_in_browser_tab_falls_back_to_gate(self, context, base_url_fixture):
         """Browser tab + marker + 401 + no cache → the PR #49 safety net
         kicks in (quiet email gate). We never leave the user staring at a


### PR DESCRIPTION
Closes #125.

## Summary

- **The trap (`app/static/app.js:8346`).** Standalone PWAs whose session cookie expired had no in-app path back to the email gate. `bootDirectoryAsApp`'s tail catch handler only handed off to `startBrowserUx` for *browser-tab*-acting-as-app, leaving standalone PWAs to render the boot-error panel for any auth failure. Clear App Cache and Reset Everything both looped right back into the same trap on reload because they cleared the cookie + IDB and the next boot hit the same 403 with no cache fallback.
- **The compounding bug (`shouldActAsApp`).** `?gate=1` was supposed to be the always-reachable escape hatch (per `email_gate.md` invariant 7), but `shouldActAsApp` checked standalone-mode *before* the override, so navigating a stuck PWA to `/?gate=1` was a no-op. The function comment promised the documented behavior; only the check order was wrong.
- **Net effect.** A user whose 7-day session cookie aged out, opened the installed PWA, and saw the boot-error panel had no in-app way to recover. Their only escape was uninstalling the PWA or opening the URL in a regular Chrome tab to re-auth.

Both fixes are tiny:

1. `shouldActAsApp`: check `parseGateOverride().force` *before* the standalone short-circuit. `?gate=1` now works in every display mode.
2. `bootDirectoryAsApp` catch: extend the handoff to fire on any HTTP 401/403, regardless of display mode. Standalone PWAs land on the email gate when their session expires, just like browser-tab users do.

Plus the Force-email-gate diag button as a permanent escape hatch for any future trap we haven't anticipated:

- New `#diag-force-gate` button in the Diagnostics toolbar.
- On confirm: `POST /api/logout` (clears HttpOnly cookie server-side) → `localStorage.clear()` → `sessionStorage.clear()` → `location.replace('/?gate=1')`. Now actually reaches the gate even from a standalone PWA, thanks to the `shouldActAsApp` reorder above.

Telemetry: a new `kind=worker, msg=boot_failed_auth` event fires from the auth-handoff branch so operators can see incidence in journald via `just prod-stats`.

## Self-healing for users already trapped on prod

`registerServiceWorker()` runs unconditionally at the IIFE bottom — even when the boot-error panel is showing — so the *New version available — Reload* banner will appear at the top of the panel for any stuck PWA once this ships. One click replaces the bundle with the fixed one; on next launch the auth-failure handoff fires and they land on the gate. No manual intervention needed for already-trapped instances.

## Test plan

- [x] `just test-fast` — 63 passed.
- [x] `just test-e2e` (full) — **175 passed, 12 skipped** (up from 173: two new tests).
- [x] **New: `tests/e2e/test_offline_only_mode.py::TestOfflineOnlyMode::test_401_without_cached_data_in_standalone_pwa_falls_back_to_gate`** — pins the trap fix. Standalone display mode + 401 from `/api/fellows` and `/fellows.db` + empty IDB → email gate renders, boot-error panel hidden.
- [x] **New: `tests/e2e/test_diagnostics_panel.py::test_force_email_gate_button_signs_out_and_navigates_to_gate`** — auto-confirms the dialog, clicks the button, asserts `?gate=1` URL + gate UI render + `fellows_authenticated_once` localStorage marker is wiped.
- [x] Existing `test_gate_override_forces_email_gate_panel` (browser-tab `?gate=1`) still passes — the reorder is a strict expansion.

## Manual QA for the maintainer

After deploy:

1. Watch a stuck-PWA user (or simulate one): `just ship` deploys; their installed PWA's SW polls `/build-meta.json`, detects the new SHA, the *New version available — Reload* banner appears at the top of their boot-error panel. Click Reload → new bundle → email gate.
2. Diagnostics panel → click **Force email gate**. Confirm. URL flips to `/?gate=1`, gate panel renders, you can submit your email and re-auth.
3. Synthetic trap-trigger: in the deployed PWA, manually expire your cookie (DevTools → Application → Cookies → delete `fellows_session`), then close + reopen the PWA. Pre-fix would have shown the boot-error panel; post-fix you land on the email gate.
4. Watch journald: `just prod-stats` → look for `boot_failed_auth` events. (None expected on a healthy install; appears when a session ages out.)

🤖 Generated with [Claude Code](https://claude.com/claude-code)