### PR TITLE
feat(about): full-width HTML stats bars; multicol Field Completeness

### DIFF
--- a/app/static/app.js
+++ b/app/static/app.js
@@ -5468,28 +5468,35 @@
 
   // ===== End groups feature ============================================
 
-  function statsSection(title, items, color) {
+  /** Render a stats section as semantic HTML bars instead of SVG.
+   *  Each row is a CSS grid: label · bar-track (with proportional fill) ·
+   *  count. Bar heights are fixed in CSS so they stay legible at any
+   *  viewport — issue #132. The SVG predecessor coupled bar height to
+   *  width via aspect-ratio scaling, which made bars shrink in both
+   *  dimensions on narrow columns. `multicol` opts the section into a
+   *  two-column wrap above the desktop breakpoint — appropriate for the
+   *  long Field Completeness list. */
+  function statsSection(title, items, color, multicol) {
     if (!items || !items.length) return '';
     var maxCount = items[0].count;
-    var barHeight = 28;
-    var labelWidth = 220;
-    var gap = 4;
-    var chartWidth = 500;
-    var svgHeight = items.length * (barHeight + gap);
-    var totalWidth = labelWidth + chartWidth + 60;
-
-    var svg = '<svg class="stats-chart" width="100%" viewBox="0 0 ' + totalWidth + ' ' + svgHeight + '" role="img" aria-label="' + escapeHtml(title) + '">';
+    var rows = '';
     for (var i = 0; i < items.length; i++) {
       var item = items[i];
-      var y = i * (barHeight + gap);
-      var barWidth = maxCount > 0 ? (item.count / maxCount) * chartWidth : 0;
-      svg += '<text x="' + (labelWidth - 8) + '" y="' + (y + barHeight / 2 + 5) + '" text-anchor="end" font-size="13" fill="#333">' + escapeHtml(item.label) + '</text>';
-      svg += '<rect x="' + labelWidth + '" y="' + y + '" width="' + barWidth + '" height="' + barHeight + '" rx="3" fill="' + color + '" opacity="0.85"/>';
-      svg += '<text x="' + (labelWidth + barWidth + 6) + '" y="' + (y + barHeight / 2 + 5) + '" font-size="13" fill="#333">' + item.count + '</text>';
+      var pct = maxCount > 0 ? (item.count / maxCount) * 100 : 0;
+      var ariaLabel = title + ': ' + item.label + ' — ' + item.count;
+      rows += '<li class="stats-bar-row" aria-label="' + escapeHtml(ariaLabel) + '">' +
+        '<span class="stats-bar-label">' + escapeHtml(item.label) + '</span>' +
+        '<span class="stats-bar-track">' +
+          '<span class="stats-bar-fill" style="width: ' + pct.toFixed(1) + '%"></span>' +
+        '</span>' +
+        '<span class="stats-bar-count">' + escapeHtml(String(item.count)) + '</span>' +
+      '</li>';
     }
-    svg += '</svg>';
-
-    return '<div class="detail-section"><h3 class="detail-section-title">' + escapeHtml(title) + '</h3><div class="detail-section-body">' + svg + '</div></div>';
+    var sectionClass = 'stats-section' + (multicol ? ' stats-section--multicol' : '');
+    return '<section class="' + sectionClass + '" style="--stats-bar-color: ' + color + '">' +
+      '<h3 class="stats-section-title">' + escapeHtml(title) + '</h3>' +
+      '<ol class="stats-bars">' + rows + '</ol>' +
+    '</section>';
   }
 
   function renderAboutPage() {
@@ -5702,14 +5709,16 @@
         var gridEl = document.getElementById('stats-grid');
         if (totalEl) totalEl.innerHTML = 'Total Fellows: <strong>' + escapeHtml(String(data.total)) + '</strong>';
         if (gridEl) {
-          var gh = '<div class="stats-col stats-col--left">';
+          // Issue #132: stack sections single-column at full pane width
+          // so bars use the available horizontal space; Field
+          // Completeness opts into a 2-column wrap (CSS-only) above the
+          // desktop breakpoint to keep its ~30 entries scannable
+          // without dwarfing the others.
+          var gh = '';
           gh += statsSection('Fellows by Type', data.by_fellow_type, '#0066cc');
           gh += statsSection('Fellows by Cohort', data.by_cohort, '#2c6a4a');
           gh += statsSection('Fellows by Region', data.by_region, '#2c4a6a');
-          gh += '</div>';
-          gh += '<div class="stats-col stats-col--right">';
-          gh += statsSection('Field Completeness', data.field_completeness, '#5a5a5a');
-          gh += '</div>';
+          gh += statsSection('Field Completeness', data.field_completeness, '#5a5a5a', true);
           gridEl.innerHTML = gh;
         }
       })

--- a/app/static/styles.css
+++ b/app/static/styles.css
@@ -973,14 +973,10 @@ h1 {
 }
 
 .stats-grid {
-  display: grid;
-  grid-template-columns: 1fr 1fr;
+  display: flex;
+  flex-direction: column;
   gap: 1.5rem;
-  align-items: start;
-}
-
-.stats-col {
-  min-width: 0;
+  align-items: stretch;
 }
 
 .stats-title {
@@ -991,6 +987,90 @@ h1 {
 .stats-total {
   font-size: 1.1rem;
   margin-bottom: 1.5rem;
+}
+
+/* Stats sections (issue #132): semantic HTML bars at full pane width.
+   Replaces the prior SVG renderer whose viewBox-based scaling shrank
+   bars in both dimensions on narrow columns. */
+.stats-section {
+  --stats-bar-color: #0066cc;
+  margin: 0;
+  padding: 0;
+}
+
+.stats-section-title {
+  margin: 0 0 0.6rem 0;
+  font-size: 1rem;
+  font-weight: 600;
+  color: #222;
+}
+
+.stats-bars {
+  list-style: none;
+  margin: 0;
+  padding: 0;
+}
+
+.stats-bar-row {
+  display: grid;
+  grid-template-columns: minmax(80px, max-content) 1fr 3em;
+  align-items: center;
+  gap: 0.6rem;
+  height: 28px;
+  margin-bottom: 4px;
+  break-inside: avoid;
+}
+
+.stats-bar-label {
+  font-size: 0.85rem;
+  color: #333;
+  text-align: right;
+  white-space: nowrap;
+  overflow: hidden;
+  text-overflow: ellipsis;
+}
+
+.stats-bar-track {
+  display: block;
+  height: 100%;
+  background: #f0f3f7;
+  border-radius: 3px;
+  overflow: hidden;
+}
+
+.stats-bar-fill {
+  display: block;
+  height: 100%;
+  background: var(--stats-bar-color);
+  opacity: 0.85;
+  border-radius: 3px;
+  min-width: 2px;
+}
+
+.stats-bar-count {
+  font-size: 0.85rem;
+  color: #333;
+  font-variant-numeric: tabular-nums;
+  text-align: left;
+}
+
+/* Field Completeness opts into a 2-column wrap above the desktop
+   breakpoint so its ~30 entries don't push the rest of the page into
+   a long scroll. Single column below 1100px. */
+@media (min-width: 1100px) {
+  .stats-section--multicol .stats-bars {
+    column-count: 2;
+    column-gap: 2rem;
+  }
+}
+
+@media (max-width: 700px) {
+  /* Fellow-detail tables can overflow narrow viewports; allow a local
+     horizontal scroll rather than breaking the layout. (Was paired
+     with stats-chart rules in the SVG era; those are gone.) */
+  .detail-section-body {
+    overflow-x: auto;
+  }
 }
 
 .about-body {
@@ -1044,24 +1124,6 @@ h1 {
   vertical-align: middle;
 }
 
-.stats-chart {
-  display: block;
-  margin: 0.5rem 0 1rem 0;
-  max-width: 100%;
-  height: auto;
-}
-
-@media (max-width: 700px) {
-  .stats-grid {
-    grid-template-columns: 1fr;
-  }
-  .stats-chart {
-    min-width: 600px;
-  }
-  .detail-section-body {
-    overflow-x: auto;
-  }
-}
 
 /* PWA install landing (browser tab only) */
 .install-landing {

--- a/tests/e2e/test_about_stats.py
+++ b/tests/e2e/test_about_stats.py
@@ -1,0 +1,202 @@
+"""E2E: the About-page Fellowship Statistics layout.
+
+Issue #132: the SVG-based stats charts shrank in both dimensions when
+the column was narrow (viewBox aspect-ratio scaling), and the inner
+2-column grid halved the available width on every viewport. The
+replacement renders semantic HTML bars at full pane width, with
+Field Completeness opting into a 2-column wrap above 1100px.
+
+These tests pin the new structure: four sections render as
+.stats-section nodes, each row is a .stats-bar-row with a fill width
+proportional to count/maxCount, and the multicol rule is active at
+desktop width but inactive below 1100px.
+"""
+from __future__ import annotations
+
+from playwright.sync_api import expect
+
+from conftest import _STANDALONE_DISPLAY_INIT
+
+
+def _make_standalone_page(context):
+    page = context.new_page()
+    page.add_init_script(_STANDALONE_DISPLAY_INIT)
+    return page
+
+
+def _boot_then_open_about(page, base_url):
+    """Boot to the directory FIRST, wait for boot to settle, THEN open
+    About via hash. This avoids a race where boot's two route() calls
+    (after getList, then again after getFull) each wipe and re-render
+    the about grid asynchronously — so the test can land on a partially
+    rendered grid mid-refresh.
+    """
+    page.goto(base_url + "/", wait_until="domcontentloaded")
+    page.wait_for_function(
+        "() => window.__dataProvider && window.__dataProvider.kind === 'worker'",
+        timeout=15000,
+    )
+    page.wait_for_function(
+        "() => window.__bootMarks && window.__bootMarks.get_full_done != null",
+        timeout=15000,
+    )
+    page.evaluate("location.hash = '#/about'")
+    _wait_for_stats(page)
+
+
+def _wait_for_stats(page):
+    """Stats render async after dataProvider.getStats() resolves AND
+    the total count line shows the resolved value. Waiting for the
+    total text + a stable bar-row count across 4 sections gives a
+    deterministic anchor — the .stats-section selector firing alone
+    is racy mid-render."""
+    page.wait_for_function(
+        """
+        () => {
+          const total = document.getElementById('stats-total');
+          if (!total || !/Total Fellows:\\s*\\d+/.test(total.textContent || '')) {
+            return false;
+          }
+          const sections = document.querySelectorAll(
+            '.stats-grid .stats-section'
+          );
+          if (sections.length !== 4) return false;
+          for (const s of sections) {
+            if (s.querySelectorAll('.stats-bar-row').length === 0) {
+              return false;
+            }
+          }
+          return true;
+        }
+        """,
+        timeout=15000,
+    )
+
+
+class TestAboutStatsLayout:
+    def test_four_sections_render_as_html_not_svg(self, context, base_url_fixture):
+        """All four sections (Type, Cohort, Region, Field Completeness)
+        render as .stats-section nodes containing .stats-bar-row entries.
+        The old SVG renderer is gone: there should be no .stats-chart in
+        the DOM."""
+        page = _make_standalone_page(context)
+        try:
+            _boot_then_open_about(page, base_url_fixture)
+
+            sections = page.locator(".stats-grid .stats-section")
+            expect(sections).to_have_count(4)
+
+            # Title text confirms which section is which.
+            titles = sections.locator(".stats-section-title").all_inner_texts()
+            assert titles == [
+                "Fellows by Type",
+                "Fellows by Cohort",
+                "Fellows by Region",
+                "Field Completeness",
+            ], f"unexpected section order or titles: {titles}"
+
+            # Every section has at least one bar row.
+            for i in range(4):
+                rows = sections.nth(i).locator(".stats-bar-row")
+                assert rows.count() >= 1, (
+                    f"section {titles[i]} has zero bar rows"
+                )
+
+            # The SVG renderer is fully retired.
+            assert page.locator(".stats-chart").count() == 0
+            assert page.locator(".stats-grid svg").count() == 0
+        finally:
+            page.close()
+
+    def test_bar_widths_match_count_proportions(self, context, base_url_fixture):
+        """The inline style.width on each .stats-bar-fill is set to
+        (count / maxCount) * 100. Read the data the page rendered against
+        and verify the widths line up — within 0.15% to absorb the
+        toFixed(1) rounding."""
+        page = _make_standalone_page(context)
+        try:
+            _boot_then_open_about(page, base_url_fixture)
+
+            # Pull (label, count, rendered_pct) tuples for the first section.
+            # The first section is "Fellows by Type" — small, predictable.
+            rows = page.locator(
+                ".stats-grid .stats-section:first-child .stats-bar-row"
+            )
+            n = rows.count()
+            assert n >= 1
+
+            labels = []
+            counts = []
+            rendered_widths = []
+            for i in range(n):
+                row = rows.nth(i)
+                labels.append(row.locator(".stats-bar-label").inner_text())
+                counts.append(int(row.locator(".stats-bar-count").inner_text()))
+                style = row.locator(".stats-bar-fill").get_attribute("style") or ""
+                # Parse "width: NN.N%"
+                assert "width:" in style, f"row {i} fill missing width style: {style!r}"
+                w = float(style.split("width:")[1].split("%")[0].strip())
+                rendered_widths.append(w)
+
+            # First row sets the scale (it's the largest by count, since the
+            # API returns sections sorted DESC by count).
+            max_count = counts[0]
+            assert max_count > 0, f"first row should have nonzero count: {counts}"
+            for i in range(n):
+                expected_pct = (counts[i] / max_count) * 100
+                assert abs(rendered_widths[i] - expected_pct) < 0.15, (
+                    f"row {i} ({labels[i]}, count={counts[i]}): rendered "
+                    f"{rendered_widths[i]}% vs expected {expected_pct}%"
+                )
+        finally:
+            page.close()
+
+    def test_field_completeness_multicol_at_desktop_width(
+        self, context, base_url_fixture
+    ):
+        """Field Completeness opts into 2-column wrap above 1100px via the
+        .stats-section--multicol class. At ≥1100px the inner ol applies
+        column-count: 2; at narrower widths it stays single-column."""
+        page = _make_standalone_page(context)
+        try:
+            page.set_viewport_size({"width": 1400, "height": 900})
+            _boot_then_open_about(page, base_url_fixture)
+
+            fc = page.locator(".stats-section--multicol")
+            expect(fc).to_have_count(1)
+            expect(fc.locator(".stats-section-title")).to_have_text(
+                "Field Completeness"
+            )
+
+            # At desktop width, the bars list inherits 2-column layout from
+            # the @media (min-width: 1100px) rule.
+            col_count_desktop = fc.locator(".stats-bars").evaluate(
+                "el => getComputedStyle(el).columnCount"
+            )
+            assert col_count_desktop == "2", (
+                f"expected column-count:2 at 1400px viewport; got {col_count_desktop!r}"
+            )
+        finally:
+            page.close()
+
+    def test_field_completeness_single_column_below_breakpoint(
+        self, context, base_url_fixture
+    ):
+        """Below 1100px the multicol rule does not apply — narrow viewports
+        are read top-to-bottom in a single column."""
+        page = _make_standalone_page(context)
+        try:
+            page.set_viewport_size({"width": 900, "height": 900})
+            _boot_then_open_about(page, base_url_fixture)
+
+            fc = page.locator(".stats-section--multicol")
+            col_count_narrow = fc.locator(".stats-bars").evaluate(
+                "el => getComputedStyle(el).columnCount"
+            )
+            # CSS default for an element with no column-count is 'auto'.
+            assert col_count_narrow != "2", (
+                f"multicol should NOT apply at 900px viewport; got "
+                f"column-count={col_count_narrow!r}"
+            )
+        finally:
+            page.close()


### PR DESCRIPTION
Closes #132.

## Summary

- Replace the SVG renderer in `statsSection()` with semantic HTML bars rendered at full pane width.
- Drop the inner 2-column grid in `renderAboutPage()` so each section spans the whole detail pane.
- Field Completeness opts into a 2-column CSS column-wrap above 1100 px to keep its ~30 entries scannable without dwarfing Type / Cohort / Region.

## What was wrong

After PR #128 hid the rails on About + Settings at desktop, the About page still rendered cramped charts. Two compounded problems:

1. **`.stats-grid { grid-template-columns: 1fr 1fr }`** packed three charts into a left column and Field Completeness into a right column, so each chart got ~half the available pane width.
2. **`statsSection()` emitted SVG** with `viewBox="0 0 780 H"` and `width: 100%; height: auto`. Browsers scale SVG aspect-ratio uniformly — a narrower container shrank bar height proportionally too. Both dimensions collapsed together. Result: cramped bars even on a 1716 px monitor.

## What changed

| File | Before → After |
|---|---|
| `app/static/app.js` `statsSection()` | SVG `<rect>`s with hard-coded coordinates → `<ol class="stats-bars">` with `<li class="stats-bar-row">` containing label · `.stats-bar-track` · count. Inline `style=\"width: NN.N%\"` on `.stats-bar-fill`. New `multicol` parameter for Field Completeness. |
| `app/static/app.js` `renderAboutPage()` | Manual `<div class=\"stats-col stats-col--left/right\">` wrappers → single `gh += statsSection(...)` chain; the four sections render in order at full width. |
| `app/static/styles.css` | New `.stats-section`, `.stats-section-title`, `.stats-bars`, `.stats-bar-row`, `.stats-bar-track`, `.stats-bar-fill`, `.stats-bar-label`, `.stats-bar-count` rules + `@media (min-width: 1100px) .stats-section--multicol .stats-bars { column-count: 2 }`. Removed `.stats-chart`, `.stats-col`, the `.stats-grid { grid-template-columns: 1fr 1fr }` rule, and the stale `@media (max-width: 700px)` block that pinned `.stats-chart { min-width: 600px }` and forced `overflow-x: auto` on `.detail-section-body` (kept the latter under a narrower scope for fellow-detail's tables). |
| `tests/e2e/test_about_stats.py` (new) | Four new tests — see Test plan. |

## Accessibility wins

- Real HTML text labels — selectable, screen-reader friendly, browser-zoomable. (SVG `<text>` was none of those.)
- Per-row `aria-label`: \"Fellows by Cohort: Manu Tukutuku — 95\". Previously the SVG had only a single section-level aria-label.

## Test plan

- [x] `just test` — **383 passed, 12 skipped** (was 379; +4 new tests).
- [x] `tests/e2e/test_about_stats.py` (4 tests, all green 5/5 isolated runs):
  - `test_four_sections_render_as_html_not_svg` — exactly four `.stats-section` nodes in the right order, each has ≥1 `.stats-bar-row`, no `.stats-chart` or `<svg>` survives in the grid.
  - `test_bar_widths_match_count_proportions` — the inline `width: NN.N%` on each `.stats-bar-fill` matches `(count / maxCount) * 100` within 0.15% (toFixed rounding).
  - `test_field_completeness_multicol_at_desktop_width` — at 1400 × 900, `.stats-section--multicol .stats-bars` reports `getComputedStyle(...).columnCount === \"2\"`.
  - `test_field_completeness_single_column_below_breakpoint` — at 900 × 900, the same selector does NOT report column-count: 2.
- [x] `tests/e2e/test_route_focus_mode.py` still green (3 tests) — focus-mode + this PR don't conflict.
- [x] No data-layer changes; `getStats` API contract unchanged.

### Manual QA the maintainer can do

1. `just serve-fg`, hard-reload `http://localhost:8765/#/about`.
2. Resize browser between ≥1100 px and < 1100 px — Field Completeness should snap from 2 columns to 1.
3. Confirm bar heights stay constant (~28 px) at every width — no more proportional shrink.
4. Tab into the page — focus on a bar reads out *\"Fellows by Cohort: Manu Tukutuku — 95\"* etc.
5. Compare side-by-side against the screenshot in #132 — bars should now occupy ~full pane width.

## Note on the flake fix

The first iteration of the test was flaky because `route()` is called twice during boot (after `getList`, then again after `getFull`), and each call wipes-and-re-renders the about grid asynchronously. The fix is to boot to `/` first, wait for `__bootMarks.get_full_done`, *then* navigate to `#/about` via hash — only fires `route()` once. Five consecutive runs now green.

🤖 Generated with [Claude Code](https://claude.com/claude-code)