### PR TITLE
fix(css): focus mode on About + Settings at desktop widths (#121)

### DIFF
--- a/app/static/styles.css
+++ b/app/static/styles.css
@@ -3423,6 +3423,19 @@ a.group-action-btn--primary {
   }
 }
 
+/* Focus mode (desktop subset): About and Settings are pure reading
+   surfaces with no list-scanning workflow — at desktop widths the
+   directory list and composer rail squeezed the central column into
+   an unreadable strip on common laptop widths (1025px–1500px).
+   Hide them on these two routes at every width. Other non-directory
+   routes (fellow detail, group detail, groups list) intentionally
+   keep the rails visible at desktop because their workflow includes
+   scanning the directory while reading. Issue #121. */
+body:is(.route-about, .route-settings) #directory,
+body:is(.route-about, .route-settings) #group-rail {
+  display: none;
+}
+
 /* =========================================================================
  * Mobile redesign — Phase 3 step 3: interaction surfaces (PR 2).
  *

--- a/tests/e2e/test_route_focus_mode.py
+++ b/tests/e2e/test_route_focus_mode.py
@@ -1,0 +1,82 @@
+"""E2E: focus mode hides the directory list and composer rail on
+About / Settings at every viewport width.
+
+Issue #121: at desktop widths (>1024px) the About and Settings pages
+rendered with the directory list on the left and the composer rail on
+the right, squeezing the page content into an unreadable middle column.
+The mobile-redesign focus-mode rule existed only inside @media
+(max-width: 1024px); the desktop side had no equivalent for these two
+routes.
+
+The fix is intentionally narrow: only About and Settings get focus mode
+at desktop. Fellow detail and group pages keep the rails visible
+because their workflow includes scanning the directory list while
+reading (covered by test_click_another_fellow_updates_detail in
+tests/e2e/test_detail_view.py).
+
+These tests pin the route-class → focus-mode mapping at desktop widths.
+The default Playwright viewport (1280x720) is already desktop. The
+mobile-redesign tests in tests/e2e/mobile/ cover the narrow side.
+"""
+from __future__ import annotations
+
+import pytest
+from playwright.sync_api import expect
+
+
+class TestDesktopFocusMode:
+    """At desktop widths, only the directory route (and edit mode) shows
+    #directory and #group-rail. About / Settings / Fellow detail / Group
+    pages are full-width.
+    """
+
+    def test_directory_route_keeps_directory_and_rail_visible(
+        self, page, base_url_fixture
+    ):
+        """Sanity: the default route is the one place focus mode does NOT
+        apply. Without this assertion we can't tell whether a "rails are
+        hidden everywhere" test is actually catching a regression that
+        broke the directory page itself.
+        """
+        page.goto(base_url_fixture + "/", wait_until="domcontentloaded")
+        page.locator("#loading").wait_for(state="hidden", timeout=10000)
+
+        # The directory is the default route — #directory must render.
+        expect(page.locator("#directory")).to_be_visible()
+        # The rail (composer) is also visible on the directory route.
+        expect(page.locator("#group-rail")).to_be_visible()
+        # Body class confirms route classification.
+        body_classes = page.evaluate("document.body.className")
+        assert "route-directory" in body_classes, body_classes
+
+    @pytest.mark.parametrize(
+        "hash_route,expected_class",
+        [
+            ("#/about", "route-about"),
+            ("#/settings", "route-settings"),
+        ],
+    )
+    def test_about_and_settings_hide_directory_and_rail(
+        self, page, base_url_fixture, hash_route, expected_class
+    ):
+        """The user-reported regression in #121: at desktop widths, About
+        and Settings rendered the directory list + composer rail in side
+        columns, squeezing the central page content. Both must be hidden
+        on these routes regardless of viewport width.
+        """
+        page.goto(base_url_fixture + "/", wait_until="domcontentloaded")
+        page.locator("#loading").wait_for(state="hidden", timeout=10000)
+
+        # Navigate via hash; route() picks up the class.
+        page.evaluate(f"location.hash = '{hash_route}'")
+        # Wait for the body class to flip.
+        page.wait_for_function(
+            f"() => document.body.classList.contains('{expected_class}')",
+            timeout=3000,
+        )
+
+        # The load-bearing assertion: #directory and #group-rail must
+        # be display: none. Playwright's to_be_hidden is the right
+        # idiom for "rendered absent or display:none".
+        expect(page.locator("#directory")).to_be_hidden()
+        expect(page.locator("#group-rail")).to_be_hidden()


### PR DESCRIPTION
Closes #121.

## Summary

The mobile-redesign focus-mode rule (\`#directory\` + \`#group-rail\` hidden on non-directory routes) was wrapped in \`@media (max-width: 1024px)\`, so at desktop widths the About and Settings pages rendered with the directory list on one side and the composer rail on the other — squeezing the central content into an unreadable strip on common laptop widths (1025–1500px). PR #117 added the *Update directory data* row to About, which made it more cramped.

Narrow fix: a new top-level CSS rule that extends focus mode to **About** and **Settings only**, at all viewport widths.

\`\`\`css
body:is(.route-about, .route-settings) #directory,
body:is(.route-about, .route-settings) #group-rail {
  display: none;
}
\`\`\`

Other non-directory routes (fellow detail, group detail, groups list, group visual directory) intentionally keep the rails visible at desktop because their workflow includes scanning the directory while reading. \`test_click_another_fellow_updates_detail\` in \`tests/e2e/test_detail_view.py\` exercises that pattern; an earlier broader version of this fix broke it, which is what caught the over-reach.

## Test plan

- [x] \`just test-fast\` — 63 passed.
- [x] \`just test-e2e\` (full) — **178 passed, 12 skipped** (up from 175: three new route-focus-mode tests).
- [x] **New: \`tests/e2e/test_route_focus_mode.py::TestDesktopFocusMode\`** — three cases:
  - \`test_directory_route_keeps_directory_and_rail_visible\` — sanity: rails are visible on the default route. Without this, a "rails are hidden" test could pass for the wrong reason.
  - \`test_about_and_settings_hide_directory_and_rail\` (parametrized over \`#/about\` and \`#/settings\`) — pins the load-bearing assertion.
- [x] \`test_click_another_fellow_updates_detail\` (existing) still passes — the desktop fellow-detail workflow is preserved.

## Manual QA

After deploy, at desktop (>1024px viewport):

1. \`https://fellows.globaldonut.com/#/about\` — should render full-width with no directory list or composer rail visible.
2. \`https://fellows.globaldonut.com/#/settings\` — same.
3. \`https://fellows.globaldonut.com/#/fellow/<some-slug>\` — directory list and rail still visible (intentional).
4. Resize to <1024px — focus mode applies on every non-directory route as before (mobile behavior unchanged).

🤖 Generated with [Claude Code](https://claude.com/claude-code)