### PR TITLE
Tier 1 security hardening: CSP, HMAC allowlist, token registry

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -53,3 +53,8 @@ backup/*.zip
 
 # Ansible become-password temp files — never commit
 BECOME_PASS*
+
+# Security analyses, notes, and threat-model write-ups. Local-only by
+# default — these can name fields, hash schemes, and other internal
+# detail we don't want indexed publicly.
+security_review/

--- a/app/server.py
+++ b/app/server.py
@@ -294,6 +294,38 @@ class Handler(BaseHTTPRequestHandler):
         # safe (no cross-origin scripts / fonts / images to break).
         self.send_header("Cross-Origin-Opener-Policy", "same-origin")
         self.send_header("Cross-Origin-Embedder-Policy", "require-corp")
+        # Strict CSP — without it a single XSS today exfiltrates the
+        # entire OPFS (relationships.db + fellows.db) to an attacker-
+        # controlled origin. The policy is strict by design: no inline
+        # scripts/styles, no third-party origins. `'wasm-unsafe-eval'`
+        # is the modern carve-out for sqlite3.wasm's WebAssembly
+        # compilation. Mirrors deploy/server.py so dev and prod enforce
+        # identical policies — drift is the bug that lets a CSP-
+        # incompatible pattern slip into a release.
+        self.send_header(
+            "Content-Security-Policy",
+            "default-src 'self'; "
+            "script-src 'self' 'wasm-unsafe-eval'; "
+            "worker-src 'self'; "
+            "connect-src 'self'; "
+            "img-src 'self' data:; "
+            "style-src 'self'; "
+            "font-src 'self'; "
+            "object-src 'none'; "
+            "base-uri 'self'; "
+            "frame-ancestors 'none';",
+        )
+        # Disable browser features the app does not use, to reduce the
+        # leverage available to an XSS payload that does land.
+        self.send_header(
+            "Permissions-Policy",
+            "geolocation=(), camera=(), microphone=(), payment=(), "
+            "accelerometer=(), gyroscope=(), magnetometer=(), usb=(), "
+            "midi=(), serial=(), bluetooth=()",
+        )
+        self.send_header("Cross-Origin-Resource-Policy", "same-origin")
+        self.send_header("Referrer-Policy", "strict-origin-when-cross-origin")
+        self.send_header("X-Content-Type-Options", "nosniff")
         super().end_headers()
 
     def send_json(self, data, status=200):

--- a/app/static/app.js
+++ b/app/static/app.js
@@ -6164,7 +6164,13 @@
    *  width via aspect-ratio scaling, which made bars shrink in both
    *  dimensions on narrow columns. `multicol` opts the section into a
    *  two-column wrap above the desktop breakpoint — appropriate for the
-   *  long Field Completeness list. */
+   *  long Field Completeness list.
+   *
+   *  Per-row width and per-section color are emitted as `data-pct` /
+   *  `data-bar-color` attributes (not inline `style="..."`) so the page
+   *  is CSP-compliant under `style-src 'self'`. The caller applies them
+   *  via `applyStatsBarStyles(rootEl)` after innerHTML lands in the
+   *  DOM — CSSOM writes don't count as inline styles for CSP. */
   function statsSection(title, items, color, multicol) {
     if (!items || !items.length) return '';
     var maxCount = items[0].count;
@@ -6183,15 +6189,34 @@
           '<span class="stats-bar-count">' + escapeHtml(String(item.count)) + '</span>' +
         '</span>' +
         '<span class="stats-bar-track">' +
-          '<span class="stats-bar-fill" style="width: ' + pct.toFixed(1) + '%"></span>' +
+          '<span class="stats-bar-fill" data-pct="' + pct.toFixed(1) + '"></span>' +
         '</span>' +
       '</li>';
     }
     var sectionClass = 'stats-section' + (multicol ? ' stats-section--multicol' : '');
-    return '<section class="' + sectionClass + '" style="--stats-bar-color: ' + color + '">' +
+    return '<section class="' + sectionClass + '" data-bar-color="' + escapeHtml(color) + '">' +
       '<h3 class="stats-section-title">' + escapeHtml(title) + '</h3>' +
       '<ol class="stats-bars">' + rows + '</ol>' +
     '</section>';
+  }
+
+  /** Apply per-row widths and per-section bar colors via CSSOM after
+   *  `gridEl.innerHTML = ...` has parsed the markup. Pairs with
+   *  `statsSection`, which writes the values into `data-pct` /
+   *  `data-bar-color` instead of inline `style="..."` attributes (the
+   *  latter are blocked by `style-src 'self'`; CSSOM is not). */
+  function applyStatsBarStyles(rootEl) {
+    if (!rootEl) return;
+    var fills = rootEl.querySelectorAll('.stats-bar-fill[data-pct]');
+    for (var i = 0; i < fills.length; i++) {
+      var pct = fills[i].getAttribute('data-pct');
+      if (pct) fills[i].style.width = pct + '%';
+    }
+    var sections = rootEl.querySelectorAll('.stats-section[data-bar-color]');
+    for (var j = 0; j < sections.length; j++) {
+      var color = sections[j].getAttribute('data-bar-color');
+      if (color) sections[j].style.setProperty('--stats-bar-color', color);
+    }
   }
 
   function renderAboutPage() {
@@ -6415,6 +6440,7 @@
           gh += statsSection('Fellows by Region', data.by_region, '#2c4a6a');
           gh += statsSection('Field Completeness', data.field_completeness, '#5a5a5a', true);
           gridEl.innerHTML = gh;
+          applyStatsBarStyles(gridEl);
         }
       })
       .catch(function () {

--- a/build/build_pwa.py
+++ b/build/build_pwa.py
@@ -2,13 +2,18 @@
 """Assemble deploy/dist/ from app/static/ for production (Python stdlib only).
 
 Copies static assets, sqlite-wasm vendor files, fellows.db, and profile images.
-Writes allowed_emails.json (SHA-256 of lowercased contact_email) for Phase 4 magic-link gate.
+
+The magic-link allowlist is no longer written to ``dist/`` — the
+production server builds it in memory at startup by HMAC-ing every
+distinct ``contact_email`` in ``fellows.db`` (see
+``deploy/magic_link_auth.py:load_allowlist_from_db``). Keeping it
+off-disk means a routing or filesystem mistake cannot expose a hash
+file to the public internet.
 """
 
 import hashlib
 import json
 import shutil
-import sqlite3
 import subprocess
 import sys
 from datetime import datetime, timezone
@@ -135,31 +140,6 @@ def write_build_meta(dest: Path, label: str, db_path: Path | None = None) -> Non
     dest.write_text(json.dumps(meta, indent=2) + "\n", encoding="utf-8")
 
 
-def write_allowed_email_hashes(db_path: Path, dest_json: Path) -> None:
-    """SHA-256 hex of lowercased contact_email per Phase 4 plan."""
-    conn = sqlite3.connect(str(db_path))
-    try:
-        cur = conn.execute(
-            """
-            SELECT DISTINCT lower(trim(contact_email)) AS e
-            FROM fellows
-            WHERE contact_email IS NOT NULL AND trim(contact_email) != ''
-            """
-        )
-        hashes = []
-        seen = set()
-        for (raw,) in cur.fetchall():
-            if not raw:
-                continue
-            h = hashlib.sha256(raw.encode("utf-8")).hexdigest()
-            if h not in seen:
-                seen.add(h)
-                hashes.append(h)
-        dest_json.write_text(json.dumps({"hashes": hashes}, indent=0) + "\n", encoding="utf-8")
-    finally:
-        conn.close()
-
-
 def main() -> int:
     if not STATIC_DIR.is_dir():
         print(f"Missing static directory: {STATIC_DIR}", file=sys.stderr)
@@ -173,7 +153,6 @@ def main() -> int:
     write_build_meta(DIST_DIR / "build-meta.json", label, db_path=DB_SRC)
     if DB_SRC.is_file():
         shutil.copy2(DB_SRC, DIST_DIR / "fellows.db")
-        write_allowed_email_hashes(DB_SRC, DIST_DIR / "allowed_emails.json")
     else:
         print(f"Warning: no database at {DB_SRC} — run build/restore_from_knack_scrapefile.py", file=sys.stderr)
     img_src = IMAGES_SRC if IMAGES_SRC.is_dir() else (IMAGES_FALLBACK if IMAGES_FALLBACK.is_dir() else None)

--- a/deploy/magic_link_auth.py
+++ b/deploy/magic_link_auth.py
@@ -1,6 +1,11 @@
 """Magic-link authentication helpers for deploy/server.py (stdlib only).
 
-Used when allowed_emails.json exists in the dist root and FELLOWS_SESSION_SECRET is set.
+Auth is active when both ``FELLOWS_SESSION_SECRET`` and
+``FELLOWS_ALLOWLIST_HMAC_KEY`` are set, and ``fellows.db`` contains at
+least one ``contact_email`` row. The allowlist is materialised in
+memory at server startup by HMAC-ing every distinct ``contact_email``
+in the bundled DB — there is no longer any ``allowed_emails.json``
+artifact on disk.
 """
 
 from __future__ import annotations
@@ -12,6 +17,7 @@ import json
 import os
 import re
 import secrets
+import sqlite3
 import threading
 import time
 import urllib.error
@@ -34,7 +40,7 @@ INSTALL_WINDOW = TOKEN_TTL  # window (from token issue) during which install lan
 GRACE_WINDOW = 60
 RATE_WINDOW = 3600
 RATE_MAX = 3
-SESSION_VERSION = "v2"
+SESSION_VERSION = "v3"
 
 _EMAIL_RE = re.compile(r"^[^@\s]+@[^@\s]+\.[^@\s]+$")
 
@@ -47,22 +53,70 @@ class AuthState:
     # token within GRACE_WINDOW seconds. Cleaned up by cleanup_stale_tokens.
     consumed: dict[str, dict] = {}
     rate_buckets: dict[str, list[float]] = {}
-
-
-def load_allowlist(dist_dir: Path) -> set[str]:
-    p = dist_dir / "allowed_emails.json"
-    if not p.is_file():
-        return set()
-    try:
-        data = json.loads(p.read_text(encoding="utf-8"))
-        hashes = data.get("hashes") or []
-        return {str(h).lower() for h in hashes if h}
-    except (json.JSONDecodeError, OSError):
-        return set()
+    # session_id (32-char hex) -> {"issued_at": float, "expires_at": float}.
+    # Populated by consume_token on each successful magic-link verify;
+    # required by verify_session_value (a cookie whose session_id isn't here
+    # is rejected). This is the server-side binding that defends against a
+    # leaked FELLOWS_SESSION_SECRET — without the registry an attacker
+    # holding only the secret could mint arbitrary cookies. In-memory only:
+    # a server restart revokes every outstanding session, which is the
+    # intentional one-time logout behaviour on each deploy.
+    sessions: dict[str, dict] = {}
 
 
 def sha256_email(email: str) -> str:
+    """Plain SHA-256 of the normalized email. Used for journald
+    correlation prefixes (``email_hash_prefix``) and rate-limit bucket
+    keys — both stable identifiers, neither security-load-bearing.
+    Allowlist comparison uses ``hmac_email`` instead.
+    """
     return hashlib.sha256(email.strip().lower().encode("utf-8")).hexdigest()
+
+
+def hmac_email(email: str, key: bytes) -> str:
+    """HMAC-SHA256 of the normalized email, hex-encoded.
+
+    Used for allowlist membership comparison only. The HMAC key lives
+    in ``/etc/fellows/fellows-pwa.env`` (``FELLOWS_ALLOWLIST_HMAC_KEY``)
+    and never leaves the server's memory. With the key kept off-bundle,
+    a wordlist crack of intercepted hashes is no longer feasible even
+    for a known-org email pattern: an attacker would need both the
+    hash set *and* the key, where the prior plain-SHA-256 scheme
+    allowed crack-from-file-alone once the file was reachable.
+    """
+    normalized = email.strip().lower().encode("utf-8")
+    return hmac.new(key, normalized, hashlib.sha256).hexdigest()
+
+
+def allowlist_hmac_key() -> Optional[bytes]:
+    """Return the HMAC key bytes from env, or None if unset."""
+    s = os.environ.get("FELLOWS_ALLOWLIST_HMAC_KEY", "").strip()
+    if not s:
+        return None
+    return s.encode("utf-8")
+
+
+def load_allowlist_from_db(db_path: Path, hmac_key: bytes) -> set[str]:
+    """Build the allowlist set in memory by HMAC-ing every distinct
+    ``contact_email`` in ``fellows.db``. No file artifact is written;
+    the allowlist exists only as in-memory state on the server. A cold
+    start re-reads the DB; a deploy that ships a new ``fellows.db``
+    re-derives the set on the next restart.
+    """
+    if not db_path.is_file():
+        return set()
+    try:
+        conn = sqlite3.connect(str(db_path))
+        try:
+            cur = conn.execute(
+                "SELECT DISTINCT lower(trim(contact_email)) FROM fellows "
+                "WHERE contact_email IS NOT NULL AND trim(contact_email) != ''"
+            )
+            return {hmac_email(raw, hmac_key) for (raw,) in cur.fetchall() if raw}
+        finally:
+            conn.close()
+    except sqlite3.Error:
+        return set()
 
 
 def is_valid_email_shape(email: str) -> bool:
@@ -79,6 +133,29 @@ def cleanup_stale_tokens() -> None:
         for t, rec in list(AuthState.consumed.items()):
             if (now - rec["consumed_at"]) >= GRACE_WINDOW:
                 del AuthState.consumed[t]
+        for sid, srec in list(AuthState.sessions.items()):
+            if srec["expires_at"] < now:
+                del AuthState.sessions[sid]
+
+
+def _register_session(now: float, token_issued_at: float) -> str:
+    """Mint and register a session_id. Caller must hold ``AuthState.lock``."""
+    session_id = secrets.token_hex(16)
+    AuthState.sessions[session_id] = {
+        "issued_at": token_issued_at,
+        "expires_at": now + SESSION_MAX_AGE,
+    }
+    return session_id
+
+
+def revoke_session(session_id: Optional[str]) -> None:
+    """Drop a session_id from the registry. Used by the logout handler
+    so that explicitly-cleared cookies cannot be replayed even if
+    captured from a network log later."""
+    if not session_id:
+        return
+    with AuthState.lock:
+        AuthState.sessions.pop(session_id, None)
 
 
 def check_rate_limit(email_hash: str) -> bool:
@@ -107,12 +184,16 @@ def consume_token(tok: str) -> dict:
     """Consume a magic-link token.
 
     Returns one of:
-      {"status": "ok", "issued_at": <epoch>} — token was valid and unexpired,
-          OR was consumed within the last GRACE_WINDOW seconds. On a fresh
-          consume the issued_at is derived from the live token's stored
-          expiry; on a re-consume within the grace window it's the
-          issued_at that was captured at first consume. Caller signs the
-          session cookie with this value.
+      {"status": "ok", "issued_at": <epoch>, "session_id": <hex>} —
+          token was valid and unexpired, OR was consumed within the
+          last GRACE_WINDOW seconds. On a fresh consume the issued_at
+          is derived from the live token's stored expiry; on a
+          re-consume within the grace window it's the issued_at that
+          was captured at first consume. The session_id is freshly
+          minted on each consume and registered in
+          ``AuthState.sessions`` so the cookie that signs over it
+          will pass ``verify_session_value`` until the session
+          expires or is revoked.
       {"status": "expired"} — token existed but was past TTL. Shown to user as
           "that link expired".
       {"status": "invalid"} — token was never issued, or was consumed more
@@ -133,11 +214,21 @@ def consume_token(tok: str) -> dict:
                 "issued_at": issued_at,
                 "consumed_at": now,
             }
-            return {"status": "ok", "issued_at": issued_at}
+            session_id = _register_session(now, issued_at)
+            return {
+                "status": "ok",
+                "issued_at": issued_at,
+                "session_id": session_id,
+            }
         # Token not in the live set — check whether it was just consumed.
         rec = AuthState.consumed.get(tok)
         if rec and (now - rec["consumed_at"]) < GRACE_WINDOW:
-            return {"status": "ok", "issued_at": rec["issued_at"]}
+            session_id = _register_session(now, rec["issued_at"])
+            return {
+                "status": "ok",
+                "issued_at": rec["issued_at"],
+                "session_id": session_id,
+            }
         if rec:
             # Past the grace window; drop opportunistically so memory doesn't
             # accumulate even when cleanup_stale_tokens hasn't run recently.
@@ -238,18 +329,33 @@ def send_postmark_magic_link(to_email: str, magic_url: str) -> dict:
         }
 
 
-def sign_session_value(secret: bytes, token_issued_at: Optional[float] = None) -> str:
-    """Sign a v2 session cookie carrying token_issued_at.
+def sign_session_value(
+    secret: bytes,
+    token_issued_at: Optional[float] = None,
+    session_id: Optional[str] = None,
+) -> str:
+    """Sign a v3 session cookie binding to a server-recorded session_id.
 
-    Payload format (utf-8): ``v2:<exp>:<token_issued_at>:<nonce>``
-    token_issued_at is ``int(time.time())`` of the magic-link token that granted
-    this session. Pass None only in legacy/test paths where no token context is
-    available — callers in production must always pass a value.
+    Payload format (utf-8): ``v3:<exp>:<token_issued_at>:<session_id>:<nonce>``
+
+    The session_id is required for verification: ``verify_session_value``
+    rejects any cookie whose session_id is not in
+    ``AuthState.sessions``. This means a leaked
+    ``FELLOWS_SESSION_SECRET`` alone cannot mint a valid cookie — an
+    attacker would also need to have written into the in-memory
+    session registry, which no HTTP path exposes.
+
+    Pass ``session_id=None`` (or empty) only in unit tests that pin
+    the pure crypto path; such cookies will fail verification against
+    a real running server. Production callers in
+    ``deploy/server.py:_handle_verify_token`` always pass the
+    session_id minted by ``consume_token``.
     """
     exp = int(time.time()) + SESSION_MAX_AGE
     nonce = secrets.token_hex(16)
     tia = int(token_issued_at) if token_issued_at is not None else 0
-    payload = f"{SESSION_VERSION}:{exp}:{tia}:{nonce}".encode("utf-8")
+    sid = session_id or ""
+    payload = f"{SESSION_VERSION}:{exp}:{tia}:{sid}:{nonce}".encode("utf-8")
     sig = hmac.new(secret, payload, hashlib.sha256).hexdigest()
     return (
         base64.urlsafe_b64encode(payload).decode("ascii").rstrip("=") + "." + sig
@@ -257,11 +363,14 @@ def sign_session_value(secret: bytes, token_issued_at: Optional[float] = None) -
 
 
 def verify_session_value(cookie_val: str, secret: bytes) -> Optional[dict]:
-    """Verify a v2 session cookie.
+    """Verify a v3 session cookie.
 
-    Returns ``{"token_issued_at": <int>}`` on success. Returns None on any
-    failure (bad signature, expired, malformed, v1 cookies). Callers relying on
-    boolean semantics still work because None is falsy and a dict is truthy.
+    Returns ``{"token_issued_at": <int>, "session_id": <str>}`` on
+    success. Returns None on any failure: bad signature, expired,
+    malformed, v1/v2 cookies (always rejected — forces a clean
+    re-login on each version bump), missing session_id, or session_id
+    not present in ``AuthState.sessions``. Callers relying on boolean
+    semantics still work because None is falsy and a dict is truthy.
     """
     try:
         parts = cookie_val.strip().split(".", 1)
@@ -275,14 +384,24 @@ def verify_session_value(cookie_val: str, secret: bytes) -> Optional[dict]:
             return None
         text = payload.decode("utf-8")
         fields = text.split(":")
-        if len(fields) < 4 or fields[0] != SESSION_VERSION:
-            # v1 cookies (no version prefix) land here and are rejected by
-            # design — forces a clean re-login after this deploy.
+        if len(fields) < 5 or fields[0] != SESSION_VERSION:
+            # v1 / v2 cookies land here and are rejected by design —
+            # forces a clean re-login on the v2→v3 cutover (server-
+            # side session registry).
             return None
-        _ver, exp_s, tia_s, _nonce = fields[0], fields[1], fields[2], ":".join(fields[3:])
+        _ver, exp_s, tia_s, sid = fields[0], fields[1], fields[2], fields[3]
         if int(exp_s) < time.time():
             return None
-        return {"token_issued_at": int(tia_s)}
+        if not sid:
+            return None
+        with AuthState.lock:
+            rec = AuthState.sessions.get(sid)
+            if rec is None:
+                return None
+            if rec["expires_at"] < time.time():
+                AuthState.sessions.pop(sid, None)
+                return None
+        return {"token_issued_at": int(tia_s), "session_id": sid}
     except (ValueError, UnicodeDecodeError):
         return None
 

--- a/deploy/server.py
+++ b/deploy/server.py
@@ -8,17 +8,22 @@ When ``fellows.db`` is present in that directory, also serves the same read-only
 JSON API as ``app/server.py`` so the installed PWA can fall back if sqlite-wasm
 / OPFS is unavailable (static distribution has no separate API process).
 
-Phase 4 (optional): magic-link auth when ``allowed_emails.json`` exists in dist
-and ``FELLOWS_SESSION_SECRET`` is set. See ``magic_link_auth.py`` and README.
+Magic-link auth activates when both ``FELLOWS_SESSION_SECRET`` and
+``FELLOWS_ALLOWLIST_HMAC_KEY`` are set, and ``fellows.db`` contains at
+least one ``contact_email`` row. The allowlist is built in memory at
+startup by HMAC-ing every distinct contact_email — no
+``allowed_emails.json`` file is written. See ``magic_link_auth.py`` and
+``docs/email_gate.md``.
 
 Environment:
-  PORT                  Listen port (default 8765).
-  FELLOWS_DIST_ROOT     Absolute path to the static root (default: <this_dir>/dist).
-  FELLOWS_SESSION_SECRET   HMAC secret for session cookie (required for auth).
-  FELLOWS_POSTMARK_TOKEN   Send magic links via Postmark (required to actually email).
-  FELLOWS_MAIL_FROM        From address (default: EHF Directory App <admin@fellows.globaldonut.com>).
-  FELLOWS_PUBLIC_ORIGIN    Base URL for magic links (default: infer from Host / X-Forwarded-Proto).
-  FELLOWS_COOKIE_INSECURE  Set to 1 to omit Secure on session cookie (local HTTP testing).
+  PORT                          Listen port (default 8765).
+  FELLOWS_DIST_ROOT             Absolute path to the static root (default: <this_dir>/dist).
+  FELLOWS_SESSION_SECRET        HMAC secret for session cookie (required for auth).
+  FELLOWS_ALLOWLIST_HMAC_KEY    HMAC key used to build the in-memory allowlist (required for auth).
+  FELLOWS_POSTMARK_TOKEN        Send magic links via Postmark (required to actually email).
+  FELLOWS_MAIL_FROM             From address (default: EHF Directory App <admin@fellows.globaldonut.com>).
+  FELLOWS_PUBLIC_ORIGIN         Base URL for magic links (default: infer from Host / X-Forwarded-Proto).
+  FELLOWS_COOKIE_INSECURE       Set to 1 to omit Secure on session cookie (local HTTP testing).
 
 Request lines are logged to stdout for journald under systemd.
 """
@@ -44,6 +49,15 @@ DB_PATH = DIST_DIR / "fellows.db"
 
 # Set by init_auth() before listen.
 AUTH_ACTIVE = False
+# In-memory allowlist of HMAC'd contact_emails, populated by init_auth() at
+# startup. Replaces the prior dist/allowed_emails.json artifact — the
+# allowlist now lives only in this process's RAM, derived from fellows.db
+# at boot. Never written to disk; never served over HTTP.
+ALLOWLIST: set[str] = set()
+# HMAC key used to derive ALLOWLIST entries and to hash incoming emails on
+# /api/send-unlock. Sourced from FELLOWS_ALLOWLIST_HMAC_KEY at init_auth();
+# kept in memory for the life of the process.
+HMAC_KEY: bytes | None = None
 # Populated in main() from dist/build-meta.json (written by build/build_pwa.py).
 BUILD_META: dict = {}
 
@@ -61,18 +75,41 @@ def load_build_meta(dist_dir: Path) -> dict:
 
 
 def init_auth() -> None:
-    global AUTH_ACTIVE
-    allow = ml.load_allowlist(DIST_DIR)
+    """Populate AUTH_ACTIVE / ALLOWLIST / HMAC_KEY from env + fellows.db.
+
+    Called once at startup and from the test fixture. Auth is active
+    when:
+      * FELLOWS_SESSION_SECRET is set, and
+      * FELLOWS_ALLOWLIST_HMAC_KEY is set, and
+      * fellows.db exists and has at least one contact_email row.
+
+    Any missing piece flips AUTH_ACTIVE to False and logs a one-line
+    warning. The send-unlock / verify-token / cookie paths all gate on
+    AUTH_ACTIVE, so the failure mode is "no magic links can be issued"
+    rather than "anyone can sign in" — fail-closed.
+    """
+    global AUTH_ACTIVE, ALLOWLIST, HMAC_KEY
     sec = ml.session_secret_bytes()
-    AUTH_ACTIVE = bool(sec and allow)
-    if sec and not allow:
+    HMAC_KEY = ml.allowlist_hmac_key()
+    if sec and not HMAC_KEY:
         print(
-            "Warning: FELLOWS_SESSION_SECRET set but allowed_emails.json missing or empty — auth disabled.",
+            "Warning: FELLOWS_SESSION_SECRET set but FELLOWS_ALLOWLIST_HMAC_KEY unset — auth disabled.",
             file=sys.stderr,
         )
-    if allow and not sec:
+    if HMAC_KEY and not sec:
         print(
-            "Warning: allowed_emails.json present but FELLOWS_SESSION_SECRET unset — auth disabled.",
+            "Warning: FELLOWS_ALLOWLIST_HMAC_KEY set but FELLOWS_SESSION_SECRET unset — auth disabled.",
+            file=sys.stderr,
+        )
+    if not sec or not HMAC_KEY:
+        ALLOWLIST = set()
+        AUTH_ACTIVE = False
+        return
+    ALLOWLIST = ml.load_allowlist_from_db(DB_PATH, HMAC_KEY)
+    AUTH_ACTIVE = bool(ALLOWLIST)
+    if not ALLOWLIST:
+        print(
+            "Warning: FELLOWS_ALLOWLIST_HMAC_KEY set but fellows.db missing or has no contact_email rows — auth disabled.",
             file=sys.stderr,
         )
 
@@ -136,6 +173,49 @@ class Handler(SimpleHTTPRequestHandler):
             self.send_header("X-Fellows-Build", bid[:64])
         self.send_header("X-Fellows-Auth-Active", "1" if AUTH_ACTIVE else "0")
 
+    def _security_headers(self) -> None:
+        """Strict CSP + adjacent hardening, on every response.
+
+        CSP is the load-bearing one — without it a single XSS bug today
+        exfiltrates the entire OPFS (relationships.db + fellows.db) to
+        an attacker-controlled origin. The policy is strict by design:
+        no inline scripts/styles, no third-party origins, no eval.
+        `'wasm-unsafe-eval'` is the modern carve-out for sqlite3.wasm's
+        WebAssembly compilation in the dedicated worker.
+
+        HSTS, Cross-Origin-Opener-Policy and Cross-Origin-Embedder-Policy
+        are set by Caddy at the edge (see
+        ansible/roles/caddy/templates/Caddyfile.j2) and not duplicated
+        here. The dev server (app/server.py) mirrors this exact CSP /
+        Permissions-Policy / CORP block so dev and prod enforce
+        identical policies — any drift is the bug that lets a
+        CSP-incompatible pattern slip into a release.
+        """
+        self.send_header(
+            "Content-Security-Policy",
+            "default-src 'self'; "
+            "script-src 'self' 'wasm-unsafe-eval'; "
+            "worker-src 'self'; "
+            "connect-src 'self'; "
+            "img-src 'self' data:; "
+            "style-src 'self'; "
+            "font-src 'self'; "
+            "object-src 'none'; "
+            "base-uri 'self'; "
+            "frame-ancestors 'none';",
+        )
+        # Disable browser features the app does not use, to reduce the
+        # leverage available to an XSS payload that does land.
+        self.send_header(
+            "Permissions-Policy",
+            "geolocation=(), camera=(), microphone=(), payment=(), "
+            "accelerometer=(), gyroscope=(), magnetometer=(), usb=(), "
+            "midi=(), serial=(), bluetooth=()",
+        )
+        self.send_header("Cross-Origin-Resource-Policy", "same-origin")
+        self.send_header("Referrer-Policy", "strict-origin-when-cross-origin")
+        self.send_header("X-Content-Type-Options", "nosniff")
+
     def has_valid_session(self) -> bool:
         return self.session_payload() is not None
 
@@ -169,6 +249,10 @@ class Handler(SimpleHTTPRequestHandler):
             return
 
         if path == "/allowed_emails.json":
+            # Defence in depth. The file no longer exists in dist (the
+            # allowlist is built in memory from fellows.db at startup),
+            # but this stub stays so a future routing change or stale
+            # dist tree can't accidentally reintroduce the leak.
             self.send_error(HTTPStatus.NOT_FOUND, "Not Found")
             return
 
@@ -209,14 +293,15 @@ class Handler(SimpleHTTPRequestHandler):
             return
 
         if path == "/api/debug/diagnostics":
-            allow = ml.load_allowlist(DIST_DIR)
             sec = ml.session_secret_bytes()
+            hkey = ml.allowlist_hmac_key()
             postmark = bool(os.environ.get("FELLOWS_POSTMARK_TOKEN", "").strip())
             self.send_json(
                 {
                     "authActive": AUTH_ACTIVE,
-                    "allowlistHashCount": len(allow),
+                    "allowlistHashCount": len(ALLOWLIST),
                     "sessionSecretConfigured": bool(sec),
+                    "allowlistHmacKeyConfigured": bool(hkey),
                     "postmarkTokenConfigured": postmark,
                     "fellowsDbPresent": DB_PATH.is_file(),
                     "build": BUILD_META,
@@ -308,7 +393,21 @@ class Handler(SimpleHTTPRequestHandler):
 
         Always 200 — we don't reveal whether the caller had a valid session.
         Client navigates to ``/?gate=1`` after this.
+
+        Also revokes the cookie's session_id from the in-memory registry
+        when the cookie is well-formed, so the same cookie value cannot
+        be replayed even if captured from a network log later. Logout
+        does not require a valid session (idempotent by design), so a
+        bad/expired cookie is silently accepted; only the registry side
+        effect is gated on a parseable cookie.
         """
+        sec = ml.session_secret_bytes()
+        if sec:
+            cookie_val = ml.parse_cookie_header(self.headers.get("Cookie"), ml.SESSION_COOKIE)
+            if cookie_val:
+                payload = ml.verify_session_value(cookie_val, sec)
+                if payload:
+                    ml.revoke_session(payload.get("session_id"))
         cookie = ml.clear_session_cookie_line(self.headers)
         self.send_json_with_headers({"ok": True}, 200, [("Set-Cookie", cookie)])
 
@@ -318,16 +417,21 @@ class Handler(SimpleHTTPRequestHandler):
         if not ml.is_valid_email_shape(email):
             self.send_json({"sent": True})
             return
-        if not AUTH_ACTIVE:
+        if not AUTH_ACTIVE or HMAC_KEY is None:
             self.send_json({"sent": True})
             return
+        # Rate-limit and journald correlation use plain SHA-256 of the
+        # email — neither is security-load-bearing (rate-limit key is a
+        # dict bucket; the prefix is a non-reversible 12-hex correlator
+        # that the client also computes for lastSubmitHashPrefix). The
+        # *allowlist* check uses HMAC, so a leaked log line cannot be
+        # cross-referenced against any persisted hash file.
         h = ml.sha256_email(email)
         if not ml.check_rate_limit(h):
             print("Rate limit: send-unlock for hash prefix " + h[:12], file=sys.stderr)
             self.send_json({"sent": True})
             return
-        allow = ml.load_allowlist(DIST_DIR)
-        if h not in allow:
+        if ml.hmac_email(email, HMAC_KEY) not in ALLOWLIST:
             self.send_json({"sent": True})
             return
         token = ml.issue_token()
@@ -404,7 +508,11 @@ class Handler(SimpleHTTPRequestHandler):
         if not sec:
             self.send_json({"ok": False, "error": "server_misconfigured"}, status=500)
             return
-        val = ml.sign_session_value(sec, token_issued_at=result.get("issued_at"))
+        val = ml.sign_session_value(
+            sec,
+            token_issued_at=result.get("issued_at"),
+            session_id=result.get("session_id"),
+        )
         cookie = ml.set_session_cookie_line(val, self.headers)
         self.send_json_with_headers({"ok": True}, 200, [("Set-Cookie", cookie)])
 
@@ -514,6 +622,7 @@ class Handler(SimpleHTTPRequestHandler):
             else:
                 self.send_header("Cache-Control", "no-cache")
         self._telemetry_headers()
+        self._security_headers()
         super().end_headers()
 
 

--- a/docs/DevOps.md
+++ b/docs/DevOps.md
@@ -196,8 +196,9 @@ That run creates the `fellows` system user, adds the operator to the `fellows` g
 Canonical shape:
 
 ```env
-# Hard-required. The auth gate disables itself if either is unset.
+# Hard-required. The auth gate disables itself if any are unset.
 FELLOWS_SESSION_SECRET=...
+FELLOWS_ALLOWLIST_HMAC_KEY=...
 FELLOWS_POSTMARK_TOKEN=...
 
 # Required in practice. Code has fallbacks but they're fragile.
@@ -208,7 +209,7 @@ FELLOWS_PUBLIC_ORIGIN=https://fellows.globaldonut.com
 FELLOWS_REPLY_TO=you+fellows@example.com
 ```
 
-Generate a session secret:
+Generate a session secret or allowlist HMAC key:
 
 ```bash
 python -c "import secrets; print(secrets.token_urlsafe(48))"
@@ -217,10 +218,13 @@ python -c "import secrets; print(secrets.token_urlsafe(48))"
 | Variable | Tier | Purpose | What breaks if unset or wrong |
 |---|---|---|---|
 | `FELLOWS_SESSION_SECRET` | hard-required | HMAC key (≥48 chars) for the session cookie. | `deploy/server.py` logs "auth disabled" at startup; `/api/auth/status` returns `authEnabled: false` for every request; nobody can sign in. Rotation invalidates every outstanding session. |
+| `FELLOWS_ALLOWLIST_HMAC_KEY` | hard-required | HMAC key used to derive the in-memory allowlist from `contact_email` rows in `fellows.db`. The previous flow shipped an `allowed_emails.json` file in `dist/`; the new flow keeps the key off-disk and the allowlist exists only in process memory. | Auth disables itself with a startup warning. Rotation requires every fellow to log in again only if you also rotate the session secret — the allowlist itself is rebuilt on the next start regardless. |
 | `FELLOWS_POSTMARK_TOKEN` | hard-required | Postmark Server API token. | `POST /api/send-unlock` raises; users see the anti-enumeration "we'll send a link if it's allowed" reply but no email goes out. journald logs `event=send_unlock_email result=error`. |
 | `FELLOWS_MAIL_FROM` | required for non-canonical deploys | Sender on outgoing magic-link emails. In-code default `EHF Directory App <admin@fellows.globaldonut.com>` works for the canonical deploy; **forks must override**. | If set as a bare address (no `Display Name <addr>`), most clients render the local-part as the sender — reads as spam. If unset on a fork, sends as the canonical domain and fails Postmark sender verification. |
 | `FELLOWS_PUBLIC_ORIGIN` | required in practice | Base origin for magic-link URLs in email bodies. | Server falls back to inferring from `X-Forwarded-Proto`/`Host`. Works when Caddy forwards both headers; produces malformed links when either is missing. Set it to take the risk off the table. |
 | `FELLOWS_REPLY_TO` | optional | Sets the email's `Reply-To` header. Use when the From address isn't a human inbox. | Replies fall through to `FELLOWS_MAIL_FROM`. |
+
+**Migration note (one-time, after `security/tier1-hardening` lands):** an existing droplet's `/etc/fellows/fellows-pwa.env` will not have `FELLOWS_ALLOWLIST_HMAC_KEY`. After deploying the new bundle, the service starts with auth disabled until you add the key. Re-run `just prod-configure-env` (which now prompts for it and offers to generate one) or append the line manually with `python -c "import secrets; print(secrets.token_urlsafe(48))"` and `sudo systemctl restart fellows-pwa`. Every fellow's session also re-logs once on this deploy because cookies bumped from v2 to v3 (server-side session registry).
 
 **Dev-only.** `FELLOWS_COOKIE_INSECURE=1` drops the `Secure` flag from the session cookie so it works over plain HTTP. Used by the in-process test fixture; never set on prod. `FELLOWS_DIST_ROOT` overrides the static-root path the prod server reads from (default `<deploy>/dist`) — useful for staging deploys, not in the bootstrap script.
 

--- a/docs/email_gate.md
+++ b/docs/email_gate.md
@@ -12,7 +12,7 @@ Operator procedures (Postmark, env file, Postmark response interpretation) stay 
 
 ## Definitions
 
-- **Session cookie** — `fellows_session`, HttpOnly, HMAC-signed, carrying `token_issued_at` (epoch seconds). v2 format; v1 cookies are rejected on sight so prior sessions re-login cleanly after this ships.
+- **Session cookie** — `fellows_session`, HttpOnly, HMAC-signed, carrying `token_issued_at` (epoch seconds) and a server-side `session_id`. v3 format; v1 and v2 cookies are rejected on sight so prior sessions re-login cleanly after each version bump.
 - **Magic-link token** — single-use, `TOKEN_TTL = 30 min` from issue. Random 32-byte hex.
 - **Install window** — `INSTALL_WINDOW = 30 min` measured from token issue (not from click). Same duration as token TTL by design: a user has 30 min from the email being sent to finish clicking and installing.
 - **Display mode** — *browser* (`display-mode != standalone`) vs *PWA* (`display-mode: standalone`).
@@ -251,16 +251,19 @@ Operator query: `journalctl -u fellows-pwa | grep '"kind": "worker"'`. Pair `boo
 
 
 
-## Cookie format (v2)
+## Cookie format (v3)
 
-Plaintext payload (utf-8): `v2:<session_expires_at>:<token_issued_at>:<nonce>`
+Plaintext payload (utf-8): `v3:<session_expires_at>:<token_issued_at>:<session_id>:<nonce>`
 Cookie value: `base64url(payload) + "." + hex(hmac_sha256(secret, payload))`
 
-- `session_expires_at` = `int(time.time()) + SESSION_MAX_AGE`
+- `session_expires_at` = `int(time.time()) + SESSION_MAX_AGE`.
 - `token_issued_at` = the `issued_at` of the magic-link token that granted this session (epoch seconds). `0` only in legacy/test paths.
+- `session_id` = a 32-char hex identifier minted by `consume_token` and recorded in `AuthState.sessions`. Required: a cookie whose `session_id` is not in the registry fails verification, so a leaked `FELLOWS_SESSION_SECRET` alone cannot mint a working cookie.
 - Sig = `hmac_sha256(FELLOWS_SESSION_SECRET, payload)`.
 
-On every request the server recomputes HMAC, rejects on mismatch, and rejects if `session_expires_at < now`. The install-window check is *separate*: `now - token_issued_at < INSTALL_WINDOW`.
+On every request the server recomputes HMAC, rejects on mismatch, rejects if `session_expires_at < now`, and rejects if `session_id` is missing from the in-memory registry. The install-window check is *separate*: `now - token_issued_at < INSTALL_WINDOW`.
+
+The session registry is in-memory only — a server restart drops it, which is the deliberate one-time logout on each deploy. Every fellow re-authenticates once; subsequent requests within the cookie's 7-day TTL keep working.
 
 ## Security notes
 

--- a/docs/email_system_management.md
+++ b/docs/email_system_management.md
@@ -10,7 +10,8 @@ Environment variables used in this section:
 
 | Variable | Purpose |
 |---|---|
-| `FELLOWS_SESSION_SECRET` | Long random signing key. Generate with `python -c "import secrets; print(secrets.token_urlsafe(48))"`. |
+| `FELLOWS_SESSION_SECRET` | Long random signing key for session cookies. Generate with `python -c "import secrets; print(secrets.token_urlsafe(48))"`. |
+| `FELLOWS_ALLOWLIST_HMAC_KEY` | HMAC key used to derive the in-memory allowlist from `contact_email` rows in `fellows.db`. Generate the same way as the session secret. Replaces the prior `allowed_emails.json` file artifact (no longer written to `dist/`); the allowlist exists only in the running server's memory. |
 | `FELLOWS_POSTMARK_TOKEN` | Postmark Server API token from the server's settings page. |
 | `FELLOWS_MAIL_FROM` | Sender that users see on the magic-link email. Defaults to `EHF Directory App <admin@fellows.globaldonut.com>` — the display name (`EHF Directory App`) is what shows in the inbox; the address part must be a verified Sender Signature (or an address on a domain-verified domain) in Postmark. Override only if your fork uses a different domain or display name. **Always use the `Display Name <addr>` shape** when overriding — a bare address renders as just the local-part (`admin`) in most mail clients, which reads as spam. **Do not use `noreply@` addresses** — Postmark actively refuses them and they hurt your sender reputation. |
 | `FELLOWS_REPLY_TO` | Optional. When set, becomes the `Reply-To` header. Use this to route replies to a real operator mailbox (e.g. `richbodo+fellows@gmail.com`) while `admin@fellows.globaldonut.com` is the visible sender. When unset, replies go to `FELLOWS_MAIL_FROM`. |

--- a/docs/justfile.md
+++ b/docs/justfile.md
@@ -161,6 +161,12 @@ Export them or inline: `FELLOWS_BASE_URL=https://staging.example.com just smoke`
   a refresh cheat-sheet (Cmd-Shift-R bypasses the SW shell cache;
   Clear App Cache preserves OPFS; incognito is the nuclear baseline).
   Use when "is this the version I think it is?" comes up.
+- **`prod-ssh`** — interactive SSH into the prod droplet using
+  `FELLOWS_HOST` / `FELLOWS_SSH_PORT` / `FELLOWS_SSH_USER`. No IP, port,
+  or operator account to remember. Use this when you need a real shell
+  on the box (e.g. `sudo nano /etc/fellows/fellows-pwa.env`); for
+  one-off non-interactive commands the targeted recipes below are
+  shorter (`prod-logs`, `prod-status`, `prod-env`).
 - **`prod-logs [UNIT]`** — SSH + `journalctl -u UNIT -f`. Default unit
   `fellows-pwa`; try `just prod-logs caddy` for the reverse proxy.
 - **`prod-stats [SINCE]`** — summary of page views, magic-link send/verify

--- a/justfile
+++ b/justfile
@@ -393,6 +393,11 @@ drift:
     echo "origin/main:"
     git log -1 --format='  %h %cI  %s' origin/main 2>/dev/null || echo "  (no origin/main)"
 
+# Interactive SSH into the prod droplet (uses FELLOWS_HOST / FELLOWS_SSH_PORT / FELLOWS_SSH_USER).
+[group('prod')]
+prod-ssh:
+    ssh -p {{ssh_port}} {{ssh_user}}@{{host}}
+
 # Tail journald for UNIT (default fellows-pwa).
 [group('prod')]
 prod-logs unit="fellows-pwa":

--- a/scripts/configure_email_auth_env.sh
+++ b/scripts/configure_email_auth_env.sh
@@ -45,6 +45,12 @@ generate_session_secret() {
   python3 -c "import secrets; print(secrets.token_urlsafe(48))"
 }
 
+# The allowlist HMAC key is symmetric and only needs to be unguessable.
+# Same generation as the session secret (urlsafe base64 of 48 random bytes).
+generate_hmac_key() {
+  python3 -c "import secrets; print(secrets.token_urlsafe(48))"
+}
+
 require_cmd ssh
 require_cmd scp
 require_cmd python3
@@ -73,12 +79,26 @@ else
   session_secret="$(prompt_secret_required "FELLOWS_SESSION_SECRET (input hidden)")"
 fi
 
+# FELLOWS_ALLOWLIST_HMAC_KEY: HMAC key used to derive the in-memory
+# allowlist from contact_email values in fellows.db. Must be set or
+# the server boots with auth disabled. The key never leaves the prod
+# server — `build/build_pwa.py` no longer writes any allowlist file.
+default_hmac_key="$(generate_hmac_key)"
+read -r -p "Generate FELLOWS_ALLOWLIST_HMAC_KEY now? [Y/n]: " gen_hmac
+if [[ -z "${gen_hmac}" || "${gen_hmac}" =~ ^[Yy]$ ]]; then
+  hmac_key="$default_hmac_key"
+  echo "Generated allowlist HMAC key."
+else
+  hmac_key="$(prompt_secret_required "FELLOWS_ALLOWLIST_HMAC_KEY (input hidden)")"
+fi
+
 echo
 echo "Will configure host ${ssh_user}@${host}:${port}"
 echo "  FELLOWS_MAIL_FROM=${mail_from}"
 echo "  FELLOWS_PUBLIC_ORIGIN=${public_origin}"
 echo "  FELLOWS_POSTMARK_TOKEN=<hidden>"
 echo "  FELLOWS_SESSION_SECRET=<hidden>"
+echo "  FELLOWS_ALLOWLIST_HMAC_KEY=<hidden>"
 read -r -p "Continue? [y/N]: " confirm
 if [[ ! "${confirm}" =~ ^[Yy]$ ]]; then
   echo "Aborted."
@@ -91,6 +111,7 @@ chmod 600 "$tmp_env"
 
 cat >"$tmp_env" <<EOF
 FELLOWS_SESSION_SECRET=$session_secret
+FELLOWS_ALLOWLIST_HMAC_KEY=$hmac_key
 FELLOWS_POSTMARK_TOKEN=$postmark_token
 FELLOWS_MAIL_FROM=$mail_from
 FELLOWS_PUBLIC_ORIGIN=$public_origin

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -1,6 +1,4 @@
 """Pytest configuration and shared fixtures."""
-import hashlib
-import json
 import os
 import shutil
 import sqlite3
@@ -141,18 +139,35 @@ def deploy_server(tmp_path_factory):
             f"DB not found at {src_db}. Run: python build/restore_from_knack_scrapefile.py"
         )
 
-    # Build a tmp dist root: app shell + a copy of fellows.db + a single-entry
-    # allowlist for the test email. Copy (not symlink) so a stray write through
-    # any future code path can't corrupt the dev DB.
+    # Build a tmp dist root: app shell + a copy of fellows.db. Copy
+    # (not symlink) so a stray write through any future code path
+    # can't corrupt the dev DB. The allowlist now lives in memory on
+    # the server (built from contact_email rows in fellows.db at
+    # init_auth() time), so we INSERT a row for the test email rather
+    # than writing a separate allowed_emails.json file.
     dist_dir = tmp_path_factory.mktemp("deploy_dist")
     shutil.copytree(repo_root / "app" / "static", dist_dir, dirs_exist_ok=True)
     shutil.copy2(src_db, dist_dir / "fellows.db")
 
     test_email = "round-trip-tester@example.com"
-    email_hash = hashlib.sha256(test_email.strip().lower().encode("utf-8")).hexdigest()
-    (dist_dir / "allowed_emails.json").write_text(
-        json.dumps({"hashes": [email_hash]}), encoding="utf-8"
-    )
+    test_db = dist_dir / "fellows.db"
+    conn = sqlite3.connect(str(test_db))
+    try:
+        # `slug` is NOT NULL with a UNIQUE index — pick a stable slug
+        # that won't collide with any real fellow.
+        conn.execute(
+            "INSERT OR REPLACE INTO fellows "
+            "(record_id, slug, name, contact_email) VALUES (?, ?, ?, ?)",
+            (
+                "test-rt-record",
+                "round-trip-tester",
+                "Round Trip Tester",
+                test_email,
+            ),
+        )
+        conn.commit()
+    finally:
+        conn.close()
 
     # `deploy/server.py` reads DIST_DIR / PORT at import time. Set env first,
     # save originals so teardown leaves the process clean.
@@ -160,6 +175,7 @@ def deploy_server(tmp_path_factory):
     for k in (
         "FELLOWS_DIST_ROOT",
         "FELLOWS_SESSION_SECRET",
+        "FELLOWS_ALLOWLIST_HMAC_KEY",
         "FELLOWS_COOKIE_INSECURE",
         "PORT",
         "FELLOWS_POSTMARK_TOKEN",
@@ -167,6 +183,7 @@ def deploy_server(tmp_path_factory):
         saved_env[k] = os.environ.get(k)
     os.environ["FELLOWS_DIST_ROOT"] = str(dist_dir)
     os.environ["FELLOWS_SESSION_SECRET"] = "test-secret-for-round-trip-suite"
+    os.environ["FELLOWS_ALLOWLIST_HMAC_KEY"] = "test-hmac-key-for-round-trip-suite"
     os.environ["FELLOWS_COOKIE_INSECURE"] = "1"
     os.environ["PORT"] = str(DEPLOY_PORT)
     os.environ.pop("FELLOWS_POSTMARK_TOKEN", None)

--- a/tests/e2e/test_sw_post_caching.py
+++ b/tests/e2e/test_sw_post_caching.py
@@ -93,8 +93,12 @@ def deploy_clean_page_with_sw(context, deploy_server):
     deploy_server["sent"].clear()
 
     page.goto(deploy_server["base_url"] + "/?gate=1", wait_until="load")
+    # Wrap as an arrow function so Playwright uses Runtime.callFunctionOn
+    # rather than Runtime.evaluate (the latter trips CSP `script-src 'self'`
+    # because it injects via eval; the former is exempt). The condition
+    # itself is unchanged.
     page.wait_for_function(
-        "navigator.serviceWorker && navigator.serviceWorker.controller !== null",
+        "() => navigator.serviceWorker && navigator.serviceWorker.controller !== null",
         timeout=10000,
     )
 
@@ -111,7 +115,9 @@ def deploy_clean_page_with_sw(context, deploy_server):
 
 
 def _cache_put_attempts(sw):
-    return sw.evaluate("self.__cachePutAttempts__ || []")
+    # Same CSP-bypass dance as wait_for_function: arrow function → Playwright
+    # uses Runtime.callFunctionOn instead of Runtime.evaluate.
+    return sw.evaluate("() => self.__cachePutAttempts__ || []")
 
 
 def test_sw_does_not_attempt_to_cache_post_responses(

--- a/tests/test_deploy_auth_round_trip.py
+++ b/tests/test_deploy_auth_round_trip.py
@@ -76,12 +76,15 @@ def _token_from_url(magic_url):
 
 @pytest.fixture(autouse=True)
 def _reset_auth_state(deploy_server):
-    """Each test starts with empty rate buckets, no live tokens, no consumed-token grace records, no recorded sends."""
+    """Each test starts with empty rate buckets, no live tokens, no
+    consumed-token grace records, no registered sessions, and no
+    recorded sends."""
     state = deploy_server["auth_state"]
     with state.lock:
         state.tokens.clear()
         state.consumed.clear()
         state.rate_buckets.clear()
+        state.sessions.clear()
     deploy_server["sent"].clear()
 
 

--- a/tests/test_magic_link_auth.py
+++ b/tests/test_magic_link_auth.py
@@ -1,5 +1,6 @@
 """Unit tests for deploy/magic_link_auth.py (no HTTP)."""
 import base64
+import sqlite3
 import sys
 import time
 from pathlib import Path
@@ -19,20 +20,137 @@ def test_sha256_email_normalizes():
     assert len(a) == 64
 
 
-def test_session_roundtrip_v2_carries_token_issued_at(monkeypatch):
+def test_hmac_email_normalizes():
+    """HMAC matches the SHA-256 normalization rules (trim + lowercase)
+    so the allowlist hash for an email is stable across input casing
+    and whitespace."""
+    key = b"unit-test-key"
+    a = ml.hmac_email("  Test@Example.COM  ", key)
+    b = ml.hmac_email("test@example.com", key)
+    assert a == b
+    assert len(a) == 64
+    # Different key on the same email yields a distinct hash. This is
+    # the property that prevents a stolen allowlist from being cracked
+    # with a wordlist when the key remains in /etc/fellows/.
+    assert ml.hmac_email("test@example.com", b"different-key") != a
+
+
+def test_load_allowlist_from_db(tmp_path):
+    """load_allowlist_from_db reads contact_email rows, normalizes them,
+    and HMAC's each. NULL / empty strings are excluded."""
+    db = tmp_path / "fellows.db"
+    conn = sqlite3.connect(str(db))
+    conn.execute(
+        "CREATE TABLE fellows (record_id TEXT PRIMARY KEY, slug TEXT, contact_email TEXT)"
+    )
+    conn.execute("INSERT INTO fellows VALUES ('1', 'a', 'A@example.com')")
+    conn.execute("INSERT INTO fellows VALUES ('2', 'b', '  b@example.COM  ')")
+    conn.execute("INSERT INTO fellows VALUES ('3', 'c', '')")
+    conn.execute("INSERT INTO fellows VALUES ('4', 'd', NULL)")
+    conn.commit()
+    conn.close()
+
+    key = b"unit-test-key"
+    s = ml.load_allowlist_from_db(db, key)
+    expected = {
+        ml.hmac_email("a@example.com", key),
+        ml.hmac_email("b@example.com", key),
+    }
+    assert s == expected
+
+
+def test_load_allowlist_from_db_returns_empty_when_db_missing(tmp_path):
+    """Missing DB → empty set rather than raising; init_auth flips
+    AUTH_ACTIVE to False on this path."""
+    s = ml.load_allowlist_from_db(tmp_path / "nope.db", b"unit-test-key")
+    assert s == set()
+
+
+def test_session_roundtrip_v3_carries_token_issued_at_and_session_id(monkeypatch):
+    """Happy path: a cookie minted with a registered session_id verifies
+    and recovers both token_issued_at and session_id."""
     monkeypatch.setenv("FELLOWS_SESSION_SECRET", "unit-test-secret")
     sec = ml.session_secret_bytes()
     assert sec
     tia = int(time.time()) - 60
-    v = ml.sign_session_value(sec, token_issued_at=tia)
+    sid = "deadbeef" * 4  # 32 hex chars
+    with ml.AuthState.lock:
+        ml.AuthState.sessions.clear()
+        ml.AuthState.sessions[sid] = {
+            "issued_at": tia,
+            "expires_at": time.time() + 3600,
+        }
+    v = ml.sign_session_value(sec, token_issued_at=tia, session_id=sid)
     payload = ml.verify_session_value(v, sec)
     assert payload is not None
     assert payload["token_issued_at"] == tia
+    assert payload["session_id"] == sid
+    # Tampered signature still rejected.
     assert ml.verify_session_value(v + "x", sec) is None
 
 
+def test_verify_rejects_cookie_with_unregistered_session_id(monkeypatch):
+    """Defence against leaked FELLOWS_SESSION_SECRET: a cookie whose
+    session_id was never registered fails verification even when the
+    signature is otherwise valid. This is the property that makes the
+    secret leak alone insufficient to mint working cookies."""
+    monkeypatch.setenv("FELLOWS_SESSION_SECRET", "unit-test-secret")
+    sec = ml.session_secret_bytes()
+    with ml.AuthState.lock:
+        ml.AuthState.sessions.clear()
+    forged_sid = "ff" * 16  # 32 hex chars, not registered
+    v = ml.sign_session_value(
+        sec, token_issued_at=int(time.time()), session_id=forged_sid
+    )
+    assert ml.verify_session_value(v, sec) is None
+
+
+def test_verify_rejects_cookie_with_empty_session_id(monkeypatch):
+    """Cookies signed without a session_id (test-only path) must not
+    verify against a real running server."""
+    monkeypatch.setenv("FELLOWS_SESSION_SECRET", "unit-test-secret")
+    sec = ml.session_secret_bytes()
+    v = ml.sign_session_value(sec, token_issued_at=int(time.time()), session_id=None)
+    assert ml.verify_session_value(v, sec) is None
+
+
+def test_revoke_session_makes_cookie_invalid(monkeypatch):
+    """Logout's revoke_session() drops the session_id from the registry;
+    subsequent presentations of the same cookie value fail verification."""
+    monkeypatch.setenv("FELLOWS_SESSION_SECRET", "unit-test-secret")
+    sec = ml.session_secret_bytes()
+    sid = "ab" * 16
+    with ml.AuthState.lock:
+        ml.AuthState.sessions.clear()
+        ml.AuthState.sessions[sid] = {
+            "issued_at": int(time.time()),
+            "expires_at": time.time() + 3600,
+        }
+    v = ml.sign_session_value(sec, token_issued_at=int(time.time()), session_id=sid)
+    assert ml.verify_session_value(v, sec) is not None
+    ml.revoke_session(sid)
+    assert ml.verify_session_value(v, sec) is None
+
+
+def test_consume_token_yields_session_id_and_registers_it():
+    """consume_token's success result includes a 32-char hex session_id,
+    and that session_id is now in AuthState.sessions — so any cookie
+    signed with it passes verify_session_value."""
+    with ml.AuthState.lock:
+        ml.AuthState.tokens.clear()
+        ml.AuthState.consumed.clear()
+        ml.AuthState.sessions.clear()
+    tok = ml.issue_token()
+    r = ml.consume_token(tok)
+    assert r["status"] == "ok"
+    sid = r["session_id"]
+    assert isinstance(sid, str) and len(sid) == 32
+    with ml.AuthState.lock:
+        assert sid in ml.AuthState.sessions
+
+
 def test_verify_rejects_v1_cookies(monkeypatch):
-    """Old v1 cookies must no longer verify — forces clean re-login on deploy."""
+    """Old v1 cookies (no version prefix) must not verify."""
     monkeypatch.setenv("FELLOWS_SESSION_SECRET", "unit-test-secret")
     sec = ml.session_secret_bytes()
     import hmac as _hmac
@@ -44,6 +162,24 @@ def test_verify_rejects_v1_cookies(monkeypatch):
     v1_cookie = base64.urlsafe_b64encode(payload).decode("ascii").rstrip("=") + "." + sig
 
     assert ml.verify_session_value(v1_cookie, sec) is None
+
+
+def test_verify_rejects_v2_cookies(monkeypatch):
+    """v2 cookies (token_issued_at but no server-side registry binding)
+    must not verify after the v3 cutover. Every fellow re-logs-in once
+    when this PR ships — deliberate one-time logout."""
+    monkeypatch.setenv("FELLOWS_SESSION_SECRET", "unit-test-secret")
+    sec = ml.session_secret_bytes()
+    import hmac as _hmac
+    import hashlib as _hashlib
+
+    exp = int(time.time()) + 3600
+    tia = int(time.time()) - 30
+    payload = f"v2:{exp}:{tia}:deadbeefcafebabe".encode("utf-8")
+    sig = _hmac.new(sec, payload, _hashlib.sha256).hexdigest()
+    v2_cookie = base64.urlsafe_b64encode(payload).decode("ascii").rstrip("=") + "." + sig
+
+    assert ml.verify_session_value(v2_cookie, sec) is None
 
 
 def test_install_recently_allowed_window_math():
@@ -149,6 +285,26 @@ def test_cleanup_stale_tokens_drops_expired_consumed_entries():
         assert "fresh-consumed" in ml.AuthState.consumed
 
 
+def test_cleanup_stale_tokens_drops_expired_sessions():
+    """cleanup_stale_tokens also prunes session_ids past expires_at,
+    keeping AuthState.sessions bounded across long uptimes."""
+    with ml.AuthState.lock:
+        ml.AuthState.sessions.clear()
+        now = time.time()
+        ml.AuthState.sessions["expired-sid"] = {
+            "issued_at": now - 100,
+            "expires_at": now - 10,
+        }
+        ml.AuthState.sessions["fresh-sid"] = {
+            "issued_at": now - 5,
+            "expires_at": now + 3600,
+        }
+    ml.cleanup_stale_tokens()
+    with ml.AuthState.lock:
+        assert "expired-sid" not in ml.AuthState.sessions
+        assert "fresh-sid" in ml.AuthState.sessions
+
+
 def test_clear_session_cookie_line_has_max_age_0():
     class H:
         def get(self, key, default=None):
@@ -158,13 +314,6 @@ def test_clear_session_cookie_line_has_max_age_0():
     assert ml.SESSION_COOKIE + "=" in line
     assert "Max-Age=0" in line
     assert "Path=/" in line
-
-
-def test_allowlist_load(tmp_path):
-    p = tmp_path / "allowed_emails.json"
-    p.write_text('{"hashes": ["aa", "bb"]}', encoding="utf-8")
-    s = ml.load_allowlist(tmp_path)
-    assert s == {"aa", "bb"}
 
 
 def test_gated_paths():


### PR DESCRIPTION
## Summary

First batch of security hardening for the local-first directory app. Three coordinated improvements, all compatible with the Never-SaaS contract — no new server-side per-user routes, no on-demand fetches.

1. **Strict CSP + adjacent headers** in both `app/server.py` and `deploy/server.py`. CSP closes the highest-leverage gap: today a single XSS dumps the entire OPFS (`relationships.db` + `fellows.db`) to an attacker-controlled origin. New policy: `script-src 'self' 'wasm-unsafe-eval'` (carve-out for sqlite-wasm); `style-src 'self'` (no inline styles — refactored the only two in `statsSection` to `data-*` + CSSOM); strict everything else. Plus Permissions-Policy, Cross-Origin-Resource-Policy, Referrer-Policy, X-Content-Type-Options.

2. **HMAC allowlist; remove `allowed_emails.json` entirely.** Build pipeline no longer writes it. `deploy/server.py` builds the allowlist in memory at startup by HMAC-ing every distinct `contact_email` from `fellows.db` using a new env var `FELLOWS_ALLOWLIST_HMAC_KEY`. The key never leaves the server. Defence-in-depth: the `/allowed_emails.json` 404 stub stays in case a future routing change reintroduces the leak.

3. **Server-side token registry; v3 cookie format.** `consume_token` mints a `session_id`, registers it in `AuthState.sessions`. Cookie binds to that id; verification rejects any cookie whose `session_id` is missing from the registry. Neutralises "leaked `FELLOWS_SESSION_SECRET` → arbitrary cookie minting." v1/v2 cookies rejected on sight (one-time forced re-login on deploy).

Also includes a small DX recipe: `just prod-ssh` opens an interactive shell on the prod droplet using `FELLOWS_HOST` / `FELLOWS_SSH_PORT` / `FELLOWS_SSH_USER`.

Background and the prioritized list of Tier 2-4 follow-ups: `security_review/2026-05-08_local_vs_saas_risk.md` (the directory is gitignored).

## Test plan

Tests run on this branch:
- [x] `pytest tests/test_magic_link_auth.py tests/test_build_pwa.py` — 29 passed (new coverage for `hmac_email`, `load_allowlist_from_db`, v3 round-trip, forged-session-id rejection, `revoke_session`, v2-cookie rejection, session pruning)
- [x] `pytest tests/test_deploy_auth_round_trip.py` — 14 passed
- [x] Remaining unit + API: 160 passed
- [x] `pytest tests/e2e/` — 196 passed, 12 skipped (platform-specific)
- [x] Smoke-checked dev server response headers via `curl` — CSP, Permissions-Policy, CORP, Referrer-Policy, X-Content-Type-Options all present and correct

## Manual QA for the maintainer

**Before merging / deploying:**
- [x] **Postmark token scope** — confirmed prod is on a Server-scoped API token, not an Account API token. Postmark doesn't expose finer-grained scope within a Server token, so no further action needed. (Original description suggested "narrow to outbound-transactional-only"; that was based on a misread of Postmark's model. The Server-vs-Account distinction is the actual knob.)

**At deploy time (one-shot migration):**
- [ ] Run `just prod-configure-env` to add `FELLOWS_ALLOWLIST_HMAC_KEY` to `/etc/fellows/fellows-pwa.env`. Without it the new server boots with auth disabled (fail-closed) and prints a clear startup warning.
- [ ] After deploy: `just smoke` should still pass. `just prod-status` should show the service running.
- [ ] Open `https://fellows.globaldonut.com/?diag=1` in an existing tab — confirm the diag panel still renders. Existing v2 cookies will be rejected; you'll be redirected to the email gate. This is expected (cookie format bump).
- [ ] Request a magic link with your own email; confirm verify-token sets the new v3 cookie and the directory loads.
- [ ] DevTools Network tab: confirm responses carry `Content-Security-Policy: default-src 'self'; …` and `Permissions-Policy: …` headers.
- [ ] DevTools Console: should be clean. Any `Refused to execute … because it violates the following Content Security Policy` is a real bug — please report.

**Known operator-side breakage (Tier 3 follow-up, not load-bearing):**
- `scripts/debug_email_delivery.py --dump-allowlist` will fail because it reads the now-removed `dist/allowed_emails.json`. Other features in that script (event mining, MessageID resolution) still work. Will be updated for the HMAC + DB-derived flow in a follow-up PR.

🤖 Generated with [Claude Code](https://claude.com/claude-code)