### PR TITLE
chore(ansible): auto-reboot after unattended security upgrades at 04:00 UTC

### DIFF
--- a/ansible/roles/common/tasks/main.yml
+++ b/ansible/roles/common/tasks/main.yml
@@ -12,6 +12,24 @@
     state: present
     update_cache: true
 
+# unattended-upgrades is enabled by default on Ubuntu 24.04 and applies the
+# -security pocket nightly, but never reboots — so kernel/libc updates land
+# and then strand the box on the old kernel until someone reboots manually.
+# Drop-in lives alongside (not inside) the distro-managed 50unattended-upgrades
+# so package upgrades won't clobber it. Server is in UTC; 04:00 is the
+# quietest window for the EHF audience (NZ 16:00, US PT 21:00 prior day).
+- name: Configure unattended-upgrades auto-reboot
+  ansible.builtin.copy:
+    dest: /etc/apt/apt.conf.d/52unattended-upgrades-local
+    owner: root
+    group: root
+    mode: "0644"
+    content: |
+      // Managed by Ansible (roles/common). Do not edit by hand.
+      Unattended-Upgrade::Automatic-Reboot "true";
+      Unattended-Upgrade::Automatic-Reboot-WithUsers "true";
+      Unattended-Upgrade::Automatic-Reboot-Time "04:00";
+
 # Service identity: a system account with no login shell and no home, per
 # Ubuntu convention for daemons (www-data, postgres, etc.). The account
 # exists only to run fellows-pwa and own /opt/fellows.


### PR DESCRIPTION
## Summary

- Drops `/etc/apt/apt.conf.d/52unattended-upgrades-local` via the common role with `Automatic-Reboot "true"`, `Automatic-Reboot-WithUsers "true"`, `Automatic-Reboot-Time "04:00"`.
- Stays on the Ubuntu default of security-pocket only — no widening to `noble-updates`. The manual `apt upgrade` sweep still covers non-security `-updates` periodically.
- Server is in UTC; 04:00 lands at NZ 16:00 / US PT 21:00 (prior day) — the quietest window for the EHF audience.

## Why

`unattended-upgrades` was already enabled and applying `-security` packages nightly, but `Automatic-Reboot` defaulted to `false`. After 61d uptime, prod had 5 stranded kernels (`-101`, `-106`, `-107`, `-110`, `-111`) installed-but-not-running plus `libc6` and friends queued in `/var/run/reboot-required`. Going forward, the box will install + reboot itself in the 04:00 window when a kernel/libc security update arrives.

The drop-in lives alongside (not inside) the distro-managed `50unattended-upgrades` so a `unattended-upgrades` package upgrade won't clobber the override.

## Test plan (maintainer manual QA)

Already performed before opening this PR — included for the record / reproduction:

- [x] Manual `apt upgrade -y && reboot` to clear the backlog. Kernel jumped `6.8.0-71` → `6.8.0-111`, `/var/run/reboot-required` cleared, `fellows-pwa` and `caddy` came back active, all three `just smoke` checks 200 OK.
- [x] `just bootstrap` (dry-run `--check --diff` first, then real run) — single changed task: `Configure unattended-upgrades auto-reboot`.
- [x] On prod: `cat /etc/apt/apt.conf.d/52unattended-upgrades-local` shows the three knobs.
- [x] On prod: `apt-config dump | grep Unattended-Upgrade::Automatic-Reboot` resolves to `"true"` / `"true"` / `"04:00"` — confirming `unattended-upgrades` will read the override.

To verify after merge:

- [ ] Re-run `just bootstrap` from `main` — should be a no-op (idempotent).
- [ ] In a few weeks when a kernel security update lands: `journalctl -u unattended-upgrades` should show the reboot fired in the 04:00 window, and `/var/run/reboot-required` should be absent on the next morning's check.

🤖 Generated with [Claude Code](https://claude.com/claude-code)