### PR TITLE
feat(telemetry): kind=boot client beacon (Phase B of install-version telemetry)

### DIFF
--- a/app/static/app.js
+++ b/app/static/app.js
@@ -4186,6 +4186,59 @@
     } catch (e) { /* ignore */ }
   }
 
+  // Fire-once guard for reportBootEvent — see comments there.
+  var bootBeaconFired = false;
+
+  // Reports a single boot-success beacon to /api/client-errors so the
+  // maintainer can grep journald for `event=client_error` lines with
+  // `"kind": "boot"` and answer "what build is each installed PWA
+  // actually running right now?" This is the load-bearing telemetry
+  // for `just installed-versions` (plans/install_version_telemetry.md
+  // Phase B); the `build` field carries the running build_label, and
+  // `lastSubmitHashPrefix` (when present from a prior magic-link gate
+  // submit) is the join key back to the user's email.
+  //
+  // Cardinality is exactly one event per page load — guarded by
+  // bootBeaconFired so retries / re-renders don't multiply events.
+  // Fire-and-forget; never blocks boot.
+  function reportBootEvent() {
+    if (bootBeaconFired) return;
+    bootBeaconFired = true;
+    var build = '';
+    if (bootBuildMeta && (bootBuildMeta.git_sha || bootBuildMeta.built_at)) {
+      build = (bootBuildMeta.git_sha || '') +
+        (bootBuildMeta.built_at ? ' @ ' + bootBuildMeta.built_at : '');
+    }
+    var route = '';
+    try { route = String(location.hash || location.pathname || ''); } catch (e) {}
+    var displayMode = isStandaloneDisplayMode() ? 'standalone' : 'browser-tab';
+    var providerKind = '';
+    try { providerKind = String((window.__dataProvider && window.__dataProvider.kind) || ''); } catch (e) {}
+    var extraParts = ['displayMode=' + displayMode];
+    if (providerKind) extraParts.push('provider=' + providerKind);
+    var ev = { kind: 'boot', msg: 'cold_start', extra: extraParts.join(' ') };
+    var payload = {
+      events: [ev],
+      ua: String(navigator.userAgent || ''),
+      build: build,
+      route: route,
+      displayMode: displayMode
+    };
+    try { payload.online = Boolean(navigator.onLine); } catch (e) {}
+    if (lastSubmitInfo && lastSubmitInfo.emailHashPrefix) {
+      payload.lastSubmitHashPrefix = lastSubmitInfo.emailHashPrefix;
+    }
+    try {
+      fetch('/api/client-errors', {
+        method: 'POST',
+        headers: { 'Content-Type': 'application/json' },
+        credentials: 'same-origin',
+        body: JSON.stringify(payload),
+        keepalive: true
+      }).catch(function () { /* ignore — telemetry is best-effort */ });
+    } catch (e) { /* ignore */ }
+  }
+
   // Reports a single worker spawn/init outcome to /api/client-errors so
   // the operator can grep journald for `event=client_error` lines with
   // `"kind": "worker"` to answer questions like "what fraction of boots
@@ -9310,6 +9363,13 @@
         // browser has been authenticated here at least once. Record the
         // marker so the URL-just-works path works on next visit.
         markAuthenticatedOnce();
+        // Phase B of install-version telemetry: fire the one-per-load
+        // boot beacon so the operator can answer "what build is this
+        // user actually running?" via `just installed-versions`. Same
+        // signal as markAuthenticatedOnce — both mean "boot succeeded
+        // for this origin." Guarded internally; safe to call from any
+        // path that reaches this point.
+        reportBootEvent();
         list = Array.isArray(data) ? data : [];
         // Backfill display names for any draft members loaded before
         // we had data (record_id was saved, name wasn't, or the saved

--- a/deploy/client_error_sanitizer.py
+++ b/deploy/client_error_sanitizer.py
@@ -59,10 +59,13 @@ MAX_BUILD_LEN = 64
 # iOS Safari advisory). `worker` carries spawn / init-handshake
 # outcomes for the OPFS worker (vendor/sqlite-worker.js) — the worker
 # is the sole OPFS owner post-Phase-1, so a spawn failure means the
-# user dropped to the API+IDB fallback and we want to know. Privacy
-# boundary is the same — same free-text sanitization on `msg` and
-# `extra` — so adding kinds doesn't widen what a caller can put in
-# the journald log.
+# user dropped to the API+IDB fallback and we want to know. `boot`
+# is the once-per-page-load beacon that carries the running
+# build_label back to the maintainer — Phase B of install-version
+# telemetry (plans/install_version_telemetry.md). Privacy boundary
+# is the same — same free-text sanitization on `msg` and `extra` —
+# so adding kinds doesn't widen what a caller can put in the
+# journald log.
 ALLOWED_EVENT_KINDS = frozenset({
     "http",
     "sw",
@@ -71,6 +74,7 @@ ALLOWED_EVENT_KINDS = frozenset({
     "console.error",
     "install",
     "worker",
+    "boot",
 })
 
 ALLOWED_DISPLAY_MODES = frozenset({"standalone", "browser-tab"})

--- a/docs/email_gate.md
+++ b/docs/email_gate.md
@@ -237,6 +237,18 @@ Spawn / init outcomes for the dedicated SQLite worker (`vendor/sqlite-worker.js`
 
 Operator query: `journalctl -u fellows-pwa | grep '"kind": "worker"'`. Pair `boot_stuck` events with the user's `ua` and `lastSubmitHashPrefix` (if any) to find the matching session and reproduce.
 
+#### `kind=boot` events
+
+Once-per-page-load success beacon, fired after `bootMark('get_list_done')` succeeds. This is the load-bearing input for `just installed-versions` (see [`plans/install_version_telemetry.md`](../plans/install_version_telemetry.md)) — it's how the operator learns *what build each installed PWA is currently executing*, regardless of whether the user has done anything in this session beyond opening the app.
+
+| `msg` | Fired when |
+|---|---|
+| `cold_start` | `bootDirectoryAsApp` reached `get_list_done` (success — fresh API or cached). `extra` carries `displayMode=<x>` and, when the data provider has resolved, `provider=<worker|api+idb|api>`. |
+
+Cardinality is bounded to one per page load (module-scope `bootBeaconFired` guard). When `lastSubmitInfo.emailHashPrefix` is in localStorage from a prior magic-link gate submit, the payload includes `lastSubmitHashPrefix` — the join key that ties each boot back to the user's `email_hash_prefix` from the matching `send_unlock_email` event. Anonymous boots (Clear-App-Cache'd, never gated) still report the running `build`, just without the email join.
+
+Operator query: `journalctl -u fellows-pwa | grep '"kind": "boot"'`. `just installed-versions` does the join + plaintext-email lookup automatically.
+
 ### Anti-abuse posture
 
 - **Always 204 No Content.** No echo, no error message, no oracle. A probing attacker can't tell whether their payload was logged, dropped on shape, dropped on rate-limit, or dropped because all events were filtered.

--- a/tests/e2e/test_boot_beacon.py
+++ b/tests/e2e/test_boot_beacon.py
@@ -1,0 +1,94 @@
+"""E2E: kind=boot beacon fires once per successful cold boot.
+
+Phase B of install-version telemetry (plans/install_version_telemetry.md).
+This is the operator-visible signal `just installed-versions` will join
+against to answer "what build is each installed PWA currently running?".
+
+The privacy boundary is server-side
+(deploy/client_error_sanitizer.py — tested in
+tests/test_client_error_sanitizer.py). What this test pins is the
+client-side firing contract: one POST per page load, after
+`bootMark('get_list_done')`, with the running build_label in the
+`build` field. Without this test a refactor of `bootDirectoryAsApp`
+could silently stop firing the beacon and the maintainer wouldn't
+notice until `just installed-versions` started returning stale data.
+"""
+from playwright.sync_api import expect
+
+from conftest import _STANDALONE_DISPLAY_INIT
+
+
+def _boot_as_app(context):
+    """Page that boots straight into directory mode.
+
+    Two preconditions reproduced from tests/e2e/test_offline_only_mode.py:
+      * matchMedia('(display-mode: standalone)') returns matches=true so
+        the boot path enters `bootDirectoryAsApp` rather than the gate.
+      * fellows_authenticated_once='1' so the URL-just-works marker is
+        set even when we don't go through the magic-link flow (the dev
+        server returns authEnabled=false; that's the existing dev
+        passthrough used by the rest of the e2e suite).
+    """
+    page = context.new_page()
+    page.add_init_script(_STANDALONE_DISPLAY_INIT)
+    page.add_init_script(
+        "window.localStorage.setItem('fellows_authenticated_once', '1');"
+    )
+    return page
+
+
+def test_boot_beacon_fires_once_after_get_list_done(context, base_url_fixture):
+    """Cold boot triggers exactly one /api/client-errors POST with
+    kind=boot. The payload carries the running build label (top-level
+    `build`), displayMode, and UA — the three fields `just
+    installed-versions` reads. lastSubmitHashPrefix is absent here
+    because we didn't go through the magic-link gate (the dev server
+    has no real gate); production boots that did will include it."""
+    page = _boot_as_app(context)
+    try:
+        boot_posts = []
+        page.on(
+            "request",
+            lambda r: (
+                boot_posts.append(r)
+                if (
+                    "/api/client-errors" in r.url
+                    and r.method == "POST"
+                    and (r.post_data or "").find('"kind":"boot"') >= 0
+                )
+                else None
+            ),
+        )
+        page.goto(base_url_fixture + "/", wait_until="domcontentloaded")
+        # Wait for the directory to render — that confirms
+        # bootMark('get_list_done') ran, which is the firing point.
+        expect(page.locator("#directory-list")).to_be_visible(timeout=15000)
+        # Give the keepalive fetch a tick to be observed by the request
+        # listener (fire-and-forget doesn't block render).
+        page.wait_for_timeout(300)
+
+        assert len(boot_posts) >= 1, (
+            "expected at least one kind=boot POST after directory render; "
+            "got zero — reportBootEvent did not fire"
+        )
+        # Cardinality: bootBeaconFired guard means exactly one even if
+        # the boot path re-enters or the SW retries.
+        assert len(boot_posts) == 1, (
+            f"expected exactly one kind=boot POST, got {len(boot_posts)} — "
+            "the fire-once guard regressed"
+        )
+
+        body = boot_posts[0].post_data_json
+        assert body["events"][0]["kind"] == "boot"
+        assert body["events"][0]["msg"] == "cold_start"
+        # Build label is what the operator reads — it MUST be in the
+        # payload, not just in `extra`.
+        assert isinstance(body.get("build"), str) and body["build"], (
+            f"build label missing from boot payload: {body}"
+        )
+        assert body["displayMode"] == "standalone"
+        # Provider kind threaded through `extra` is what tells us
+        # whether this boot used the worker vs api+idb fallback.
+        assert "provider=" in body["events"][0].get("extra", "")
+    finally:
+        page.close()

--- a/tests/test_client_error_sanitizer.py
+++ b/tests/test_client_error_sanitizer.py
@@ -188,6 +188,25 @@ def test_sanitize_payload_accepts_worker_kind():
     assert out["events"][1]["extra"] == "rpc=1 schema=1"
 
 
+def test_sanitize_payload_accepts_boot_kind():
+    """Once-per-page-load boot beacon (plans/install_version_telemetry.md
+    Phase B). Carries the running build_label in the top-level `build`
+    field; `kind=boot` is what `just installed-versions` will grep for.
+    Same free-text sanitization as other kinds — the privacy boundary
+    is unchanged."""
+    body = {"events": [
+        {"kind": "boot", "msg": "cold_start",
+         "extra": "displayMode=standalone opfsCapable=true provider=worker"},
+    ]}
+    out = ces.sanitize_payload(body)
+    assert len(out["events"]) == 1
+    assert out["events"][0]["kind"] == "boot"
+    assert out["events"][0]["msg"] == "cold_start"
+    assert out["events"][0]["extra"] == (
+        "displayMode=standalone opfsCapable=true provider=worker"
+    )
+
+
 def test_sanitize_payload_install_kind_still_redacts_email_in_msg():
     """The kind allowlist doesn't bypass the email-redaction rule on
     free-text fields. A buggy caller that tries to send the user's


### PR DESCRIPTION
## Summary

Phase B of the install-version telemetry plan (see [plans/install_version_telemetry.md](./plans/install_version_telemetry.md), landed in #148). Every successful cold boot now fires a single \`kind=boot\` event to \`/api/client-errors\` carrying the *running* build_label. This is the load-bearing input for \`just installed-versions\` — it answers \"what build is each installed PWA executing right now?\", independent of when the user last clicked a magic link.

## What ships

- \`deploy/client_error_sanitizer.py\` — \`boot\` added to \`ALLOWED_EVENT_KINDS\`. Same email/route sanitization rules as the existing kinds; privacy boundary unchanged.
- \`app/static/app.js\` — \`reportBootEvent()\` (modeled on \`reportWorkerEvent\`) with a module-scope \`bootBeaconFired\` boolean to enforce one-per-page-load. Fires from \`bootDirectoryAsApp\` right after \`bootMark('get_list_done')\` and \`markAuthenticatedOnce()\` — same \"boot succeeded\" signal. Payload includes \`lastSubmitHashPrefix\` from \`lastSubmitInfo\` when set (the join key back to \`email_hash_prefix\`).
- \`docs/email_gate.md\` — \`kind=boot\` section after \`kind=worker\`, with operator query.
- \`tests/test_client_error_sanitizer.py\` — \`test_sanitize_payload_accepts_boot_kind\`.
- \`tests/e2e/test_boot_beacon.py\` (new) — pins the firing contract (exactly one POST per cold boot, with \`build\`, \`displayMode\`, and \`provider=<x>\` in \`extra\`).

## Wire shape

\`\`\`jsonc
{
  "events": [{
    "kind": "boot", "msg": "cold_start",
    "extra": "displayMode=standalone provider=worker"
  }],
  "ua": "Mozilla/5.0 (iPhone; …)",
  "build": "abc1234 @ 2026-05-12T…Z",       // the JS actually running
  "route": "#/",
  "displayMode": "standalone",
  "online": true,
  "lastSubmitHashPrefix": "8151ea0a4fc9"    // when present in localStorage
}
\`\`\`

## Test plan

- [x] Unit: \`tests/test_client_error_sanitizer.py\` 31/31 green; \`tests/test_deploy_client_errors.py\` 12/12 green.
- [x] Round-trip + magic-link unit: \`tests/test_magic_link_auth.py\` + \`tests/test_deploy_auth_round_trip.py\` 45/45 green.
- [x] E2E: \`tests/e2e/test_boot_beacon.py\` passes; \`tests/e2e/test_email_gate.py\` + \`test_directory.py\` + \`test_bug_report.py\` + \`test_local_first_boot.py\` 31/31 green (no regression in existing \`/api/client-errors\` paths).
- [ ] **Maintainer manual QA after deploy**:
  1. \`just ship\`
  2. Open prod in an installed PWA. \`ssh ... 'journalctl -u fellows-pwa --since \"2 min ago\" | grep \\\"kind\\\": \\\"boot\\\"'\` — confirm one boot event lands per session with the running build label.
  3. From a clean (Clear App Cache'd) browser tab pointed at prod, verify the boot event STILL fires (anonymous boot — payload has \`build\` but no \`lastSubmitHashPrefix\`).

## Next

Phase C: \`scripts/installed_versions.py\` + \`just installed-versions\` recipe that joins \`verify_token\` (Phase A) + \`kind=boot\` events to plaintext emails via \`fellows.db\`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)