### PR TITLE
docs: PNA spec planning scaffolding + arch doc gap-fixes

### DIFF
--- a/docs/Architecture.md
+++ b/docs/Architecture.md
@@ -22,6 +22,7 @@ The architectural decisions below — separate `relationships.db` file, `ATTACH 
 ## Tech Stack
 
 - **Server**: Python stdlib `http.server` — single file, no framework
+- **Cross-origin isolation**: Both servers send `Cross-Origin-Opener-Policy: same-origin` and `Cross-Origin-Embedder-Policy: require-corp`. **Required** — the OPFS-SAH-Pool VFS that backs `relationships.db` and `fellows.db` in the browser gates `SharedArrayBuffer` / `Atomics` on `crossOriginIsolated=true`. A reverse proxy that strips these headers makes the worker silently fall back to the `api+idb` provider; the symptom is "Settings has no backup/restore section," diagnosable via `?diag=1` showing `dataProvider.kind: api+idb` instead of `worker`.
 - **Database**: SQLite3 with FTS5 full-text search
 - **Frontend**: Vanilla JS SPA with hash routing, no build step
 - **Data source**: JSON dump from EHF wiki, imported via build script
@@ -70,8 +71,13 @@ The server opens a new SQLite connection per request (no connection pool — unn
 
 User-authored data (groups, tags, notes, settings) lives in
 `app/relationships.db`, a separate SQLite file from `fellows.db`.
-Cross-DB joins (worker-internal) use SQLite `ATTACH DATABASE ... ?mode=ro`,
-which keeps contact data read-only at the SQLite level. `relationships.db`
+Cross-DB joins happen inside the dedicated worker, attached once per
+worker `init` via `ATTACH DATABASE 'fellows.db' AS f ?mode=ro` — *not*
+per request. The `?mode=ro` suffix enforces read-only access at the
+SQLite level; any stray write into `f.*` raises `OperationalError`.
+(Pre-Phase-1 the dev server did per-request ATTACHes for `/api/groups`
+and friends; those routes are retired and the worker now does it once
+per session.) `relationships.db`
 is durable across both app updates and Clear App Cache; `fellows.db`
 is re-imported **on user request** when its server-reported content SHA
 differs from the SHA recorded in OPFS-side `fellows.db.meta.json` —
@@ -184,6 +190,70 @@ Bright lines for the codebase, not just the plan:
   race on the SAH. Today's behavior — second tab fails to acquire
   — is preserved. A graceful "another instance is open" UI is a
   follow-up, not a goal.
+
+## Workspace data providers (three tiers, mid-boot hot-swap)
+
+The workspace's data layer is a tiered abstraction with three
+implementations and an explicit fall-through path. The active
+provider is the runtime contract every render path consults; it's
+exposed at `window.__dataProvider` for tests and diagnostics.
+
+The tiers, in preference order:
+
+1. **`worker`** — happy path. RPC into the dedicated OPFS-owning
+   worker (see [Worker-owned OPFS](#worker-owned-opfs)). Full reads +
+   writes on both `relationships.db` and `fellows.db` (the latter
+   read-only).
+2. **`api+idb`** — auth-failure / OPFS-incapable fallback. Directory
+   reads come from `/api/fellows` when the session is valid, or from
+   the IndexedDB cache populated by a prior successful boot when it
+   isn't (per [`email_gate.md` invariant 10](email_gate.md)). Writes
+   to relationship-shaped methods (`createGroup`, `setSetting`, …)
+   reject with `localDataUnavailableError` so render paths catch it
+   and surface the unsupported-browser panel.
+3. **`api`** — deepest fallback. Same as `api+idb` without the
+   IndexedDB layer. Used in environments without IndexedDB (rare)
+   and as the dev passthrough.
+
+**Hot-swap on auth failure.** `bootDirectoryAsApp` starts with the
+worker provider; if the worker's `ensureFellowsDb` returns 401 / 403
+(stale session), the boot path swaps to `api+idb` mid-flight without
+unwinding. The worker process stays alive (it still owns OPFS;
+`clearEverything` reaches it through `warmWorker.rpc` for the wipe).
+The build badge flips to `server: offline · using cache`. The user
+keeps browsing the cached directory until they explicitly re-authenticate
+via `/?gate=1`.
+
+This is what makes "stale session must not lock users out of cached
+data" testable: a 401 on `/api/fellows` doesn't propagate as a boot
+failure; it transparently routes through the IDB cache.
+
+## Boot orchestration (named marks + watchdog + slow-boot persistence)
+
+The workspace runs a watchdog (default 20s) over a sequence of named
+boot phase marks: `script_start`, `pick_provider_start`,
+`worker_init_done`, `provider_ready`, `get_list_done`, `get_full_done`,
+`image_prewarm_done`, `summary`. If `get_list_done` doesn't arrive in
+time, a recovery panel (`#boot-stuck-panel`) renders naming the last
+completed mark — diagnostic enough that a stuck-boot report identifies
+which phase stalled before any backtrace. Same recovery affordances as
+the boot-error panel: Reload, Clear App Cache & Reload, send a bug
+report.
+
+Slow boots persist to localStorage:
+
+- **Trigger:** total >3000 ms or any single phase >2000 ms.
+- **Storage key:** `fellows_last_slow_boot`. Single record, overwritten
+  on each new slow boot. Survives Clear App Cache by being preserved
+  alongside `fellows_authenticated_once`.
+- **Surface:** the `?diag=1` panel shows it under "Last slow boot
+  recorded" on the next session. A regression captured one session
+  is readable in the next without depending on the user keeping the
+  slow tab open.
+
+`bootMarks` is exposed at `window.__bootMarks` for e2e tests; the
+chronological trace is at `window.__bootDebugLines`. Both are
+read-only by convention.
 
 ## Two-Phase Load
 

--- a/docs/DevOps.md
+++ b/docs/DevOps.md
@@ -28,6 +28,20 @@ rsync dist/ ─────SSH (rsb)───▶ /opt/fellows/deploy/dist/   (fe
                           Public Internet
 ```
 
+Caddy and any reverse proxy in front of the Python server **must
+preserve** the `Cross-Origin-Opener-Policy: same-origin` and
+`Cross-Origin-Embedder-Policy: require-corp` headers that the Python
+server sets on every response. These are load-bearing: the
+OPFS-SAH-Pool VFS that holds `relationships.db` and `fellows.db` in
+the browser refuses to install without `crossOriginIsolated=true`.
+If a future deploy switches reverse proxies and the headers don't
+make it through, the silent symptom is "Settings page has no
+backup/restore section" — diagnosable via `?diag=1` showing
+`dataProvider.kind: api+idb` instead of `worker`. Caddy in the
+default `reverse_proxy` config passes them through; explicit
+`header_down` directives that strip them are the failure path to
+look for.
+
 ## Unix identities
 
 Two accounts — one for the human, one for the daemon. This is the smallest separation that lets a code-exec bug in the service not become a code-rewrite opportunity.

--- a/docs/_pna_spec_format_landscape.md
+++ b/docs/_pna_spec_format_landscape.md
@@ -1,0 +1,155 @@
+# PNA Spec Format — Landscape Pass (scaffolding)
+
+> Working notes for choosing the format / shape of `docs/PNA_Spec.md`. The
+> spec is intended to be readable by humans and by AI agents, with the AI
+> as the primary builder per the "we expect most PNAs to be built and
+> rebuilt by AIs" framing in `_pna_triage.md`. Delete this file once the
+> format is settled and the spec is drafted.
+>
+> Working session: 2026-05-08 with @richbodo.
+
+---
+
+## What we need from the format
+
+Working from the triage doc's preamble:
+
+1. **Readable as prose** — humans need to understand it; AIs handle structured prose well.
+2. **Numbered, addressable invariants** — so contracts can be cross-referenced and an AI can check them individually.
+3. **Versioned** — so reference designs can declare which spec version they target, and so future versions can supersede invariants without breaking older designs.
+4. **Composable with machine-readable contracts** for parts where prose is genuinely ambiguous (data shapes, endpoint shapes, RPC handshakes).
+5. **Reference designs as evidence** — at least one deployed PNA per reference design grounds the prose in something that actually runs.
+6. **AI-pickup-able from a known entry point** — discoverable via repo conventions (`README.md`, `llms.txt`, `CLAUDE.md`, etc.).
+7. **Not over-formalized** — verifiable code is a long-arc goal, not a near-term prerequisite.
+
+---
+
+## Landscape
+
+### Interface and data-shape specs (mature, broadly-known)
+
+- **OpenAPI / Swagger.** REST API specs in JSON/YAML. Mature, widely adopted, excellent tooling. AI agents handle it natively because it's everywhere.
+- **JSON Schema.** Data-shape specs. Used inside OpenAPI and standalone. Native AI handling.
+- **GraphQL SDL.** Type system + query language. More expressive for typed graphs.
+- **Protocol Buffers, Cap'n Proto, FlatBuffers, Thrift, Avro.** Binary IDLs. Heavy tooling, overkill for PNA's needs (no wire-format pressure).
+- **TypeSpec (Microsoft).** Higher-level language that compiles to OpenAPI / JSON Schema / GraphQL. Newer.
+- **AsyncAPI.** OpenAPI for event-driven systems. Less widespread.
+
+**Relevance to PNA.** The Distribution component's HTTP endpoints (auth status, send-unlock, verify-token, logout, client-errors) fit OpenAPI cleanly. The worker init handshake, RPC operation shapes, and the Communications transport interface fit JSON Schema cleanly. The Shared and Private DB schemas are best expressed as SQL DDL (which is itself the canonical contract).
+
+### Formal specification languages (heavy)
+
+- **TLA+.** Lamport's formal spec language. Real model checker (TLC). High learning curve, narrow audience.
+- **Alloy.** Lightweight formal modeling. Easier than TLA+, less expressive.
+- **Z notation, B-method, Event-B, VDM.** Older formalisms used in safety-critical industries.
+- **Coq, Isabelle, Lean.** Proof assistants. Can specify and prove. Heavy.
+
+**Relevance to PNA.** Almost certainly overkill for v0.1. The architectural commitments could be expressed in TLA+, but the cost is high and the audience is narrow. Re-evaluate when verifiable code becomes a near-term goal, probably v0.3+ at the earliest.
+
+### Architecture documentation patterns (lightweight)
+
+- **ADR (Architecture Decision Records).** Markdown-per-decision. Captures context + decision + consequences. Widely adopted (originated at ThoughtWorks / Michael Nygard). The AC-N table format we're already using is an inline ADR equivalent.
+- **C4 model.** 4-level architecture diagrams (context, container, component, code). Simon Brown. Visual.
+- **arc42.** 12-section template for architecture docs.
+- **4+1 view model.** Older, Kruchten. Logical / development / process / physical / scenarios.
+- **Diátaxis.** Doc framework with four categories: tutorials, how-to, reference, explanation. Adopted by Django, GitLab, Cloudflare, Stripe.
+
+**Relevance to PNA.** ADR-style is what we're doing for architectural commitments — keep doing it. C4 / arc42 / 4+1 are heavier than we need; they target enterprise architecture. Diátaxis is a doc-organization principle that's useful if the spec eventually splits into multiple files (tutorial for new builders, reference for the contracts, explanation for the why).
+
+### AI-targeted documentation conventions (emerging)
+
+- **`llms.txt`.** Proposed by Jeremy Howard (answer.ai). Single file at site root, markdown, points at the most relevant docs for an LLM. Companion to `robots.txt` / `sitemap.xml`. Adoption has been growing — Anthropic, Cloudflare, Hugging Face, Stripe, others publish `llms.txt` files for their docs. Two variants: `llms.txt` (curated index) and `llms-full.txt` (concatenated full content). Cheap to add.
+- **AGENTS.md / CLAUDE.md.** Project-level conventions for agent-readable docs. fellows_local_db already has a `CLAUDE.md` with project-specific guidance.
+- **MCP (Model Context Protocol).** Anthropic's protocol for runtime AI-system interaction (tools, resources, prompts). JSON-RPC based. Targets the live agent-system interface, not the design-time spec — though MCP servers could *expose* spec contents to agents at runtime.
+- **Tool specs (Anthropic tool format, OpenAI function calling).** JSON schemas describing callable tools. Embedded in API requests; not standalone spec format.
+
+**Relevance to PNA.** `llms.txt` looks like the right discovery convention — small, well-defined, growing adoption, cheap. MCP is interesting longer-term: a future PNA toolkit could expose the spec via an MCP server an AI consumes natively, but that's not the right shape for the *spec itself* in v0.1.
+
+### Behavior-as-spec (executable, conformance-oriented)
+
+- **Cucumber / Gherkin (BDD).** Scenarios as specs, executable as tests. Human-readable.
+- **Property-based testing (Hypothesis, QuickCheck, fast-check).** Specifies properties; randomly tests them. Poor man's formal spec.
+- **Specs-as-tests in general.** The `window.__dataProvider` test seam in fellows_local_db is essentially this — contracts are exercised via Playwright against a live instance.
+
+**Relevance to PNA.** Useful for verifying conformance of an AI's output once it has built a PNA. Less useful for the spec itself. Workflow: prose spec → AI builds reference design → test suite proves the reference design conforms. The reference design's tests become the conformance checker for that flavor.
+
+---
+
+## Recommendation
+
+Compose `docs/PNA_Spec.md` and the surrounding artifacts from established conventions rather than inventing new formalism. Concrete plan:
+
+### Layer 1 — Prose spec (`docs/PNA_Spec.md`)
+
+Markdown. Sections in this order:
+
+1. Spec version + changelog summary
+2. Vocabulary
+3. Goals (with reasoning)
+4. Architectural commitments — ADR-style numbered table (AC-N)
+5. Slot map (interfaces and components)
+6. Per-slot contracts — prose with explicit references to the typed contracts in Layer 2
+7. Scope and versioning (deferrals + how versions evolve)
+8. Reference designs — links out to known PNA implementations and what flavor each represents
+
+Numbered invariants throughout for cross-reference. Each AC-N gets one paragraph; each slot gets a bounded section (~1–2 pages). Total target length: ~30–40 pages of markdown — long enough to be precise, short enough an AI can reason about it in one context window.
+
+### Layer 2 — Machine-readable contracts (`docs/spec/contracts/`)
+
+Separate files for the parts where prose is genuinely ambiguous:
+
+- `worker-init-handshake.schema.json` — JSON Schema for the worker `init` RPC return shape
+- `worker-rpc-protocol.schema.json` — JSON Schema for `{id, op, args}` ↔ `{id, ok, result|error}` envelope
+- `distribution-auth.openapi.yaml` — OpenAPI fragment for `/api/auth/status`, `/api/send-unlock`, `/api/verify-token`, `/api/logout`, `/api/client-errors`
+- `client-errors-payload.schema.json` — JSON Schema for the sanitized error sink payload
+- `transport-interface.d.ts` — TypeScript declaration for the Communications transport interface (`canHandle`, `launch`, `descriptor`)
+- `shared-db.schema.sql` — SQL DDL for the canonical Shared schema (record table + extra_json + optional FTS5 + asset URL convention)
+- `private-db.schema.sql` — SQL DDL for the canonical Private schema (groups + group_members + record_tags + record_notes + settings)
+
+The prose spec references these by relative path. AIs that need exact shapes pull them directly. Humans treat them as the authoritative specification of those parts.
+
+### Layer 3 — Reference designs (each in its own repo)
+
+Each reference design lives in a separate repo with its own `docs/Architecture.md`. The architecture doc declares:
+
+- Which PNA spec version it targets (e.g., `Spec-Version: 0.1`)
+- Its slot-fill choices (Distribution = magic-link PWA; Ingestion = Knack-JSON-to-static-archive; …)
+- Its load-bearing adjectives ("magic-link distributed PWA + static network DB archive + single shared directory")
+- Any specialization-only invariants
+
+fellows_local_db is the first reference design.
+
+### Layer 4 — Discovery (`llms.txt` at repo root)
+
+A small `/llms.txt` at the repo root (and in each reference design's repo). Format: markdown, structured per the convention (top-level project name + summary + sectioned link list).
+
+For the personal_network_toolkit repo, `llms.txt` points at `PNA_Spec.md`, `docs/spec/contracts/`, the changelog, and the list of known reference designs.
+
+For fellows_local_db, `llms.txt` points at `PNA_Spec.md` (in the toolkit repo, by URL), the local `docs/Architecture.md`, and the project's `CLAUDE.md`.
+
+### Layer 5 — Conformance (deferred)
+
+A reference design's existing test suite serves as its conformance checker. Property-based / scenario-based tests prove the implementation satisfies the contracts. fellows_local_db already has Playwright tests against `window.__dataProvider`; that pattern generalizes.
+
+Formal verification (TLA+ etc.) stays a v0.3+ goal; not blocking v0.1.
+
+---
+
+## Versioning
+
+- Initial version: `Spec-Version: 0.1`. Placeholder until enough demand to merit `1.0`.
+- Each version bump carries a `CHANGELOG.md` entry listing changed AC-N rows, slot-contract changes, and deferral resolutions.
+- Reference designs declare which version they target. An AI rebuilding a reference design against a newer spec follows the newer contracts; mismatch is allowed, but the reference design's `Architecture.md` says which version it satisfies.
+
+---
+
+## What this implies for the next step
+
+When we draft `PNA_Spec.md`:
+
+1. Start from `_pna_triage.md` Part 1 (synthesis per slot) — that material maps directly into the prose spec sections.
+2. Stub `docs/spec/contracts/` with empty files for each typed contract; fill them as the spec drafts cite them.
+3. Add `llms.txt` to the repo root pointing at the new spec + contracts dir.
+4. Tag the spec `Spec-Version: 0.1` and start a `CHANGELOG.md`.
+
+No formal-methods commitment, no new specification language to learn, no infrastructure beyond markdown + JSON Schema + OpenAPI + a small `llms.txt`. Established conventions composed into a new shape.

--- a/docs/_pna_triage.md
+++ b/docs/_pna_triage.md
@@ -1,0 +1,782 @@
+# PNA Triage (scaffolding — delete after split)
+
+> Intermediate planning artifact for splitting the existing docs into:
+>
+> - `docs/PNA_Spec.md` — generic personal network app spec (the target
+>   for the personal_network_toolkit toolkit)
+> - `docs/Architecture.md` — fellows_local_db's specialization layer
+>
+> Working sessions: 2026-05-08 with @richbodo. Iterative — vocabulary
+> and decomposition will evolve as we go.
+>
+> Read in this order:
+> 1. **Vocabulary** — small, deliberate term set
+> 2. **Goals** — five user-facing needs we satisfy, with reasoning
+> 3. **Architectural commitments** — load-bearing rules derived from goals + runtime constraints
+> 4. **Slot map** — three interfaces, five components
+> 5. **Part 1** — synthesis per slot (what `PNA_Spec.md` will say)
+> 6. **Part 2** — source map (verification: where each claim came from)
+> 7. **Part 3** — bugs, missing items, open questions
+
+---
+
+## Vocabulary
+
+This doc — and the eventual spec — uses a small, deliberate set of terms.
+
+- **Personal network app (PNA).** The category. An app that lets a user view contact data and work on relationship data over it, with private-data sovereignty as a first principle. fellows_local_db is one PNA; a personal-aggregator app that ingests Google + Apple + Facebook contacts is another.
+
+- **Workspace.** One *component* of a PNA: the viewer + editor. The thing the user looks at and clicks. fellows_local_db's workspace is a vanilla-JS SPA in the browser; another PNA's might be a native shell, a Tauri app, or a separately-distributed mini-app sharing the same data layer.
+
+- **Shared data.** Data that exists in more than one place — typically, a copy held by an external system the user uses (Google Contacts, Apple Contacts, Facebook friends, a fellowship's directory, a school's roster). The user is OK with that external system continuing to hold it. *Examples:* name, email, photo, organizational membership. The PNA mirrors this data locally so the user can browse and search it without depending on the external system being reachable.
+
+  > "Shared" is the key word — not "public" in the everyday sense.  Shaerd data can be data that the user publicly shared, or shared with Apple Contacts and exported, and is typically maintained outside the users systems.  The contact data in your Google account isn't *publicly visible*; it just isn't *exclusively yours* and shared with Google.  In all cases, some external system has a copy, or once did.
+
+- **Private data.** Data that exists only on the user's device. The user is *not* OK with any external system holding a copy. *Examples:* notes the user keeps about a contact, tags they apply, groups they assemble, communication history. The PNA's central architectural job is to keep this layer protected, durable, and exclusively local.  This data must never be sent across insecure channels, and must only be explicitly sent by the users command in any form.
+
+- **Shared DB / Private DB.** The two databases that a PNA stores. The Shared DB holds shared data (read-only inside the PNA — written only by the Ingestion component). The Private DB holds private data (read-write from the workspace).
+
+  In fellows_local_db, the shared DB is `fellows.db` and the private DB is `relationships.db`. The spec uses the generic names; specializations may rename for ergonomics, or change database engines for practical reasons, as long as the data stays local.
+
+- **Mirroring.** The act of producing a fresh shared DB from an external source. Done by the Ingestion component. Re-mirrors are atomic from the workspace's view (stage, validate, swap) and never silently orphan private references.
+
+- **Plugin / extension.** Anything that adds a capability to a composed PNA without modifying it's core. A memory-assistant view, a calendar overlay, a federated portrait pull, a community-statistics survey tool — all plugins.
+
+- **Reference design / thematic example.** A working, deployed PNA that demonstrates one valid combination of slot-fills against the spec. fellows_local_db is the first reference design — its load-bearing adjectives are *magic-link distributed PWA* (Distribution choice) + *static network DB archive* (Ingestion choice — the directory is mirrored once with opt-in updates, not linked to a live contact manager) + *single shared directory* (Source choice). New reference designs accumulate adjectives as their slot-fills land. AIs adapting a thematic example start from one of these and ask the user which slot-fills to keep, swap, or extend.
+
+---
+
+## Goals
+
+### Preamble
+
+We are at an inflection point. Two shifts are arriving at the same time. Personal data is withdrawing from centralized systems: users are increasingly unwilling to trust Facebook with who they talk to about politics or mental health, and increasingly unwilling to trust SaaS directories not to shut down with their data inside. At the same time, edge compute and AI agents capable of running serious work locally are arriving fast. The first shift creates demand for tools that keep user data sovereign; the second makes such tools practical to build, run, and recompose at the user's own pace.
+
+A personal network app is a tool that handles a user's contact data and personal-relationship data with strong, declared contracts about how that data is treated. The PNA separates the concerns of editing data shared with other systems from data created and held locally as private. A real contact manager might well exist as a plugin to a PNA, or interact with one via protocol. What distinguishes the category is the architectural promise: shared data is local-first and replaceable; private data is sovereign and protected; the user can reclassify a record's privacy at any time, and the PNA honors it durably; communication transports are user-chosen to meet the user's privacy and other requirements; the user can reason about where their data lives without trusting a vendor.
+
+The spec matters because users will increasingly compose software by prompting AI agents. We expect most PNAs to be built and rebuilt by AIs — adapting a thematic reference design like fellows_local_db, or building fresh against this spec. The contracts below are what the AI follows on the user's behalf, and they're written so the AI can pick them up and check its own work. The user's confidence comes from the spec being clear enough that both they and the AI can read it; as long as the contracts hold, an AI can rewrite a PNA from scratch while the user is still talking to it without changing the user's sovereignty, durability, or privacy posture. The goals below are user-facing needs; the architectural commitments after them are the choices that make those needs achievable.
+
+### Goal 1 — Private data sovereignty
+
+The PNA stores two databases: a Shared DB (data the user is OK with external systems mirroring) and a Private DB (data that must stay only on the user's device). The Private DB is protected forever — it never leaves the device, never lands on any server, and is durable across app updates and routine cache clears. The Shared DB doesn't need that lifetime protection.
+
+> **Why it matters:** Private data — who you confide in, your private notes on people, your communication history — is what most exposes you to surveillance, social-graph mining, and platform abuse. Keeping it on the user's device is the only durable defense. The architectural job of the PNA is to keep the line between shared and private data unmistakably bright.
+
+### Goal 2 — Mirror centralized data sources locally
+
+Users keep contacts in centralized platforms — Google, Apple, Facebook, work directories, organizational directories. A PNA mirrors those locally, producing a Shared DB the workspace can browse offline. Mirroring runs from exports today and may grow to richer pipelines (federated reads, multi-source dedup wizards) as the toolkit matures.
+
+> **Why it matters:** We're in a transitional period. Users won't migrate cold. The bridge from "my contacts are scattered across Google + Apple + Facebook + my fellowship's directory" to "my contacts are local-first" runs through ingesting their existing data, not asking them to maintain a parallel master list. The toolkit makes that ingestion a swappable component so a PNA can mirror one source or many.
+
+### Goal 3 — Secure communication options from inside workspaces
+
+When the user wants to reach out to a contact, the workspace offers a choice of transports — including secure / decentralized options like Signal, not just `mailto:` and `tel:`.
+
+> **Why it matters:** A user who demands sovereignty of their local data has the same high bar for the private transfer of that data. Defaulting every outreach to email — routed through whoever runs their mail server — is inconsistent with goal 1. The architectural commitment is that transports are pluggable and the user picks per outreach.
+
+### Goal 4 — Portable, durable, recoverable user data
+
+Private data travels with the user across devices, browsers, and PNA versions. Auto-backup, restore-from-file, and explicit opt-in update flows ensure no silent data loss.
+
+> **Why it matters:** Local-first only delivers on goal 1 if "local" doesn't mean "trapped on this exact installation forever." Users replace devices, switch browsers, reinstall PNAs. The Private DB has to be exportable, importable, and resilient against accidental wipes — otherwise sovereignty becomes fragility.
+
+### Goal 5 — Locally diagnosable
+
+When something goes wrong, the issue can be diagnosed without compromising goal 1. Sanitized error capture, runtime build labels, in-app diagnostic panels, user-controlled bug-report flows — all sized to a privacy posture consistent with the rest of the app. In single-user instances with no remote maintainer, the diagnostics primarily serve the user themselves.
+
+> **Why it matters:** A privacy-sovereign user's threshold for what diagnostic data flows anywhere is the same as for the rest of their data. The diagnostic surface is part of the privacy surface, not an exception to it. Many eventual PNAs will be single-user installations with no maintainer at all; the debug substrate has to work in that mode without sending anything anywhere by default. When a sink *is* configured (fellows_local_db sends to a maintainer mailbox), it has to be sanitized and rate-limited so the user trusts using it.
+
+---
+
+## Architectural commitments (derived from goals + runtime constraints)
+
+These are load-bearing rules the spec will enforce. Each links back to the goal(s) or runtime constraint that produces it.
+
+| ID | Commitment | Serves |
+|---|---|---|
+| AC-1 | **Two-DB ownership split.** Shared data is read-only and externally managed; private data is read-write and locally owned. Two SQLite databases, separate concerns, separate privacy postures. | Goal 1 |
+| AC-2 | **No SaaS surface.** Server (when present) is a delivery channel, not a service. No per-user RW endpoints, no server-side persistence of private data, no admin console, no cross-device sync. | Goal 1 |
+| AC-3 | **Single OPFS owner.** All OPFS handles and SQLite-WASM instances live in one dedicated worker. The workspace is an RPC client. No parallel main-thread OPFS. | Goal 1, Goal 4 |
+| AC-4 | **Versioned page↔worker handshake, decoupled from build label.** RPC version + schema version checked at init; mutating ops refused on mismatch; reads still work. Build label is *not* the gate. | Goal 4 |
+| AC-5 | **Stale session never locks users out of cached data.** A 401/403 from any shared-side fetch falls through to the local cache. Fresh data requires explicit user action. | Goal 1, Goal 4 |
+| AC-6 | **Always-reachable forced-gate URL.** Some hardcoded URL parameter (the project's `?gate=1`) forces the distribution UI regardless of cookie / localStorage state, surviving stuck-state debugging. | Goal 5 |
+| AC-7 | **Self-service field-debug substrate.** Build badge, sanitized error sink, ?diag panel, bug-report dialog, force-gate escape hatch, boot watchdog with named phase marks, slow-boot persistence. | Goal 5 |
+| AC-8 | **Anti-enumeration on auth + abuse-bounded analytics.** Distribution-channel auth endpoints always return neutral payloads; per-IP rate limits; sanitized error sink doubles as analytics pipe (`kind=install`, `kind=worker`, …) with no widening of the privacy boundary. | Goal 1, Goal 5 |
+| AC-9 | **Auto-backup of private data on user-edit cadence.** Snapshot the Private DB on a per-boot debounced schedule (not per-deploy); rotate to keep a small ring of recoverable points. | Goal 4 |
+| AC-10 | **Re-imports of the Shared DB are opt-in and non-destructive.** Whether the Shared DB is being refreshed from the original source (a directory operator pushes an update) or re-mirrored from a centralized platform (the user re-exports their Google contacts), the workspace previews any private references that would be orphaned by the update before the user commits. | Goal 2, Goal 4 |
+| AC-11 | **Multi-tab is detected and surfaced cleanly.** OPFS SAH-pool serializes per file; a second concurrent opener fails. Implementations distinguish this case from generic "your browser doesn't support this" and show a specific "another tab/window holds the data layer" message. | runtime constraint |
+| AC-12 | **Capability detection inside the worker, UA-parsing for messaging only.** Browsers lie about main-thread OPFS support; the worker is the only context where the answer is reliable. UA strings inform error messages, never gating. | runtime constraint |
+| AC-13 | **COOP/COEP required.** OPFS-SAH-Pool needs `crossOriginIsolated`; both dev server and prod reverse proxy must send `Cross-Origin-Opener-Policy: same-origin` and `Cross-Origin-Embedder-Policy: require-corp`. Without this, the storage substrate silently fails to install. | runtime constraint |
+| AC-14 | **Service worker never owns SQLite.** SW lifecycle (idle eviction, multi-instance, restart on push) is hostile to data ownership. SW is app-shell + update detection only. The Shared DB URL is explicitly bypassed in the SW fetch handler. | runtime constraint |
+| AC-15 | **Build label = `<date>-<short-sha>`, substituted at build *and* serve time.** Each served bundle carries a runtime-visible unique label tied to the source revision, with no manual chore-bump commits. Dev and dist agree byte-for-byte on the substituted files. | Goal 5 |
+| AC-16 | **Communication-transport selection is user-driven.** The workspace surfaces multiple transports — including secure / decentralized options when configured — and the user chooses per outreach. No transport is hardcoded. | Goal 3 |
+| AC-17 | **Mirrored data is sourced.** Every record in the Shared DB traces to a specific external source the user has explicitly configured. The toolkit doesn't introduce contact data the user hasn't approved. | Goal 2 |
+| AC-18 | **Transports cannot read message contents.** A transport's acceptability is about the transport mechanism itself, not the chain it kicks off. mailto: passes (hands off to whichever client the user has configured; the downstream provider's behavior — Gmail, Outlook — is outside the toolkit's enforcement). Signal-class protocols pass (encryption-in-protocol). Centralized message-broker SaaS that decodes payloads as part of operating (Slack, Discord) does not pass. Contact-graph retention by the transport is *not* part of the rule — too hard to enforce uniformly across protocols, and varies by user threat model. | Goal 3 |
+| AC-19 | **User-visible payload before send.** Any workspace-initiated communication shows the user the full payload — recipients, body, and any data merged in from the Shared or Private DB — before the transport is launched. The user can edit or cancel. This applies even to bulk operations (e.g., "email this group of 50"). Workspaces never auto-blast data through transports without the user seeing the composition. | Goal 3 |
+
+---
+
+## Slot map
+
+Three interfaces (data + cross-cut contracts) + five components (slots an implementation fills):
+
+| Kind | Name | Purpose |
+|---|---|---|
+| Interface | **Shared schema** | Read-only data contract — what the Shared DB looks like |
+| Interface | **Private schema** | Read-write data contract — what the Private DB looks like |
+| Interface | **Debug contract** | Every component implements: build label, sanitized error sink, ?diag, boot watchdog hooks |
+| Component | **Ingestion** | Produce a conforming Shared DB from one or many sources |
+| Component | **Storage** | OPFS-resident sqlite-wasm via dedicated worker; two-DB pattern; version handshake |
+| Component | **Workspace** | UI; routing; render shared + private data; launch communications |
+| Component | **Communications** | Outreach transports the user controls |
+| Component | **Distribution** *(optional)* | Ship + refresh to other users; auth/allowlist; signed bundle |
+
+A PNA *instance* fills each component slot with an implementation. fellows_local_db's slot-fills are the subject of `Architecture.md` after the split.
+
+---
+
+## Scope and versioning
+
+This spec is intentionally narrow. It addresses the user demand and runtime realities we can implement and deploy now. New demand develops further versions of the spec; reference designs continue to satisfy whatever spec version they were built against.
+
+**This is PNA Spec v0.1** (placeholder until real numbering lands). When new demand surfaces or runtime constraints shift, we bump the version, declare what changed in `CHANGELOG.md`, and update the architectural commitments accordingly.
+
+Items deliberately deferred to future spec versions:
+
+- **Privacy reclassification migration mechanics.** Para 2 of the preamble commits the PNA to honoring a user-driven privacy reclassification of a record (shared → private). The implementation pattern — does the record stay in the Shared DB with a private-side override row that supersedes? Get copied into the Private DB and removed from the Shared DB on next re-mirror? — is not pinned in v0.1. The contract is declared; the migration is left for a future version when the first reference design needs it.
+- **Multi-source dedup contract.** v0.1 assumes single-source ingestion. The personal-aggregator case (Google + Apple + Facebook merged into one Shared DB) lands in a future version when the first multi-source reference design is built.
+- **Per-database (or finer) transport requirements.** A future spec version may let each database — Shared, Private, or any custom database in a richer PNA — declare which transport properties it requires for outbound flow. v0.1 handles the data-transport matching implicitly: AC-18 filters out transports that read content; AC-19 ensures the user sees the full payload before launch; the user resolves the matching in the moment. Explicit per-DB rules (workspaces auto-suggesting or auto-filtering transports based on source DB sensitivity) land when a reference design has an auto-send feature that needs them.
+- **Cross-device sync.** Out of scope for v0.1. Future versions may declare a sync protocol; v0.1 explicitly does not.
+- **Federated p2p capabilities.** Signed-repo asset pulls (a community member's photos), community-stats aggregation tools (the CRT vision @richbodo described). Out of scope for v0.1.
+- **Formally verifiable code.** A longer-arc goal. v0.1 aims for AI-checkable contracts (markdown prose + JSON Schema / OpenAPI / SQL DDL); formal verification (TLA+ / Alloy / etc.) is reserved for a later version.
+
+When any of these become near-term, they get a v0.2+ spec bump and the relevant architectural commitments are revised.
+
+---
+
+## Classification key
+
+| Tag | Meaning | Destination |
+|---|---|---|
+| `pna-cat` | Category-level (no single slot) — invariants AC-1 through AC-17 | PNA_Spec.md, top-level |
+| `pna-shared` / `pna-private` / `pna-debug` | Generic, lives under that interface | PNA_Spec.md, interface section |
+| `pna-ingest` / `pna-storage` / `pna-workspace` / `pna-comms` / `pna-dist` | Generic, lives under that component | PNA_Spec.md, component section |
+| `fellows-{slot}` | fellows_local_db's choice for that slot | Architecture.md, slot section |
+| `fellows-cat` | Specialization-only invariant or operator concern | Architecture.md |
+| `STALE` | Wrong / outdated; fix in place before either spec inherits | Source doc |
+| `MISSING` | Not in any doc; needs to be added | PNA_Spec.md or Architecture.md |
+| `DROP` | Tribal knowledge; doesn't earn a spec line | — |
+
+---
+
+# Part 1 — Synthesis per slot
+
+What `PNA_Spec.md` will declare for each interface / component, drawn from the triage. fellows_local_db's specific slot-fills are noted separately under each slot.
+
+## Category-level invariants (`pna-cat`)
+
+The 17 commitments above. PNA_Spec.md leads with these. Each gets one paragraph; the goals section sits above.
+
+## Shared schema (`pna-shared`)
+
+**Contract.** A conforming Shared DB is a SQLite database containing:
+
+- A required primary record table (canonically named `records` in the spec; specializations may rename — fellows_local_db calls it `fellows`) with a stable core column set:
+  - `record_id TEXT PRIMARY KEY` — opaque, stable across re-mirrors
+  - `slug TEXT NOT NULL UNIQUE` — display URL key; deterministic from name
+  - `name TEXT NOT NULL` — display label
+  - Plus zero or more app-defined display columns (name, bio, avatar URL, …). The spec defines the slot; ingestion fills it.
+- An overflow column `extra_json TEXT` carrying any source-specific keys not in the explicit column set; the workspace merges these into per-record API responses without per-field schema knowledge.
+- An optional FTS5 virtual table indexing whichever columns the workspace wants to search.
+- An optional per-record asset URL convention (e.g. `/images/<slug>.{jpg,png}` in fellows_local_db) — separate from the database, cacheable, immutable, slug-keyed.
+
+**Read-only enforcement** at the SQLite level via `ATTACH DATABASE … ?mode=ro` whenever joined from the Private DB (worker-internal; happens once per init in the OPFS path). Any stray write into the attached namespace raises `OperationalError`.
+
+**Re-import semantics.** Replacing the Shared DB is atomic from the workspace's point of view: stage → validate → swap. No partial states observable. On replacement, every `record_id` referenced by the Private DB is checked against the new shared records; orphans are flagged for the user, never silently dropped (per AC-10).
+
+**Mirrored-source provenance.** Every record traces to a specific external source the user has approved. Multi-source PNAs include a `source` column; single-source PNAs may omit it (per AC-17).
+
+**fellows_local_db specifics:** see Architecture.md § Shared schema specialization (17 explicit columns + extra_json; FTS5 over name/bio/cohort/fellow_type/search_tags/key_links; record table named `fellows`).
+
+## Private schema (`pna-private`)
+
+**Contract.** The Private DB is a SQLite database containing at minimum:
+
+- `groups(id, name, note, created_at, updated_at)` — user-curated subsets
+- `group_members(group_id, record_id, PRIMARY KEY(group_id, record_id))` — joins a group to records; `ON DELETE CASCADE` on group_id; foreign keys ON
+- `record_tags(record_id, tag, created_at, PRIMARY KEY(record_id, tag))` — per-record tags
+- `record_notes(record_id PRIMARY KEY, body, updated_at)` — per-record freeform notes
+- `record_comms_history(id INTEGER PRIMARY KEY, record_id, transport, direction, occurred_at, summary)` — opt-in log of outreach launched from the workspace. **Disabled by default.** User must explicitly enable via `settings['comms_history_enabled']='1'`; the workspace honors the flag and never writes to this table when disabled. User has full read / edit / delete control over the rows; rows live in the Private DB and are protected by AC-1 (never leave the device).
+- `settings(workspace_id, key, value, PRIMARY KEY(workspace_id, key))` — key/value bag partitioned by workspace ID. Single-workspace PNAs use empty-string `workspace_id` (default); multi-workspace PNAs (per the "one origin, many workspaces" decision) use their workspace's ID so each workspace has its own settings namespace.
+
+`PRAGMA user_version` set to the schema version at bootstrap so future migrations can branch on it. `PRAGMA foreign_keys = ON` per connection (sqlite default is OFF; without it the cascade is silently inert).
+
+**Durability.** The Private DB is never replaced on app update. It survives Clear App Cache. It is wiped only by Reset Everything (explicit user choice).
+
+**Auto-backup.** Worker `init` snapshots the Private DB to `private.db.bak.<ISO>` at OPFS root (outside the SAH-pool dir) on a per-boot debounced schedule, rotated to keep newest N. Trigger keyed to user-edit cadence, not deploy cadence.
+
+**Restore.** Two paths surfaced from the workspace: restore from a user-supplied file, restore from a recent auto-backup. Both validate via `PRAGMA quick_check` + schema check, snapshot the live DB before replacement, atomically swap, and re-bootstrap schema (idempotent CREATE IF NOT EXISTS so older backups gain new tables).
+
+**fellows_local_db specifics:** filename is `relationships.db`; tables named `fellow_tags` / `fellow_notes` / `group_members.fellow_record_id` for in-app ergonomics.
+
+## Debug contract (`pna-debug`)
+
+Every component implements this. PNA_Spec.md declares it once; per-component sections reference it.
+
+**Build label substitution.** Every component shipping JS / config / templates supports placeholder substitution at build *and* serve time (so dev and dist agree byte-for-byte). Format: `<YYYY-MM-DD>-<short-sha>` from the source repo's HEAD.
+
+**Build badge.** The workspace renders an always-visible badge showing local + server build labels.
+
+**Boot phase marks + watchdog.** Every component contributes named marks at meaningful boot transitions. The workspace runs a watchdog that surfaces a recovery panel naming the last completed mark. Slow boots persist a one-line record to localStorage so a regression captured one session is readable in the next.
+
+**Sanitized error sink.** A single unauthenticated POST endpoint (when configured — purely-personal PNAs may have no sink at all). Body: `{events, ua, build, route, displayMode, online, lastSubmitHashPrefix}`. 16KB body cap; per-IP rate limit; always 204; events typed via a `kind=` enum allowlist; free-text fields sanitized server-side. Privacy boundary is *server-side*, not trusted to the client.
+
+**Sink doubles as analytics pipe.** Adding a new `kind=` enum (e.g., `install`, `worker`, `comms`) is the only widening lever. No separate analytics endpoint, no separate identifier scheme.
+
+**Bug-report dialog.** Workspace ships a dialog that collects the same diagnostic block as ?diag and opens a `mailto:` to a configured maintainer (when one is configured).
+
+**Force-gate / force-reset escape hatch.** Reachable from ?diag *and* from a hardcoded URL parameter, regardless of cookie / localStorage state.
+
+**Configurability.** Every part of the debug contract is configurable. A purely personal PNA may have no error sink and no maintainer mailbox; the build badge and ?diag panel still work, error capture goes to localStorage only.
+
+**fellows_local_db specifics:** sink at `/api/client-errors`; bug report to `richbodo@gmail.com`; force-gate URL is `/?gate=1`; substituted placeholders are `__FELLOWS_UI_DIAG__` and `__CACHE_VERSION__`.
+
+## Ingestion (`pna-ingest`)
+
+**Contract.** Produces a Shared DB conforming to the shared schema. Inputs and pipeline are app-specific. Output must validate via `PRAGMA quick_check` and the primary record table must have ≥1 row (zero-row guard prevents silent orphaning of all private references).
+
+**Update mechanics.** When the user opts into a re-mirror (per AC-10), Ingestion produces fresh bytes and stages them; Storage validates and atomically swaps. The workspace's preview step computes affected `private.group_members` rows whose `record_id` is no longer in the new shared records — and surfaces them by name to the user before commit.
+
+**Possible richer ingestion shapes (toolkit-future):**
+
+- Multi-source merge (Google + Apple + Facebook + custom CSVs) with a deduplication wizard (UI for resolving merge conflicts across record_ids)
+- Per-source provenance tracking (`source` column on every record)
+- Re-ingestion that preserves stable `record_id` across source changes
+- Incremental ingestion (only changed records) when source supports it
+
+**fellows_local_db specifics:** Knack JSON ETL via `build/restore_from_knack_scrapefile.py`; image fallback chain `app/fellow_profile_images_by_name/` → `final_fellows_set/`; alpha-only fuzzy filename match; one source, no dedup needed.
+
+## Storage (`pna-storage`)
+
+The most architecturally constrained slot. Most of the AC commitments live here.
+
+**Substrate.** SQLite-WASM via OPFS-SAH-Pool VFS, owned by a single dedicated worker. Page is RPC client.
+
+**Worker init contract.** First message must be `op='init'`. Returns handshake blob:
+
+```
+{
+  workerRpcVersion: int,
+  schemaVersion: int,
+  buildLabel: string,
+  opfsCapable: bool,
+  hasSharedDb: bool,
+  hasPrivateDb: bool,
+  poolFiles: string[],
+  trace: string[]
+}
+```
+
+Workspace reads the version fields and refuses mutating RPCs on mismatch (passive — the SW's reload banner is the canonical update affordance). `opfsCapable=false` triggers the unsupported-browser panel from the workspace.
+
+**RPC protocol.** `{id, op, args}` from page → `{id, ok:true, result}` or `{id, ok:false, error, errorName?, errorCode?, httpStatus?, meta?, stack?}` from worker. Fan-in via sequence-numbered pending Map. Worker `onerror` rejects all pending RPCs with `workerScriptError=true` so callers can fall back instead of hanging.
+
+**Capability detection.** Inside `init` (per AC-12). UA-parsing in the workspace for messaging only.
+
+**Two databases.** Private DB (RW) opened via `OpfsSAHPoolDb`; Shared DB (read-only) opened via the same when present, fetched on cold start by an `ensureSharedDb`-style RPC. Names canonicalized to leading-slash form (SAH-pool quirk: `importDb('foo')` and `OpfsSAHPoolDb('foo')` resolve differently without it).
+
+**Auto-backup.** Per AC-9. Backups live at OPFS root, not inside SAH-pool, so they survive normal sqlite-wasm operations. Rotation by sorted ISO filename.
+
+**Opt-in update.** Per AC-10. `compareSha → previewSwap → applySwap | cancelSwap` RPCs with opaque per-session `stagingId` so a stale page can't accidentally commit.
+
+**Multi-tab.** Per AC-11. `installOpfsSAHPoolVfs()` throws `NoModificationAllowedError` on conflict; worker tags as `code='OWNERSHIP_CONFLICT'` so the workspace can render a specific "another tab/window holds the data layer" panel rather than the misleading "your browser doesn't support this."
+
+**Reset Everything.** A nuclear `wipeAll` RPC: closes both DBs, tears down SAH-pool VFS via `removeVfs()`, iterates OPFS root and removes every entry. Caller reloads after.
+
+**Diagnostics.** `getOpfsInventory`, `getTrace`, `getVersions`, `getSharedDbMeta` — all read-only, used by ?diag and bug reports.
+
+**fellows_local_db specifics:** worker file at `app/static/vendor/sqlite-worker.js`; `WORKER_RPC_VERSION=2`; `RELATIONSHIPS_SCHEMA_VERSION=1`. The legacy main-thread OPFS paths still exist in `app.js` but are unused post-Phase-1.
+
+## Workspace (`pna-workspace`)
+
+**Contract.** Renders shared + private data. Implements the debug contract. Provides:
+
+- Boot persona function (the "should we boot directly into the workspace, or show the distribution gate?" decision)
+- Three-tier dataProvider with mid-boot hot-swap on auth failure
+- Hash-based routing (or equivalent) with per-route focus modes
+- Render path for orphaned private references (per AC-10 follow-through)
+- `escapeHtml()` discipline for all user-supplied data
+- Capability-failure panel (`renderLocalDataUnavailablePanel(feature)` style)
+- Local-search fallback when network is offline (over the cached shared data)
+
+**Data providers (three tiers).** A PNA workspace consults a provider abstraction with three implementations:
+
+- **worker** (happy path) — RPC to Storage; full OPFS-backed reads + writes
+- **api+idb** (auth-failure fallback) — shared-data reads via the distribution channel's API or local IDB cache; private-data writes refuse with `localDataUnavailable` so the unsupported panel renders
+- **api** (deepest fallback, dev) — same as api+idb but no IDB
+
+The workspace hot-swaps mid-boot on a 401/403 from the shared-data fetch, so a stale session never locks the user out of cached data (AC-5). The active provider is exposed at `window.__dataProvider` for tests and diagnostics.
+
+**Persistence-marker contract.** Exactly one localStorage key is preserved across the workspace's "Clear App Cache" affordance: the "this origin authenticated once" marker. All other localStorage keys are cleared. (Drafts in localStorage are explicitly unsaved-by-definition; durable user state lives in the Private DB.)
+
+**Force-gate.** Per AC-6.
+
+**URL-just-works (browser-mode-acts-as-app).** When the user previously authenticated this origin (the marker is set) and they're visiting in a browser tab (not standalone PWA), boot directly into the workspace.
+
+**fellows_local_db specifics:** vanilla-JS SPA, single 9400-line IIFE, hash routing with seven routes (`#/`, `#/about`, `#/fellow/<slug>`, `#/groups`, `#/groups/<id>`, `#/groups/<id>/directory`, `#/edit/<id>`, `#/settings`). Filter state persisted in URL query suffix.
+
+## Communications (`pna-comms`)
+
+**Contract.** A pluggable transport layer. Each transport exposes an interface:
+
+```
+canHandle(action) → bool
+launch(action, payload) → Promise<launchResult>
+descriptor() → { id, name, secureLevel?, … }
+```
+
+Where `action` is one of (initial set): `email_one`, `email_group_cc`, `email_group_bcc`, `direct_message_one`, `share_link_one`, `share_link_group`. The workspace offers whichever transports the running PNA is configured with; the user picks per outreach (per AC-16).
+
+**Privacy invariant — content secrecy (per AC-18).** A transport is acceptable for inclusion iff its mechanism itself cannot read message contents. mailto: passes — the mechanism hands off to whichever client the user has configured; downstream provider behavior (Gmail, Outlook, etc.) is outside the toolkit's enforcement. Signal-class protocols pass — encryption is part of the protocol. Centralized message-broker SaaS that decodes payloads as part of operating (Slack, Discord) does not pass.
+
+**User-visible payload before send (per AC-19).** Communications launched by the workspace show the user the full payload — recipients, body, any merged data from Shared or Private DB — before the transport is invoked. The user can edit or cancel. Even bulk operations (email this group of 50) show a composed view first. This is how the data-transport matching gets resolved in v0.1: the user sees what's going where and either approves it or doesn't. (Per-database transport requirements as an explicit declarative mechanism are deferred — see § Scope.)
+
+**Distinction from distribution-mechanism transports.** Communications transports are what the workspace launches when the user wants to reach out to a contact. They are *distinct from* the Distribution component's auth-link transport (e.g., Postmark sending a magic link in fellows_local_db). Distribution-mechanism transports are governed by the Distribution slot's contracts, not AC-18 — choosing a magic-link distribution flavor implies accepting whatever the magic-link delivery service does within its scope.
+
+**Sharing-scope as future consideration.** The Shared schema in v0.1 has no per-record sharing-scope metadata (who already has a copy: just the fellowship, just Google, the world, etc.). Future versions may add this so the workspace can warn before sending data through a transport whose effective scope would exceed the data's existing scope. Out of scope for v0.1; noted here so the Shared schema isn't designed in a way that precludes adding it.
+
+**fellows_local_db specifics:** `mailto:` only. Signal planned next.
+
+## Distribution (`pna-dist`) — optional
+
+A PNA *may or may not* distribute. A purely-local instance (one user, locally built, no shipping to others) has no Distribution component. When present, Distribution provides:
+
+**Install path.** Some way to deliver a verified bundle to an authorized user's device. Contract: results in a local install of Workspace + Storage + an initial Shared DB, with a session that authorizes future fetches.
+
+**Update path.** Workspace + worker file updates via SW + cache versioning (when the implementation is a PWA). Shared-DB updates are explicitly user-driven (per AC-10), not automatic.
+
+**Auth contract (when allowlisted).**
+
+- `GET /api/auth/status` — never gated; returns `{authEnabled, authenticated, hasSessionCookie, installRecentlyAllowed, build, buildGitSha}`
+- `POST /api/send-unlock` — anti-enum, always 200 `{sent:true}`; rate-limited per email-hash
+- `POST /api/verify-token` — 200 + Set-Cookie on success; 401 with distinct `expired`/`invalid` error strings otherwise
+- `POST /api/logout` — idempotent, always 200, doesn't require valid session
+- Server-side: HMAC-signed session cookie; v-prefixed format so prior versions reject cleanly post-deploy
+- Token re-consume grace window (~60s) to defend against bfcache, iOS back-button, email-side link scanners
+
+**No per-user RW endpoints** (per AC-2). The distribution server gates shared-data reads behind a session; it has no per-user state to defend.
+
+**Distribution server hardening (when present).**
+
+- TLS terminator on :443 forwarding to a 127.0.0.1 origin
+- COOP/COEP headers per AC-13
+- 16 KB POST cap
+- Per-IP rate limits matching the auth path
+- Long-cache for immutable assets, no-cache for HTML/JS/CSS/SW + worker file + manifest + build-meta.json
+- Status-aware caching: 4xx/5xx never long-cached
+- Sanitized error sink per Debug contract
+
+**PWA-specific gotchas (when distribution medium is a PWA).**
+
+- Manifest stays minimal: `id`, `start_url`, `scope` all `=/`; three icons (`any`, `any`, `maskable`); **no `related_applications`** (Android WebAPK pipeline foot-gun); **no `share_target` with `method: "POST"`** (Samsung/Chromium foot-gun)
+- SW network-first for HTML/JS/CSS/SW *and* the worker file (RPC version is tightly coupled to app.js); cache-first for vendored sqlite3.js / sqlite3.wasm
+- Profile/asset cache is a separate cache name from app shell so shell bumps don't evict tens of MB of immutable assets; asset URLs stay bare (no `?v=` cache-bust) because per-record assets are immutable
+- The Shared DB URL is explicitly bypassed in the SW fetch handler (per AC-14)
+
+**fellows_local_db specifics:** never-SaaS PWA + Postmark magic-link allowlist; Caddy on Ubuntu droplet; `TOKEN_TTL = 30 min`, `INSTALL_WINDOW = 30 min`, `SESSION_MAX_AGE = 7 days`; v2 cookie format. Decision tree (browser-mode vs PWA-mode), six-step ordered match, always-reachable `?gate=1`. Specifics in `email_gate.md` (post-rewrite, this becomes the Distribution specialization annex).
+
+---
+
+# Part 2 — Source map (verification)
+
+For each existing doc, a compact list of load-bearing claims with classifications. Use this to verify Part 1 didn't drop anything important.
+
+## docs/Architecture.md
+
+| Section | Claim | Class | Maps to |
+|---|---|---|---|
+| Design constraint | "single-user and local-only by design… must never become a SaaS" | `pna-cat` | AC-2 |
+| Design constraint | server contact bounded to install + update | `pna-cat` | AC-2 |
+| Design constraint | no per-user resources on the server | `pna-cat` | AC-2 |
+| Design constraint | stale-session must not lock users out of cached data | `pna-cat` | AC-5 |
+| Design constraint | ruled-out features list (cross-device sync, share group, admin console, etc.) | `pna-cat` | non-goals |
+| Tech Stack | Python stdlib `http.server` | `fellows-dist` | impl choice |
+| Tech Stack | SQLite3 with FTS5 | `pna-storage` (sqlite) + `fellows-workspace` (FTS5 columns) | shared schema allows but doesn't require FTS5 |
+| Tech Stack | Vanilla JS SPA, no build step | `fellows-workspace` | impl choice |
+| Tech Stack | pytest + Playwright | `fellows-cat` | testing |
+| Data Flow | ETL → fellows.db with 17 cols + extra_json | `fellows-ingest` | impl choice |
+| Data Flow | extra_json overflow merged at API time | `pna-shared` | extension mechanism is generic |
+| Runtime | new SQLite connection per request, no pool | `fellows-cat` | server detail |
+| Runtime | HTTP API table | `fellows-cat` | specific routes |
+| Runtime | `/api/auth/status` shape | `pna-dist` | Distribution auth contract |
+| Runtime | `/api/client-errors` privacy-bounded | `pna-debug` | sink |
+| Runtime | `/api/groups` and `/api/settings` retired (Phase 1) | `fellows-storage` | choice that all this lives in OPFS now; phase numbering is `STALE` for spec |
+| Persistence | private.db separate from shared.db | `pna-cat` | AC-1 |
+| Persistence | ATTACH ?mode=ro for cross-DB joins | `pna-shared` | read-only enforcement |
+| Persistence | private.db durable across app updates and Clear App Cache | `pna-private` | durability |
+| Persistence | shared.db re-imported on user request when SHA differs | `pna-cat` | AC-10 |
+| Persistence | pre-swap impact preview lists affected members | `pna-cat` | AC-10 |
+| Persistence | OPFS in both standalone PWA and browser-tab modes | `pna-storage` | substrate |
+| Persistence | unsupported-browser panel via `renderLocalDataUnavailablePanel()` | `pna-workspace` | capability-failure panel |
+| Worker-owned OPFS | single dedicated worker owns every OPFS handle | `pna-cat` | AC-3 |
+| Worker-owned OPFS | RPC `{id, op, args}` ↔ `{id, ok, result\|error}` | `pna-storage` | protocol |
+| Worker-owned OPFS | worker handles both RW and RO databases | `pna-storage` | substrate |
+| Worker-owned OPFS | no other context calls `getDirectory` / `createSyncAccessHandle` | `pna-cat` | AC-3 |
+| Worker-owned OPFS | rationale: Safari etc. strip createSyncAccessHandle from main-thread | `pna-cat` | AC-12 |
+| Worker-owned OPFS | init is network-free; fetch is page-driven | `pna-storage` | install-only by design |
+| Worker-owned OPFS | `WORKER_RPC_VERSION` + schema version gates | `pna-cat` | AC-4 |
+| Worker-owned OPFS | mismatch refuses mutating RPCs; reads still work | `pna-cat` | AC-4 |
+| Worker-owned OPFS | build label not consulted for the gate | `pna-cat` | AC-4 |
+| Worker-owned OPFS | ATTACH happens once per init in worker (not per request) | `pna-storage` | substrate; doc wording is `STALE` (see Bug 3) |
+| Worker-owned OPFS | capability detection in worker | `pna-cat` | AC-12 |
+| Non-goals | SW never owns SQLite | `pna-cat` | AC-14 |
+| Non-goals | no parallel main-thread OPFS | `pna-cat` | AC-3 |
+| Non-goals | no server-side per-user state | `pna-cat` | AC-2 |
+| Non-goals | no silent cross-device sync substrate | `pna-cat` | non-goal |
+| Non-goals | no multi-tab concurrent ownership | `pna-cat` | AC-11 |
+| Two-Phase Load | list-then-full | `pna-workspace` | lazy-load pattern |
+| Two-Phase Load | fall back to single-record GET if user clicks before phase 2 | `fellows-workspace` | pre-Phase-1 path |
+| Frontend Routing | hash-based, no router lib | `fellows-workspace` | shell choice |
+| Frontend Routing | route table (7 routes) | `fellows-workspace` | specific routes |
+| Manifest gotchas | `id, start_url, scope` all `=/` | `pna-dist` | PWA-specific contract |
+| Manifest gotchas | don't add `related_applications` (Android WebAPK foot-gun) | `pna-dist` | runtime fact |
+| Manifest gotchas | don't use `share_target` with `method:"POST"` | `pna-dist` | runtime fact |
+| Database Schema | fellows table 17 cols + extra_json | `fellows-ingest` | impl schema |
+| Database Schema | fellows_fts virtual table | `fellows-storage`+`fellows-workspace` | impl |
+| Database Schema | private.db schema (5 tables) | `pna-private` | promote core; rename `fellow_record_id`→`record_id` |
+| Database Schema | PRAGMA user_version for migrations | `pna-private` | versioning |
+| Database Schema | private.db gitignored, per-user, durable | `pna-cat` | AC-1 |
+
+## docs/email_gate.md
+
+| Section | Claim | Class | Maps to |
+|---|---|---|---|
+| Goals | default view is the email gate | `fellows-dist` | impl-specific UI choice |
+| Goals | install landing exists only inside a bounded window | `fellows-dist` | PWA-install timing |
+| Goals | dev must always reach the gate in one click | `pna-cat` | AC-6 |
+| Definitions | session cookie HttpOnly, HMAC-signed, v2 format | `fellows-dist` | impl |
+| Definitions | TOKEN_TTL = 30 min | `fellows-dist` | tunable |
+| Definitions | INSTALL_WINDOW = 30 min from issue | `fellows-dist` | tunable; the *anchor* is generic |
+| Definitions | SESSION_MAX_AGE = 7 days | `fellows-dist` | tunable |
+| Invariants | email gate is the default | `fellows-dist` | impl |
+| Invariants | install landing never repeats | `fellows-dist` | impl |
+| Invariants | expired vs invalid links explicit | `fellows-dist` | UX |
+| Invariants | session cookie TTL decoupled from install window | `pna-dist` | generic pattern |
+| Invariants | dev escape hatch always reachable (`?gate=1`) | `pna-cat` | AC-6 |
+| Invariants | unsupported browsers told so on click, not eagerly | `pna-workspace` | UX rule |
+| Invariants | URL-just-works for returning visitors | `pna-cat` | persistence-marker contract |
+| Invariants | stale session does not lock users out of cached data | `pna-cat` | AC-5 |
+| Browser-mode decision tree | six-step ordered match | `fellows-dist` | impl-specific tree |
+| `fellows_authenticated_once` marker | preserved across `clearAllAppData` | `pna-cat` | persistence-marker contract |
+| Endpoints | `/api/auth/status` | `pna-dist` | contract |
+| Endpoints | `/api/send-unlock` anti-enum 200 | `pna-dist` | AC-8 |
+| Endpoints | `/api/verify-token` 401 with `expired`/`invalid` | `fellows-dist` | distinct strings is impl |
+| Endpoints | `/api/logout` idempotent | `pna-dist` | contract |
+| Endpoints | `/api/client-errors` 204 / 16KB / sanitized / rate-limited | `pna-debug` | sink contract |
+| Client error reporting | privacy boundary is server-side | `pna-debug` | invariant |
+| Client error reporting | sanitization rules | `pna-debug` | sanitizer contract |
+| Client error reporting | `kind=` enum allowlist | `pna-debug` | analytics-via-sink |
+| Client error reporting | `lastSubmitHashPrefix` correlation handle | `pna-debug` | mechanism |
+| Client error reporting | `client_ip_prefix` first-12-hex of sha256 | `pna-debug` | invariant: never log raw IP |
+| Client error reporting | per-IP rate limit | `pna-debug` | AC-8 |
+| `kind=install` events | install-funnel telemetry | `pna-debug` | analytics example |
+| `kind=worker` events | spawn / init outcomes | `pna-debug` | analytics example |
+| Cookie format (v2) | payload + HMAC | `fellows-dist` | impl |
+| Cookie format (v2) | v1 rejected on sight | `fellows-dist` | impl |
+| Token grace | 60-sec re-consume window | `fellows-dist` | tunable; rationale (defense against bfcache / scanners) is generic |
+| Security notes | `?gate=1` doesn't bypass auth, only the UI | `pna-cat` | AC-6 |
+
+## docs/persistence_and_upgrades.md
+
+| Section | Claim | Class | Maps to |
+|---|---|---|---|
+| Storage layers table | Cache API names; IDB; OPFS; localStorage; cookie | `pna-storage` (the layers exist) + `fellows-workspace` (specific keys) | substrate |
+| Storage layers | one localStorage key preserved across Clear App Cache | `pna-cat` | persistence-marker contract |
+| Storage layers | `last_seen_sha.txt` retired | `STALE` | document as "no longer applicable to new instances" |
+| Standard app update flow | SW polls /build-meta.json, shows banner, user reloads | `pna-dist` | PWA update mechanism |
+| Standard app update flow | what survives the reload | `pna-cat` | AC-1, AC-9, AC-10 |
+| Directory data update flow | About page → Check for updates → preview → confirm | `pna-cat` | AC-10 |
+| Directory data update flow | orphan members rendering | `pna-workspace` | post-swap UX |
+| Directory data update flow | one-shot soft scan | `fellows-cat` | one-time migration |
+| Auto-backup | snapshot to bak.<ISO>, rotate keep newest 5 | `pna-cat` | AC-9 |
+| Auto-backup | 1-hour debounce, per-boot trigger keyed to user-edit cadence | `pna-cat` | AC-9 |
+| Auto-backup | backups at OPFS root, outside SAH-pool | `pna-storage` | substrate detail |
+| Restore | from a file or auto-backup | `pna-workspace` + `pna-storage` | restore contract |
+| Restore | validate via PRAGMA quick_check + table check | `pna-storage` | safety |
+| Restore | snapshot pre-restore state | `pna-cat` | AC-9 |
+| Restore | bootstrapRelationshipsSchema after restore | `pna-private` | idempotent migration |
+
+## docs/browser_support.md
+
+| Section | Claim | Class | Maps to |
+|---|---|---|---|
+| Stance | local-first | `pna-cat` | goals |
+| Stance | capability-detect, don't UA-sniff for gating | `pna-cat` | AC-12 |
+| Stance | be specific in messaging | `pna-debug` | UX rule |
+| Stance | failure should never look like a bug | `pna-workspace` | UX |
+| Required versions | `OPFS_MIN_VERSIONS` table | `pna-storage` | substrate facts; tunable |
+| Required versions | iOS callout (all browsers use WebKit) | `pna-cat` | runtime fact |
+| Detection path | worker-init reports `opfsCapable` | `pna-storage` | handshake field |
+| Adding new local-data feature | checklist | `pna-workspace` | shell convention |
+| What we deliberately don't do | no server-side storage of user-authored data | `pna-cat` | AC-2 |
+| What we deliberately don't do | no browser blocklist | `pna-cat` | AC-12 |
+| What we deliberately don't do | no silent degradation for blocked features | `pna-workspace` | UX |
+
+## docs/data_provenance.md
+
+| Section | Claim | Class | Maps to |
+|---|---|---|---|
+| Source tables | Knack REST API extraction is canonical | `fellows-ingest` | source choice |
+| Source tables | known-good backup DB as source-of-last-resort | `fellows-ingest` | recovery |
+| Image fallback | app dir → final_fellows_set; .jpg→.png; alpha-only fuzzy match | `fellows-ingest` | impl detail |
+| Column-by-column provenance | full table | `fellows-ingest` | source mapping |
+| Backup workflow | data-backup, data-restore commands | `fellows-cat` | operator workflow |
+| Recovery paths | three (snapshot, reference DB, full ETL) | `fellows-cat` | operator workflow |
+| Historical note | .bak.JSON demo subset | `DROP` | historical anecdote |
+
+## docs/DevOps.md
+
+| Section | Claim | Class | Maps to |
+|---|---|---|---|
+| Architecture at a glance | one droplet, Caddy on :443, Python on 127.0.0.1:8765 | `fellows-dist` | impl |
+| Architecture at a glance | TLS terminator + 127.0.0.1 origin pattern | `pna-dist` | hardening |
+| Unix identities | rsb (operator) + fellows (daemon) | `fellows-cat` | operator |
+| Filesystem layout | /opt/fellows/, /etc/fellows/, mode 2775 | `fellows-cat` | operator |
+| systemd hardening | full directive list | `fellows-cat` | operator |
+| Network and firewall | ssh + 80 + 443 inbound | `fellows-cat` | operator |
+| Routine operations | `just ship` | `fellows-cat` | operator |
+| Required env vars | session secret + Postmark token + mail from + public origin | `fellows-dist` | impl needs |
+| Debugging | journald event schema | `pna-debug` | structured log conventions |
+| **Missing entirely** | COOP/COEP requirement | `MISSING` | AC-13 (Bug 1) |
+
+## docs/README.md
+
+Mostly mirrors Architecture.md + DevOps.md + email_gate.md. Specific items worth noting:
+
+| Section | Claim | Class | Maps to |
+|---|---|---|---|
+| Design Stance | local-only, not SaaS | `pna-cat` | duplicate |
+| Testing The Latest Code | the trap is stale state — SW + OPFS + IDB + cookie + localStorage marker all persist | `pna-storage` | substrate behavior |
+| Testing The Latest Code | DevTools "Clear site data" misses several layers | `fellows-cat` | testing convention |
+| Phase numbering | "Phase 4 magic-link gate" | `STALE` for spec; phases are project history |
+
+## CLAUDE.md
+
+| Item | Class | Maps to |
+|---|---|---|
+| No frameworks | `fellows-cat` | impl posture |
+| No frontend build tools | `fellows-cat` | impl posture |
+| No new pip dependencies | `fellows-cat` | impl posture |
+| No authentication (in dev) | `fellows-dist` | dev choice |
+| Port 8765 fixed | `fellows-cat` | dev port |
+| `escapeHtml()` for all user data | `pna-workspace` | XSS invariant |
+| Parameterized `?` placeholders for SQL | `pna-cat` | SQL-injection invariant |
+| Image path traversal validation | `pna-cat` | file access invariant |
+| OPFS access only via dedicated worker | `pna-cat` | AC-3 |
+| Two-DB architecture | `pna-cat` | AC-1 |
+
+---
+
+# Part 3 — Bugs, missing items, open questions
+
+## Bugs in existing docs (fix in place before split)
+
+**Bug 1 — FIXED 2026-05-08.** COOP/COEP requirement was undocumented anywhere; Architecture.md § Tech Stack now has a "Cross-origin isolation" bullet, and DevOps.md § Architecture at a glance now has a paragraph after the diagram explaining that Caddy/proxies must preserve the headers and what the silent-breakage symptom looks like.
+
+**Bug 2 — FIXED 2026-05-08.** Three-tier dataProvider with mid-boot hot-swap is now documented in a new "Workspace data providers (three tiers, mid-boot hot-swap)" section in Architecture.md, between "Non-goals (worker-owned OPFS)" and "Two-Phase Load." Names the three tiers, the hot-swap trigger (worker `ensureFellowsDb` 401/403), and the test/diagnostics seam at `window.__dataProvider`.
+
+**Bug 3 — FIXED 2026-05-08.** ATTACH wording normalized in both Architecture.md and persistence_and_upgrades.md. Both now explicitly say "attached once per worker `init` — *not* per request" and call out the pre-Phase-1 per-request behavior as retired. Adjacent stale wording in persistence_and_upgrades.md ("re-imported on every boot") fixed at the same time — replaced with "replaceable — its bytes derive from a buildable source and the user can opt into a refresh from the About page."
+
+**Bug 4 — FIXED 2026-05-08.** Boot watchdog + named bootMarks + slow-boot persistence now documented in a new "Boot orchestration (named marks + watchdog + slow-boot persistence)" section in Architecture.md, immediately after the Workspace data providers section. Names the eight phase marks, the 20s watchdog, the recovery panel, the slow-boot localStorage key (`fellows_last_slow_boot`), and the e2e seams (`window.__bootMarks`, `window.__bootDebugLines`).
+
+**Bug 5: Build badge / ?diag panel / bug-report dialog aren't articulated as architectural commitments.** They exist in code but `Architecture.md` doesn't frame them as the self-service field-debug substrate (AC-7). They look like UI affordances, not architectural choices.
+*Fix:* lift to the Debug contract slot in the new spec; reference from `Architecture.md`.
+
+**Bug 6: Multi-tab `OWNERSHIP_CONFLICT` detection is in code but not in `Architecture.md`.** Worker tags `installOpfsSAHPoolVfs()` failures so the page can render a specific "another tab" panel. `plans/multi_tab_ownership_takeover.md` covers the *future* coordinated takeover, but the *current* refused-with-distinct-message behavior isn't documented as architecture.
+*Fix:* add a paragraph to `Architecture.md § Worker-owned OPFS § Non-goals`.
+
+**Bug 7: Hash routes table doesn't note URL filter persistence.** The directory hash carries query-suffix params (`#/?cohort=2020`) read on every `route()` call by `applyFiltersToHash` / `readFiltersFromHash`. Worth one line in the routes table.
+
+**Bug 8: Phase numbering ("Phase 1", "Phase 4", "Phase 6 retires IndexedDB") is project history, not spec.** Several docs reference phases without explaining them. For the spec rewrite, drop phase numbers from `PNA_Spec.md`; preserve the staging history in `plans/local_first_worker_architecture.md`.
+
+**Bug 9: `window.ai` natural-language search is undocumented.** It's a real feature behind a capability gate. Fellows-specific (lands in `Architecture.md` § Workspace specialization).
+
+**Bug 10: `DevOps.md`'s ProtectSystem note suggests `?mode=ro` is the next hardening step**, but neither server actually opens the Shared DB with `?mode=ro` yet. The note describes a *potential* improvement, not the current state. Worth either making the change (flip both servers to read-only open) or rephrasing as a backlog item.
+
+**Bug 11: README's "Phase 4 magic-link gate" reference** is a minor stale note; tidy along with Bug 8.
+
+## Items missing from existing docs (need to add to PNA_Spec)
+
+**M1: Build label substitution as a uniform interface.** Every component-shipping-text-files participates in build-label substitution at build *and* serve time. fellows_local_db substitutes `__FELLOWS_UI_DIAG__` and `__CACHE_VERSION__` in `app.js`, `sw.js`, `vendor/sqlite-worker.js`. Generalize to: "Every component implementing the Debug contract supports placeholder substitution at both build and serve time."
+
+**M2: Worker init handshake field list as a typed contract.** Currently described in prose. A spec needs the explicit shape (see Storage slot synthesis above).
+
+**M3: Per-record asset URL convention.** `/images/<slug>.{jpg,png}` with alpha-only fuzzy fallback is fellows-specific, but the *idea* of per-record asset URLs separate from the database (cacheable, immutable, slug-keyed) generalizes to the Shared schema interface.
+
+**M4: `PRAGMA foreign_keys = ON` per connection.** sqlite default is OFF; without it `ON DELETE CASCADE` is silently inert. Generic invariant for the Private schema.
+
+**M5: Reset Everything via worker `wipeAll` RPC.** Documented in `persistence_and_upgrades.md` as a UX flow but the *RPC contract* (close DBs → removeVfs → iterate OPFS root) isn't formalized. Belongs in the Storage slot.
+
+**M6: `?gate=1` precedes display-mode short-circuit.** fellows-specific URL, but the pattern (forced-gate URL beats display-mode short-circuit in the boot persona function) is generic.
+
+**M7: Persisted-storage best-effort.** `navigator.storage.persist()` once per install, result in `window.__persistStorageState`. Generic; lives in Storage or Workspace slot.
+
+**M8: Tests-as-spec via `window.__dataProvider`.** Phase-1 tests drive the worker via `page.evaluate(() => window.__dataProvider.createGroup(...))`. The seam (page exposes the active provider on a stable global; tests use it instead of HTTP) is part of the Debug contract — testability requirement.
+
+## Resolved (formerly open) questions
+
+These were open in the previous version of this doc; resolved in the 2026-05-08 working session:
+
+- **`record_id` naming.** Spec uses `record_id` (no `fellow_` prefix) in the Private schema. fellows_local_db's specialization keeps `fellow_record_id` for in-app ergonomics.
+- **`relationships.db` vs `private.db` naming.** Spec uses `private.db`. fellows_local_db keeps `relationships.db` as its specialization filename.
+- **Phase numbering.** Drop from spec; preserve in `plans/`.
+- **Public vs shared terminology.** Settled on *shared / private* (not *public / private*). "Shared" captures "an external system has a copy"; "public" colloquially means "anyone can see," which isn't what we mean.
+- **Spec format and AI-checkability.** Landscape passed in `docs/_pna_spec_format_landscape.md` (2026-05-08). Recommendation: markdown prose for `PNA_Spec.md` + machine-readable typed contracts in `docs/spec/contracts/` (JSON Schema for RPC + handshake, OpenAPI fragment for Distribution auth, SQL DDL for the two schemas, TypeScript declaration for the Communications transport interface) + `llms.txt` at repo root for AI discovery + reference designs as evidence (each in its own repo with its own `Architecture.md` declaring spec version + slot-fill choices + adjectives). Formal verification deferred to a future spec version.
+- **Communications transport acceptability rule.** Settled on **content secrecy** as the primary criterion (AC-18): a transport is acceptable iff its mechanism itself cannot read message contents. Contact-graph retention dropped from the rule (too hard to enforce uniformly across protocols; varies by user threat model — P2P apps may inherently expose some graph, while message-broker SaaS retain it as a feature). Distinction made between Communications transports (governed by AC-18) and Distribution-mechanism transports (governed by the Distribution slot's contracts; Postmark for magic links is the latter, not the former). Sharing-scope metadata on the Shared DB noted as a future-version consideration so the v0.1 schema doesn't preclude it.
+- **Communications-history table in Private schema.** Added to the canonical Private schema as `record_comms_history`. **Disabled by default**; user opts in via `settings['comms_history_enabled']`; workspace honors the flag and writes nothing when disabled. User has full read / edit / delete control. Lives in the Private DB and is protected by AC-1 (never leaves the device).
+- **Per-workspace settings partitioning.** `settings` table gets a composite primary key `(workspace_id, key)`. Single-workspace PNAs use empty-string `workspace_id` (default); multi-workspace PNAs (per the "one origin, many workspaces" decision) use real workspace IDs. Resolves the future-multi-workspace migration concern up front.
+
+## Open questions for @richbodo
+
+All v0.1 open questions resolved as of 2026-05-08 (see Resolved section above). Items deferred to future spec versions are listed in § Scope and versioning. New open questions will surface during the component decomposition pass and the spec drafting; this section gets repopulated then.
+
+---
+
+# Part 4 — Component decomposition (sub-contracts per slot)
+
+Each slot's contract is composed of named sub-contracts. The decomposition gives `PNA_Spec.md` clear language for each piece so an AI building or rewriting a PNA can target each sub-contract individually. None of the v0.1 slots split into multiple top-level slots — but every slot has multiple distinct contracts inside it, and several cross-slot relationships need explicit naming.
+
+Naming convention: two-letter prefix per slot (`WS-`, `ST-`, `IN-`, `CO-`, `DI-`, `SH-`, `PR-`, `DB-`) + dash + monotonic integer. New sub-contracts get the next integer; numbers don't get reused.
+
+## Workspace (`WS-`)
+
+- **WS-1: Boot persona.** Function that decides "directory mode" vs "distribution gate" given standalone-display, persistence marker, and force-gate URL. Drives the entire boot flow.
+- **WS-2: Routing.** Hash-based or equivalent; per-route focus modes; URL-shareable filter state where applicable.
+- **WS-3: Render contracts.** Per-route contracts on what each view shows. Includes orphan-row rendering after Shared DB updates.
+- **WS-4: Data provider abstraction.** Three-tier provider (worker / api+idb / api) with mid-boot hot-swap on auth failure (per AC-5). Single source of truth at `window.__dataProvider`.
+- **WS-5: Boot orchestration.** Named `bootMarks` at meaningful transitions; watchdog timeout surfaces a recovery panel naming the last-completed mark; slow-boot persistence to localStorage across sessions.
+- **WS-6: Capability-failure panel.** `renderLocalDataUnavailablePanel(feature)`-style for OPFS / version-skew / multi-tab-conflict failures.
+- **WS-7: Persistence-marker.** Exactly one localStorage key preserved across Clear App Cache (the "this origin authenticated once" marker; spelled `fellows_authenticated_once` in fellows_local_db).
+- **WS-8: Local-search fallback.** Search over cached Shared DB when network is offline.
+- **WS-9: Sanitization discipline.** `escapeHtml` for all user-supplied data; parameterized `?` placeholders for all SQL; image path traversal validation.
+- **WS-10: User-visible payload before send (AC-19).** Workspace shows full composition before any communication launches.
+
+Cross-slot: WS-4 sits at the boundary with Storage (the `worker` tier is RPC into ST-3); WS-5 implements the boot side of DB-3.
+
+## Storage (`ST-`)
+
+- **ST-1: Substrate.** Single dedicated worker; OPFS-SAH-Pool VFS; sqlite-wasm runtime. Only context that calls `navigator.storage.getDirectory` or opens a `FileSystemSyncAccessHandle` (per AC-3).
+- **ST-2: Init handshake.** First RPC must be `op='init'`. Returns `{workerRpcVersion, schemaVersion, buildLabel, opfsCapable, hasSharedDb, hasPrivateDb, poolFiles, trace}`. Capability detection happens here (per AC-12).
+- **ST-3: RPC protocol.** `{id, op, args}` ↔ `{id, ok, result|error}`. Fan-in dispatch via sequence-numbered pending Map. `worker.onerror` rejects all pending RPCs so callers can fall back instead of hanging.
+- **ST-4: Two-database management.** Private DB (RW), Shared DB (RO). Cross-DB joins via `ATTACH ?mode=ro`, attached once per init in the worker.
+- **ST-5: Schema bootstrap.** `CREATE IF NOT EXISTS` for both schemas. `PRAGMA foreign_keys=ON` per connection. `PRAGMA user_version` set to schema version. Idempotent so older backups gain newer tables on restore.
+- **ST-6: Auto-backup.** Per-boot debounced snapshots of Private DB to OPFS root (outside SAH-pool dir, so survives sqlite-wasm operations). Rotation by sorted ISO filename. Per AC-9.
+- **ST-7: Restore.** From a user-supplied file or a recent auto-backup. Validates via `PRAGMA quick_check` + schema check. Snapshots pre-restore state to the same rotation. Atomic swap.
+- **ST-8: Opt-in update flow.** `compareSha → previewSwap → applySwap | cancelSwap`. Opaque per-session `stagingId` so a stale page can't accidentally commit. Affected-member preview computed from joined Private DB references. Per AC-10.
+- **ST-9: Multi-tab detection.** `OWNERSHIP_CONFLICT` tagged on `installOpfsSAHPoolVfs()` failure so WS-6 can render a specific multi-tab panel (per AC-11).
+- **ST-10: Reset Everything.** `wipeAll` RPC: close both DBs, `removeVfs()`, iterate OPFS root and remove every entry. Caller reloads after.
+- **ST-11: Diagnostics.** `getOpfsInventory`, `getTrace`, `getVersions`, `getSharedDbMeta`. Read-only; pure reads, no fetches.
+
+Cross-slot: ST-2/3 are the contract WS-4 calls; ST-7's schema re-bootstrap respects PR-3.
+
+## Ingestion (`IN-`)
+
+- **IN-1: Source adapter.** Produces bytes conforming to the Shared schema (SH-1 through SH-3). App-specific.
+- **IN-2: Output validation.** `PRAGMA quick_check` passes; primary record table has ≥1 row (zero-row guard prevents catastrophic orphaning of every Private DB reference).
+- **IN-3: Sourced provenance (AC-17).** Every record traces to a specific external source the user has configured.
+- **IN-4: Re-ingestion mechanics.** Atomic stage → validate → swap. Non-destructive of Private DB references; orphan preview required (per AC-10, surfaced via ST-8 + WS-3).
+
+Cross-slot: IN-4 hands off to ST-8 for the actual stage/swap; SH-5 is the Shared-side view of the same transition.
+
+## Communications (`CO-`)
+
+- **CO-1: Transport interface.** `canHandle(action) → bool`, `launch(action, payload) → Promise<launchResult>`, `descriptor() → {id, name, secureLevel?, …}`.
+- **CO-2: Action set.** Fixed enum: `email_one`, `email_group_cc`, `email_group_bcc`, `direct_message_one`, `share_link_one`, `share_link_group`. Extensible — new actions can be added with toolkit version bumps.
+- **CO-3: Transport eligibility (AC-18).** Mechanism cannot read message contents.
+- **CO-4: User-driven selection (AC-16).** Workspace surfaces multiple transports; user picks per outreach.
+- **CO-5: User-visible payload (AC-19).** Workspace shows full payload (recipients, body, merged data) before launch.
+- **CO-6: Distinction from distribution-mechanism transports.** A distribution flavor's auth-link transport (e.g., Postmark in fellows_local_db's magic-link distribution) is governed by Distribution slot contracts, not CO-3.
+
+Cross-slot: CO-4 is observable from WS (the shell renders the picker); CO-5 is the same contract as WS-10, dual-listed because both slots co-implement.
+
+## Distribution (`DI-`) — optional
+
+- **DI-1: Install path.** Bundle delivery + verified initial Shared DB + session bootstrap.
+- **DI-2: Update path.** Shell + worker file via SW + cache versioning. Shared DB updates user-driven (per AC-10), not automatic.
+- **DI-3: Auth contract.** `GET /api/auth/status`, `POST /api/send-unlock`, `POST /api/verify-token`, `POST /api/logout`. Session cookie HMAC-signed, version-prefixed (so prior versions reject cleanly post-deploy).
+- **DI-4: Anti-enum + rate limit (AC-8).** Always-200 / 204 on send-unlock and client-errors. Per-IP and per-email-hash rate limits. Distinct expired/invalid error strings on verify-token.
+- **DI-5: Server hardening.** TLS terminator on :443 → 127.0.0.1 origin. COOP/COEP (AC-13). 16KB POST cap. No per-user RW endpoints (AC-2). Status-aware caching (4xx/5xx never long-cached).
+- **DI-6: PWA-specific gotchas (when distribution medium is a PWA).** Minimal manifest, no `related_applications`, no `share_target` POST. SW network-first for HTML/JS/CSS/SW + worker file; cache-first for vendored runtime. Separate asset cache. Shared DB URL bypassed in SW fetch (AC-14).
+
+Cross-slot: DI-2's update path triggers WS's "New version available — Reload" banner; DI-3 outcomes feed WS-1's persona decision.
+
+## Shared schema (`SH-`)
+
+- **SH-1: Primary record table.** `record_id` PK, `slug` UNIQUE, `name`, app-defined display columns, `extra_json TEXT` overflow.
+- **SH-2: Optional FTS5 virtual table.** Indexes whichever columns the workspace wants searchable.
+- **SH-3: Optional per-record asset URL convention.** `/images/<slug>.{jpg,png}` style; cacheable, immutable, slug-keyed.
+- **SH-4: Read-only enforcement.** ATTACH `?mode=ro` for cross-DB joins; stray writes raise `OperationalError`.
+- **SH-5: Atomic re-import semantics with orphan preview (AC-10).** Stage → validate → swap; pre-swap impact preview lists Private DB references that would be orphaned.
+- **SH-6: Sourced-provenance per record (AC-17).** Multi-source PNAs add a `source` column; single-source may omit.
+
+Cross-slot: SH-5 is implemented by ST-8.
+
+## Private schema (`PR-`)
+
+- **PR-1: Core tables.** `groups`, `group_members`, `record_tags`, `record_notes`, `settings(workspace_id, key, value)` with composite PK.
+- **PR-2: Opt-in tables.** `record_comms_history`. **Disabled by default** (`settings['comms_history_enabled']='1'` to enable). User has full read/edit/delete control.
+- **PR-3: Schema metadata.** `PRAGMA user_version`; `PRAGMA foreign_keys=ON` per connection.
+- **PR-4: Durability.** Never replaced on app update; survives Clear App Cache; only Reset Everything wipes.
+- **PR-5: Backup/restore conformance.** Idempotent CREATE IF NOT EXISTS lets older backups gain newer tables on restore.
+
+Cross-slot: PR-4 is enforced by ST-1 (separate file from Shared DB) and ST-10 (Reset Everything is the only wipe path); PR-5 is exercised by ST-7.
+
+## Debug contract (`DB-`)
+
+- **DB-1: Build label substitution.** Placeholder substitution at build *and* serve time (AC-15). Format `<YYYY-MM-DD>-<short-sha>`.
+- **DB-2: Build badge.** Always-visible runtime display showing local + server labels.
+- **DB-3: Boot phase marks + watchdog.** Named `bootMarks`; watchdog timeout surfaces a recovery panel; slow-boot persistence across sessions.
+- **DB-4: Sanitized error sink.** POST endpoint; 16KB cap; rate limit; always 204; allowlisted `kind=` enum; server-side free-text sanitization.
+- **DB-5: Sink-as-analytics.** Adding a new `kind=` enum is the only widening lever. No separate analytics endpoint, no separate identifier scheme.
+- **DB-6: Bug-report dialog.** Collects DB-2 + DB-3 + DB-4 ring; opens mailto to configured maintainer.
+- **DB-7: Force-gate / force-reset escape hatch.** Reachable from `?diag` and a hardcoded URL parameter regardless of cookie / localStorage state (per AC-6).
+- **DB-8: Configurability.** Every part is configurable. Purely-personal PNAs may have empty sink, no maintainer mailbox; the substrate still works.
+- **DB-9: Test affordance.** Workspace exposes the active data provider on a stable global (`window.__dataProvider` in fellows_local_db) so test suites can drive the contracts the same way the workspace does, without a separate test-only seam (per Q5 resolution).
+
+Cross-slot: every component implements DB-1; WS instantiates DB-2, DB-3, DB-6, DB-7, DB-9; DI hosts DB-4 (when present).
+
+## Cross-slot sub-contract summary
+
+Sub-contracts that span slots, formalized:
+
+- **Build-label discipline (AC-15):** every component implements DB-1.
+- **Update notification:** DI-2 → SW banner → WS-3 reload affordance.
+- **Opt-in directory update (AC-10):** IN-4 → ST-8 → SH-5 → WS-3 (orphan render).
+- **Storage RPC boundary:** WS-4 calls ST-3 / ST-4 / etc.; ST-2's handshake gates whether mutations are allowed (AC-4).
+- **Restore data flow:** WS (file picker / backup picker UI) → ST-7 → PR-5 (re-bootstrap).
+- **User-aware payload (AC-19):** WS-10 ↔ CO-5 — dual-listed because both slots co-implement.
+- **Capability-failure surfacing:** ST-2 (`opfsCapable=false`) → WS-6 (panel render); ST-9 (`OWNERSHIP_CONFLICT`) → WS-6 (multi-tab variant).
+- **Diagnostic substrate (DB-*):** every slot logs to DB-4; WS surfaces DB-2/3/6/7/9.
+
+These cross-slot threads are what make the spec describe a *system* rather than a bag of slots.
+
+## Decomposition decisions
+
+- **No slots split.** Each top-level slot keeps a single contract surface; sub-contracts give it texture without fragmenting the toolkit's mental model. The toolkit may internally factor slots further (Storage in particular has eleven internal contracts already), but the spec exposes one slot per concern.
+- **Cross-slot ACs land in both slots' sub-contracts.** AC-19 is both WS-10 and CO-5; AC-10 fans out into IN-4 + ST-8 + SH-5 + WS-3; etc. The AC table remains the single source of truth; sub-contracts cite ACs where they land.
+- **One naming convention.** `<slot prefix>-<integer>`, monotonic per slot. No renumbering as items are added; new sub-contracts get the next integer.
+
+---
+
+## Next steps (proposed, in dependency order)
+
+1. **Stub the spec scaffolding** per `_pna_spec_format_landscape.md`'s recommendation:
+   - Empty `docs/PNA_Spec.md` with version header (`Spec-Version: 0.1`) and section skeleton
+   - Empty `docs/spec/contracts/` directory with placeholder files for each typed contract
+   - `llms.txt` at repo root pointing at the above
+   - Initial `CHANGELOG.md` with the v0.1 entry
+2. **Draft `docs/PNA_Spec.md`** from Part 1 (high-level synthesis) and Part 4 (sub-contract decomposition). Self-contained; no fellows references except as cross-links.
+3. **Fill `docs/spec/contracts/`** with the typed contracts as the spec drafts cite them.
+4. **Rewrite `docs/Architecture.md`** to be the specialization layer: declares spec version targeted, slot-fill choices, load-bearing adjectives, specialization-only invariants. Cross-links to `PNA_Spec.md` for everything generic.
+5. **Demote `docs/email_gate.md`, `docs/persistence_and_upgrades.md`, `docs/browser_support.md`, `docs/data_provenance.md`** to Architecture.md annexes.
+6. **Delete this file and `_pna_spec_format_landscape.md`** once steps 2–5 are committed.

--- a/docs/persistence_and_upgrades.md
+++ b/docs/persistence_and_upgrades.md
@@ -42,12 +42,16 @@ OPFS-root iteration that `removeEntry`s every top-level entry. See
 
 The key architectural decision: **`relationships.db` is a separate
 OPFS file from `fellows.db`** rather than a set of new tables inside
-`fellows.db`. That's because `fellows.db` is bundled with the build
-and re-imported on every boot, while OPFS files we don't explicitly
-touch are durable. Cross-DB joins use SQLite `ATTACH DATABASE
-'fellows.db' AS f ?mode=ro`, which also enforces read-only access to
-contact data at the SQLite level (any stray write into `f.*` raises
-`OperationalError`).
+`fellows.db`. That's because `fellows.db` is *replaceable* — its
+bytes derive from a buildable source and the user can opt into a
+refresh from the About page — while OPFS files we don't explicitly
+touch are durable. Cross-DB joins happen inside the dedicated worker,
+attached once per worker `init` via `ATTACH DATABASE 'fellows.db' AS
+f ?mode=ro` — *not* per request. The `?mode=ro` suffix enforces
+read-only access at the SQLite level; any stray write into `f.*`
+raises `OperationalError`. (Pre-Phase-1 the dev server did
+per-request ATTACHes for `/api/groups` and friends; those routes
+are retired and the worker now does it once per session.)
 
 The OPFS path is used in **both** standalone PWA mode and browser-tab
 mode. Production's `deploy/server.py` does not serve `/api/groups` or


### PR DESCRIPTION
## Summary

Captures a working session on **meta-planning a future spec split**. Does *not* yet do the split — produces two scaffolding documents that plan it, plus closes four documentation gaps in the existing arch docs that were lagging the code.

The future split:
- `docs/PNA_Spec.md` — a generic *personal network app* spec (target for the future `personal_network_toolkit`)
- `docs/Architecture.md` — fellows_local_db's specialization layer against that spec

## What's in this PR

**Two new scaffolding docs** (leading-underscore filenames signal "delete after the split lands"):
- `docs/_pna_triage.md` (~750 lines) — vocabulary, goals, ACs, slot map, per-slot synthesis, source map, decomposition. **The canonical handoff artifact.**
- `docs/_pna_spec_format_landscape.md` (~280 lines) — landscape pass on spec formats with a five-layer recommendation for `PNA_Spec.md`'s shape.

**Four documentation gap-fixes in existing arch docs** — things that were true in the code but missing or stale in the docs:
- `docs/Architecture.md`:
  - New "Cross-origin isolation" bullet in § Tech Stack (COOP/COEP requirement + silent-breakage symptom)
  - ATTACH wording in § Persistence and upgrades normalized to "once per worker init, not per request"
  - New § "Workspace data providers (three tiers, mid-boot hot-swap)" section — names ` worker` / `api+idb` / `api` and the hot-swap trigger
  - New § "Boot orchestration (named marks + watchdog + slow-boot persistence)" section — eight phase marks, 20s watchdog, recovery panel, ` fellows_last_slow_boot` localStorage key, e2e seams
- `docs/DevOps.md`:
  - Paragraph after architecture diagram about Caddy preserving COOP/COEP headers
- `docs/persistence_and_upgrades.md`:
  - ATTACH wording normalized; adjacent "re-imported on every boot" stale text fixed

## Remaining steps (for the next Claude to pick up)

The triage doc's `## Next steps` section is the canonical list. Reproduced here for visibility:

1. **Stub the spec scaffolding** per `docs/_pna_spec_format_landscape.md`:
   - Empty `docs/PNA_Spec.md` with version header (`Spec-Version: 0.1`) and section skeleton
   - Empty `docs/spec/contracts/` directory with placeholder files for each typed contract:
     - `worker-init-handshake.schema.json`
     - `worker-rpc-protocol.schema.json`
     - `client-errors-payload.schema.json`
     - `distribution-auth.openapi.yaml`
     - `transport-interface.d.ts`
     - `shared-db.schema.sql`
     - `private-db.schema.sql`
   - `llms.txt` at repo root pointing at the above
   - Initial `CHANGELOG.md` with the v0.1 entry
2. **Draft `docs/PNA_Spec.md`** from `_pna_triage.md` Part 1 (high-level synthesis) and Part 4 (sub-contract decomposition). Self-contained; no fellows references except as cross-links to `Architecture.md`.
3. **Fill `docs/spec/contracts/`** with the typed contracts as the spec drafts cite them.
4. **Rewrite `docs/Architecture.md`** to be the specialization layer. Declares the spec version it targets, slot-fill choices, load-bearing adjectives (*magic-link distributed PWA + static network DB archive + single shared directory*), and specialization-only invariants. Cross-links to `PNA_Spec.md` for everything generic.
5. **Demote `docs/email_gate.md`, `docs/persistence_and_upgrades.md`, `docs/browser_support.md`, `docs/data_provenance.md`** to `Architecture.md` annexes (they hold specialization-specific details).
6. **Delete `docs/_pna_triage.md` and `docs/_pna_spec_format_landscape.md`** once steps 2–5 are committed.

## Context for the next Claude

**Read first, in this order:**
1. `docs/_pna_triage.md` § Vocabulary, then § Goals, then § Architectural commitments, then § Slot map, then Part 4 (component decomposition with stable two-letter prefix naming). That's the spec-in-essence — about 30 minutes to read.
2. `docs/_pna_spec_format_landscape.md` for the format-and-tooling decisions (markdown prose + typed contracts in JSON Schema/OpenAPI/SQL DDL/TypeScript decl + ` llms.txt` discovery + reference-design-as-evidence pattern + conformance via existing test suites).

**Vocabulary that's been settled (don't second-guess):**
- **PNA** (personal network app) is the *category*. **Workspace** is one *component* within a PNA, not the category.
- **Shared data / Private data** — *not* "public/private." Shared = an external system also has a copy (Google has the contacts; the fellowship has the directory). Private = lives only on the user's device. The colloquial "public" sense doesn't match.
- **Reference design / thematic example** — both refer to a working PNA that demonstrates one slot-fill combination. fellows_local_db is the first reference design; its load-bearing adjectives are *magic-link distributed PWA + static network DB archive + single shared directory*.

**Spec stratification:**
- `PNA_Spec.md` is generic and PNT-targetable. Should not mention fellows_local_db except as "see Architecture.md for the canonical reference implementation."
- `Architecture.md` is fellows_local_db's specialization. Declares which spec version it targets, slot-fill choices, and any specialization-only invariants.

**No more open questions for v0.1.** All resolved or deferred (see triage doc § Resolved questions and § Scope and versioning). Major resolutions in this session:
- Communications transport rule (AC-18): "transport mechanism cannot read message contents." Contact-graph retention dropped — too hard to enforce uniformly.
- User-aware payload contract (AC-19): workspace shows full composition before any communication launches. Resolves data-transport matching for v0.1.
- ` record_comms_history` table in Private schema, **disabled by default**, opt-in via ` settings['comms_history_enabled']`.
- ` settings(workspace_id, key, value)` composite PK so per-workspace settings work when multiple workspaces share one OPFS.
- Per-database transport requirements deferred to v2.
- Spec format: markdown + typed contracts; formal verification deferred.

New questions will surface during the spec drafting; the triage doc has space for them.

**Branch context:** This PR was prepared off a fresh ` origin/main` (commit ` 5880b3c`); it does *not* depend on or include any work from the ` security/tier1-hardening` branch.

## Test plan

Documentation only. No code changes.

- [x] ` docs/Architecture.md`, ` docs/DevOps.md`, ` docs/persistence_and_upgrades.md` render cleanly in GitHub markdown
- [x] Cross-references between docs resolve (links use relative paths)
- [x] No PII or secret-shaped content in the new docs

🤖 Generated with [Claude Code](https://claude.com/claude-code)