### PR TITLE
feat(groups): '(fellow data unavailable)' hint in rail / visual / exports

### DIFF
--- a/app/static/app.js
+++ b/app/static/app.js
@@ -5056,16 +5056,33 @@
     groupDraft.members.forEach(function (rid) {
       var li = document.createElement('li');
       li.className = 'group-rail-member';
+      var resolvedName = groupDraft.memberNames[rid];
+      // Unresolved when no name was stored, OR when the stored name
+      // equals the record_id itself (attachMemberNamesFromCache /
+      // edit-mode loader both fall back to `rid` as the "name" when
+      // the fellow row is missing from fellows.db).
+      var unresolved = !resolvedName || resolvedName === rid;
       var name = document.createElement('span');
       name.className = 'group-rail-member-name';
-      name.textContent = groupDraft.memberNames[rid] || rid;
+      name.textContent = resolvedName || rid;
+      if (unresolved) {
+        // Edit-mode rail can include an orphan whose fellow row is
+        // gone from fellows.db; chip would otherwise show a raw
+        // record_id with no context. See issue #111.
+        li.classList.add('group-rail-member--unresolved');
+        var hint = document.createElement('span');
+        hint.className = 'fellow-data-unavailable-hint';
+        hint.textContent = '(fellow data unavailable)';
+        name.appendChild(document.createTextNode(' '));
+        name.appendChild(hint);
+      }
       var rm = document.createElement('button');
       rm.type = 'button';
       rm.className = 'group-rail-member-remove';
       rm.title = 'remove';
       rm.textContent = '×';
       rm.addEventListener('click', function () {
-        toggleDraftMember(rid, name.textContent);
+        toggleDraftMember(rid, resolvedName || rid);
       });
       li.appendChild(name);
       li.appendChild(rm);
@@ -6573,12 +6590,21 @@
         } else {
           imgSrc = PORTRAIT_SVG_PLACEHOLDER;
         }
-        html += '<button type="button" class="group-directory-cell" data-member-idx="' + escapeHtml(String(idx)) + '">' +
+        // Unresolved member: resolveMembersForView fell back to rid as
+        // the display name. See issue #111.
+        var unresolved = m.record_id && m.name === m.record_id;
+        var hintHtml = unresolved
+          ? '<div class="fellow-data-unavailable-hint">(fellow data unavailable)</div>'
+          : '';
+        html += '<button type="button" class="group-directory-cell' +
+          (unresolved ? ' group-directory-cell--unresolved' : '') +
+          '" data-member-idx="' + escapeHtml(String(idx)) + '">' +
           '<div class="group-directory-portrait">' +
             '<img src="' + escapeHtml(imgSrc) + '" alt="' + escapeHtml(m.name) +
             '" loading="lazy" onerror="this.onerror=null;this.src=\'' + PORTRAIT_SVG_PLACEHOLDER + '\';">' +
           '</div>' +
           '<div class="group-directory-name">' + escapeHtml(m.name) + '</div>' +
+          hintHtml +
         '</button>';
       });
       html += '</div></div>';
@@ -6675,6 +6701,15 @@
       ? '<a class="fellow-modal-profile-link" href="' + escapeHtml(profileHref) + '">View full profile →</a>'
       : '';
 
+    // See issue #111: portrait was clicked from a group whose member's
+    // fellow row is gone from fellows.db; modal would otherwise show the
+    // raw record_id as the heading with no context.
+    var unresolved = m.record_id && m.name === m.record_id;
+    var unresolvedHintHtml = unresolved
+      ? '<div class="fellow-data-unavailable-hint fellow-modal-unresolved-hint">' +
+          '(fellow data unavailable)' +
+        '</div>'
+      : '';
     var overlay = document.createElement('div');
     overlay.className = 'fellow-modal-overlay';
     overlay.setAttribute('role', 'presentation');
@@ -6686,6 +6721,7 @@
           '" onerror="this.onerror=null;this.src=\'' + PORTRAIT_SVG_PLACEHOLDER + '\';">' +
         '</div>' +
         '<h3 class="fellow-modal-name" id="fellow-modal-name">' + escapeHtml(m.name || '') + '</h3>' +
+        unresolvedHintHtml +
         '<ul class="fellow-modal-rows">' + rowsHtml + '</ul>' +
         profileHtml +
       '</div>';
@@ -6743,6 +6779,9 @@
     'overflow:hidden;background:#eee;}' +
     '.portrait img{width:100%;height:100%;object-fit:cover;display:block;}' +
     '.cell-name{font-size:0.78rem;margin-top:4px;line-height:1.2;}' +
+    '.fellow-data-unavailable-hint{font-size:0.72rem;color:#888;font-style:italic;' +
+    'margin:2px 0 0;line-height:1.2;}' +
+    '.fellow-card .fellow-data-unavailable-hint{margin:-0.2rem 0 0.6rem;font-size:0.85rem;}' +
     '.back-link{display:inline-block;margin:1.2rem 0 0.4rem;color:#0066cc;font-size:0.85rem;}' +
     '.fellow-card{max-width:420px;margin:0 auto 1rem;background:#fff;border:1px solid #ccc;' +
     'border-radius:4px;padding:1.2rem 1.4rem;}' +
@@ -6771,10 +6810,17 @@
     members.forEach(function (m) {
       var slug = m.slug || slugifyForFilename(m.name);
       var imgSrc = imgMap[m.slug] || PORTRAIT_SVG_PLACEHOLDER;
+      // See issue #111: orphan members in an exported group otherwise
+      // print as a portrait placeholder under a raw record_id.
+      var unresolved = m.record_id && m.name === m.record_id;
+      var hintHtml = unresolved
+        ? '<div class="fellow-data-unavailable-hint">(fellow data unavailable)</div>'
+        : '';
       html += '<a class="cell" href="#fellow-' + escapeHtml(slug) + '">' +
         '<div class="portrait"><img src="' + escapeHtml(imgSrc) +
         '" alt="' + escapeHtml(m.name) + '"></div>' +
         '<div class="cell-name">' + escapeHtml(m.name) + '</div>' +
+        hintHtml +
       '</a>';
     });
     return html + '</div>';
@@ -6783,6 +6829,10 @@
   function buildExportFellowSection(group, m, imgMap) {
     var slug = m.slug || slugifyForFilename(m.name);
     var imgSrc = imgMap[m.slug] || PORTRAIT_SVG_PLACEHOLDER;
+    var unresolved = m.record_id && m.name === m.record_id;
+    var unresolvedHintHtml = unresolved
+      ? '<p class="fellow-data-unavailable-hint">(fellow data unavailable)</p>'
+      : '';
     var rows = [];
     if (m.contact_email) {
       rows.push('<tr><td class="label">email</td><td><a href="mailto:' +
@@ -6808,6 +6858,7 @@
         '<div class="fellow-portrait"><img src="' + escapeHtml(imgSrc) +
           '" alt="' + escapeHtml(m.name) + '"></div>' +
         '<h2>' + escapeHtml(m.name) + '</h2>' +
+        unresolvedHintHtml +
         (rows.length
           ? '<table class="field-table"><tbody>' + rows.join('') + '</tbody></table>'
           : '<p>(No public contact info on file.)</p>') +
@@ -6960,8 +7011,20 @@
         var nameY = y + portraitSize + nameLineH;
         var nameTextW = doc.getStringUnitWidth(m.name) * 9;
         doc.text(m.name, x + (cellW - nameTextW) / 2, nameY);
-        // Email (clickable mailto annotation)
-        if (m.contact_email) {
+        // Unresolved member: render a muted italic hint where the email
+        // line would go. See issue #111.
+        var unresolved = m.record_id && m.name === m.record_id;
+        if (unresolved) {
+          doc.setFont('helvetica', 'italic');
+          doc.setFontSize(8);
+          doc.setTextColor(136);
+          var hintText = '(fellow data unavailable)';
+          var hintY = nameY + emailLineH;
+          var hintW = doc.getStringUnitWidth(hintText) * 8;
+          doc.text(hintText, x + (cellW - hintW) / 2, hintY);
+          doc.setTextColor(34);
+        } else if (m.contact_email) {
+          // Email (clickable mailto annotation)
           doc.setFont('helvetica', 'normal');
           doc.setFontSize(8);
           doc.setTextColor(0, 102, 204);

--- a/app/static/styles.css
+++ b/app/static/styles.css
@@ -1658,6 +1658,32 @@ h1 {
   white-space: nowrap;
 }
 
+/* Inline hint shown next to a member chip when fellow data is missing —
+   composer rail (edit-mode orphan), visual-directory portrait + modal,
+   and group exports. See issue #111 for context. */
+.fellow-data-unavailable-hint {
+  font-size: 0.72rem;
+  color: var(--muted-soft, #888);
+  font-style: italic;
+  font-weight: 400;
+}
+
+.group-rail-member--unresolved .group-rail-member-name {
+  color: var(--muted, #555);
+}
+
+.group-directory-name + .fellow-data-unavailable-hint {
+  display: block;
+  margin-top: 2px;
+  line-height: 1.2;
+}
+
+.fellow-modal-unresolved-hint {
+  text-align: center;
+  margin: -0.4rem 0 0.6rem;
+  font-size: 0.85rem;
+}
+
 .group-rail-member-remove {
   background: transparent;
   border: 0;

--- a/docs/users_manual.md
+++ b/docs/users_manual.md
@@ -324,6 +324,11 @@ render in group detail as **Profile no longer available (record_id:
 no longer in the active snapshot. You can leave the row in place
 (harmless) or click **Remove** to drop it from the group.
 
+The same row also appears with a small *(fellow data unavailable)*
+note anywhere else the group surfaces — composer rail when editing,
+visual directory grid, and PDF / HTML exports — so you can spot the
+gap without opening group detail.
+
 ---
 
 ## Clearing app data

--- a/tests/e2e/test_orphan_soft_scan.py
+++ b/tests/e2e/test_orphan_soft_scan.py
@@ -123,6 +123,68 @@ def test_soft_scan_fires_toast_once_and_marks_done(context, base_url_fixture):
         page.close()
 
 
+def test_unresolved_member_shows_hint_in_rail_and_visual_directory(
+    context, base_url_fixture
+):
+    """Issue #111 second half: when a group_member's record_id can't be
+    resolved against fellows.db, the composer rail (edit mode) and the
+    visual-directory portrait grid both render a muted '(fellow data
+    unavailable)' hint instead of just the raw record_id.
+
+    Group detail itself uses the richer 'Profile no longer available'
+    orphan row (PR #117); this test covers the other surfaces.
+    """
+    page = _make_standalone_page(context)
+    try:
+        page.goto(base_url_fixture + "/", wait_until="domcontentloaded")
+        _wait_for_worker_ready(page)
+
+        _seed_orphan_group(
+            page,
+            group_name="orphan-hint-canary",
+            orphan_rid="rec_orphan_for_hint_render",
+        )
+        group_id = page.evaluate(
+            """
+            async () => {
+              const groups = await window.__dataProvider.listGroups();
+              const g = groups.find((x) => x.name === 'orphan-hint-canary');
+              return g ? g.id : null;
+            }
+            """
+        )
+        assert group_id is not None
+
+        # Visual directory: hint shows under the portrait.
+        page.goto(
+            base_url_fixture + "/#/groups/" + str(group_id) + "/directory",
+            wait_until="domcontentloaded",
+        )
+        unresolved_cell = page.locator(".group-directory-cell--unresolved")
+        expect(unresolved_cell).to_be_visible(timeout=5000)
+        expect(unresolved_cell).to_contain_text("(fellow data unavailable)")
+        expect(unresolved_cell).to_contain_text("rec_orphan_for_hint_render")
+
+        # Modal opened from that cell carries the same hint.
+        unresolved_cell.click()
+        modal_hint = page.locator(".fellow-modal-unresolved-hint")
+        expect(modal_hint).to_be_visible(timeout=3000)
+        expect(modal_hint).to_contain_text("(fellow data unavailable)")
+        page.locator(".fellow-modal-close").click()
+
+        # Edit mode: rail chip carries the hint instead of just the rid.
+        page.goto(
+            base_url_fixture + "/#/edit/" + str(group_id),
+            wait_until="domcontentloaded",
+        )
+        rail_chip = page.locator(".group-rail-member--unresolved")
+        expect(rail_chip).to_be_visible(timeout=5000)
+        expect(rail_chip).to_contain_text("(fellow data unavailable)")
+        expect(rail_chip).to_contain_text("rec_orphan_for_hint_render")
+    finally:
+        page.close()
+
+
 def test_orphan_row_renders_with_remove_affordance(context, base_url_fixture):
     """Group detail flags orphan members and offers a Remove button.
     Clicking Remove drops the row from group_members and re-renders."""


### PR DESCRIPTION
## Summary

- Closes **half-2 of #111** (the Phase 2 plan leftover): when a group_member's `record_id` can't be resolved against local `fellows.db`, surfaces a small muted *(fellow data unavailable)* hint instead of just the raw record_id.
- Touched only the surfaces that still showed the bare rid. Group detail's richer *Profile no longer available [Remove]* row (from PR #117) remains the canonical affordance and is **not** changed by this PR.

### Where the hint now appears

| Surface | Function | Render |
|---|---|---|
| Composer rail (edit mode) | `renderRailMembers` | inline span next to chip name |
| Visual directory portrait grid | `renderGroupDirectoryPage` | block under the name |
| Visual-directory contact modal | `openFellowContactModal` | centered block under the H3 |
| HTML export — index | `buildExportIndexGrid` | block under the cell name |
| HTML export — per-fellow card | `buildExportFellowSection` | paragraph under the H2 |
| PDF export | inside `exportGroupAsPdf`'s page loop | italic 8pt grey at the email-line position (no email exists for orphans) |

CSS lives in `styles.css` (`.fellow-data-unavailable-hint`); the HTML export inlines an equivalent rule into `EXPORT_CSS` so the standalone export file renders the hint without depending on the app's stylesheet.

### Detection

Two equivalent checks depending on the data shape at the call site:
- `m.record_id && m.name === m.record_id` — used everywhere downstream of `resolveMembersForView` and `attachMemberNamesFromCache`.
- `!resolvedName || resolvedName === rid` in the rail, where `groupDraft.memberNames[rid]` is loaded by the edit-mode loader and may be set to `rid` itself when the fellow row is missing.

## Test plan

- [x] `just test` — **379 passed, 12 skipped** (was 378; new test added)
- [x] New e2e: `tests/e2e/test_orphan_soft_scan.py::test_unresolved_member_shows_hint_in_rail_and_visual_directory` — seeds an orphan group, asserts the hint shows in visual directory grid + cell modal + edit-mode rail. The existing group-detail orphan test (`test_orphan_row_renders_with_remove_affordance`) continues to assert the unchanged "Profile no longer available" row.
- [x] `just test-fast` (63 passed) — sanity check after each edit.

### Manual QA the maintainer can do

1. Visit the running app, create a group containing one member, then edit `relationships.db` outside the app to point that member at a record_id that doesn't exist in `fellows.db` (or use the e2e helper pattern via `window.__dataProvider.createGroup({fellow_record_ids:['rec_does_not_exist']})` from the DevTools console).
2. Open `#/groups/<id>/directory` — the cell should show *(fellow data unavailable)* under the rid.
3. Click the cell — the modal should carry the hint under the heading.
4. Open `#/edit/<id>` — the rail chip should carry the hint after the rid.
5. From `#/groups/<id>` → ⬇ Export a directory → PDF: open the PDF, the orphan cell should have an italic *(fellow data unavailable)* line at the email row. Same for HTML export.

### Notes

- Plan reference: `plans/local_first_worker_architecture.md` Phase 2 — *"Group-detail rendering when a member's record_id can't be resolved against the local fellows.db shows the record_id with a small 'fellow data unavailable' hint instead of a hard error."*
- This PR completes the only literal Phase 0–4 leftover I found while priming. With it merged, Phase 5 (test infra paired with each phase) is also satisfied for this gap.

🤖 Generated with [Claude Code](https://claude.com/claude-code)