### PR TITLE
docs(devops): make env-file requirement first-class in bootstrap flow

### DIFF
--- a/ansible/README.md
+++ b/ansible/README.md
@@ -66,13 +66,18 @@ cp ansible/group_vars/fellows.yml.example ansible/group_vars/fellows.yml
 # edit ansible_host, ansible_port, ansible_user, key path, caddy_admin_email
 just ansible-collections
 just bootstrap
+just prod-configure-env       # required: writes /etc/fellows/fellows-pwa.env
+just smoke                    # verify
 ```
+
+`just bootstrap` brings up the unix accounts, systemd unit, Caddy, and starts the service — but the service can't authenticate users until `just prod-configure-env` lands `FELLOWS_SESSION_SECRET`, `FELLOWS_POSTMARK_TOKEN`, and `FELLOWS_PUBLIC_ORIGIN`. See [`docs/DevOps.md` § Required environment variables](../docs/DevOps.md#required-environment-variables) for what each var does and what breaks if it's missing or wrong.
 
 Lower-level equivalents (same commands `just` invokes):
 
 ```bash
 ansible-galaxy collection install -r ansible/collections/requirements.yml -p ansible/collections
 ansible-playbook ansible/site.yml --tags bootstrap --ask-become-pass
+./scripts/configure_email_auth_env.sh
 ```
 
 On first run, the `common` role adds the operator (e.g. `rsb`) to the `fellows` group and then runs `meta: reset_connection` so subsequent tasks in the same playbook see the new group membership. If you ever see rsync errors about permission on `/opt/fellows/deploy/dist/`, the most likely cause is that the operator is not yet in the `fellows` group — run `just bootstrap` once.
@@ -138,6 +143,6 @@ ssh -p 52221 rsb@170.64.243.67 'systemctl status fellows-pwa caddy --no-pager'
 
 ## Magic-link env
 
-The deploy bundle includes `allowed_emails.json` (from `build/build_pwa.py`). To turn on the browser gate, the `fellows-pwa` service needs env vars `FELLOWS_SESSION_SECRET` and `FELLOWS_POSTMARK_TOKEN`. Run `just prod-configure-env` (wraps `./scripts/configure_email_auth_env.sh`) from the repo root to install `/etc/fellows/fellows-pwa.env` (`root:fellows 0640`) and the systemd `EnvironmentFile=` drop-in. Without these, `deploy/server.py` serves without the email gate. Use `just prod-env` to read back what's currently installed, and `just prod-repair-env` for the documented env-file repair playbook.
+The deploy bundle includes `allowed_emails.json` (from `build/build_pwa.py`), but the `fellows-pwa` service can't authenticate users without env vars in `/etc/fellows/fellows-pwa.env`. The full list, with what-breaks-if-missing notes, lives in [`docs/DevOps.md` § Required environment variables](../docs/DevOps.md#required-environment-variables); the operator runbook (Postmark sender setup, debugging, journald event schema) lives in [`docs/email_system_management.md`](../docs/email_system_management.md).
 
-See [`docs/email_system_management.md`](../docs/email_system_management.md) for full operator runbook, Postmark debugging, and journald event schema.
+Run `just prod-configure-env` (wraps `./scripts/configure_email_auth_env.sh`) once after bootstrap to install the env file and the systemd `EnvironmentFile=` drop-in. `just prod-env` reads back current values; `just prod-repair-env` is the playbook for a malformed file.

--- a/deploy/magic_link_auth.py
+++ b/deploy/magic_link_auth.py
@@ -158,20 +158,23 @@ def install_recently_allowed(token_issued_at: Optional[float], now: Optional[flo
     return (now - token_issued_at) < INSTALL_WINDOW
 
 
-DEFAULT_MAIL_FROM = "EHF Directory <admin@fellows.globaldonut.com>"
+DEFAULT_MAIL_FROM = "EHF Directory App <admin@fellows.globaldonut.com>"
 
 
 def build_postmark_body(to_email: str, magic_url: str) -> dict:
     """Construct the Postmark /email payload. Pure function; no network.
 
-    From defaults to ``EHF Directory <admin@fellows.globaldonut.com>``.
+    From defaults to ``EHF Directory App <admin@fellows.globaldonut.com>``.
     Postmark validates the address part against the verified Sender
     Signature / domain; the display name is what fellows actually see in
-    their inbox (``admin`` alone reads as spam-adjacent). Override via
-    FELLOWS_MAIL_FROM — pass either a bare address or the same
-    ``Display Name <addr>`` shape. Reply-To is taken from
-    FELLOWS_REPLY_TO when set — useful when admin@ doesn't route to a
-    human mailbox yet and replies should land with the operator directly.
+    their inbox (a bare address like ``admin@…`` shows as just ``admin``
+    in most mail clients, which reads as spam-adjacent — see the 2026-05-06
+    incident). Override via FELLOWS_MAIL_FROM only if you need a custom
+    display name or address (e.g., a fork running a different org's
+    deployment); pass either a bare address or the same
+    ``Display Name <addr>`` shape. Reply-To is taken from FELLOWS_REPLY_TO
+    when set — useful when admin@ doesn't route to a human mailbox yet
+    and replies should land with the operator directly.
     """
     from_addr = os.environ.get("FELLOWS_MAIL_FROM", DEFAULT_MAIL_FROM).strip()
     reply_to = os.environ.get("FELLOWS_REPLY_TO", "").strip()

--- a/docs/DevOps.md
+++ b/docs/DevOps.md
@@ -164,32 +164,45 @@ ssh -p 52221 rsb@fellows.globaldonut.com 'systemctl status fellows-pwa caddy --n
 
 ## Bootstrapping a fresh droplet
 
+If you're forking this repo for your own org, this is the section you want. Bootstrap is **two phases**: provision/playbook, then secrets. Both are required before the email gate works — the service starts after step 4 below but won't be able to send magic links or verify sessions until step 5 lands the secrets.
+
 ```bash
 # 1. Provision Droplet, assign Reserved IP (170.64.243.67), create DNS A record.
-# 2. Ensure your SSH key is in /home/rsb/.ssh/authorized_keys on the droplet.
-# 3. From the repo root:
+# 2. Ensure your SSH key is in /home/<operator>/.ssh/authorized_keys on the droplet.
+# 3. Edit ansible/inventory/hosts.ini and ansible/group_vars/fellows.yml from the
+#    .example templates (host, port, user, key path, caddy_admin_email).
+# 4. From the repo root:
 just ansible-collections    # one-time per workstation
 just bootstrap              # ansible site.yml --tags bootstrap --ask-become-pass
+# 5. Install required env vars (Postmark token, session secret, public origin):
+just prod-configure-env     # interactive; writes /etc/fellows/fellows-pwa.env
+# 6. Verify:
+just smoke                  # /healthz, /manifest.webmanifest, /api/debug/diagnostics
 ```
 
-Under the hood:
+Under the hood for step 4:
 
 ```bash
 ansible-galaxy collection install -r ansible/collections/requirements.yml -p ansible/collections
 ansible-playbook ansible/site.yml --tags bootstrap --ask-become-pass
 ```
 
-The first run creates the `fellows` system user, adds `rsb` to the `fellows` group, writes the hardened systemd unit, and starts the service. If a legacy `deploy` account is present from a pre-migration droplet, the second play in `site.yml` removes it.
+That run creates the `fellows` system user, adds the operator to the `fellows` group, writes the hardened systemd unit, and starts the service. If a legacy `deploy` account is present from a pre-migration droplet, the second play in `site.yml` removes it. The service starts but **does not yet have its env vars** — auth status reports `authEnabled: false`, no magic links can be issued — until step 5 runs.
 
-## Magic-link env file
+## Required environment variables
 
-After bootstrap, install Postmark + session secrets once:
+The `fellows-pwa.service` reads these from `/etc/fellows/fellows-pwa.env` (mode `0640`, owned `root:fellows`). Without all four set, the production server runs without the email gate. The interactive setup script `scripts/configure_email_auth_env.sh` (wrapped by `just prod-configure-env`) prompts for each value; re-run only when a secret rotates.
 
-```bash
-just prod-configure-env
-```
+| Variable | Required | Purpose | What breaks if missing or wrong |
+|---|---|---|---|
+| `FELLOWS_SESSION_SECRET` | yes | Long random key (≥48 chars) used to HMAC-sign the session cookie. Generate with `python -c "import secrets; print(secrets.token_urlsafe(48))"`. | Without it, the auth gate refuses to issue or verify cookies; users land on a generic "auth check failed" panel. Rotation invalidates every outstanding session. |
+| `FELLOWS_POSTMARK_TOKEN` | yes | Postmark Server API token (one per project, found on the server's settings page in Postmark). | Without it, `POST /api/send-unlock` fails — fellows submit their email and see the silent "we'll send a link if it's allowed" anti-enumeration response, but no email goes out. Operator-side: `event=send_unlock_email` in journald logs `result=error`. |
+| `FELLOWS_PUBLIC_ORIGIN` | yes (recommended) | The HTTPS origin used to build magic-link URLs in email bodies (e.g., `https://fellows.globaldonut.com`). | If unset, the server falls back to inferring origin from `X-Forwarded-Proto`/`Host`. That fallback works when Caddy is correctly forwarding headers, but a bare `Host` with no `X-Forwarded-Proto` produces malformed `https://` links. Set it explicitly to take that risk off the table. |
+| `FELLOWS_MAIL_FROM` | optional | Override of the default From: header. The in-code default is `EHF Directory App <admin@fellows.globaldonut.com>` (`deploy/magic_link_auth.py:DEFAULT_MAIL_FROM`). **Forks running a different domain or display name must override.** | If set to a *bare address* (no display name brackets), most mail clients show only the local-part (`admin`) as the sender — reads as spam in users' inboxes. Always pass `Display Name <addr@domain>`. |
+| `FELLOWS_REPLY_TO` | optional | When set, becomes the email's `Reply-To` header. Use when `admin@` isn't a human mailbox and you want replies to land with the operator (e.g., `you+fellows@gmail.com`). | If unset, replies go to `FELLOWS_MAIL_FROM`. |
+| `FELLOWS_COOKIE_INSECURE` | optional, dev only | When `1`, drops the `Secure` flag from the session cookie so it works over plain HTTP (used by the in-process test fixture). **Never set on prod.** | Sets the cookie without `Secure`, allowing it over HTTP — a session-hijack risk if used outside localhost. |
 
-That wraps `./scripts/configure_email_auth_env.sh`, which prompts for `FELLOWS_MAIL_FROM`, `FELLOWS_PUBLIC_ORIGIN`, `FELLOWS_POSTMARK_TOKEN`, `FELLOWS_SESSION_SECRET`, then SSHes to the droplet and creates `/etc/fellows/fellows-pwa.env` (`root:fellows 0640`) and the systemd drop-in. Re-run only when a secret rotates.
+Operators rotating any of the above values: edit `/etc/fellows/fellows-pwa.env` (`sudo nano …`), then `sudo systemctl restart fellows-pwa`. `just prod-env` reads the current values back (raw, paste-ready). `just prod-repair-env` is the documented playbook for a malformed env file. Full operator runbook (Postmark sender setup, debugging, journald event schema): [`docs/email_system_management.md`](email_system_management.md).
 
 ## Debugging
 

--- a/docs/email_system_management.md
+++ b/docs/email_system_management.md
@@ -12,7 +12,7 @@ Environment variables used in this section:
 |---|---|
 | `FELLOWS_SESSION_SECRET` | Long random signing key. Generate with `python -c "import secrets; print(secrets.token_urlsafe(48))"`. |
 | `FELLOWS_POSTMARK_TOKEN` | Postmark Server API token from the server's settings page. |
-| `FELLOWS_MAIL_FROM` | Sender that users see on the magic-link email. Defaults to `EHF Directory <admin@fellows.globaldonut.com>` — the display name (`EHF Directory`) is what shows in the inbox; the address part must be a verified Sender Signature (or an address on a domain-verified domain) in Postmark. Pass either a bare address or the same `Display Name <addr>` shape. **Do not use `noreply@` addresses** — Postmark actively refuses them and they hurt your sender reputation. |
+| `FELLOWS_MAIL_FROM` | Sender that users see on the magic-link email. Defaults to `EHF Directory App <admin@fellows.globaldonut.com>` — the display name (`EHF Directory App`) is what shows in the inbox; the address part must be a verified Sender Signature (or an address on a domain-verified domain) in Postmark. Override only if your fork uses a different domain or display name. **Always use the `Display Name <addr>` shape** when overriding — a bare address renders as just the local-part (`admin`) in most mail clients, which reads as spam. **Do not use `noreply@` addresses** — Postmark actively refuses them and they hurt your sender reputation. |
 | `FELLOWS_REPLY_TO` | Optional. When set, becomes the `Reply-To` header. Use this to route replies to a real operator mailbox (e.g. `richbodo+fellows@gmail.com`) while `admin@fellows.globaldonut.com` is the visible sender. When unset, replies go to `FELLOWS_MAIL_FROM`. |
 | `FELLOWS_PUBLIC_ORIGIN` | Public HTTPS origin for the deployed app, for example `https://fellows.globaldonut.com`. Used to build the magic-link URL in the email body. |
 
@@ -108,7 +108,7 @@ If you do want the address to appear in Postmark's Signatures list (so the dashb
 ssh -p 52221 rsb@fellows.globaldonut.com
 sudo nano /etc/fellows/fellows-pwa.env
 # Edit:
-#   FELLOWS_MAIL_FROM=EHF Directory <admin@fellows.globaldonut.com>
+#   FELLOWS_MAIL_FROM=EHF Directory App <admin@fellows.globaldonut.com>
 #   FELLOWS_REPLY_TO=richbodo+fellows@gmail.com   # or any mailbox you check
 sudo systemctl restart fellows-pwa
 ```
@@ -124,7 +124,7 @@ just prod-env           # confirms the change landed (values shown raw — copy/
 
 1. Open `https://fellows.globaldonut.com/?gate=1` in a fresh incognito window (forces the email gate even if you already have a session cookie).
 2. Submit a known-allowlisted address.
-3. Check the inbox — the sender column should show `EHF Directory` and the `From:` header should read `EHF Directory <admin@fellows.globaldonut.com>`. If you click Reply, your MUA should pre-fill `FELLOWS_REPLY_TO`.
+3. Check the inbox — the sender column should show `EHF Directory App` and the `From:` header should read `EHF Directory App <admin@fellows.globaldonut.com>`. If you click Reply, your MUA should pre-fill `FELLOWS_REPLY_TO`.
 4. From your laptop:
    ```bash
    just email-debug '10 minutes ago'

--- a/tests/test_magic_link_auth.py
+++ b/tests/test_magic_link_auth.py
@@ -175,13 +175,15 @@ def test_gated_paths():
     assert ml.is_protected_data_path("/images/foo.jpg")
 
 
-def test_build_postmark_body_default_sender_is_ehf_directory(monkeypatch):
-    """Default From carries the ``EHF Directory`` display name so the inbox
-    shows a recognizable sender rather than bare ``admin@``."""
+def test_build_postmark_body_default_sender_is_ehf_directory_app(monkeypatch):
+    """Default From carries the ``EHF Directory App`` display name so the
+    inbox shows a recognizable sender rather than bare ``admin@`` (which
+    most mail clients render as just ``admin``, reading as spam-adjacent —
+    see the 2026-05-06 incident)."""
     monkeypatch.delenv("FELLOWS_MAIL_FROM", raising=False)
     monkeypatch.delenv("FELLOWS_REPLY_TO", raising=False)
     body = ml.build_postmark_body("user@example.com", "https://fellows.globaldonut.com/#/unlock/tok")
-    assert body["From"] == "EHF Directory <admin@fellows.globaldonut.com>"
+    assert body["From"] == "EHF Directory App <admin@fellows.globaldonut.com>"
     assert body["To"] == "user@example.com"
     assert body["MessageStream"] == "outbound"
     assert "expires in 30 minutes" in body["Subject"]
@@ -193,10 +195,10 @@ def test_build_postmark_body_default_sender_is_ehf_directory(monkeypatch):
 
 def test_build_postmark_body_reply_to_env_wins(monkeypatch):
     """FELLOWS_REPLY_TO becomes the ReplyTo header when set."""
-    monkeypatch.setenv("FELLOWS_MAIL_FROM", "EHF Directory <admin@fellows.globaldonut.com>")
+    monkeypatch.setenv("FELLOWS_MAIL_FROM", "EHF Directory App <admin@fellows.globaldonut.com>")
     monkeypatch.setenv("FELLOWS_REPLY_TO", "richbodo+fellows@gmail.com")
     body = ml.build_postmark_body("u@x.com", "https://example/#/unlock/tok")
-    assert body["From"] == "EHF Directory <admin@fellows.globaldonut.com>"
+    assert body["From"] == "EHF Directory App <admin@fellows.globaldonut.com>"
     assert body["ReplyTo"] == "richbodo+fellows@gmail.com"
 
 


### PR DESCRIPTION
## Summary

Bootstrapping was effectively a two-phase flow (`just bootstrap` then `just prod-configure-env`) but read as one-step + optional postscript. A fork-for-own-org operator could run bootstrap, see the service start, and never realize the email gate was inert until they hunted for the env-config command. The 2026-05-06 incident (admin@ as sender, see #122) is a downstream symptom — the env file felt like a fiddly aside rather than a required step.

This PR makes the env-file step first-class:

- `docs/DevOps.md` — restructure "Bootstrapping" as one numbered list that includes `just prod-configure-env` and `just smoke`. Replace the trailing "Magic-link env file" stub with a full "Required environment variables" table covering each var, its purpose, and **what breaks if missing or wrong** (`FELLOWS_MAIL_FROM` bare → "admin" in inbox; `FELLOWS_PUBLIC_ORIGIN` unset → fragile origin inference; `FELLOWS_POSTMARK_TOKEN` unset → silent send failure).
- `ansible/README.md` — promote `just prod-configure-env` into the first-run checklist; defer to DevOps.md for the canonical env-vars list rather than duplicating.
- `docs/email_system_management.md` — align display-name copy with the new default and call out the bare-address gotcha explicitly.

Plus the underlying default fix:

- `deploy/magic_link_auth.py` — `DEFAULT_MAIL_FROM` updated from `"EHF Directory <admin@fellows.globaldonut.com>"` to `"EHF Directory App <admin@fellows.globaldonut.com>"`.
- `tests/test_magic_link_auth.py` — assertion updated to match.

With the new default, prod's `/etc/fellows/fellows-pwa.env` can simply omit `FELLOWS_MAIL_FROM` and inherit the right display name from code. One less silent-failure surface in the env-file editing flow.

## Test plan

- [x] `just test-fast` — 63 passed (covers the updated `test_build_postmark_body_default_sender_is_ehf_directory_app`).

## Maintainer follow-up after merge + ship

Closes #122 once these two operator steps land:

1. After `just ship` deploys the new bundle, edit `/etc/fellows/fellows-pwa.env` on the droplet:
   ```
   ssh -p 52221 rsb@fellows.globaldonut.com
   sudo nano /etc/fellows/fellows-pwa.env
   ```
   **Delete** the `FELLOWS_MAIL_FROM=admin@fellows.globaldonut.com` line entirely (the new code default will apply).
2. `sudo systemctl restart fellows-pwa`, then verify with a fresh magic-link send — From: should now read `EHF Directory App <admin@…>`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)