### PR TITLE
fix(export): download path on macOS PWA; doc: github issue links

### DIFF
--- a/app/static/app.js
+++ b/app/static/app.js
@@ -6946,34 +6946,47 @@
       "</svg>"
     );
 
-  /** Trigger a Blob download. On platforms that support
-   *  navigator.share with files (iOS 16.4+, modern Android), prefer the
-   *  share sheet — gives the user Save to Files / AirDrop / Mail
-   *  options. Fall back to <a download> for desktop and older mobile.
-   *  Per the PR 1 mitigation plan in docs/persistence_and_upgrades.md. */
+  /** Trigger a Blob download. On mobile (iOS 16.4+, modern Android),
+   *  prefer the share sheet — gives the user Save to Files / AirDrop /
+   *  Mail. Desktop always uses <a download>: on macOS Chrome PWA the
+   *  share sheet has no Save-to-Downloads entry, just AirDrop/Messages.
+   *  If share() rejects (Chromium's file-share allowlist excludes
+   *  text/html, which surfaced as "permission denied" on Android too),
+   *  fall back to <a download> — but skip the fallback on AbortError,
+   *  which is the user dismissing the sheet. */
   function downloadBlob(blob, filename) {
+    function triggerAnchorDownload() {
+      return new Promise(function (resolve) {
+        var url = URL.createObjectURL(blob);
+        var a = document.createElement('a');
+        a.href = url;
+        a.download = filename;
+        a.style.display = 'none';
+        document.body.appendChild(a);
+        a.click();
+        setTimeout(function () {
+          try { document.body.removeChild(a); } catch (e) {}
+          try { URL.revokeObjectURL(url); } catch (e) {}
+          resolve();
+        }, 100);
+      });
+    }
     try {
-      if (navigator.canShare && typeof File === 'function') {
+      var ua = navigator.userAgent || '';
+      var isMobile = /iPad|iPhone|iPod|Android/.test(ua) ||
+                     (navigator.platform === 'MacIntel' && navigator.maxTouchPoints > 1);
+      if (isMobile && navigator.canShare && typeof File === 'function') {
         var file = new File([blob], filename, { type: blob.type || 'application/octet-stream' });
         if (navigator.canShare({ files: [file] })) {
-          return navigator.share({ files: [file], title: filename });
+          return navigator.share({ files: [file], title: filename })
+            .catch(function (err) {
+              if (err && err.name === 'AbortError') return;
+              return triggerAnchorDownload();
+            });
         }
       }
     } catch (e) { /* fall through to <a download> */ }
-    return new Promise(function (resolve) {
-      var url = URL.createObjectURL(blob);
-      var a = document.createElement('a');
-      a.href = url;
-      a.download = filename;
-      a.style.display = 'none';
-      document.body.appendChild(a);
-      a.click();
-      setTimeout(function () {
-        try { document.body.removeChild(a); } catch (e) {}
-        try { URL.revokeObjectURL(url); } catch (e) {}
-        resolve();
-      }, 100);
-    });
+    return triggerAnchorDownload();
   }
 
   /** For each member, look up the full fellow record from fellowsBySlug.

--- a/docs/users_manual.md
+++ b/docs/users_manual.md
@@ -53,7 +53,9 @@ also drag the icon from `~/Applications/Chrome Apps/` onto your Dock to
 keep it one click away.
 
 If Spotlight / Start menu / launcher all come up empty, it probably didn't
-install — try *Can't install at all?* below.
+install — try *Can't install at all?* below. If that doesn't help either,
+file a [GitHub issue](https://github.com/richbodo/fellows_local_db/issues)
+(ask Rich for repo access if you don't have it).
 
 And remember: `https://fellows.globaldonut.com` always works in a browser
 tab. Once you've installed, the URL skips the install landing and opens
@@ -74,7 +76,9 @@ ask for help:
   — green/red checklist of what's missing.
 
 Both are free and don't require sign-in. Send the report to the EHF
-Communications Working Group along with what you tried.
+Communications Working Group along with what you tried, or file a
+[GitHub issue](https://github.com/richbodo/fellows_local_db/issues)
+(ask Rich for repo access first if you don't have it).
 
 ---
 
@@ -442,6 +446,12 @@ submit), the gate has its own diagnostics block:
   in
   [`deploy/client_error_sanitizer.py`](https://github.com/richbodo/fellows_local_db/blob/main/deploy/client_error_sanitizer.py).
 
+Prefer GitHub? File an issue at
+[github.com/richbodo/fellows_local_db/issues](https://github.com/richbodo/fellows_local_db/issues)
+— useful when you want a thread to track the fix in, or when the in-app
+report can't reach the server. Ask Rich to add you to the repo if you
+don't have access yet.
+
 ---
 
 ## Offline
@@ -480,8 +490,10 @@ update iOS itself (iPhone 8 and newer support 16.4+).
 
 - **General questions** — fellows channels, or EHF Communications
   Working Group.
-- **Bug reports / feature requests** — GitHub issue (link on About
-  page; you'll need to be added — ask Rich).
+- **Bug reports / feature requests** — file a
+  [GitHub issue](https://github.com/richbodo/fellows_local_db/issues)
+  (you'll need to be added to the repo first — ask Rich). The same
+  GitHub link is on the About page.
 - **Lost or expired install link** — request a fresh one from the
   operator.
 


### PR DESCRIPTION
## Summary

- **Mac PWA export was broken in two ways.** `downloadBlob()` preferred `navigator.share()` whenever `canShare({files})` returned true. On macOS Chrome PWA: PDF popped the iOS-style share sheet (AirDrop / Messages / Notes — no Save-to-Downloads, dead end); HTML threw "permission denied" because Chromium's Web Share file-type allowlist excludes `text/html` for XSS-prevention reasons.
- **Gate the share path behind a mobile UA check** so desktop (macOS / Windows / Linux, browser tab or installed PWA) always uses `<a download>`.
- **On mobile, catch async `share()` rejections.** Respect `AbortError` (user dismissed the sheet — silently resolve, no fallback); fall back to `<a download>` for `NotAllowedError` / `DataError` / etc. This also closes the HTML allowlist case on Android Chrome PWA, where the same Chromium allowlist applies.
- **Manual:** add `github.com/richbodo/fellows_local_db/issues` links to four frustration-prone spots — *Can't find the app*, *Can't install at all*, *Reporting a bug*, *Getting help* — so users who'd prefer a tracked thread over the in-app report dialog have a direct path. Each mention notes the "ask Rich for repo access" caveat.

## Test plan

- [ ] **macOS Chrome PWA — PDF export**: file lands in Downloads (no share sheet)
- [ ] **macOS Chrome PWA — HTML export**: file lands in Downloads (no "permission denied" notification)
- [ ] **macOS browser tab (Chrome / Safari) — both formats**: regression check, downloads as before
- [ ] **iPhone PWA — PDF export**: share sheet appears with Save to Files / AirDrop / Mail
- [ ] **iPhone PWA — HTML export**: share sheet OR transparent fallback to download (depending on iOS WebKit's allowlist for that version)
- [ ] **iPhone — dismiss the share sheet on PDF**: verify *no* duplicate `<a download>` triggers (AbortError handling)
- [ ] **Android Chrome PWA — PDF export**: share sheet works
- [ ] **Android Chrome PWA — HTML export**: previously "permission denied", now should fall back to a real download
- [ ] **User manual rendering** at https://github.com/richbodo/fellows_local_db/blob/fix/export-download-fallback/docs/users_manual.md — confirm the four new GitHub-issue links render in the right sections

🤖 Generated with [Claude Code](https://claude.com/claude-code)