### PR TITLE
feat(boot-error): user-actionable panel + inline recovery buttons (#124)

### DIFF
--- a/app/static/app.js
+++ b/app/static/app.js
@@ -2935,6 +2935,32 @@
     }
   }
 
+  // Same pattern for the boot-error panel (issue #124). The panel
+  // surfaces when bootDirectoryAsApp's catch handler can't recover
+  // — post-#126 that's no longer the auth-failure case (which now
+  // hands off to startBrowserUx → email gate), so the panel only
+  // shows for genuinely unknown failures (network, 5xx, unexpected
+  // exceptions). Inline Reload / Clear App Cache & Reload buttons
+  // give the user a productive next step without forcing them to
+  // hunt for the floating chrome at the bottom of the page.
+  function initBootErrorPanelButtons() {
+    var reloadBtn = document.getElementById('boot-error-reload-button');
+    if (reloadBtn) {
+      reloadBtn.addEventListener('click', function (ev) {
+        ev.preventDefault();
+        window.location.reload();
+      });
+    }
+    var clearBtn = document.getElementById('boot-error-clear-cache-button');
+    if (clearBtn) {
+      clearBtn.addEventListener('click', function (ev) {
+        ev.preventDefault();
+        var globalBtn = document.getElementById('clear-app-cache-button');
+        if (globalBtn) globalBtn.click();
+      });
+    }
+  }
+
   // ===== Mobile shell: appbar + tabs + kebab sheet =======================
   // Phase 3 of the mobile redesign (plans/mobile_redesign/). The appbar
   // and tab strip are mobile-only persistent chrome (CSS hides them at
@@ -8281,6 +8307,7 @@
   initDiagnosticsPanel();
   initBugReportButtons();
   initBootStuckPanelButtons();
+  initBootErrorPanelButtons();
   initKebabSheet();
   initComposerFab();
   initGroupCardSheet();

--- a/app/static/index.html
+++ b/app/static/index.html
@@ -287,22 +287,26 @@
   <div id="loading-panel" class="loading-panel hidden">
     <p id="loading">Loading…</p>
     <div id="boot-error-panel" class="boot-error-panel hidden" role="alert">
-      <p class="boot-error-lead"><strong>Could not load the directory.</strong></p>
+      <p class="boot-error-lead"><strong>We couldn't load the directory.</strong></p>
       <p class="boot-error-hint">
-        If you are debugging: use the report below and the browser console. Common causes include a stale service worker
-        (use <strong>Reload</strong> on the update banner), missing <code>fellows.db</code> or API routes on the server,
-        or OPFS / SQLite blocked in this context.
+        Something went wrong starting up — usually a transient network hiccup or a stuck local cache.
+        Your saved groups, notes, and settings are preserved on this device.
       </p>
-      <pre id="boot-error-pre" class="boot-error-pre"></pre>
       <p class="boot-error-actions">
+        <button type="button" id="boot-error-reload-button" class="bug-report-inline-button">Reload</button>
+        <button type="button" id="boot-error-clear-cache-button" class="bug-report-inline-button">Clear App Cache &amp; Reload</button>
         <button
           type="button"
           id="bug-report-button-boot-error"
           class="bug-report-inline-button"
           data-bug-report-context="boot-error"
           data-sync-only="1"
-        >Send this report to the maintainer</button>
+        >Send report to the maintainer</button>
       </p>
+      <details class="boot-error-details">
+        <summary class="boot-error-summary">Show technical details</summary>
+        <pre id="boot-error-pre" class="boot-error-pre"></pre>
+      </details>
     </div>
     <div id="boot-stuck-panel" class="boot-error-panel hidden" role="alert">
       <p class="boot-error-lead"><strong>This is taking longer than expected.</strong></p>

--- a/app/static/styles.css
+++ b/app/static/styles.css
@@ -454,6 +454,29 @@ body {
   font-family: ui-monospace, "Cascadia Code", Menlo, Monaco, Consolas, monospace;
 }
 
+/* Collapsible diagnostics block on the boot-error panel (issue #124).
+   Default-collapsed so the user-facing copy isn't dominated by a wall
+   of green text; power users + bug-report flows expand it manually. */
+.boot-error-details {
+  margin-top: 0.75rem;
+}
+
+.boot-error-summary {
+  cursor: pointer;
+  font-size: 0.8rem;
+  color: var(--muted, #666);
+  user-select: none;
+  padding: 0.25rem 0;
+}
+
+.boot-error-summary:hover {
+  color: var(--ink-deep, #222);
+}
+
+.boot-error-details[open] .boot-error-summary {
+  margin-bottom: 0.5rem;
+}
+
 /* Side-by-side: directory (left) + detail (right) so detail is always visible */
 #app-wrap {
   display: flex;

--- a/tests/e2e/test_boot_error_panel.py
+++ b/tests/e2e/test_boot_error_panel.py
@@ -1,0 +1,131 @@
+"""E2E: boot-error panel surfaces actionable copy + recovery affordances.
+
+Issue #124. The previous panel led with a debugger-flavored hint
+("If you are debugging: use the report below…") and pointed users at
+a *Reload on the update banner* that doesn't exist in this state.
+After PR #126 (the standalone-PWA auth-trap fix), the auth-failure
+case no longer reaches this panel — it routes to the email gate. So
+the panel is now strictly for genuinely-unknown failures (network
+errors, 5xx, unexpected exceptions). The new copy + buttons reflect
+that scope.
+
+To force the panel to render in tests we need:
+  - Standalone PWA mode (so bootDirectoryAsApp runs and PR #126's
+    auth handoff is bypassed for non-auth errors).
+  - /fellows.db AND /api/fellows returning 500 (non-auth error so
+    the catch falls through to showBootFailure rather than handing
+    off to startBrowserUx).
+  - Empty IDB cache (default for fresh test contexts) so the
+    api+idb fallback can't recover.
+"""
+from __future__ import annotations
+
+from playwright.sync_api import expect
+
+from conftest import _STANDALONE_DISPLAY_INIT
+
+
+FELLOWS_DB = "**/fellows.db"
+API_FELLOWS = "**/api/fellows**"
+
+
+class TestBootErrorPanel:
+    def test_panel_renders_actionable_copy_and_buttons(self, context, base_url_fixture):
+        """Force a 500 boot failure and verify the new structure: lead
+        copy, three action buttons, and a default-collapsed details
+        block. Pre-#124 the panel led with debugger copy and offered
+        only the Send-report button.
+        """
+        page = context.new_page()
+        page.add_init_script(_STANDALONE_DISPLAY_INIT)
+        page.add_init_script(
+            "window.localStorage.setItem('fellows_authenticated_once', '1');"
+        )
+        # Server-error (non-auth) on both critical fetches: forces the
+        # boot chain into the showBootFailure branch rather than the
+        # auth-handoff branch (PR #126) or the boot-stuck watchdog
+        # branch (PR #119, fires only when getList never resolves).
+        context.route(
+            FELLOWS_DB,
+            lambda r: r.fulfill(status=500, body="server error"),
+        )
+        context.route(
+            API_FELLOWS,
+            lambda r: r.fulfill(status=500, body="server error"),
+        )
+        try:
+            page.goto(base_url_fixture + "/", wait_until="domcontentloaded")
+            page.locator("#boot-error-panel").wait_for(state="visible", timeout=10000)
+
+            # Lead copy is user-facing, not debugger-flavored. Scoped to
+            # this panel — `.boot-error-lead` is also used by the
+            # boot-stuck and auth-error panels.
+            panel = page.locator("#boot-error-panel")
+            lead = panel.locator(".boot-error-lead").inner_text()
+            assert "couldn't load the directory" in lead.lower(), (
+                f"lead should be user-facing copy; got: {lead!r}"
+            )
+
+            # The misleading "Reload on the update banner" hint is gone.
+            hint = panel.locator(".boot-error-hint").inner_text()
+            assert "update banner" not in hint.lower(), (
+                f"old debugger hint about the update banner should be gone; got: {hint!r}"
+            )
+
+            # Three action buttons present.
+            expect(page.locator("#boot-error-reload-button")).to_be_visible()
+            expect(page.locator("#boot-error-clear-cache-button")).to_be_visible()
+            expect(page.locator("#bug-report-button-boot-error")).to_be_visible()
+
+            # Diagnostic dump is wrapped in a <details> and default-closed.
+            details = page.locator(".boot-error-details")
+            expect(details).to_be_visible()
+            is_open = page.evaluate(
+                "() => document.querySelector('.boot-error-details').open"
+            )
+            assert is_open is False, "details should be default-collapsed"
+
+            # The pre still renders inside the details (so the dump is
+            # there, just hidden by default). Use text_content (DOM
+            # textContent) rather than inner_text, since collapsed
+            # details content is display:none and inner_text returns "".
+            pre_text = page.locator("#boot-error-pre").text_content()
+            assert pre_text, "diagnostic pre should be populated"
+        finally:
+            context.unroute(FELLOWS_DB)
+            context.unroute(API_FELLOWS)
+            page.close()
+
+    def test_reload_button_triggers_navigation(self, context, base_url_fixture):
+        """The new in-panel Reload button must actually reload the page
+        (delegates to window.location.reload). Pre-fix the panel had
+        no in-panel reload affordance — the user had to find the red
+        button at the bottom of the page or restart the PWA.
+        """
+        page = context.new_page()
+        page.add_init_script(_STANDALONE_DISPLAY_INIT)
+        page.add_init_script(
+            "window.localStorage.setItem('fellows_authenticated_once', '1');"
+        )
+        context.route(
+            FELLOWS_DB,
+            lambda r: r.fulfill(status=500, body="server error"),
+        )
+        context.route(
+            API_FELLOWS,
+            lambda r: r.fulfill(status=500, body="server error"),
+        )
+        try:
+            page.goto(base_url_fixture + "/", wait_until="domcontentloaded")
+            page.locator("#boot-error-panel").wait_for(state="visible", timeout=10000)
+
+            # Drop the route blocks so the reload can settle (otherwise
+            # it boots straight back into the same panel and the
+            # navigation event behavior gets noisy).
+            context.unroute(FELLOWS_DB)
+            context.unroute(API_FELLOWS)
+
+            with page.expect_navigation(timeout=10000):
+                page.click("#boot-error-reload-button")
+        finally:
+            page.close()


### PR DESCRIPTION
Closes #124.

## Summary

The boot-error panel led with a debugger-flavored hint and pointed users at *"Reload on the update banner"* — a banner that doesn't exist in this state. Post-#126 the auth-failure case no longer reaches this panel (it routes to the email gate), so the panel is now strictly for genuinely-unknown failures (network errors, 5xx, unexpected exceptions). The copy and structure should reflect that scope.

- **Lead**: *"We couldn't load the directory."* (was: *"Could not load the directory."*)
- **Hint**: plain English about what's preserved + likely cause. Drops the misleading *update banner* reference and the *missing fellows.db on the server* debugger note.
- **Three inline action buttons** replace the lone Send-report row: **Reload**, **Clear App Cache & Reload**, **Send report to the maintainer**. Reload delegates to \`window.location.reload\`; Clear App Cache delegates to the existing global \`#clear-app-cache-button\` so the click is indistinguishable from the user pressing the same button at the bottom of the page (single source of truth for the confirm dialog + \`clearAllAppData\` re-entrancy guards). Same pattern as the boot-stuck panel from PR #119.
- **Diagnostic dump** moves into a default-collapsed \`<details>\` block so the user-facing copy isn't dominated by a wall of green text. Power users + bug-report flows expand it.

## Test plan

- [x] \`just test-fast\` — 63 passed.
- [x] \`just test-e2e\` (full) — **183 passed, 12 skipped** (up from 181: two new cases).
- [x] **New: \`tests/e2e/test_boot_error_panel.py\`** — forces a 500 boot failure (route both \`/fellows.db\` and \`/api/fellows\` to 500) and verifies:
  - Lead copy is user-facing, not debugger-flavored.
  - Hint no longer mentions the *update banner* (the misleading recovery hint).
  - Three action buttons are present + visible.
  - The \`<details>\` block is default-collapsed.
  - Diagnostic content is still in the DOM (just hidden).
  - **Reload button** triggers a real navigation.

## Manual QA

After deploy, force a boot failure (DevTools → Network → Block request URL on \`fellows.db\` and \`api/fellows\`, or take the box offline). The panel should:

1. Lead with *"We couldn't load the directory."*
2. Show three buttons in a row: Reload, Clear App Cache & Reload, Send report.
3. Have a small *Show technical details* disclosure below the buttons. Click to reveal the diagnostic dump.
4. Reload button → page reloads. Clear App Cache button → same confirm dialog as the global red button → reset on accept. Send report → opens bug-report dialog with diagnostics pre-filled.

🤖 Generated with [Claude Code](https://claude.com/claude-code)