### PR TITLE
Tier 2 #1: SRI on app.js + vendor/jspdf in index.html

### DIFF
--- a/app/server.py
+++ b/app/server.py
@@ -602,6 +602,30 @@ class Handler(BaseHTTPRequestHandler):
             text = data.decode("utf-8")
             stamped = _build_pwa.substitute_build_label(text, BUILD_LABEL)
             data = stamped.encode("utf-8")
+        # SRI substitution for index.html. The integrity for app.js must
+        # cover the post-stamp bytes the dev server WILL serve, not the
+        # source-tree bytes — otherwise the browser computes one hash and
+        # rejects the script. We mirror the stamping rule above (file
+        # name in {app.js, sw.js, vendor/sqlite-worker.js}) but here only
+        # app.js's hash is consumed.
+        if file_path.name == "index.html":
+            text = data.decode("utf-8")
+            app_js_path = STATIC_DIR / "app.js"
+            if app_js_path.is_file():
+                stamped_app_js = _build_pwa.substitute_build_label(
+                    app_js_path.read_text(encoding="utf-8"), BUILD_LABEL
+                ).encode("utf-8")
+                text = text.replace(
+                    _build_pwa.PLACEHOLDER_APP_JS_INTEGRITY,
+                    _build_pwa.compute_sri_hash_bytes(stamped_app_js),
+                )
+            jspdf_path = STATIC_DIR / "vendor" / "jspdf-2.5.1.umd.min.js"
+            if jspdf_path.is_file():
+                text = text.replace(
+                    _build_pwa.PLACEHOLDER_JSPDF_INTEGRITY,
+                    _build_pwa.compute_sri_hash(jspdf_path),
+                )
+            data = text.encode("utf-8")
         self.send_response(200)
         self.send_header("Content-Type", ctype)
         self.send_header("Content-Length", str(len(data)))

--- a/app/static/index.html
+++ b/app/static/index.html
@@ -536,7 +536,7 @@
     <div class="sheet__divider" aria-hidden="true"></div>
     <button type="button" id="filter-sheet-done" class="filter-sheet__done">Done</button>
   </aside>
-  <script src="/vendor/jspdf-2.5.1.umd.min.js"></script>
-  <script src="/app.js"></script>
+  <script src="/vendor/jspdf-2.5.1.umd.min.js" integrity="__JSPDF_INTEGRITY__" crossorigin="anonymous"></script>
+  <script src="/app.js" integrity="__APP_JS_INTEGRITY__" crossorigin="anonymous"></script>
 </body>
 </html>

--- a/build/build_pwa.py
+++ b/build/build_pwa.py
@@ -11,6 +11,7 @@ off-disk means a routing or filesystem mistake cannot expose a hash
 file to the public internet.
 """
 
+import base64
 import hashlib
 import json
 import shutil
@@ -33,6 +34,15 @@ IMAGES_FALLBACK = REPO_ROOT / "final_fellows_set" / "fellow_profile_images_by_na
 # what the badge shows.
 PLACEHOLDER_UI_DIAG = "__FELLOWS_UI_DIAG__"
 PLACEHOLDER_CACHE_VERSION = "__CACHE_VERSION__"
+
+# Subresource Integrity placeholders in app/static/index.html. Substituted
+# at build time and at request time so a tampered `app.js` or vendor
+# `jspdf-...js` is rejected by the browser before execution. Compute order
+# matters: stamp_static_assets must run before stamp_sri_attributes,
+# because app.js carries build-label substitutions and the SRI hash must
+# cover the *post-stamp* bytes the browser will fetch.
+PLACEHOLDER_APP_JS_INTEGRITY = "__APP_JS_INTEGRITY__"
+PLACEHOLDER_JSPDF_INTEGRITY = "__JSPDF_INTEGRITY__"
 
 
 def get_short_sha(repo_root: Path = REPO_ROOT) -> str | None:
@@ -72,6 +82,47 @@ def substitute_build_label(text: str, label: str) -> str:
     return text.replace(PLACEHOLDER_UI_DIAG, label).replace(
         PLACEHOLDER_CACHE_VERSION, label
     )
+
+
+def compute_sri_hash_bytes(b: bytes) -> str:
+    """Return ``sha384-<base64>`` for the given bytes — the value the
+    browser puts in a script tag's ``integrity`` attribute. SHA-384 is
+    SRI's middle option; SHA-256 is acceptable but SHA-384 is the
+    common recommendation. Base64 (not base64url) per the SRI spec."""
+    digest = hashlib.sha384(b).digest()
+    return "sha384-" + base64.b64encode(digest).decode("ascii")
+
+
+def compute_sri_hash(path: Path) -> str:
+    """SRI hash for the on-disk bytes at ``path``."""
+    return compute_sri_hash_bytes(path.read_bytes())
+
+
+def stamp_sri_attributes(dist_dir: Path) -> None:
+    """Substitute SRI placeholders in ``index.html`` with hashes of the
+    scripts the browser will actually fetch.
+
+    Must run AFTER ``stamp_static_assets`` so the hash for ``app.js``
+    reflects the build-label-stamped bytes, not the source placeholders.
+    No-op when ``index.html`` is missing. If a target script is missing
+    the placeholder ships unchanged — that's a fail-loud signal in the
+    browser console (broken integrity), not a silent no-op.
+
+    The dev server (``app/server.py``) performs the equivalent
+    substitution on ``index.html`` at request time so dev and prod
+    enforce the same integrity check.
+    """
+    index_path = dist_dir / "index.html"
+    if not index_path.is_file():
+        return
+    text = index_path.read_text(encoding="utf-8")
+    app_js = dist_dir / "app.js"
+    if app_js.is_file():
+        text = text.replace(PLACEHOLDER_APP_JS_INTEGRITY, compute_sri_hash(app_js))
+    jspdf = dist_dir / "vendor" / "jspdf-2.5.1.umd.min.js"
+    if jspdf.is_file():
+        text = text.replace(PLACEHOLDER_JSPDF_INTEGRITY, compute_sri_hash(jspdf))
+    index_path.write_text(text, encoding="utf-8")
 
 
 def stamp_static_assets(dist_dir: Path, label: str) -> None:
@@ -150,6 +201,7 @@ def main() -> int:
     shutil.copytree(STATIC_DIR, DIST_DIR)
     label = compute_build_label()
     stamp_static_assets(DIST_DIR, label)
+    stamp_sri_attributes(DIST_DIR)
     write_build_meta(DIST_DIR / "build-meta.json", label, db_path=DB_SRC)
     if DB_SRC.is_file():
         shutil.copy2(DB_SRC, DIST_DIR / "fellows.db")

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -149,6 +149,17 @@ def deploy_server(tmp_path_factory):
     shutil.copytree(repo_root / "app" / "static", dist_dir, dirs_exist_ok=True)
     shutil.copy2(src_db, dist_dir / "fellows.db")
 
+    # Mirror what `build/build_pwa.py main()` does to a real prod dist:
+    # stamp the build label into app.js / sw.js / vendor/sqlite-worker.js,
+    # then compute the SRI hashes and substitute them into index.html.
+    # Without this the browser would refuse to execute app.js (literal
+    # `__APP_JS_INTEGRITY__` placeholder doesn't match any computed
+    # SHA-384) and every e2e test would fail at script-load time.
+    sys.path.insert(0, str(repo_root / "build"))
+    import build_pwa as _build_pwa  # noqa: E402  (path-dependent)
+    _build_pwa.stamp_static_assets(dist_dir, _build_pwa.compute_build_label(repo_root))
+    _build_pwa.stamp_sri_attributes(dist_dir)
+
     test_email = "round-trip-tester@example.com"
     test_db = dist_dir / "fellows.db"
     conn = sqlite3.connect(str(test_db))

--- a/tests/test_build_pwa.py
+++ b/tests/test_build_pwa.py
@@ -9,11 +9,20 @@ the raw file bytes.
 """
 from __future__ import annotations
 
+import base64
 import hashlib
 import json
 from pathlib import Path
 
-from build.build_pwa import compute_fellows_db_sha, write_build_meta
+from build.build_pwa import (
+    PLACEHOLDER_APP_JS_INTEGRITY,
+    PLACEHOLDER_JSPDF_INTEGRITY,
+    compute_fellows_db_sha,
+    compute_sri_hash,
+    compute_sri_hash_bytes,
+    stamp_sri_attributes,
+    write_build_meta,
+)
 
 
 def test_compute_fellows_db_sha_matches_hashlib(tmp_path: Path):
@@ -87,3 +96,73 @@ def test_write_build_meta_emits_sha_when_db_file_exists(tmp_path: Path):
 
     assert meta["fellows_db_sha"] == hashlib.sha256(b"hello").hexdigest()
     assert meta["fellows_db_sha"] == compute_fellows_db_sha(db_path)
+
+
+def test_compute_sri_hash_bytes_matches_spec(tmp_path: Path):
+    """SRI hash format is `sha384-<base64(digest)>` per the W3C spec.
+    Browsers compute the digest the same way; if this helper drifts,
+    every page load fails at script-tag-integrity-check time."""
+    payload = b"console.log('hi');"
+    expected = "sha384-" + base64.b64encode(hashlib.sha384(payload).digest()).decode("ascii")
+    assert compute_sri_hash_bytes(payload) == expected
+    assert compute_sri_hash_bytes(payload).startswith("sha384-")
+
+
+def test_compute_sri_hash_reads_path_bytes(tmp_path: Path):
+    """`compute_sri_hash(path)` is `compute_sri_hash_bytes(path.read_bytes())`.
+    Pin the equivalence so a future "stream the file in chunks" rewrite
+    doesn't silently change the hash for non-trivial inputs."""
+    payload = b"a" * (3 * (1 << 20) + 7)  # >1 MiB so a chunked impl would matter
+    p = tmp_path / "blob.js"
+    p.write_bytes(payload)
+    assert compute_sri_hash(p) == compute_sri_hash_bytes(payload)
+
+
+def test_stamp_sri_attributes_substitutes_index_html(tmp_path: Path):
+    """End-to-end: with a dist dir holding `index.html` (placeholders),
+    `app.js`, and `vendor/jspdf-...js`, `stamp_sri_attributes` rewrites
+    the placeholders in-place. Hashes must match the post-stamp bytes."""
+    (tmp_path / "vendor").mkdir()
+    app_js_bytes = b"// stamped app.js bytes"
+    jspdf_bytes = b"// jspdf vendored bytes"
+    (tmp_path / "app.js").write_bytes(app_js_bytes)
+    (tmp_path / "vendor" / "jspdf-2.5.1.umd.min.js").write_bytes(jspdf_bytes)
+    (tmp_path / "index.html").write_text(
+        f'<script src="/vendor/jspdf-2.5.1.umd.min.js" '
+        f'integrity="{PLACEHOLDER_JSPDF_INTEGRITY}" crossorigin="anonymous"></script>\n'
+        f'<script src="/app.js" integrity="{PLACEHOLDER_APP_JS_INTEGRITY}" '
+        f'crossorigin="anonymous"></script>\n',
+        encoding="utf-8",
+    )
+
+    stamp_sri_attributes(tmp_path)
+
+    html = (tmp_path / "index.html").read_text(encoding="utf-8")
+    assert PLACEHOLDER_APP_JS_INTEGRITY not in html
+    assert PLACEHOLDER_JSPDF_INTEGRITY not in html
+    assert compute_sri_hash_bytes(app_js_bytes) in html
+    assert compute_sri_hash_bytes(jspdf_bytes) in html
+
+
+def test_stamp_sri_attributes_is_noop_when_index_missing(tmp_path: Path):
+    """No `index.html` → silent return (no exception, no file created)."""
+    stamp_sri_attributes(tmp_path)
+    assert not (tmp_path / "index.html").exists()
+
+
+def test_stamp_sri_attributes_leaves_placeholder_when_target_missing(tmp_path: Path):
+    """If a target script is missing, the corresponding placeholder is
+    left intact rather than silently dropped. Browser console then shows
+    a clear "missing or invalid integrity" error — fail loud, not soft.
+    Explicit choice: a missing script during build is a build bug, not
+    a graceful-degradation case."""
+    (tmp_path / "index.html").write_text(
+        f'<script integrity="{PLACEHOLDER_APP_JS_INTEGRITY}"></script>\n'
+        f'<script integrity="{PLACEHOLDER_JSPDF_INTEGRITY}"></script>\n',
+        encoding="utf-8",
+    )
+    # Neither app.js nor vendor/jspdf-...js present.
+    stamp_sri_attributes(tmp_path)
+    html = (tmp_path / "index.html").read_text(encoding="utf-8")
+    assert PLACEHOLDER_APP_JS_INTEGRITY in html
+    assert PLACEHOLDER_JSPDF_INTEGRITY in html


### PR DESCRIPTION
## Summary

Tier 2 item #1 from `security_review/2026-05-08_local_vs_saas_risk.md`.

Browsers refuse to execute a script whose fetched bytes don't hash to the value in the tag's `integrity=` attribute. With CSP `script-src 'self'` already in place from PR #139, SRI closes the residual "compromised origin served a poisoned `app.js`" path: even when the bytes flow through the browser cache or the service worker cache, the page-side integrity check runs against the bytes the browser is about to execute.

This is the smaller-scoped sibling of Tier 2 #2 (signed bundles + SW signature verify). SRI is checked by the browser; bundle signing would be checked by the SW before activation. They stack — neither obviates the other.

## Mechanism

Two `<script src>` tags in `index.html` get `integrity="__{APP_JS,JSPDF}_INTEGRITY__"` placeholders. The build pipeline (`build/build_pwa.py`) computes SHA-384 of the **post-build-label-stamped** `app.js` and the static jspdf bundle, and substitutes the placeholders. The dev server (`app/server.py`) does the same substitution at request time so dev and prod produce **byte-identical integrity hashes**.

The order matters: `stamp_static_assets` (build-label substitution) runs before `stamp_sri_attributes` so the SRI hash covers the bytes the browser will actually fetch.

## Test plan

- [x] 5 new unit tests in `tests/test_build_pwa.py` covering: hash format spec, chunked-vs-bytes equivalence, end-to-end stamping, missing-index no-op, missing-target fail-loud.
- [x] `pytest tests/test_build_pwa.py tests/test_magic_link_auth.py` — 34 passed.
- [x] Full e2e: 196 passed, 12 skipped (platform-specific). Same as the post-Tier-1 baseline. SRI didn't break a single flow.
- [x] Manual `curl http://localhost:8765/` shows substituted `integrity=` for both scripts; an independent SHA-384 of `curl /app.js` matches the value in `index.html`.
- [x] Manual `python build/build_pwa.py` produces `dist/index.html` whose hashes match an independent SHA-384 over `dist/app.js` and `dist/vendor/jspdf-...js`. Dev and prod produce identical values.

## Manual QA for the maintainer

- [ ] After merge + `just ship`, open DevTools Network tab on `https://fellows.globaldonut.com/` and confirm `app.js` and `vendor/jspdf-...js` requests carry the integrity attribute and load successfully (status 200, no console errors).
- [ ] DevTools Console: any `Failed to find a valid digest in the 'integrity' attribute …` is a real bug — please report. Recovery is Cmd-Shift-R or Clear App Cache & Reload.
- [ ] Existing tabs may briefly serve a stale `index.html` against a fresh `app.js` (or vice versa) during the SW activation handoff; the standard "New version available — Reload" banner is the fix path.

## Atomic-deploy story

The service worker precaches `index.html` and `app.js` together on each install. As long as the SW serves them as a unit, integrity matches. A stale tab uses its own cached old pair. After the deploy banner reload, the new pair lands together. The existing reload banner is the recovery path.

## Compatibility with the unmerged docs PR (#142)

This PR doesn't touch `docs/Architecture.md`. PR #142 (Tier 1 doc cleanup) and this one are orthogonal — no conflict expected. After both merge, a small follow-up doc edit can add an "SRI" mention next to the CSP bullet that #142 introduces.

🤖 Generated with [Claude Code](https://claude.com/claude-code)