### PR TITLE
feat(directory): cohort/type/region/citizenship filter sheet (#86)

### DIFF
--- a/app/static/app.js
+++ b/app/static/app.js
@@ -5468,28 +5468,35 @@
 
   // ===== End groups feature ============================================
 
-  function statsSection(title, items, color) {
+  /** Render a stats section as semantic HTML bars instead of SVG.
+   *  Each row is a CSS grid: label · bar-track (with proportional fill) ·
+   *  count. Bar heights are fixed in CSS so they stay legible at any
+   *  viewport — issue #132. The SVG predecessor coupled bar height to
+   *  width via aspect-ratio scaling, which made bars shrink in both
+   *  dimensions on narrow columns. `multicol` opts the section into a
+   *  two-column wrap above the desktop breakpoint — appropriate for the
+   *  long Field Completeness list. */
+  function statsSection(title, items, color, multicol) {
     if (!items || !items.length) return '';
     var maxCount = items[0].count;
-    var barHeight = 28;
-    var labelWidth = 220;
-    var gap = 4;
-    var chartWidth = 500;
-    var svgHeight = items.length * (barHeight + gap);
-    var totalWidth = labelWidth + chartWidth + 60;
-
-    var svg = '<svg class="stats-chart" width="100%" viewBox="0 0 ' + totalWidth + ' ' + svgHeight + '" role="img" aria-label="' + escapeHtml(title) + '">';
+    var rows = '';
     for (var i = 0; i < items.length; i++) {
       var item = items[i];
-      var y = i * (barHeight + gap);
-      var barWidth = maxCount > 0 ? (item.count / maxCount) * chartWidth : 0;
-      svg += '<text x="' + (labelWidth - 8) + '" y="' + (y + barHeight / 2 + 5) + '" text-anchor="end" font-size="13" fill="#333">' + escapeHtml(item.label) + '</text>';
-      svg += '<rect x="' + labelWidth + '" y="' + y + '" width="' + barWidth + '" height="' + barHeight + '" rx="3" fill="' + color + '" opacity="0.85"/>';
-      svg += '<text x="' + (labelWidth + barWidth + 6) + '" y="' + (y + barHeight / 2 + 5) + '" font-size="13" fill="#333">' + item.count + '</text>';
+      var pct = maxCount > 0 ? (item.count / maxCount) * 100 : 0;
+      var ariaLabel = title + ': ' + item.label + ' — ' + item.count;
+      rows += '<li class="stats-bar-row" aria-label="' + escapeHtml(ariaLabel) + '">' +
+        '<span class="stats-bar-label">' + escapeHtml(item.label) + '</span>' +
+        '<span class="stats-bar-track">' +
+          '<span class="stats-bar-fill" style="width: ' + pct.toFixed(1) + '%"></span>' +
+        '</span>' +
+        '<span class="stats-bar-count">' + escapeHtml(String(item.count)) + '</span>' +
+      '</li>';
     }
-    svg += '</svg>';
-
-    return '<div class="detail-section"><h3 class="detail-section-title">' + escapeHtml(title) + '</h3><div class="detail-section-body">' + svg + '</div></div>';
+    var sectionClass = 'stats-section' + (multicol ? ' stats-section--multicol' : '');
+    return '<section class="' + sectionClass + '" style="--stats-bar-color: ' + color + '">' +
+      '<h3 class="stats-section-title">' + escapeHtml(title) + '</h3>' +
+      '<ol class="stats-bars">' + rows + '</ol>' +
+    '</section>';
   }
 
   function renderAboutPage() {
@@ -5702,14 +5709,16 @@
         var gridEl = document.getElementById('stats-grid');
         if (totalEl) totalEl.innerHTML = 'Total Fellows: <strong>' + escapeHtml(String(data.total)) + '</strong>';
         if (gridEl) {
-          var gh = '<div class="stats-col stats-col--left">';
+          // Issue #132: stack sections single-column at full pane width
+          // so bars use the available horizontal space; Field
+          // Completeness opts into a 2-column wrap (CSS-only) above the
+          // desktop breakpoint to keep its ~30 entries scannable
+          // without dwarfing the others.
+          var gh = '';
           gh += statsSection('Fellows by Type', data.by_fellow_type, '#0066cc');
           gh += statsSection('Fellows by Cohort', data.by_cohort, '#2c6a4a');
           gh += statsSection('Fellows by Region', data.by_region, '#2c4a6a');
-          gh += '</div>';
-          gh += '<div class="stats-col stats-col--right">';
-          gh += statsSection('Field Completeness', data.field_completeness, '#5a5a5a');
-          gh += '</div>';
+          gh += statsSection('Field Completeness', data.field_completeness, '#5a5a5a', true);
           gridEl.innerHTML = gh;
         }
       })

--- a/app/static/app.js
+++ b/app/static/app.js
@@ -129,6 +129,14 @@
   var groupCardScrimEl = document.getElementById('group-card-scrim');
   var groupActionbarSheetEl = document.getElementById('group-actionbar-sheet');
   var groupActionbarScrimEl = document.getElementById('group-actionbar-scrim');
+  // Directory filter UI (issue #86). Trigger sits beside the search input;
+  // the sheet is the single point of entry on every viewport. Controls
+  // are populated lazily once phase 2 (?full=1) lands. See
+  // filterState / filterOptions / buildFilterOptions below.
+  var filterTriggerEl = document.getElementById('filter-trigger');
+  var filterTriggerCountEl = document.getElementById('filter-trigger-count');
+  var filterSheetEl = document.getElementById('filter-sheet');
+  var filterScrimEl = document.getElementById('filter-scrim');
   var deferredInstallPrompt = null;
   var directoryDataSource = 'api';
   var dataProvider = null;
@@ -607,6 +615,11 @@
           if (f.slug) fellowsBySlug.set(f.slug, f);
           if (f.record_id) fellowsBySlug.set(f.record_id, f);
         });
+        // Re-derive filter options after a directory-data swap; the new
+        // bytes may have introduced or removed cohort/region/citizenship
+        // values. Existing filterState is preserved — values that no
+        // longer exist in the data simply match nothing.
+        activateFiltersFromFullData(full);
       }
       // Re-route data-rendering views (group detail, fellow detail,
       // visual directory) so the new bytes show through. Skip when
@@ -4603,9 +4616,432 @@
     return !!(f.contact_email && String(f.contact_email).trim());
   }
 
-  function applyHasEmailFilter(items) {
-    if (!hasEmailOnly) return items;
-    return items.filter(fellowHasEmail);
+  // Directory filter UI (issue #86). filterState is the source of truth
+  // for what's active; filterOptions caches the distinct values scanned
+  // out of the loaded fellow set after phase 2 (?full=1). The trigger
+  // button stays disabled until filterOptions is populated, which is
+  // why has-email + keyword search remain valid during phase 1 (their
+  // codepaths don't depend on filterOptions).
+  var filterState = {
+    cohort: null,           // string | null  (single-select)
+    fellowType: null,       // string | null  (single-select)
+    regions: [],            // string[]       (any-of multi-select)
+    citizenship: null       // string | null  (single-select)
+  };
+  var filterOptions = null;
+  var filterSheetWired = false;
+  // Re-entry guard: applyFiltersToHash() writes the URL via
+  // history.replaceState which doesn't fire 'hashchange', but defensive
+  // code paths may also call route() directly. The flag lets the
+  // hash-read pass bail when we initiated the change ourselves.
+  var filtersWritingHash = false;
+
+  function activeFilterCount() {
+    var n = 0;
+    if (filterState.cohort) n++;
+    if (filterState.fellowType) n++;
+    if (filterState.regions && filterState.regions.length) n++;
+    if (filterState.citizenship) n++;
+    return n;
+  }
+
+  function filterStateSignature() {
+    // Stable serialization for change detection. Region order is
+    // normalized so reordering checkboxes doesn't look like a change.
+    var rs = (filterState.regions || []).slice().sort().join(',');
+    return [
+      filterState.cohort || '',
+      filterState.fellowType || '',
+      rs,
+      filterState.citizenship || ''
+    ].join('|');
+  }
+
+  function uniqueSorted(values, opts) {
+    var seen = Object.create(null);
+    var out = [];
+    for (var i = 0; i < values.length; i++) {
+      var v = values[i];
+      if (v == null) continue;
+      v = String(v).trim();
+      if (!v) continue;
+      if (seen[v]) continue;
+      seen[v] = true;
+      out.push(v);
+    }
+    if (opts && opts.cohort) {
+      // Cohort labels often start with a year ("2020", "2020 Cohort").
+      // Sort by leading numeric prefix when present, falling back to a
+      // string compare so "Inaugural" / "Founder" stay deterministic.
+      out.sort(function (a, b) {
+        var na = parseInt(a, 10);
+        var nb = parseInt(b, 10);
+        var aIsNum = !isNaN(na);
+        var bIsNum = !isNaN(nb);
+        if (aIsNum && bIsNum && na !== nb) return na - nb;
+        if (aIsNum && !bIsNum) return -1;
+        if (!aIsNum && bIsNum) return 1;
+        return a.localeCompare(b);
+      });
+    } else {
+      out.sort(function (a, b) { return a.localeCompare(b); });
+    }
+    return out;
+  }
+
+  function buildFilterOptions(items) {
+    if (!Array.isArray(items) || !items.length) {
+      filterOptions = null;
+      return;
+    }
+    var cohorts = [];
+    var fellowTypes = [];
+    var regions = [];
+    var citizenships = [];
+    for (var i = 0; i < items.length; i++) {
+      var f = items[i];
+      if (!f) continue;
+      cohorts.push(f.cohort);
+      fellowTypes.push(f.fellow_type);
+      citizenships.push(f.primary_citizenship);
+      var raw = f.global_regions_currently_based_in;
+      if (raw) {
+        var parts = String(raw).split(',');
+        for (var j = 0; j < parts.length; j++) regions.push(parts[j]);
+      }
+    }
+    filterOptions = {
+      cohorts: uniqueSorted(cohorts, { cohort: true }),
+      fellowTypes: uniqueSorted(fellowTypes),
+      regions: uniqueSorted(regions),
+      citizenships: uniqueSorted(citizenships)
+    };
+  }
+
+  function fellowMatchesRegions(f, picked) {
+    if (!picked || !picked.length) return true;
+    var raw = f.global_regions_currently_based_in;
+    if (!raw) return false;
+    var parts = String(raw).split(',');
+    for (var i = 0; i < parts.length; i++) {
+      var r = parts[i].trim();
+      if (!r) continue;
+      for (var j = 0; j < picked.length; j++) {
+        if (picked[j] === r) return true;
+      }
+    }
+    return false;
+  }
+
+  // Resolve a possibly-minimal directory row to the full row that has
+  // structured fields (cohort, fellow_type, etc.). The directory's
+  // `list` carries the minimal projection from /api/fellows; full rows
+  // arrive after phase 2 and are indexed in fellowsBySlug. Search
+  // results already come back as full rows, so this is a no-op in that
+  // path.
+  function resolveFullRow(f) {
+    if (!f) return null;
+    if (f.cohort !== undefined || f.fellow_type !== undefined) return f;
+    if (f.slug && fellowsBySlug.has(f.slug)) return fellowsBySlug.get(f.slug);
+    if (f.record_id && fellowsBySlug.has(f.record_id)) return fellowsBySlug.get(f.record_id);
+    return null;
+  }
+
+  function applyFilters(items) {
+    if (!Array.isArray(items)) return items;
+    var out = items;
+    if (hasEmailOnly) out = out.filter(fellowHasEmail);
+    var needsFull =
+      !!filterState.cohort ||
+      !!filterState.fellowType ||
+      (filterState.regions && filterState.regions.length > 0) ||
+      !!filterState.citizenship;
+    if (!needsFull) return out;
+    out = out.filter(function (f) {
+      var full = resolveFullRow(f);
+      if (!full) return false; // can't evaluate without full data; treat as miss
+      if (filterState.cohort && full.cohort !== filterState.cohort) return false;
+      if (filterState.fellowType && full.fellow_type !== filterState.fellowType) return false;
+      if (filterState.regions && filterState.regions.length &&
+          !fellowMatchesRegions(full, filterState.regions)) return false;
+      if (filterState.citizenship && full.primary_citizenship !== filterState.citizenship) return false;
+      return true;
+    });
+    return out;
+  }
+
+  // ----- Filter hash <-> state ------------------------------------------
+  // Filter state lives in the directory hash as a query-style suffix:
+  // #/?cohort=2020&type=Fellow&region=Africa,Asia&citizenship=United%20States.
+  // Read on directory route entry; write via history.replaceState on
+  // every filter change so reload + share-as-link round-trip cleanly
+  // without thrashing the back stack.
+
+  function readFiltersFromHash() {
+    var hash = window.location.hash || '';
+    var qIdx = hash.indexOf('?');
+    if (qIdx === -1) {
+      filterState.cohort = null;
+      filterState.fellowType = null;
+      filterState.regions = [];
+      filterState.citizenship = null;
+      return;
+    }
+    var qs = hash.slice(qIdx + 1);
+    var params;
+    try {
+      params = new URLSearchParams(qs);
+    } catch (_) {
+      return;
+    }
+    filterState.cohort = params.get('cohort') || null;
+    filterState.fellowType = params.get('type') || null;
+    var regionParam = params.get('region') || '';
+    filterState.regions = regionParam
+      ? regionParam.split(',').map(function (s) { return s.trim(); }).filter(Boolean)
+      : [];
+    filterState.citizenship = params.get('citizenship') || null;
+  }
+
+  function writeFiltersToHash() {
+    var hash = window.location.hash || '';
+    var qIdx = hash.indexOf('?');
+    var pathPart = qIdx === -1 ? hash : hash.slice(0, qIdx);
+    if (!pathPart) pathPart = '#/';
+    var qs = new URLSearchParams();
+    if (filterState.cohort) qs.set('cohort', filterState.cohort);
+    if (filterState.fellowType) qs.set('type', filterState.fellowType);
+    if (filterState.regions && filterState.regions.length) {
+      qs.set('region', filterState.regions.join(','));
+    }
+    if (filterState.citizenship) qs.set('citizenship', filterState.citizenship);
+    var qsStr = qs.toString();
+    var newHash = qsStr ? (pathPart + '?' + qsStr) : pathPart;
+    if (newHash === hash) return;
+    filtersWritingHash = true;
+    try {
+      if (window.history && window.history.replaceState) {
+        var url = window.location.pathname + window.location.search + newHash;
+        window.history.replaceState(null, '', url);
+      } else {
+        window.location.hash = newHash;
+      }
+    } finally {
+      filtersWritingHash = false;
+    }
+  }
+
+  // ----- Filter sheet UI ------------------------------------------------
+
+  function setSelectOptions(selectEl, values, currentValue, anyLabel) {
+    if (!selectEl) return;
+    var html = '<option value="">' + escapeHtml(anyLabel || 'Any') + '</option>';
+    for (var i = 0; i < values.length; i++) {
+      var v = values[i];
+      var sel = (v === currentValue) ? ' selected' : '';
+      html += '<option value="' + escapeHtml(v) + '"' + sel + '>' + escapeHtml(v) + '</option>';
+    }
+    selectEl.innerHTML = html;
+  }
+
+  function populateFilterSheetControls() {
+    if (!filterOptions) return;
+    var cohortEl = document.getElementById('filter-cohort');
+    var typeEl = document.getElementById('filter-fellow-type');
+    var citEl = document.getElementById('filter-citizenship');
+    var regionWrap = document.getElementById('filter-region-options');
+    setSelectOptions(cohortEl, filterOptions.cohorts, filterState.cohort);
+    setSelectOptions(typeEl, filterOptions.fellowTypes, filterState.fellowType);
+    setSelectOptions(citEl, filterOptions.citizenships, filterState.citizenship);
+    if (regionWrap) {
+      var html = '';
+      var picked = {};
+      for (var p = 0; p < filterState.regions.length; p++) picked[filterState.regions[p]] = true;
+      for (var i = 0; i < filterOptions.regions.length; i++) {
+        var r = filterOptions.regions[i];
+        var checked = picked[r] ? ' checked' : '';
+        html +=
+          '<label><input type="checkbox" data-filter-region value="' +
+          escapeHtml(r) + '"' + checked + ' /><span>' + escapeHtml(r) + '</span></label>';
+      }
+      regionWrap.innerHTML = html || '<p class="placeholder">No regions in data.</p>';
+    }
+  }
+
+  function syncFilterSheetControls() {
+    // Lighter than re-rendering: just reflect filterState into existing
+    // controls. Used after Reset and after readFiltersFromHash().
+    if (!filterOptions) return;
+    var cohortEl = document.getElementById('filter-cohort');
+    var typeEl = document.getElementById('filter-fellow-type');
+    var citEl = document.getElementById('filter-citizenship');
+    if (cohortEl) cohortEl.value = filterState.cohort || '';
+    if (typeEl) typeEl.value = filterState.fellowType || '';
+    if (citEl) citEl.value = filterState.citizenship || '';
+    var regionWrap = document.getElementById('filter-region-options');
+    if (regionWrap) {
+      var picked = {};
+      for (var p = 0; p < filterState.regions.length; p++) picked[filterState.regions[p]] = true;
+      var inputs = regionWrap.querySelectorAll('input[data-filter-region]');
+      for (var i = 0; i < inputs.length; i++) {
+        inputs[i].checked = !!picked[inputs[i].value];
+      }
+    }
+  }
+
+  function updateFilterTriggerUI() {
+    if (!filterTriggerEl) return;
+    var n = activeFilterCount();
+    var ready = !!filterOptions;
+    filterTriggerEl.disabled = !ready;
+    filterTriggerEl.classList.toggle('filter-trigger--active', n > 0);
+    if (filterTriggerCountEl) {
+      if (n > 0) {
+        filterTriggerCountEl.textContent = String(n);
+        filterTriggerCountEl.removeAttribute('hidden');
+      } else {
+        filterTriggerCountEl.textContent = '';
+        filterTriggerCountEl.setAttribute('hidden', '');
+      }
+    }
+    if (ready) {
+      filterTriggerEl.title = n > 0
+        ? n + ' filter' + (n === 1 ? '' : 's') + ' active'
+        : 'Filters';
+    } else {
+      filterTriggerEl.title = 'Filters available once full data loads';
+    }
+    var resetBtn = document.getElementById('filter-sheet-reset');
+    if (resetBtn) {
+      if (n > 0) resetBtn.removeAttribute('hidden');
+      else resetBtn.setAttribute('hidden', '');
+    }
+  }
+
+  function rerenderForFilterChange() {
+    var query = (searchInputEl && searchInputEl.value || '').trim();
+    if (query) {
+      runSearch(query);
+    } else if (Array.isArray(list) && list.length) {
+      renderDirectory();
+    }
+  }
+
+  function isFilterSheetOpen() {
+    return !!(filterSheetEl && !filterSheetEl.classList.contains('hidden'));
+  }
+
+  function openFilterSheet() {
+    if (!filterSheetEl) return;
+    if (!filterOptions) return; // defense in depth; trigger is also disabled
+    populateFilterSheetControls();
+    filterSheetEl.classList.remove('hidden');
+    filterSheetEl.removeAttribute('hidden');
+    if (filterScrimEl) {
+      filterScrimEl.classList.remove('hidden');
+      filterScrimEl.removeAttribute('hidden');
+    }
+    if (filterTriggerEl) filterTriggerEl.setAttribute('aria-expanded', 'true');
+  }
+
+  function closeFilterSheet() {
+    if (!filterSheetEl) return;
+    filterSheetEl.classList.add('hidden');
+    filterSheetEl.setAttribute('hidden', '');
+    if (filterScrimEl) {
+      filterScrimEl.classList.add('hidden');
+      filterScrimEl.setAttribute('hidden', '');
+    }
+    if (filterTriggerEl) filterTriggerEl.setAttribute('aria-expanded', 'false');
+  }
+
+  function resetFilters() {
+    var changed = activeFilterCount() > 0;
+    filterState.cohort = null;
+    filterState.fellowType = null;
+    filterState.regions = [];
+    filterState.citizenship = null;
+    syncFilterSheetControls();
+    updateFilterTriggerUI();
+    writeFiltersToHash();
+    if (changed) rerenderForFilterChange();
+  }
+
+  function initFilterSheet() {
+    if (filterSheetWired) return;
+    if (!filterTriggerEl || !filterSheetEl) return;
+    filterSheetWired = true;
+    filterTriggerEl.addEventListener('click', function () {
+      if (isFilterSheetOpen()) closeFilterSheet();
+      else openFilterSheet();
+    });
+    if (filterScrimEl) {
+      filterScrimEl.addEventListener('click', closeFilterSheet);
+    }
+    var closeBtn = document.getElementById('filter-sheet-close');
+    if (closeBtn) closeBtn.addEventListener('click', closeFilterSheet);
+    var doneBtn = document.getElementById('filter-sheet-done');
+    if (doneBtn) doneBtn.addEventListener('click', closeFilterSheet);
+    var resetBtn = document.getElementById('filter-sheet-reset');
+    if (resetBtn) resetBtn.addEventListener('click', resetFilters);
+    document.addEventListener('keydown', function (e) {
+      if (e.key === 'Escape' && isFilterSheetOpen()) closeFilterSheet();
+    });
+
+    var cohortEl = document.getElementById('filter-cohort');
+    if (cohortEl) {
+      cohortEl.addEventListener('change', function () {
+        filterState.cohort = cohortEl.value || null;
+        writeFiltersToHash();
+        updateFilterTriggerUI();
+        rerenderForFilterChange();
+      });
+    }
+    var typeEl = document.getElementById('filter-fellow-type');
+    if (typeEl) {
+      typeEl.addEventListener('change', function () {
+        filterState.fellowType = typeEl.value || null;
+        writeFiltersToHash();
+        updateFilterTriggerUI();
+        rerenderForFilterChange();
+      });
+    }
+    var citEl = document.getElementById('filter-citizenship');
+    if (citEl) {
+      citEl.addEventListener('change', function () {
+        filterState.citizenship = citEl.value || null;
+        writeFiltersToHash();
+        updateFilterTriggerUI();
+        rerenderForFilterChange();
+      });
+    }
+    // Region checkboxes are added dynamically; delegate at the wrap.
+    var regionWrap = document.getElementById('filter-region-options');
+    if (regionWrap) {
+      regionWrap.addEventListener('change', function (ev) {
+        var t = ev.target;
+        if (!t || !t.matches || !t.matches('input[data-filter-region]')) return;
+        var val = t.value;
+        var picked = filterState.regions.slice();
+        var idx = picked.indexOf(val);
+        if (t.checked && idx === -1) picked.push(val);
+        else if (!t.checked && idx !== -1) picked.splice(idx, 1);
+        filterState.regions = picked;
+        writeFiltersToHash();
+        updateFilterTriggerUI();
+        rerenderForFilterChange();
+      });
+    }
+  }
+
+  // Called after phase 2 (?full=1) settles. Builds option lists, enables
+  // the trigger, and re-renders if hash-derived filters were already in
+  // play during phase 1 (they applied via applyFilters but the trigger
+  // count UI couldn't update until we knew the option set was real).
+  function activateFiltersFromFullData(items) {
+    buildFilterOptions(items);
+    populateFilterSheetControls();
+    updateFilterTriggerUI();
   }
 
   function setFilterCount(msg) {
@@ -4653,7 +5089,7 @@
       updateBulkBar();
       return;
     }
-    var filtered = applyHasEmailFilter(list);
+    var filtered = applyFilters(list);
     if (!filtered.length) {
       directoryListEl.innerHTML = '<p class="placeholder">No fellows match the current filter.</p>';
       displayedList = [];
@@ -4662,8 +5098,9 @@
       displayedList = filtered;
     }
     // This UI element is defined as "count of fellows visible in the current
-    // view." In directory mode it reflects the `has email` filter; in search
-    // mode it reflects the search + filter together (see renderSearchResults).
+    // view." In directory mode it reflects all active filters (has email +
+    // structured filters from #86); in search mode it reflects search +
+    // filters together (see renderSearchResults).
     setFilterCount(
       filtered.length === list.length
         ? list.length + ' fellows visible'
@@ -5769,6 +6206,31 @@
     if (typeof closeGroupActionbarSheet === 'function' && groupActionbarSheetEl &&
         !groupActionbarSheetEl.classList.contains('hidden')) {
       closeGroupActionbarSheet();
+    }
+    if (typeof closeFilterSheet === 'function' && isFilterSheetOpen()) {
+      closeFilterSheet();
+    }
+    // Filter state lives in the directory hash. Re-read on every route()
+    // call so back/forward and externally-set hashes (shared links,
+    // diagnostics tools) hydrate correctly. Off-directory routes ignore
+    // the params; switching back to '#/' re-hydrates from whatever the
+    // hash carried at the time. Skip when we initiated the hash write
+    // ourselves (replaceState doesn't fire hashchange but defensive
+    // route() callers might reach here anyway).
+    //
+    // Also re-render the directory if filterState actually changed —
+    // the list is already in the DOM (focus mode hides it via body
+    // class, doesn't unmount it), so without an explicit re-render
+    // the user would see stale, pre-filter rows when arriving from
+    // a shared link or from another route.
+    if (!filtersWritingHash) {
+      var prevSig = filterStateSignature();
+      readFiltersFromHash();
+      syncFilterSheetControls();
+      updateFilterTriggerUI();
+      if (filterStateSignature() !== prevSig) {
+        rerenderForFilterChange();
+      }
     }
 
     // Mobile shell chrome — appbar title + active tab. Renderers that
@@ -8132,7 +8594,7 @@
 
   function renderSearchResults(results, label) {
     var total = results.length;
-    var filtered = applyHasEmailFilter(results);
+    var filtered = applyFilters(results);
     displayedList = filtered;
     // Keep the visible-count indicator in sync with what's actually shown,
     // including during search. The denominator stays at list.length (total
@@ -8384,6 +8846,12 @@
   initComposerFab();
   initGroupCardSheet();
   initGroupActionbarSheet();
+  initFilterSheet();
+  // Hydrate filterState from any query suffix on the initial hash so a
+  // shared link like #/?cohort=2020 applies before the first render.
+  // Trigger stays disabled until phase 2 builds filterOptions.
+  readFiltersFromHash();
+  updateFilterTriggerUI();
   wireCopyButtons();
 
   function bootDirectoryAsApp() {
@@ -8566,6 +9034,10 @@
             if (f.slug) fellowsBySlug.set(f.slug, f);
             if (f.record_id) fellowsBySlug.set(f.record_id, f);
           });
+          // Issue #86: derive distinct filter values now that we have the
+          // full row set. Enables the trigger button and populates sheet
+          // controls. Hash-derived filters from phase 1 still apply.
+          activateFiltersFromFullData(full);
         }
         route();
         // Kick off image prewarm in the background — does not block UI.

--- a/app/static/index.html
+++ b/app/static/index.html
@@ -249,13 +249,28 @@
   <header id="site-header" class="site-header hidden">
     <h1><a href="#/" class="site-title-link">EHF Fellows Directory</a></h1>
     <div id="search-container" class="header-search">
-      <input
-        id="search-input"
-        class="search-input"
-        type="search"
-        placeholder="Search by name, tags, cohort…"
-        autocomplete="off"
-      />
+      <div class="search-row">
+        <input
+          id="search-input"
+          class="search-input"
+          type="search"
+          placeholder="Search by name, tags, cohort…"
+          autocomplete="off"
+        />
+        <button
+          id="filter-trigger"
+          type="button"
+          class="filter-trigger"
+          aria-haspopup="dialog"
+          aria-controls="filter-sheet"
+          aria-expanded="false"
+          disabled
+          title="Filters available once full data loads"
+        >
+          <span class="filter-trigger__label">Filters</span>
+          <span id="filter-trigger-count" class="filter-trigger__count" hidden></span>
+        </button>
+      </div>
       <div class="filter-row">
         <label class="filter-checkbox">
           <input type="checkbox" id="has-email-filter" checked />
@@ -471,6 +486,48 @@
     <button type="button" class="sheet-action" data-kebab-action="report-bug">Report a bug…</button>
     <button type="button" class="sheet-action sheet-action--danger" data-kebab-action="clear-cache">Clear app cache &amp; reload</button>
     <button type="button" class="sheet-action sheet-action--danger" data-kebab-action="reset-everything">Reset everything (lose groups &amp; settings)</button>
+  </aside>
+  <div id="filter-scrim" class="sheet-scrim hidden" hidden></div>
+  <aside
+    id="filter-sheet"
+    class="sheet sheet--filter hidden"
+    role="dialog"
+    aria-modal="true"
+    aria-labelledby="filter-sheet-title"
+    hidden
+  >
+    <div class="sheet__handle" aria-hidden="true"></div>
+    <div class="sheet__head">
+      <div class="sheet__title" id="filter-sheet-title">Filters</div>
+      <button type="button" id="filter-sheet-reset" class="filter-sheet__reset" hidden>Reset</button>
+      <button type="button" id="filter-sheet-close" class="sheet__close" aria-label="Close">×</button>
+    </div>
+    <div class="filter-sheet__body">
+      <label class="filter-field">
+        <span class="filter-field__label">Cohort</span>
+        <select id="filter-cohort" class="filter-field__control">
+          <option value="">Any</option>
+        </select>
+      </label>
+      <label class="filter-field">
+        <span class="filter-field__label">Fellow type</span>
+        <select id="filter-fellow-type" class="filter-field__control">
+          <option value="">Any</option>
+        </select>
+      </label>
+      <fieldset class="filter-field filter-field--checks">
+        <legend class="filter-field__label">Region</legend>
+        <div id="filter-region-options" class="filter-checks"></div>
+      </fieldset>
+      <label class="filter-field">
+        <span class="filter-field__label">Citizenship</span>
+        <select id="filter-citizenship" class="filter-field__control">
+          <option value="">Any</option>
+        </select>
+      </label>
+    </div>
+    <div class="sheet__divider" aria-hidden="true"></div>
+    <button type="button" id="filter-sheet-done" class="filter-sheet__done">Done</button>
   </aside>
   <script src="/vendor/jspdf-2.5.1.umd.min.js"></script>
   <script src="/app.js"></script>

--- a/app/static/styles.css
+++ b/app/static/styles.css
@@ -527,6 +527,72 @@ h1 {
   outline-offset: 1px;
 }
 
+.search-row {
+  display: flex;
+  align-items: stretch;
+  gap: 0.4rem;
+}
+
+.search-row .search-input {
+  flex: 1;
+  min-width: 0;
+}
+
+.filter-trigger {
+  flex: 0 0 auto;
+  display: inline-flex;
+  align-items: center;
+  gap: 0.3rem;
+  padding: 0 0.6rem;
+  min-height: 32px;
+  font: inherit;
+  font-size: 0.85rem;
+  color: var(--ink-deep, #0f172a);
+  background: #fff;
+  border: 1px solid #bbb;
+  border-radius: 3px;
+  cursor: pointer;
+  white-space: nowrap;
+}
+
+.filter-trigger:hover:not(:disabled) {
+  background: var(--accent-soft, #eef3fb);
+}
+
+.filter-trigger:focus-visible {
+  outline: 2px solid var(--accent);
+  outline-offset: 1px;
+}
+
+.filter-trigger:disabled {
+  cursor: not-allowed;
+  opacity: 0.55;
+}
+
+.filter-trigger--active {
+  background: var(--accent-soft, #dbeafe);
+  border-color: var(--accent);
+  color: var(--accent-deeper, #003366);
+}
+
+.filter-trigger__count {
+  display: inline-flex;
+  align-items: center;
+  justify-content: center;
+  min-width: 1.4rem;
+  height: 1.1rem;
+  padding: 0 0.35rem;
+  font-size: 0.75rem;
+  font-weight: 600;
+  background: var(--accent);
+  color: #fff;
+  border-radius: 999px;
+}
+
+.filter-trigger__count[hidden] {
+  display: none;
+}
+
 .search-status {
   margin: 0.25rem 0 0;
   font-size: 0.8rem;
@@ -3440,6 +3506,137 @@ a.group-action-btn--primary {
 
 .sheet-scrim.hidden {
   display: none;
+}
+
+/* ----- Filter sheet (issue #86) -------------------------------------- */
+/* Reuses the .sheet shell. On mobile: bottom-anchored as the rest. On
+ * desktop: re-positioned as a centered modal so the bottom-sheet idiom
+ * doesn't feel out of place on a wide viewport. The trigger button is
+ * always visible (search-row); the sheet is the only point of entry. */
+
+.filter-sheet__reset {
+  border: 0;
+  background: transparent;
+  color: var(--accent);
+  font: inherit;
+  font-size: 14px;
+  cursor: pointer;
+  padding: 4px 8px;
+  margin-left: auto;
+  margin-right: 4px;
+  border-radius: 4px;
+}
+
+.filter-sheet__reset:hover {
+  background: var(--accent-soft);
+}
+
+.filter-sheet__reset[hidden] {
+  display: none;
+}
+
+.filter-sheet__body {
+  display: flex;
+  flex-direction: column;
+  gap: 14px;
+  padding: 4px 0 12px;
+}
+
+.filter-field {
+  display: flex;
+  flex-direction: column;
+  gap: 6px;
+  border: 0;
+  margin: 0;
+  padding: 0;
+}
+
+.filter-field__label {
+  font-size: 13px;
+  font-weight: 600;
+  color: var(--ink-deep, #0f172a);
+  text-transform: uppercase;
+  letter-spacing: 0.04em;
+}
+
+.filter-field__control {
+  font: inherit;
+  font-size: 16px; /* avoid iOS auto-zoom on focus */
+  padding: 8px 10px;
+  border: 1px solid var(--border-strong, #a8b8cc);
+  border-radius: 6px;
+  background: #fff;
+  min-height: 44px;
+}
+
+.filter-field__control:focus-visible {
+  outline: 2px solid var(--accent);
+  outline-offset: 1px;
+}
+
+.filter-field--checks {
+  /* fieldset reset already done above */
+}
+
+.filter-checks {
+  display: flex;
+  flex-wrap: wrap;
+  gap: 6px 12px;
+  max-height: 12rem;
+  overflow-y: auto;
+}
+
+.filter-checks label {
+  display: inline-flex;
+  align-items: center;
+  gap: 6px;
+  min-height: 32px;
+  font-size: 14px;
+  cursor: pointer;
+  user-select: none;
+}
+
+.filter-sheet__done {
+  display: block;
+  width: 100%;
+  margin-top: 4px;
+  padding: 12px 16px;
+  font: inherit;
+  font-size: 15px;
+  font-weight: 600;
+  color: #fff;
+  background: var(--accent);
+  border: 0;
+  border-radius: 6px;
+  cursor: pointer;
+  min-height: 44px;
+}
+
+.filter-sheet__done:hover {
+  background: var(--accent-hover, #004499);
+}
+
+.filter-sheet__done:focus-visible {
+  outline: 2px solid var(--accent-deeper, #003366);
+  outline-offset: 2px;
+}
+
+/* Desktop: turn the bottom sheet into a centered modal. Mobile keeps
+ * the inherited .sheet positioning. */
+@media (min-width: 1025px) {
+  .sheet--filter {
+    inset: 50% auto auto 50%;
+    transform: translate(-50%, -50%);
+    width: min(28rem, calc(100vw - 32px));
+    max-height: min(80vh, 640px);
+    border-radius: 12px;
+    border: 1px solid var(--border-strong, #a8b8cc);
+    padding: 14px 18px calc(16px + env(safe-area-inset-bottom, 0));
+  }
+
+  .sheet--filter .sheet__handle {
+    display: none;
+  }
 }
 
 .diag-list {

--- a/app/static/styles.css
+++ b/app/static/styles.css
@@ -973,14 +973,10 @@ h1 {
 }
 
 .stats-grid {
-  display: grid;
-  grid-template-columns: 1fr 1fr;
+  display: flex;
+  flex-direction: column;
   gap: 1.5rem;
-  align-items: start;
-}
-
-.stats-col {
-  min-width: 0;
+  align-items: stretch;
 }
 
 .stats-title {
@@ -991,6 +987,90 @@ h1 {
 .stats-total {
   font-size: 1.1rem;
   margin-bottom: 1.5rem;
+}
+
+/* Stats sections (issue #132): semantic HTML bars at full pane width.
+   Replaces the prior SVG renderer whose viewBox-based scaling shrank
+   bars in both dimensions on narrow columns. */
+.stats-section {
+  --stats-bar-color: #0066cc;
+  margin: 0;
+  padding: 0;
+}
+
+.stats-section-title {
+  margin: 0 0 0.6rem 0;
+  font-size: 1rem;
+  font-weight: 600;
+  color: #222;
+}
+
+.stats-bars {
+  list-style: none;
+  margin: 0;
+  padding: 0;
+}
+
+.stats-bar-row {
+  display: grid;
+  grid-template-columns: minmax(80px, max-content) 1fr 3em;
+  align-items: center;
+  gap: 0.6rem;
+  height: 28px;
+  margin-bottom: 4px;
+  break-inside: avoid;
+}
+
+.stats-bar-label {
+  font-size: 0.85rem;
+  color: #333;
+  text-align: right;
+  white-space: nowrap;
+  overflow: hidden;
+  text-overflow: ellipsis;
+}
+
+.stats-bar-track {
+  display: block;
+  height: 100%;
+  background: #f0f3f7;
+  border-radius: 3px;
+  overflow: hidden;
+}
+
+.stats-bar-fill {
+  display: block;
+  height: 100%;
+  background: var(--stats-bar-color);
+  opacity: 0.85;
+  border-radius: 3px;
+  min-width: 2px;
+}
+
+.stats-bar-count {
+  font-size: 0.85rem;
+  color: #333;
+  font-variant-numeric: tabular-nums;
+  text-align: left;
+}
+
+/* Field Completeness opts into a 2-column wrap above the desktop
+   breakpoint so its ~30 entries don't push the rest of the page into
+   a long scroll. Single column below 1100px. */
+@media (min-width: 1100px) {
+  .stats-section--multicol .stats-bars {
+    column-count: 2;
+    column-gap: 2rem;
+  }
+}
+
+@media (max-width: 700px) {
+  /* Fellow-detail tables can overflow narrow viewports; allow a local
+     horizontal scroll rather than breaking the layout. (Was paired
+     with stats-chart rules in the SVG era; those are gone.) */
+  .detail-section-body {
+    overflow-x: auto;
+  }
 }
 
 .about-body {
@@ -1044,24 +1124,6 @@ h1 {
   vertical-align: middle;
 }
 
-.stats-chart {
-  display: block;
-  margin: 0.5rem 0 1rem 0;
-  max-width: 100%;
-  height: auto;
-}
-
-@media (max-width: 700px) {
-  .stats-grid {
-    grid-template-columns: 1fr;
-  }
-  .stats-chart {
-    min-width: 600px;
-  }
-  .detail-section-body {
-    overflow-x: auto;
-  }
-}
 
 /* PWA install landing (browser tab only) */
 .install-landing {

--- a/docs/users_manual.md
+++ b/docs/users_manual.md
@@ -80,6 +80,15 @@ fellows match.](images/users_manual/01_directory_search.png)
   type.
 - **Has email** filter (top) is on by default; turn it off to see fellows
   without an email.
+- **Filters** button (next to the search input) opens a panel where you
+  can narrow the directory by **cohort**, **fellow type**, **region**,
+  and **citizenship**. Selections apply immediately; the button shows
+  how many filters are active. **Reset** clears them in one tap. Active
+  filters are written into the page URL — copy the URL to share a
+  filtered view, or reload to come back to the same filtered list.
+  (The Filters button is disabled until the directory has finished
+  loading the full fellow data; **Search** and **Has email** keep
+  working before then.)
 - The visible-count line ("142 of 515 fellows visible") tracks the
   current search + filter.
 - **📋** beside any email or phone number copies just that value to your

--- a/tests/e2e/test_about_stats.py
+++ b/tests/e2e/test_about_stats.py
@@ -1,0 +1,202 @@
+"""E2E: the About-page Fellowship Statistics layout.
+
+Issue #132: the SVG-based stats charts shrank in both dimensions when
+the column was narrow (viewBox aspect-ratio scaling), and the inner
+2-column grid halved the available width on every viewport. The
+replacement renders semantic HTML bars at full pane width, with
+Field Completeness opting into a 2-column wrap above 1100px.
+
+These tests pin the new structure: four sections render as
+.stats-section nodes, each row is a .stats-bar-row with a fill width
+proportional to count/maxCount, and the multicol rule is active at
+desktop width but inactive below 1100px.
+"""
+from __future__ import annotations
+
+from playwright.sync_api import expect
+
+from conftest import _STANDALONE_DISPLAY_INIT
+
+
+def _make_standalone_page(context):
+    page = context.new_page()
+    page.add_init_script(_STANDALONE_DISPLAY_INIT)
+    return page
+
+
+def _boot_then_open_about(page, base_url):
+    """Boot to the directory FIRST, wait for boot to settle, THEN open
+    About via hash. This avoids a race where boot's two route() calls
+    (after getList, then again after getFull) each wipe and re-render
+    the about grid asynchronously — so the test can land on a partially
+    rendered grid mid-refresh.
+    """
+    page.goto(base_url + "/", wait_until="domcontentloaded")
+    page.wait_for_function(
+        "() => window.__dataProvider && window.__dataProvider.kind === 'worker'",
+        timeout=15000,
+    )
+    page.wait_for_function(
+        "() => window.__bootMarks && window.__bootMarks.get_full_done != null",
+        timeout=15000,
+    )
+    page.evaluate("location.hash = '#/about'")
+    _wait_for_stats(page)
+
+
+def _wait_for_stats(page):
+    """Stats render async after dataProvider.getStats() resolves AND
+    the total count line shows the resolved value. Waiting for the
+    total text + a stable bar-row count across 4 sections gives a
+    deterministic anchor — the .stats-section selector firing alone
+    is racy mid-render."""
+    page.wait_for_function(
+        """
+        () => {
+          const total = document.getElementById('stats-total');
+          if (!total || !/Total Fellows:\\s*\\d+/.test(total.textContent || '')) {
+            return false;
+          }
+          const sections = document.querySelectorAll(
+            '.stats-grid .stats-section'
+          );
+          if (sections.length !== 4) return false;
+          for (const s of sections) {
+            if (s.querySelectorAll('.stats-bar-row').length === 0) {
+              return false;
+            }
+          }
+          return true;
+        }
+        """,
+        timeout=15000,
+    )
+
+
+class TestAboutStatsLayout:
+    def test_four_sections_render_as_html_not_svg(self, context, base_url_fixture):
+        """All four sections (Type, Cohort, Region, Field Completeness)
+        render as .stats-section nodes containing .stats-bar-row entries.
+        The old SVG renderer is gone: there should be no .stats-chart in
+        the DOM."""
+        page = _make_standalone_page(context)
+        try:
+            _boot_then_open_about(page, base_url_fixture)
+
+            sections = page.locator(".stats-grid .stats-section")
+            expect(sections).to_have_count(4)
+
+            # Title text confirms which section is which.
+            titles = sections.locator(".stats-section-title").all_inner_texts()
+            assert titles == [
+                "Fellows by Type",
+                "Fellows by Cohort",
+                "Fellows by Region",
+                "Field Completeness",
+            ], f"unexpected section order or titles: {titles}"
+
+            # Every section has at least one bar row.
+            for i in range(4):
+                rows = sections.nth(i).locator(".stats-bar-row")
+                assert rows.count() >= 1, (
+                    f"section {titles[i]} has zero bar rows"
+                )
+
+            # The SVG renderer is fully retired.
+            assert page.locator(".stats-chart").count() == 0
+            assert page.locator(".stats-grid svg").count() == 0
+        finally:
+            page.close()
+
+    def test_bar_widths_match_count_proportions(self, context, base_url_fixture):
+        """The inline style.width on each .stats-bar-fill is set to
+        (count / maxCount) * 100. Read the data the page rendered against
+        and verify the widths line up — within 0.15% to absorb the
+        toFixed(1) rounding."""
+        page = _make_standalone_page(context)
+        try:
+            _boot_then_open_about(page, base_url_fixture)
+
+            # Pull (label, count, rendered_pct) tuples for the first section.
+            # The first section is "Fellows by Type" — small, predictable.
+            rows = page.locator(
+                ".stats-grid .stats-section:first-child .stats-bar-row"
+            )
+            n = rows.count()
+            assert n >= 1
+
+            labels = []
+            counts = []
+            rendered_widths = []
+            for i in range(n):
+                row = rows.nth(i)
+                labels.append(row.locator(".stats-bar-label").inner_text())
+                counts.append(int(row.locator(".stats-bar-count").inner_text()))
+                style = row.locator(".stats-bar-fill").get_attribute("style") or ""
+                # Parse "width: NN.N%"
+                assert "width:" in style, f"row {i} fill missing width style: {style!r}"
+                w = float(style.split("width:")[1].split("%")[0].strip())
+                rendered_widths.append(w)
+
+            # First row sets the scale (it's the largest by count, since the
+            # API returns sections sorted DESC by count).
+            max_count = counts[0]
+            assert max_count > 0, f"first row should have nonzero count: {counts}"
+            for i in range(n):
+                expected_pct = (counts[i] / max_count) * 100
+                assert abs(rendered_widths[i] - expected_pct) < 0.15, (
+                    f"row {i} ({labels[i]}, count={counts[i]}): rendered "
+                    f"{rendered_widths[i]}% vs expected {expected_pct}%"
+                )
+        finally:
+            page.close()
+
+    def test_field_completeness_multicol_at_desktop_width(
+        self, context, base_url_fixture
+    ):
+        """Field Completeness opts into 2-column wrap above 1100px via the
+        .stats-section--multicol class. At ≥1100px the inner ol applies
+        column-count: 2; at narrower widths it stays single-column."""
+        page = _make_standalone_page(context)
+        try:
+            page.set_viewport_size({"width": 1400, "height": 900})
+            _boot_then_open_about(page, base_url_fixture)
+
+            fc = page.locator(".stats-section--multicol")
+            expect(fc).to_have_count(1)
+            expect(fc.locator(".stats-section-title")).to_have_text(
+                "Field Completeness"
+            )
+
+            # At desktop width, the bars list inherits 2-column layout from
+            # the @media (min-width: 1100px) rule.
+            col_count_desktop = fc.locator(".stats-bars").evaluate(
+                "el => getComputedStyle(el).columnCount"
+            )
+            assert col_count_desktop == "2", (
+                f"expected column-count:2 at 1400px viewport; got {col_count_desktop!r}"
+            )
+        finally:
+            page.close()
+
+    def test_field_completeness_single_column_below_breakpoint(
+        self, context, base_url_fixture
+    ):
+        """Below 1100px the multicol rule does not apply — narrow viewports
+        are read top-to-bottom in a single column."""
+        page = _make_standalone_page(context)
+        try:
+            page.set_viewport_size({"width": 900, "height": 900})
+            _boot_then_open_about(page, base_url_fixture)
+
+            fc = page.locator(".stats-section--multicol")
+            col_count_narrow = fc.locator(".stats-bars").evaluate(
+                "el => getComputedStyle(el).columnCount"
+            )
+            # CSS default for an element with no column-count is 'auto'.
+            assert col_count_narrow != "2", (
+                f"multicol should NOT apply at 900px viewport; got "
+                f"column-count={col_count_narrow!r}"
+            )
+        finally:
+            page.close()

--- a/tests/e2e/test_directory_filters.py
+++ b/tests/e2e/test_directory_filters.py
@@ -1,0 +1,185 @@
+"""E2E tests: directory filter UI (issue #86).
+
+Covers the structured-filter sheet's interaction model:
+- trigger is disabled during phase 1 (?full=1 still in flight) and enabled
+  once full data lands;
+- selecting filters narrows the visible list and updates the trigger
+  badge;
+- filter state round-trips through the URL hash on reload;
+- Reset clears every active filter and strips params from the hash.
+"""
+
+import re
+
+import pytest
+from playwright.sync_api import expect
+
+
+def _wait_full_load(page):
+    """Wait for phase 2 (?full=1) to settle so the trigger enables."""
+    page.locator("#loading").wait_for(state="hidden", timeout=15000)
+    page.locator("#directory").wait_for(state="visible", timeout=5000)
+    # The trigger button only un-disables once filterOptions is built.
+    page.wait_for_function(
+        "() => { var b = document.getElementById('filter-trigger');"
+        " return b && !b.disabled; }",
+        timeout=15000,
+    )
+
+
+class TestDirectoryFilterSheet:
+    def test_trigger_starts_disabled_then_enables_after_phase_two(
+        self, standalone_page, base_url_fixture
+    ):
+        page = standalone_page
+        page.goto(base_url_fixture + "/", wait_until="domcontentloaded")
+        # Once #directory is visible we've passed phase 1, but the trigger
+        # is gated on phase 2 / filterOptions. By the time #loading hides
+        # phase 2 has resolved on a localhost build.
+        _wait_full_load(page)
+        trigger = page.locator("#filter-trigger")
+        expect(trigger).to_be_visible()
+        expect(trigger).not_to_have_attribute("disabled", "")
+
+    def test_cohort_filter_narrows_directory_and_updates_hash(
+        self, standalone_page, base_url_fixture
+    ):
+        page = standalone_page
+        page.goto(base_url_fixture + "/", wait_until="domcontentloaded")
+        _wait_full_load(page)
+
+        unfiltered_count = page.locator("#directory a[href^='#/fellow/']").count()
+        assert unfiltered_count >= 2, "test needs more than 1 fellow"
+
+        # Open the sheet.
+        page.locator("#filter-trigger").click()
+        sheet = page.locator("#filter-sheet")
+        expect(sheet).to_be_visible()
+
+        # Pick the first real cohort option (skip the "Any" placeholder).
+        cohort_select = page.locator("#filter-cohort")
+        cohort_options = cohort_select.locator("option").all_text_contents()
+        assert len(cohort_options) >= 2, "expected at least one cohort value"
+        first_cohort = cohort_select.locator("option").nth(1).get_attribute("value")
+        assert first_cohort, "first cohort option should have a value"
+        cohort_select.select_option(first_cohort)
+
+        # Filter applies live; close the sheet.
+        page.locator("#filter-sheet-done").click()
+        expect(sheet).to_be_hidden()
+
+        # Trigger badge reflects the active count.
+        badge = page.locator("#filter-trigger-count")
+        expect(badge).to_have_text("1")
+        expect(page.locator("#filter-trigger")).to_have_class(re.compile(r"filter-trigger--active"))
+
+        # Hash carries the filter state.
+        page.wait_for_function(
+            "() => window.location.hash.indexOf('cohort=') !== -1",
+            timeout=2000,
+        )
+        hash_now = page.evaluate("() => window.location.hash")
+        assert "cohort=" in hash_now, hash_now
+
+        # Visible count should narrow but not vanish: every value in the
+        # cohort dropdown is sourced from the loaded fellow set, so
+        # picking one is guaranteed to match at least one fellow. (A
+        # zero-count regression would slip past `<= unfiltered`.)
+        filtered_count = page.locator("#directory a[href^='#/fellow/']").count()
+        assert 1 <= filtered_count < unfiltered_count, (
+            "single-cohort filter should narrow strictly; "
+            f"got filtered={filtered_count} unfiltered={unfiltered_count}"
+        )
+
+    def test_region_multiselect_combines_with_cohort(
+        self, standalone_page, base_url_fixture
+    ):
+        """Cohort + region together compose with AND semantics."""
+        page = standalone_page
+        page.goto(base_url_fixture + "/", wait_until="domcontentloaded")
+        _wait_full_load(page)
+
+        page.locator("#filter-trigger").click()
+
+        cohort_select = page.locator("#filter-cohort")
+        first_cohort = cohort_select.locator("option").nth(1).get_attribute("value")
+        cohort_select.select_option(first_cohort)
+        cohort_only = page.locator("#directory a[href^='#/fellow/']").count()
+
+        region_checks = page.locator("#filter-region-options input[data-filter-region]")
+        if region_checks.count() == 0:
+            return  # data has no regions; nothing to combine
+
+        region_checks.first.check()
+
+        # Hash carries both filters.
+        page.wait_for_function(
+            "() => window.location.hash.indexOf('region=') !== -1",
+            timeout=2000,
+        )
+        expect(page.locator("#filter-trigger-count")).to_have_text("2")
+
+        combined = page.locator("#directory a[href^='#/fellow/']").count()
+        assert combined <= cohort_only, (
+            "AND-combine cannot widen the result set; "
+            f"cohort_only={cohort_only} combined={combined}"
+        )
+
+    def test_hash_filters_round_trip_on_reload(
+        self, standalone_page, base_url_fixture
+    ):
+        page = standalone_page
+        page.goto(base_url_fixture + "/", wait_until="domcontentloaded")
+        _wait_full_load(page)
+
+        # Read a cohort that actually exists, then reload with that value
+        # already in the hash.
+        page.locator("#filter-trigger").click()
+        cohort_select = page.locator("#filter-cohort")
+        target_cohort = cohort_select.locator("option").nth(1).get_attribute("value")
+        page.locator("#filter-sheet-close").click()
+        assert target_cohort
+
+        from urllib.parse import quote
+
+        page.goto(
+            base_url_fixture + "/#/?cohort=" + quote(target_cohort),
+            wait_until="domcontentloaded",
+        )
+        _wait_full_load(page)
+
+        # Filter applied from hash → trigger shows the badge with count 1.
+        expect(page.locator("#filter-trigger-count")).to_have_text("1")
+        expect(page.locator("#filter-trigger")).to_have_class(re.compile(r"filter-trigger--active"))
+
+        # Sheet, when opened, has the cohort already selected.
+        page.locator("#filter-trigger").click()
+        expect(page.locator("#filter-cohort")).to_have_value(target_cohort)
+
+    def test_reset_clears_filters_and_hash(
+        self, standalone_page, base_url_fixture
+    ):
+        page = standalone_page
+        page.goto(base_url_fixture + "/", wait_until="domcontentloaded")
+        _wait_full_load(page)
+
+        page.locator("#filter-trigger").click()
+        cohort_select = page.locator("#filter-cohort")
+        target_cohort = cohort_select.locator("option").nth(1).get_attribute("value")
+        cohort_select.select_option(target_cohort)
+
+        # Reset button reveals once filters are active.
+        reset_btn = page.locator("#filter-sheet-reset")
+        expect(reset_btn).to_be_visible()
+        reset_btn.click()
+
+        # Trigger badge gone; cohort back to Any.
+        expect(page.locator("#filter-trigger-count")).to_be_hidden()
+        expect(cohort_select).to_have_value("")
+
+        page.wait_for_function(
+            "() => window.location.hash.indexOf('cohort=') === -1",
+            timeout=2000,
+        )
+        hash_now = page.evaluate("() => window.location.hash")
+        assert "cohort=" not in hash_now, hash_now


### PR DESCRIPTION
## Summary

Closes #86. Adds structured filtering above the directory: cohort, fellow type, region (multi-select), citizenship.

- Single **Filters** trigger button beside the search input. Tap → panel with the four controls. Apply-on-change (no batched Apply).
- **Mobile (≤1024px):** bottom sheet, reusing the existing `.sheet` shell that already powers the kebab and FAB composer.
- **Desktop (≥1025px):** same DOM, repositioned as a centered modal. One panel; one code path; scales to a 5th/6th filter without changing the trigger surface.
- Filter state lives in the URL hash (`#/?cohort=2020&type=Fellow&region=Africa,Asia&citizenship=United%20States`) and round-trips through reload + browser back/forward.
- "Has email" stays as the inline checkbox it always was. **Reset** link in the sheet header clears every active filter at once.
- Trigger is disabled until phase 2 (`?full=1`) populates the distinct-value sets. Keyword search + has-email stay usable through phase 1.

## Architecture decisions

- `applyFilters` resolves minimal directory rows to full rows via `fellowsBySlug` (the `/api/fellows` minimal projection has no `cohort`/`fellow_type`/etc., but `?full=1` rows are indexed there). Search results already arrive full, so it's a no-op in that path.
- Boot path adds `activateFiltersFromFullData(full)` after `?full=1` resolves — derives distinct sorted values for each category (cohort sorted numerically when prefixed with a year), enables the trigger, and populates sheet controls. Same hook fires after a directory-data swap so new bytes are reflected.
- Hash writes use `history.replaceState` (no hashchange storms) and `route()` re-reads + re-renders only when the filter signature actually changes.

## Test plan

- [x] `pytest tests/e2e/test_directory_filters.py` — 5 new tests covering trigger disable→enable transition, single-cohort narrowing, hash round-trip, region+cohort AND-combine, and Reset.
- [x] `just test-fast` (63 passed)
- [x] `pytest tests/e2e/test_directory.py tests/e2e/test_directory_filters.py tests/e2e/test_groups_*.py` (36 passed) — no regressions in existing directory or groups e2e.
- [ ] **Manual QA (maintainer):** open `http://localhost:8765/`, click Filters, pick a cohort + a region, verify the URL updates and visible-count drops; copy the URL to a new tab and confirm the filtered view restores. On a phone-sized window (DevTools), confirm the sheet rises from the bottom and the Done/Reset/× targets are thumb-reachable.
- [ ] **Manual QA (maintainer):** baselines under `tests/e2e/mobile/__snapshots__/` are now visually outdated (the search header shows the new Filters button at narrow widths). Run `just test-mobile` and `just test-mobile-promote` after eyeballing the captures if the new shape is acceptable.

## Out of scope (explicit follow-ups)

- Tag filter (depends on #87).
- Searchable combobox for the ~70-entry citizenship select. Native `<select>` is fine for v1; iOS picker handles it natively.
- Drag-to-dismiss on mobile.
- Folding "has email" into the sheet as a fifth row — kept separate per #86.
- Saved searches.

🤖 Generated with [Claude Code](https://claude.com/claude-code)