### PR TITLE
feat(auth): event=verify_token with UA + build_label capture (Phase A of install-version telemetry)

### DIFF
--- a/deploy/magic_link_auth.py
+++ b/deploy/magic_link_auth.py
@@ -275,6 +275,41 @@ def consume_token(tok: str) -> dict:
         return {"status": "invalid"}
 
 
+_VALID_VERIFY_RESULTS = ("ok", "expired", "invalid")
+_UA_MAX = 240
+
+
+def verify_token_event(
+    *,
+    result_status: Optional[str],
+    token: Optional[str],
+    user_agent: Optional[str],
+    build_label: Optional[str],
+) -> dict:
+    """Shape the journald event for a /api/verify-token attempt.
+
+    Pure: no I/O. The handler in deploy/server.py emits the dict via
+    ``print(json.dumps(...), file=sys.stderr)``.
+
+    The join key is ``token_prefix`` (12 hex chars) — tokens are not
+    bound to emails in AuthState, so we recover the email at query
+    time by matching against the ``send_unlock_email`` event with the
+    same ``token_prefix``. Both events land in journald within minutes
+    of each other.
+
+    Unknown ``result_status`` values clamp to ``"invalid"`` so a log
+    consumer can rely on the three-value enum.
+    """
+    result = result_status if result_status in _VALID_VERIFY_RESULTS else "invalid"
+    return {
+        "event": "verify_token",
+        "result": result,
+        "token_prefix": (token or "")[:12],
+        "user_agent": (user_agent or "")[:_UA_MAX],
+        "build_label": build_label or "",
+    }
+
+
 def install_recently_allowed(token_issued_at: Optional[float], now: Optional[float] = None) -> bool:
     """True when the browser should still show the install landing.
 

--- a/deploy/server.py
+++ b/deploy/server.py
@@ -516,6 +516,23 @@ class Handler(SimpleHTTPRequestHandler):
             return
         result = ml.consume_token(tok)
         status = (result or {}).get("status")
+        # Structured event for journald — captures the UA and the server's
+        # currently-stamped build_label so triage can answer "what build is
+        # this user on?" without a screenshot. token_prefix is the join key
+        # back to the matching send_unlock_email event (which carries
+        # email_hash_prefix). See plans/install_version_telemetry.md.
+        print(
+            json.dumps(
+                ml.verify_token_event(
+                    result_status=status,
+                    token=tok,
+                    user_agent=self.headers.get("User-Agent", ""),
+                    build_label=BUILD_META.get("build_label")
+                    or BUILD_META.get("git_sha", ""),
+                )
+            ),
+            file=sys.stderr,
+        )
         if status != "ok":
             # "expired" and "invalid" are both 401 but carry distinct error
             # strings so the client can render "link expired" vs "link invalid"

--- a/plans/install_version_telemetry.md
+++ b/plans/install_version_telemetry.md
@@ -1,0 +1,218 @@
+# Install-version telemetry
+
+End goal: `just installed-versions` prints one row per fellow with
+plaintext email, the build they installed on, the build their PWA is
+currently running, and the last User-Agent we saw — so triage like
+"Janine's photos won't load, what build is she on?" stops requiring a
+screenshot from the user.
+
+Tracking issue for the docs side: #147 (data retention docs — what the
+server keeps and how a user wipes the app).
+
+## Why this exists
+
+Today journald carries only `auth_status`, `send_unlock_email`, and
+`build_meta` — none of which capture a click, a User-Agent, or a
+client's running build. Caddy access logs are off. So for any user
+who installed before mid-2026-05, we can see *that* they were sent a
+magic link and *roughly* what build was live then, but cannot
+determine:
+
+- Whether they actually clicked it (no `verify_token` event).
+- What browser / iOS version they're on (no UA capture anywhere).
+- What build their installed PWA is currently executing (no client
+  boot beacon).
+
+The instrumentation closes those three gaps with three small,
+independent landings.
+
+## Phase A — `event=verify_token` with UA capture
+
+Smallest, deployable on its own, immediately useful for the next user
+who clicks a magic link.
+
+### Files
+
+- `deploy/magic_link_auth.py` — add pure `verify_token_event()`
+  helper alongside `consume_token` / `issue_token`. No I/O.
+- `deploy/server.py` — in `_handle_verify_token`, after
+  `consume_token` returns, `print(json.dumps(verify_token_event(...)),
+  file=sys.stderr)`.
+- `tests/test_magic_link_auth.py` — unit-test the helper.
+
+### Event shape
+
+```json
+{"event": "verify_token",
+ "result": "ok" | "expired" | "invalid",
+ "token_prefix": "0ec744d4f319",
+ "user_agent": "Mozilla/5.0 (iPhone; …)",
+ "build_label": "2026-05-12-deadbeef"}
+```
+
+Notes:
+- `email_hash_prefix` is intentionally NOT in this event — tokens
+  aren't bound to emails in `AuthState`. The join key is
+  `token_prefix`, which the matching `send_unlock_email` event
+  already carries. Both events land in journald within minutes of
+  each other, well inside any rotation window we care about.
+- `user_agent` is length-capped at 240 chars (matches
+  `client_error.ua`). No further sanitization at this layer.
+- `build_label` is the server's currently-stamped build — that's
+  the JS the client just ran. Falls back to `git_sha` if
+  `build_label` is missing (older `build-meta.json` shapes).
+- Event fires when `consume_token` runs, regardless of outcome.
+  Skipped for early-return paths (`!AUTH_ACTIVE`, empty token),
+  matching `send_unlock_email`'s "only log when the real work
+  actually runs" pattern.
+
+### Test plan
+
+Unit tests in `tests/test_magic_link_auth.py`:
+- happy-path event has all expected keys + values
+- 240-char cap on UA
+- None / empty inputs collapse to `""` rather than failing
+- `result` clamps unknown statuses to `"invalid"`
+
+No stderr-capture integration test — the in-process server fixture
+makes that fragile, and the helper is pure.
+
+### Out of scope for Phase A
+
+- Backfilling old installs.
+- Logging `email_hash_prefix` directly (the token-prefix join is
+  cheaper than threading email through `AuthState.tokens`).
+
+## Phase B — `kind=boot` client beacon
+
+Tells us what build each installed PWA is *currently running* every
+time the user opens the app.
+
+### Files
+
+- `deploy/client_error_sanitizer.py` — add `boot` to the
+  `kind` allow-list.
+- `app/static/app.js` — in `bootDirectoryAsApp`, after the
+  `get_list_done` boot mark, fire a single `kind=boot` event via
+  the existing `/api/client-errors` sink. Module-scope boolean
+  prevents repeat fires within a page load.
+- `docs/email_gate.md` — extend the `kind` table with `boot`
+  semantics next to `kind=worker`.
+- `tests/test_client_error_sanitizer.py` — unit-test the new
+  kind.
+- `tests/e2e/test_boot_beacon.py` (new) — assert exactly one
+  POST per cold boot, with `build`, `displayMode`, and (when
+  present in localStorage) `lastSubmitHashPrefix`.
+
+### Event shape (within the existing `/api/client-errors` schema)
+
+```jsonc
+{
+  "events": [{"kind": "boot", "msg": "cold_start",
+              "extra": "displayMode=standalone opfsCapable=true provider=worker"}],
+  "ua":    "...",
+  "build": "2026-05-12-deadbeef",       // the JS that's actually running
+  "route": "#/",
+  "displayMode": "standalone",
+  "online": true,
+  "lastSubmitHashPrefix": "8151ea0a4fc9"  // the join key — same prefix verify_token logs
+}
+```
+
+`lastSubmitHashPrefix` is the load-bearing field: without it, boot
+events are anonymous; with it, every boot ties back to a specific
+email_hash_prefix. The value is already stashed in localStorage at
+gate-submit time, so existing installed users start populating once
+they reload after Phase B ships.
+
+### Cardinality / rate
+
+One event per cold boot. Existing per-IP rate limit on
+`/api/client-errors` (3 per window via `check_rate_limit`) is
+already sufficient — a user can't generate more boot events than
+they can open the app.
+
+### Out of scope for Phase B
+
+- Reporting on hot navigations (route changes within an open
+  session). Boot-only.
+- Reporting boot phase timings (we already have
+  `fellows_last_slow_boot` in localStorage for that).
+- Tying back to anonymous boots (no `lastSubmitHashPrefix` in
+  localStorage). Acceptable — we report what we can.
+
+## Phase C — `installed-versions` script + recipe
+
+The user-visible deliverable.
+
+### Files
+
+- `scripts/installed_versions.py` (new) — journald reader + join.
+- `ansible/roles/fellows_app/tasks/main.yml` — deploy alongside
+  `prod_stats.py` to `/opt/fellows/bin/installed_versions`.
+- `justfile` — `installed-versions:` recipe (`ssh ... /opt/fellows/bin/installed_versions`).
+- `docs/justfile.md` — document the recipe.
+- `docs/email_gate.md` — link the script from § Operator triage.
+
+### Logic
+
+1. `journalctl -u fellows-pwa --since <window> --no-pager` (default
+   `30 days ago`; CLI flag for override).
+2. For every `event=verify_token result=ok` line, capture
+   `(token_prefix → (build_label, user_agent, ts))`.
+3. For every `event=send_unlock_email result=sent` line, capture
+   `(token_prefix → email_hash_prefix)`. Use this to translate the
+   verify_token records' `token_prefix` into `email_hash_prefix`.
+4. For every `event=client_error` line whose first event has
+   `kind=boot` AND payload has `lastSubmitHashPrefix`, capture
+   `(email_hash_prefix → (build, ua, ts, displayMode))`.
+5. Join `email_hash_prefix → contact_email` via SQLite over
+   `/opt/fellows/deploy/dist/fellows.db` — same join
+   `prod_stats.py:_recipients()` already does.
+6. Emit a single table sorted by most-recent activity:
+
+   ```
+   email                installed_build       seen_build           last_seen   ua
+   ```
+
+### Output flags
+
+- Default: human-readable table, plaintext-confidential banner.
+- `--csv`: machine-readable for downstream tooling.
+- `--since '7 days ago'`: window override (matches `prod-stats`
+  flag).
+
+### Out of scope for Phase C
+
+- Web UI / dashboard. Operator CLI only.
+- Live tail. One-shot read against journald.
+- Cross-referencing the install funnel (`kind=install` events).
+  That's a `prod-stats` concern, not an install-version concern.
+
+## Phase D — Caddy access logging *(deferred, optional)*
+
+Not needed to ship the `installed-versions` recipe. Worth doing
+later if we hit a triage case neither `verify_token` nor `boot`
+events resolve — e.g. a user who can't get past the gate at all
+and has nothing in the client-error sink either. When that happens:
+turn on Caddy structured JSON access logs to journald,
+`log_skip` for static assets to keep volume down.
+
+## Sequencing
+
+Land A → B → C, each as its own PR. A and B are independently
+valuable; C is the operator-visible glue. Don't bundle.
+
+## What this does NOT solve
+
+- **Pre-instrumentation installs are forensically opaque.** Users
+  who installed before Phase B ships only become attributable after
+  their next cold boot.
+- **Anonymous boots stay anonymous.** A user who Clear-App-Cache'd
+  and then booted without re-authenticating has no
+  `lastSubmitHashPrefix` in localStorage. Their boot event still
+  reports the running build, but we can't tie it to an email.
+- **No retroactive UA capture.** Janine's specific question
+  ("what's she running right now") only gets a forensic answer if
+  she boots once after Phase B is deployed. Until then, the
+  cheaper path is a screenshot of the About → Build badge.

--- a/tests/test_magic_link_auth.py
+++ b/tests/test_magic_link_auth.py
@@ -420,3 +420,74 @@ def test_compute_pubkey_fingerprint_matches_build_pwa(tmp_path):
     sw.write_text("const PROD_PUBLIC_KEY_HEX = '__PROD_PUBLIC_KEY_HEX__';\n")
     assert ml.compute_pubkey_fingerprint(sw) is None
     assert bp.compute_pubkey_fingerprint(sw) is None
+
+
+# --- verify_token_event (journald shape for /api/verify-token) -----------
+
+
+def test_verify_token_event_happy_path_carries_required_fields():
+    e = ml.verify_token_event(
+        result_status="ok",
+        token="abcd" * 16,  # 64 hex
+        user_agent="Mozilla/5.0 (iPhone; CPU iPhone OS 16_3)",
+        build_label="2026-05-12-deadbeef",
+    )
+    assert e == {
+        "event": "verify_token",
+        "result": "ok",
+        "token_prefix": "abcdabcdabcd",  # first 12 chars — the join key
+        "user_agent": "Mozilla/5.0 (iPhone; CPU iPhone OS 16_3)",
+        "build_label": "2026-05-12-deadbeef",
+    }
+
+
+def test_verify_token_event_caps_user_agent_at_240_chars():
+    """UA length cap matches client_error.ua. Pathological strings won't
+    blow up journald lines."""
+    long_ua = "x" * 500
+    e = ml.verify_token_event(
+        result_status="invalid",
+        token="tok",
+        user_agent=long_ua,
+        build_label="",
+    )
+    assert len(e["user_agent"]) == 240
+    assert e["user_agent"] == "x" * 240
+
+
+def test_verify_token_event_clamps_unknown_status_to_invalid():
+    """Unknown statuses (defense in depth — consume_token only returns
+    ok/expired/invalid today) collapse to the three-value enum so log
+    consumers can rely on it."""
+    e = ml.verify_token_event(
+        result_status="something_weird",
+        token="tok",
+        user_agent="ua",
+        build_label="lbl",
+    )
+    assert e["result"] == "invalid"
+
+
+def test_verify_token_event_handles_none_inputs():
+    """Defense: callers pass through .get(...) results, which can be
+    None. Don't raise; collapse to empty strings instead."""
+    e = ml.verify_token_event(
+        result_status=None,
+        token=None,
+        user_agent=None,
+        build_label=None,
+    )
+    assert e["result"] == "invalid"
+    assert e["token_prefix"] == ""
+    assert e["user_agent"] == ""
+    assert e["build_label"] == ""
+
+
+def test_verify_token_event_expired_result_preserved():
+    e = ml.verify_token_event(
+        result_status="expired",
+        token="t",
+        user_agent="",
+        build_label="2026-05-12-abcdef0",
+    )
+    assert e["result"] == "expired"


### PR DESCRIPTION
## Summary

First of three PRs that ship \`just installed-versions\` — operator-side visibility into who installed which build on which browser, without having to ask the user for a screenshot.

This PR (Phase A) closes the **\"we don't even know when users sign in\"** gap: every \`/api/verify-token\` outcome now emits a structured journald event.

- New \`verify_token_event()\` pure helper in \`deploy/magic_link_auth.py\` (5 unit tests).
- \`_handle_verify_token\` emits the event after every \`consume_token\` outcome (ok/expired/invalid), matching the existing \`send_unlock_email\` pattern.
- Join key is \`token_prefix\` (12 hex) — it matches the same field on \`send_unlock_email\`, which carries \`email_hash_prefix\`. No change to \`AuthState\` shape; tokens stay un-bound to emails in memory.

## Event shape

\`\`\`json
{"event": "verify_token",
 "result": "ok",
 "token_prefix": "0ec744d4f319",
 "user_agent": "Mozilla/5.0 (iPhone; CPU iPhone OS 16_3 …)",
 "build_label": "2026-05-12-<sha>"}
\`\`\`

- \`user_agent\` length-capped at 240 (matches \`client_error.ua\`).
- \`build_label\` is the server's currently-stamped build — what the client just executed.
- Falls back to \`git_sha\` when \`build_label\` is missing (older \`build-meta.json\` shapes).

## Plan + tracking

Full A→B→C plan at \`plans/install_version_telemetry.md\` (also in this PR):

- **A (this PR)** — \`event=verify_token\` with UA capture.
- **B** — client-side \`kind=boot\` beacon via the existing \`/api/client-errors\` sink, carrying \`lastSubmitHashPrefix\` as the join key.
- **C** — \`scripts/installed_versions.py\` + \`just installed-versions\` recipe (the operator-visible deliverable).

Related issue: #147 (Data retention docs — what the server keeps + how a user wipes the app).

## Test plan

- [x] \`tests/test_magic_link_auth.py\` — 5 new unit tests on \`verify_token_event()\` (happy path, UA cap, status clamp, None inputs, expired result).
- [x] \`tests/test_deploy_auth_round_trip.py\` — full 14-test suite still green (no behavioral regressions in verify-token responses or cookie issuance).
- [x] \`tests/test_database.py\` + \`tests/test_api.py\` — 24/24 green.
- [ ] **Maintainer manual QA after deploy**: \`just ship\`, click a magic link, then \`ssh ... 'journalctl -u fellows-pwa --since "5 min ago" | grep verify_token'\` — confirm a real \`event=verify_token\` line lands with the right UA + build_label.

🤖 Generated with [Claude Code](https://claude.com/claude-code)