### PR TITLE
feat(ops): just installed-versions — per-fellow install vs running build (Phase C)

### DIFF
--- a/ansible/roles/fellows_app/tasks/main.yml
+++ b/ansible/roles/fellows_app/tasks/main.yml
@@ -118,6 +118,14 @@
     group: "{{ service_user }}"
     mode: "0755"
 
+- name: Install installed_versions helper
+  ansible.builtin.copy:
+    src: "{{ playbook_dir }}/../scripts/installed_versions.py"
+    dest: "{{ app_root }}/bin/installed_versions"
+    owner: "{{ service_user }}"
+    group: "{{ service_user }}"
+    mode: "0755"
+
 # Preflight: confirm the operator (ansible_user, not root) can actually write
 # into every dist subdirectory before rsync tries. If normalization above
 # didn't take — filesystem ACLs, mount options, something unexpected — we

--- a/docs/email_gate.md
+++ b/docs/email_gate.md
@@ -261,6 +261,8 @@ Operator query: `journalctl -u fellows-pwa | grep '"kind": "boot"'`. `just insta
 
 `just prod-errors [SINCE]` (see `docs/justfile.md`) prints the 4xx + 5xx access-line counters AND the new `Client error reports:` count, with the recent-errors list interleaving both kinds tagged `[client_error]` vs raw access lines. Pair with the user's `lastSubmitHashPrefix` (if they shared a screenshot of the diag block) to find the matching `event=send_unlock_email` entry: `journalctl -u fellows-pwa | grep '"email_hash_prefix": "ab12cd34ef56"'`.
 
+`just installed-versions [SINCE]` (see [`docs/justfile.md`](justfile.md) and [`plans/install_version_telemetry.md`](../plans/install_version_telemetry.md)) is the "what build is this user actually running?" view. Joins `verify_token` + `kind=boot` events to plaintext emails via `fellows.db`, with a `⚠ STUCK` flag when a user's install build differs from their currently-running build — the dominant symptom of a service-worker update path that didn't take. Plaintext-confidential.
+
 
 
 ## Cookie format (v3)

--- a/docs/justfile.md
+++ b/docs/justfile.md
@@ -32,8 +32,8 @@ A few recipes respect the same env vars the underlying scripts do:
 | Variable | Default | Affects |
 |---|---|---|
 | `FELLOWS_HOST` | `fellows.globaldonut.com` | `check-env`, SSH targets |
-| `FELLOWS_SSH_PORT` | `52221` | `prod-logs`, `prod-status`, `prod-stats`, `prod-stats-long` |
-| `FELLOWS_SSH_USER` | `rsb` | `prod-logs`, `prod-status`, `prod-stats`, `prod-stats-long` |
+| `FELLOWS_SSH_PORT` | `52221` | `prod-logs`, `prod-status`, `prod-stats`, `prod-stats-long`, `installed-versions` |
+| `FELLOWS_SSH_USER` | `rsb` | `prod-logs`, `prod-status`, `prod-stats`, `prod-stats-long`, `installed-versions` |
 | `FELLOWS_BASE_URL` | `https://fellows.globaldonut.com` | `smoke`, `drift` |
 
 Export them or inline: `FELLOWS_BASE_URL=https://staging.example.com just smoke`.
@@ -187,6 +187,22 @@ Export them or inline: `FELLOWS_BASE_URL=https://staging.example.com just smoke`
   `/opt/fellows/deploy/dist/fellows.db` and matching against the
   `email_hash_prefix` the server logs per send event. Treat output as
   confidential — it contains fellow email addresses.
+- **`installed-versions [SINCE]`** — per-fellow install-build vs
+  currently-running-build inventory, joined to plaintext email. Default
+  window `30 days ago`. Joins three event streams from journald:
+  `event=verify_token` (install moment + UA, via the `token_prefix`
+  hop through `event=send_unlock_email` to recover `email_hash_prefix`)
+  and `event=client_error kind=boot` (every cold boot's running build,
+  keyed by `lastSubmitHashPrefix`). Each row shows the install build,
+  the currently-running build, and a `⚠ STUCK` flag when the two
+  differ — that's the Janine-on-iOS diagnostic (cache evicted, SW
+  update path didn't take). Anonymous boots (Clear-App-Cache'd users
+  with no gate submit in localStorage) are histogrammed at the
+  bottom by build label. Plan and rationale:
+  [`plans/install_version_telemetry.md`](../plans/install_version_telemetry.md).
+  Schema for the underlying events: [`docs/email_gate.md` §
+  Client error reporting](email_gate.md#client-error-reporting).
+  Plaintext-confidential — same posture as `prod-stats-long`.
 - **`prod-errors [SINCE]`** — focused triage view: prints the 4xx + 5xx
   counters, the new `Client error reports:` count, and the 10 most
   recent error entries verbatim — interleaving server-side access

--- a/justfile
+++ b/justfile
@@ -224,10 +224,10 @@ test-e2e filter="":
         ./scripts/ensure_port_8765_free.sh tests/e2e/ -v -k "{{filter}}"
     fi
 
-# DB + API + prod-stats only (skip Playwright; ~10x faster).
+# DB + API + prod-stats + installed-versions only (skip Playwright; ~10x faster).
 [group('test')]
 test-fast:
-    ./scripts/ensure_port_8765_free.sh tests/test_database.py tests/test_api.py tests/test_prod_stats.py -v
+    ./scripts/ensure_port_8765_free.sh tests/test_database.py tests/test_api.py tests/test_prod_stats.py tests/test_installed_versions.py -v
 
 # Mobile screenshot harness across device matrix → tests/e2e/mobile/current_state/.
 # The committed baselines under __snapshots__/ are a visual reference, not a
@@ -481,6 +481,13 @@ prod-stats since="24 hours ago":
 [group('prod')]
 prod-stats-long:
     ssh -p {{ssh_port}} {{ssh_user}}@{{host}} "/opt/fellows/bin/prod_stats --include-emails"
+
+# Per-email install vs currently-running build (joins verify_token + kind=boot).
+# Plaintext-confidential output (joins to fellow emails). See
+# plans/install_version_telemetry.md.
+[group('prod')]
+installed-versions since="30 days ago":
+    ssh -p {{ssh_port}} {{ssh_user}}@{{host}} "/opt/fellows/bin/installed_versions --since '{{since}}'"
 
 # 4xx/5xx counters and the 10 most recent error access lines (default 24h).
 [group('prod')]

--- a/scripts/installed_versions.py
+++ b/scripts/installed_versions.py
@@ -1,0 +1,461 @@
+#!/usr/bin/env python3
+"""Installed-version inventory for fellows-pwa, joined to plaintext email.
+
+Reads journald for two structured events plus one
+``event=send_unlock_email`` join hop:
+
+  * ``event=verify_token result=ok``        → ``token_prefix → (build_label, ua, ts)``
+  * ``event=send_unlock_email result=sent`` → ``token_prefix → email_hash_prefix``
+  * ``event=client_error`` w/ ``kind=boot`` → ``lastSubmitHashPrefix → (build, ua, ts, extra)``
+
+Joins ``email_hash_prefix`` → plaintext ``contact_email`` via
+``/opt/fellows/deploy/dist/fellows.db`` (prefix match on
+``sha256(lower(trim(email)))[:12]`` — the same scheme
+``deploy/server.py`` uses when emitting ``email_hash_prefix``).
+
+Output answers: *for every fellow with attributed activity, what build
+did they install on, what build is their PWA currently running, and how
+long ago did we last see them?* The gap between ``installed_build`` and
+``seen_build`` is the load-bearing diagnostic — equal == healthy, drift
+== a SW update path that didn't take.
+
+Stdlib only so it runs on the droplet without a venv. Same
+``systemd-journal``/``adm`` group membership as ``prod_stats`` —
+operator runs it without sudo.
+
+Usage:
+    installed_versions [--since "30 days ago"] [--unit fellows-pwa]
+                       [--json]
+
+Output is plaintext-confidential — the recipient list joins back to
+emails. Same posture as ``prod_stats --include-emails``.
+
+See ``plans/install_version_telemetry.md`` for the full A→B→C plan.
+"""
+
+from __future__ import annotations
+
+import argparse
+import hashlib
+import json
+import os
+import sqlite3
+import subprocess
+import sys
+from datetime import datetime, timezone
+
+
+# Group-readable (mode 2775, fellows:fellows) — no sudo needed when rsb runs.
+FELLOWS_DB_PATH = "/opt/fellows/deploy/dist/fellows.db"
+
+# Default window. 30 days is the right starting point: long enough that
+# most installed users have opened the app at least once and emitted a
+# kind=boot event; short enough that the journald scan is fast even on
+# a small droplet. Operator can widen with --since '@0' for full history.
+DEFAULT_SINCE = "30 days ago"
+
+
+def journal_entries(unit: str, since: str) -> list:
+    """Run ``journalctl -o json`` and return a list of parsed entries.
+
+    Mirrors ``prod_stats.journal_entries`` — emits a stderr hint when
+    the call succeeds with zero entries (almost always a group-membership
+    miss on systemd-journal / adm).
+    """
+    try:
+        proc = subprocess.run(
+            ["journalctl", "-u", unit, "--since", since, "-o", "json", "--no-pager"],
+            capture_output=True,
+            text=True,
+        )
+    except FileNotFoundError:
+        print("journalctl not found (not a systemd host?)", file=sys.stderr)
+        return []
+    if proc.returncode != 0:
+        print(
+            f"journalctl failed (exit {proc.returncode}): {proc.stderr.strip()}",
+            file=sys.stderr,
+        )
+        return []
+    entries = []
+    for line in proc.stdout.splitlines():
+        try:
+            entries.append(json.loads(line))
+        except json.JSONDecodeError:
+            continue
+    if not entries:
+        print(
+            f"WARNING: journalctl returned 0 entries for {unit}.\n"
+            "  Almost always this means the SSH user isn't in the\n"
+            "  systemd-journal (or adm) group. Run `id` on this host;\n"
+            "  if neither group appears, re-run `just bootstrap` from\n"
+            "  the operator workstation to re-apply the common role.",
+            file=sys.stderr,
+        )
+    return entries
+
+
+def _entry_message(entry: dict) -> str | None:
+    msg = entry.get("MESSAGE")
+    return msg if isinstance(msg, str) else None
+
+
+def _entry_ts(entry: dict) -> str | None:
+    raw = entry.get("__REALTIME_TIMESTAMP")
+    if not raw:
+        return None
+    try:
+        seconds = int(raw) / 1_000_000
+        return (
+            datetime.fromtimestamp(seconds, tz=timezone.utc)
+            .isoformat(timespec="seconds")
+            .replace("+00:00", "Z")
+        )
+    except (ValueError, OSError):
+        return None
+
+
+def _parse_struct_event(message: str, expected: str) -> dict | None:
+    """Return the parsed event dict iff ``MESSAGE`` is a JSON line whose
+    ``event`` field equals ``expected``. Cheap pre-filter via substring
+    test keeps the JSON-decode off the hot path."""
+    if not message.startswith("{") or expected not in message:
+        return None
+    try:
+        evt = json.loads(message)
+    except json.JSONDecodeError:
+        return None
+    if not isinstance(evt, dict) or evt.get("event") != expected:
+        return None
+    return evt
+
+
+def collect(entries: list) -> dict:
+    """Bucketize the three event kinds we care about. Returns a dict with:
+
+      ``send_token_to_email_prefix``: ``token_prefix → email_hash_prefix``
+          (12 hex). Built from ``send_unlock_email result=sent``. Used
+          to translate verify_token records into the canonical email
+          key. Most-recent send wins on collision (token_prefix is
+          random 12 hex; collisions are vanishingly rare).
+      ``verify_by_token_prefix``: ``token_prefix → {build_label, ua, ts}``
+          Most-recent verify_token result=ok wins on the same key.
+      ``boot_by_email_prefix``: ``lastSubmitHashPrefix → {build, ua, ts, extra}``
+          Most-recent kind=boot client_error wins on the same key.
+      ``anonymous_boots``: list of ``{build, ua, ts}`` for boots with
+          no ``lastSubmitHashPrefix`` (Clear App Cache'd, never gated).
+    """
+    send_token_to_email_prefix: dict = {}
+    verify_by_token_prefix: dict = {}
+    boot_by_email_prefix: dict = {}
+    anonymous_boots: list = []
+
+    for entry in entries:
+        m = _entry_message(entry)
+        if m is None:
+            continue
+        ts = _entry_ts(entry) or ""
+
+        evt = _parse_struct_event(m, "send_unlock_email")
+        if evt is not None:
+            if evt.get("result") == "sent":
+                tp = evt.get("token_prefix")
+                ep = evt.get("email_hash_prefix")
+                if tp and ep:
+                    # Most-recent send wins. The same token_prefix
+                    # shouldn't appear twice (random 12-hex), but if it
+                    # did we want the freshest binding.
+                    prev = send_token_to_email_prefix.get(tp)
+                    if prev is None or ts >= prev.get("ts", ""):
+                        send_token_to_email_prefix[tp] = {"email_prefix": ep, "ts": ts}
+            continue
+
+        evt = _parse_struct_event(m, "verify_token")
+        if evt is not None:
+            if evt.get("result") == "ok":
+                tp = evt.get("token_prefix")
+                if tp:
+                    prev = verify_by_token_prefix.get(tp)
+                    if prev is None or ts >= prev.get("ts", ""):
+                        verify_by_token_prefix[tp] = {
+                            "build_label": evt.get("build_label") or "",
+                            "ua": evt.get("user_agent") or "",
+                            "ts": ts,
+                        }
+            continue
+
+        evt = _parse_struct_event(m, "client_error")
+        if evt is not None:
+            inner_events = evt.get("events") or []
+            if not (isinstance(inner_events, list) and inner_events):
+                continue
+            first = inner_events[0]
+            if not isinstance(first, dict) or first.get("kind") != "boot":
+                continue
+            build = evt.get("build") or ""
+            ua = evt.get("ua") or ""
+            extra = first.get("extra") or ""
+            email_prefix = evt.get("lastSubmitHashPrefix")
+            record = {"build": build, "ua": ua, "ts": ts, "extra": extra}
+            if isinstance(email_prefix, str) and email_prefix:
+                prev = boot_by_email_prefix.get(email_prefix)
+                if prev is None or ts >= prev.get("ts", ""):
+                    boot_by_email_prefix[email_prefix] = record
+            else:
+                anonymous_boots.append(record)
+            continue
+
+    return {
+        "send_token_to_email_prefix": send_token_to_email_prefix,
+        "verify_by_token_prefix": verify_by_token_prefix,
+        "boot_by_email_prefix": boot_by_email_prefix,
+        "anonymous_boots": anonymous_boots,
+    }
+
+
+def build_email_hash_index(db_path: str = FELLOWS_DB_PATH) -> dict:
+    """Map ``sha256(lower(trim(contact_email)))`` → ``{'email','name'}``.
+
+    Empty dict on any error (plus a stderr note). Kept local so this
+    script stays single-file. The existence check is necessary because
+    ``sqlite3.connect`` creates an empty DB on a missing path rather
+    than raising — the failure would surface much later as
+    ``OperationalError: no such table: fellows``.
+    """
+    if not os.path.isfile(db_path):
+        print(f"Cannot open fellows DB {db_path}: not a file", file=sys.stderr)
+        return {}
+    try:
+        conn = sqlite3.connect(db_path)
+    except sqlite3.Error as exc:
+        print(f"Cannot open fellows DB {db_path}: {exc}", file=sys.stderr)
+        return {}
+    try:
+        conn.row_factory = sqlite3.Row
+        try:
+            cur = conn.execute(
+                "SELECT name, lower(trim(contact_email)) AS email "
+                "FROM fellows WHERE contact_email IS NOT NULL "
+                "AND trim(contact_email) != ''"
+            )
+        except sqlite3.OperationalError as exc:
+            print(f"fellows.db schema mismatch ({db_path}): {exc}", file=sys.stderr)
+            return {}
+        out: dict = {}
+        for row in cur.fetchall():
+            email = row["email"]
+            if not email:
+                continue
+            h = hashlib.sha256(email.encode("utf-8")).hexdigest()
+            out[h] = {"email": email, "name": row["name"] or ""}
+        return out
+    finally:
+        conn.close()
+
+
+def attribute(collected: dict, hash_index: dict) -> dict:
+    """Build the per-email attribution table from the bucketed events.
+
+    Returns a dict with:
+      ``rows``: list of per-email rows, each carrying both
+        ``installed_*`` (from verify_token via send_unlock_email) and
+        ``seen_*`` (from kind=boot). Sorted by ``last_activity`` desc.
+      ``anonymous_count``: int — boots we can't attribute to an email.
+      ``anonymous_builds``: ``build_label → count`` — useful even
+        without identity ("23 anonymous users on 2026-05-08-abc").
+    """
+    # Step 1: translate verify_token records into per-email-prefix records.
+    # The same email may have multiple verify_token events across different
+    # tokens (each magic-link click is a new token); we keep the most
+    # recent per email_prefix.
+    verify_by_email_prefix: dict = {}
+    for token_prefix, vrec in collected["verify_by_token_prefix"].items():
+        join = collected["send_token_to_email_prefix"].get(token_prefix)
+        if not join:
+            # verify_token without a matching send: the original send is
+            # outside the journald window. Skip — we can't attribute it.
+            continue
+        email_prefix = join["email_prefix"]
+        prev = verify_by_email_prefix.get(email_prefix)
+        if prev is None or vrec["ts"] >= prev["ts"]:
+            verify_by_email_prefix[email_prefix] = vrec
+
+    # Step 2: union of email prefixes that have ANY attributed signal.
+    all_prefixes: set = set(verify_by_email_prefix.keys()) | set(
+        collected["boot_by_email_prefix"].keys()
+    )
+
+    rows = []
+    for prefix in all_prefixes:
+        verify = verify_by_email_prefix.get(prefix)
+        boot = collected["boot_by_email_prefix"].get(prefix)
+
+        # Prefix-match join to fellows.db (same scheme prod_stats uses).
+        matches = [(h, meta) for h, meta in hash_index.items() if h.startswith(prefix)]
+
+        installed_build = verify["build_label"] if verify else ""
+        installed_ts = verify["ts"] if verify else ""
+        installed_ua = verify["ua"] if verify else ""
+
+        seen_build = boot["build"] if boot else ""
+        seen_ts = boot["ts"] if boot else ""
+        seen_ua = boot["ua"] if boot else ""
+        seen_extra = boot["extra"] if boot else ""
+
+        # Last activity = max(installed_ts, seen_ts). Drives table sort.
+        last_activity = max(installed_ts, seen_ts)
+        # Display UA = whichever signal is fresher (or whichever exists).
+        if seen_ts and seen_ts >= installed_ts:
+            last_ua = seen_ua
+        else:
+            last_ua = installed_ua
+
+        # Healthy = installed_build matches seen_build OR one side is
+        # absent (data we can't compare). Mismatch = stale shell.
+        stuck = bool(installed_build and seen_build and installed_build != seen_build)
+
+        base = {
+            "email_prefix": prefix,
+            "installed_build": installed_build,
+            "installed_ts": installed_ts,
+            "installed_ua": installed_ua,
+            "seen_build": seen_build,
+            "seen_ts": seen_ts,
+            "seen_ua": seen_ua,
+            "seen_extra": seen_extra,
+            "last_activity": last_activity,
+            "last_ua": last_ua,
+            "stuck": stuck,
+        }
+        if not matches:
+            rows.append({**base, "email": None, "name": None, "collisions": 0})
+        else:
+            collisions = len(matches) - 1
+            for _h, meta in matches:
+                rows.append({
+                    **base,
+                    "email": meta["email"],
+                    "name": meta["name"],
+                    "collisions": collisions,
+                })
+
+    rows.sort(key=lambda r: r["last_activity"], reverse=True)
+
+    # Histogram of anonymous boots by build, useful for "N people on X".
+    anonymous_builds: dict = {}
+    for rec in collected["anonymous_boots"]:
+        b = rec.get("build") or "(unknown)"
+        anonymous_builds[b] = anonymous_builds.get(b, 0) + 1
+
+    return {
+        "rows": rows,
+        "anonymous_count": len(collected["anonymous_boots"]),
+        "anonymous_builds": anonymous_builds,
+    }
+
+
+def _fmt_build(s: str) -> str:
+    return s or "—"
+
+
+def _fmt_ts(s: str) -> str:
+    """Trim a Z-suffixed ISO timestamp to its date portion for readability."""
+    if not s:
+        return "—"
+    return s.split("T", 1)[0]
+
+
+def _fmt_ua(s: str, cap: int = 60) -> str:
+    if not s:
+        return "—"
+    if len(s) <= cap:
+        return s
+    return s[: cap - 1] + "…"
+
+
+def print_human(attribution: dict, since: str, unit: str) -> None:
+    rows = attribution["rows"]
+    print(f"== installed-versions — since {since} (plaintext; confidential) ==")
+    print(f"  unit: {unit}")
+    print("")
+    if not rows:
+        print("  (no attributed verify_token / kind=boot events in window)")
+    else:
+        noun = "fellow" if len(rows) == 1 else "fellows"
+        print(f"  {len(rows)} attributed {noun}, most-recent activity first:")
+        print("")
+        for r in rows:
+            who = r["email"] or f"<unknown prefix={r['email_prefix']}>"
+            name = f"  ({r['name']})" if r.get("name") else ""
+            collisions = (
+                f"  (prefix collides with {r['collisions']} other fellow(s))"
+                if r.get("collisions")
+                else ""
+            )
+            stuck_tag = "  ⚠ STUCK" if r.get("stuck") else ""
+            print(f"  {who}{name}{collisions}{stuck_tag}")
+            print(
+                f"    installed: {_fmt_build(r['installed_build']):24s}"
+                f"  {_fmt_ts(r['installed_ts']):10s}"
+                f"  ua: {_fmt_ua(r['installed_ua'])}"
+            )
+            seen_extra = f"  ({r['seen_extra']})" if r.get("seen_extra") else ""
+            print(
+                f"    seen:      {_fmt_build(r['seen_build']):24s}"
+                f"  {_fmt_ts(r['seen_ts']):10s}"
+                f"  ua: {_fmt_ua(r['seen_ua'])}{seen_extra}"
+            )
+
+    anon_count = attribution["anonymous_count"]
+    if anon_count:
+        print("")
+        plural = "" if anon_count == 1 else "s"
+        print(f"-- Anonymous boots (no gate submit in localStorage): {anon_count} event{plural} --")
+        for build, count in sorted(
+            attribution["anonymous_builds"].items(), key=lambda kv: -kv[1]
+        ):
+            print(f"  {build:32s} {count}")
+
+
+def main(argv=None) -> int:
+    parser = argparse.ArgumentParser(description=__doc__)
+    parser.add_argument(
+        "--since",
+        default=DEFAULT_SINCE,
+        help=f"journalctl --since window (default: '{DEFAULT_SINCE}'). "
+        "'@0' for full retained journal.",
+    )
+    parser.add_argument(
+        "--unit",
+        default="fellows-pwa",
+        help="Systemd unit to read (default: fellows-pwa).",
+    )
+    parser.add_argument(
+        "--json",
+        dest="as_json",
+        action="store_true",
+        help="Emit machine-readable JSON instead of the human table.",
+    )
+    args = parser.parse_args(argv)
+
+    entries = journal_entries(args.unit, args.since)
+    collected = collect(entries)
+    hash_index = build_email_hash_index()
+    attribution = attribute(collected, hash_index)
+
+    if args.as_json:
+        payload = {
+            "unit": args.unit,
+            "since": args.since,
+            "rows": attribution["rows"],
+            "anonymous_count": attribution["anonymous_count"],
+            "anonymous_builds": attribution["anonymous_builds"],
+        }
+        print(json.dumps(payload, sort_keys=True))
+    else:
+        print_human(attribution, args.since, args.unit)
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/tests/test_installed_versions.py
+++ b/tests/test_installed_versions.py
@@ -1,0 +1,535 @@
+"""Unit tests for scripts/installed_versions.py.
+
+Mirrors tests/test_prod_stats.py: synthetic journald entries + a tiny
+synthetic fellows.db, exercising the pure functions (``collect``,
+``build_email_hash_index``, ``attribute``, ``print_human``) without
+touching real journalctl or SSH.
+"""
+import hashlib
+import importlib.util
+import io
+import json
+import os
+import sqlite3
+import sys
+from contextlib import redirect_stdout
+from datetime import datetime, timezone
+
+REPO_ROOT = os.path.dirname(os.path.dirname(os.path.abspath(__file__)))
+SCRIPT_PATH = os.path.join(REPO_ROOT, "scripts", "installed_versions.py")
+
+_spec = importlib.util.spec_from_file_location("installed_versions", SCRIPT_PATH)
+iv = importlib.util.module_from_spec(_spec)
+_spec.loader.exec_module(iv)
+
+
+# ---- helpers -------------------------------------------------------------
+
+def _entry(message: str, ts: str = "2026-05-12T10:00:00Z") -> dict:
+    """Synthesize a journald entry dict matching `journalctl -o json` output."""
+    epoch_us = int(
+        datetime.fromisoformat(ts.replace("Z", "+00:00")).timestamp() * 1_000_000
+    )
+    return {"MESSAGE": message, "__REALTIME_TIMESTAMP": str(epoch_us)}
+
+
+def _sha256_hex(s: str) -> str:
+    return hashlib.sha256(s.encode("utf-8")).hexdigest()
+
+
+def _send_evt(email_hash_prefix: str, token_prefix: str, ts: str) -> dict:
+    return _entry(
+        json.dumps({
+            "event": "send_unlock_email",
+            "result": "sent",
+            "email_hash_prefix": email_hash_prefix,
+            "token_prefix": token_prefix,
+            "postmark": {"MessageID": "x"},
+        }),
+        ts=ts,
+    )
+
+
+def _verify_evt(token_prefix: str, build_label: str, ua: str, ts: str,
+                result: str = "ok") -> dict:
+    return _entry(
+        json.dumps({
+            "event": "verify_token",
+            "result": result,
+            "token_prefix": token_prefix,
+            "user_agent": ua,
+            "build_label": build_label,
+        }),
+        ts=ts,
+    )
+
+
+def _boot_evt(last_submit_hash_prefix, build: str, ua: str, ts: str,
+              extra: str = "displayMode=standalone provider=worker") -> dict:
+    payload: dict = {
+        "event": "client_error",
+        "client_ip_prefix": "",
+        "events": [{"kind": "boot", "msg": "cold_start", "extra": extra}],
+        "ua": ua,
+        "build": build,
+        "route": "#/",
+        "displayMode": "standalone",
+        "online": True,
+    }
+    if last_submit_hash_prefix is not None:
+        payload["lastSubmitHashPrefix"] = last_submit_hash_prefix
+    return _entry(json.dumps(payload), ts=ts)
+
+
+# ---- _parse_struct_event --------------------------------------------------
+
+def test_parse_struct_event_matches_expected_event_kind():
+    msg = json.dumps({"event": "verify_token", "result": "ok"})
+    assert iv._parse_struct_event(msg, "verify_token") is not None
+    # Wrong expected kind → None.
+    assert iv._parse_struct_event(msg, "send_unlock_email") is None
+
+
+def test_parse_struct_event_returns_none_for_access_log_lines():
+    """Access log lines start with '127.0.0.1' — pre-filter must skip
+    them cheaply before json.loads runs."""
+    assert iv._parse_struct_event(
+        '127.0.0.1 - - [12/May/2026 10:00:00] "GET / HTTP/1.1" 200 -',
+        "verify_token",
+    ) is None
+
+
+def test_parse_struct_event_returns_none_for_malformed_json():
+    assert iv._parse_struct_event('{"event": "verify_token"', "verify_token") is None
+
+
+# ---- collect -------------------------------------------------------------
+
+def test_collect_groups_three_event_kinds():
+    """The bucketizer handles the three event kinds + the
+    token_prefix → email_hash_prefix translation hop."""
+    h = _sha256_hex("jane@example.com")
+    prefix = h[:12]
+    entries = [
+        _send_evt(prefix, "tok123456789a", "2026-05-01T10:00:00Z"),
+        _verify_evt("tok123456789a", "2026-05-01-aaaa", "Mozilla iPhone",
+                    "2026-05-01T10:00:30Z"),
+        _boot_evt(prefix, "2026-05-08-bbbb", "Mozilla iPhone",
+                  "2026-05-08T08:00:00Z"),
+    ]
+    c = iv.collect(entries)
+    assert c["send_token_to_email_prefix"]["tok123456789a"]["email_prefix"] == prefix
+    assert c["verify_by_token_prefix"]["tok123456789a"]["build_label"] == "2026-05-01-aaaa"
+    assert c["boot_by_email_prefix"][prefix]["build"] == "2026-05-08-bbbb"
+    assert c["anonymous_boots"] == []
+
+
+def test_collect_keeps_most_recent_per_key():
+    """Two verify_token events on the same token_prefix (shouldn't happen
+    in practice — random 12-hex — but if it does, freshest wins so the
+    report reflects the latest known build)."""
+    entries = [
+        _verify_evt("tok_dup______", "2026-05-01-old", "ua1",
+                    "2026-05-01T10:00:00Z"),
+        _verify_evt("tok_dup______", "2026-05-08-new", "ua2",
+                    "2026-05-08T10:00:00Z"),
+    ]
+    c = iv.collect(entries)
+    rec = c["verify_by_token_prefix"]["tok_dup______"]
+    assert rec["build_label"] == "2026-05-08-new"
+    assert rec["ua"] == "ua2"
+
+
+def test_collect_drops_failed_verify_attempts():
+    """Only result=ok counts — expired/invalid attempts don't reveal a
+    successful install. They still emit events (Phase A logs every
+    consume_token outcome), but the attribution table should ignore
+    them."""
+    entries = [
+        _verify_evt("tok_expired__", "2026-05-08-bld", "ua",
+                    "2026-05-08T10:00:00Z", result="expired"),
+        _verify_evt("tok_invalid__", "2026-05-08-bld", "ua",
+                    "2026-05-08T10:00:00Z", result="invalid"),
+    ]
+    c = iv.collect(entries)
+    assert c["verify_by_token_prefix"] == {}
+
+
+def test_collect_separates_anonymous_boots():
+    """Boots without lastSubmitHashPrefix land in anonymous_boots —
+    can't be joined to email but still tell us a build is running."""
+    entries = [
+        _boot_evt(None, "2026-05-08-aaa", "Chrome", "2026-05-08T10:00:00Z"),
+        _boot_evt(None, "2026-05-08-aaa", "Chrome", "2026-05-08T11:00:00Z"),
+        _boot_evt(None, "2026-05-09-bbb", "Safari", "2026-05-09T10:00:00Z"),
+    ]
+    c = iv.collect(entries)
+    assert c["boot_by_email_prefix"] == {}
+    assert len(c["anonymous_boots"]) == 3
+
+
+def test_collect_ignores_non_boot_client_errors():
+    """`kind=install` and `kind=worker` client_error events also live in
+    journald (they share the sink) — they must NOT bucket into the boot
+    map. Only the first event's kind matters."""
+    entries = [
+        _entry(json.dumps({
+            "event": "client_error",
+            "events": [{"kind": "install", "msg": "landing_shown"}],
+            "ua": "ua", "build": "2026-05-08-x", "displayMode": "browser-tab",
+            "lastSubmitHashPrefix": "abcdef012345",
+        }), ts="2026-05-08T10:00:00Z"),
+        _entry(json.dumps({
+            "event": "client_error",
+            "events": [{"kind": "worker", "msg": "spawn_ok"}],
+            "ua": "ua", "build": "2026-05-08-x", "displayMode": "standalone",
+            "lastSubmitHashPrefix": "abcdef012345",
+        }), ts="2026-05-08T10:01:00Z"),
+    ]
+    c = iv.collect(entries)
+    assert c["boot_by_email_prefix"] == {}
+    assert c["anonymous_boots"] == []
+
+
+# ---- attribute -----------------------------------------------------------
+
+def _make_db(tmp_path, emails):
+    """Build a tiny fellows.db with the given (email, name) tuples."""
+    db = tmp_path / "fellows.db"
+    conn = sqlite3.connect(str(db))
+    conn.execute(
+        "CREATE TABLE fellows (record_id TEXT PRIMARY KEY, slug TEXT, "
+        "name TEXT, contact_email TEXT)"
+    )
+    for i, (email, name) in enumerate(emails):
+        conn.execute(
+            "INSERT INTO fellows (record_id, slug, name, contact_email) "
+            "VALUES (?, ?, ?, ?)",
+            (f"r{i}", f"s{i}", name, email),
+        )
+    conn.commit()
+    conn.close()
+    return db
+
+
+def test_attribute_joins_verify_and_boot_for_same_email(tmp_path):
+    """Happy path: a fellow with both verify_token AND kind=boot in
+    window gets a single row carrying both columns + the plaintext
+    email."""
+    email = "jane@example.com"
+    h = _sha256_hex(email)
+    prefix = h[:12]
+    db = _make_db(tmp_path, [(email, "Jane Example")])
+    hash_index = iv.build_email_hash_index(str(db))
+
+    entries = [
+        _send_evt(prefix, "tok_aaaaaaaa", "2026-05-01T10:00:00Z"),
+        _verify_evt("tok_aaaaaaaa", "2026-05-01-install", "iPhone OS 16_3",
+                    "2026-05-01T10:00:30Z"),
+        _boot_evt(prefix, "2026-05-08-seen", "iPhone OS 16_3",
+                  "2026-05-08T08:00:00Z"),
+    ]
+    attribution = iv.attribute(iv.collect(entries), hash_index)
+    assert len(attribution["rows"]) == 1
+    row = attribution["rows"][0]
+    assert row["email"] == "jane@example.com"
+    assert row["installed_build"] == "2026-05-01-install"
+    assert row["seen_build"] == "2026-05-08-seen"
+    assert row["last_activity"] == "2026-05-08T08:00:00Z"
+    assert row["stuck"] is True  # install != seen
+
+
+def test_attribute_marks_healthy_when_install_matches_seen(tmp_path):
+    """Equal build labels means no stale-shell drift — stuck=False."""
+    email = "ok@example.com"
+    h = _sha256_hex(email)
+    prefix = h[:12]
+    db = _make_db(tmp_path, [(email, "OK")])
+    hash_index = iv.build_email_hash_index(str(db))
+    entries = [
+        _send_evt(prefix, "tok_okokokok", "2026-05-08T10:00:00Z"),
+        _verify_evt("tok_okokokok", "2026-05-08-x", "ua",
+                    "2026-05-08T10:00:30Z"),
+        _boot_evt(prefix, "2026-05-08-x", "ua", "2026-05-08T12:00:00Z"),
+    ]
+    attribution = iv.attribute(iv.collect(entries), hash_index)
+    assert attribution["rows"][0]["stuck"] is False
+
+
+def test_attribute_handles_install_only_row(tmp_path):
+    """A user who clicked the magic link but never booted after Phase B
+    deployed shows installed_build only — seen_build is '—'."""
+    email = "verify-only@example.com"
+    h = _sha256_hex(email)
+    prefix = h[:12]
+    db = _make_db(tmp_path, [(email, "Verify Only")])
+    hash_index = iv.build_email_hash_index(str(db))
+    entries = [
+        _send_evt(prefix, "tok_vvvvvvvv", "2026-05-08T10:00:00Z"),
+        _verify_evt("tok_vvvvvvvv", "2026-05-08-install", "ua",
+                    "2026-05-08T10:00:30Z"),
+    ]
+    attribution = iv.attribute(iv.collect(entries), hash_index)
+    row = attribution["rows"][0]
+    assert row["installed_build"] == "2026-05-08-install"
+    assert row["seen_build"] == ""
+    # stuck only triggers when BOTH builds present and they differ.
+    assert row["stuck"] is False
+
+
+def test_attribute_handles_boot_only_row(tmp_path):
+    """A user whose last verify_token was pre-Phase-A but who boots
+    after Phase B shows seen_build only — installed_build is '—'.
+    This is the dominant case for existing installs the first time
+    they open the app after telemetry ships."""
+    email = "boot-only@example.com"
+    h = _sha256_hex(email)
+    prefix = h[:12]
+    db = _make_db(tmp_path, [(email, "Boot Only")])
+    hash_index = iv.build_email_hash_index(str(db))
+    entries = [
+        _boot_evt(prefix, "2026-05-08-current", "Safari",
+                  "2026-05-08T08:00:00Z"),
+    ]
+    attribution = iv.attribute(iv.collect(entries), hash_index)
+    row = attribution["rows"][0]
+    assert row["installed_build"] == ""
+    assert row["seen_build"] == "2026-05-08-current"
+    assert row["last_activity"] == "2026-05-08T08:00:00Z"
+
+
+def test_attribute_drops_verify_without_matching_send(tmp_path):
+    """A verify_token whose matching send_unlock_email aged out of the
+    window can't be attributed — drop rather than guess. The user can
+    widen --since '@0' to recover."""
+    db = _make_db(tmp_path, [("orphan@example.com", "Orphan")])
+    hash_index = iv.build_email_hash_index(str(db))
+    entries = [
+        _verify_evt("tok_orphaned_", "2026-05-08-x", "ua",
+                    "2026-05-08T10:00:30Z"),
+    ]
+    attribution = iv.attribute(iv.collect(entries), hash_index)
+    assert attribution["rows"] == []
+
+
+def test_attribute_keeps_most_recent_verify_per_email(tmp_path):
+    """Two verify_token events for the same email (different magic-link
+    clicks) collapse to one row showing the most recent build."""
+    email = "frequent@example.com"
+    h = _sha256_hex(email)
+    prefix = h[:12]
+    db = _make_db(tmp_path, [(email, "Frequent")])
+    hash_index = iv.build_email_hash_index(str(db))
+    entries = [
+        # Old click — different token.
+        _send_evt(prefix, "tok_old111111", "2026-05-01T10:00:00Z"),
+        _verify_evt("tok_old111111", "2026-05-01-old", "ua-old",
+                    "2026-05-01T10:00:30Z"),
+        # Recent click — different token, same email.
+        _send_evt(prefix, "tok_new222222", "2026-05-08T10:00:00Z"),
+        _verify_evt("tok_new222222", "2026-05-08-new", "ua-new",
+                    "2026-05-08T10:00:30Z"),
+    ]
+    attribution = iv.attribute(iv.collect(entries), hash_index)
+    assert len(attribution["rows"]) == 1
+    row = attribution["rows"][0]
+    assert row["installed_build"] == "2026-05-08-new"
+
+
+def test_attribute_handles_unknown_prefix(tmp_path):
+    """A boot event whose lastSubmitHashPrefix doesn't match any fellow
+    in fellows.db still surfaces — email is None, name is None, prefix
+    is shown in place. This catches an off-allowlist user (rare but
+    real) or a stale DB."""
+    db = _make_db(tmp_path, [("known@example.com", "Known")])
+    hash_index = iv.build_email_hash_index(str(db))
+    entries = [
+        _boot_evt("999999999999", "2026-05-08-x", "ua",
+                  "2026-05-08T10:00:00Z"),
+    ]
+    attribution = iv.attribute(iv.collect(entries), hash_index)
+    assert len(attribution["rows"]) == 1
+    row = attribution["rows"][0]
+    assert row["email"] is None
+    assert row["email_prefix"] == "999999999999"
+
+
+def test_attribute_aggregates_anonymous_boots_by_build(tmp_path):
+    """Boots without lastSubmitHashPrefix get histogrammed by build —
+    'N anonymous users on build X' is still operationally useful even
+    without identity."""
+    db = _make_db(tmp_path, [])
+    hash_index = iv.build_email_hash_index(str(db))
+    entries = [
+        _boot_evt(None, "2026-05-08-a", "ua", "2026-05-08T10:00:00Z"),
+        _boot_evt(None, "2026-05-08-a", "ua", "2026-05-08T11:00:00Z"),
+        _boot_evt(None, "2026-05-09-b", "ua", "2026-05-09T10:00:00Z"),
+    ]
+    attribution = iv.attribute(iv.collect(entries), hash_index)
+    assert attribution["anonymous_count"] == 3
+    assert attribution["anonymous_builds"] == {
+        "2026-05-08-a": 2,
+        "2026-05-09-b": 1,
+    }
+
+
+def test_attribute_sorts_by_most_recent_activity(tmp_path):
+    """Rows must come out most-recent-first so the maintainer's eye
+    lands on the freshest signal."""
+    db = _make_db(tmp_path, [
+        ("old@example.com", "Old"),
+        ("new@example.com", "New"),
+    ])
+    hash_index = iv.build_email_hash_index(str(db))
+    old_h = _sha256_hex("old@example.com")
+    new_h = _sha256_hex("new@example.com")
+    entries = [
+        _boot_evt(old_h[:12], "build-1", "ua", "2026-04-01T10:00:00Z"),
+        _boot_evt(new_h[:12], "build-2", "ua", "2026-05-08T10:00:00Z"),
+    ]
+    attribution = iv.attribute(iv.collect(entries), hash_index)
+    assert [r["email"] for r in attribution["rows"]] == [
+        "new@example.com", "old@example.com",
+    ]
+
+
+# ---- build_email_hash_index ----------------------------------------------
+
+def test_build_email_hash_index_normalises_email(tmp_path):
+    """Mirrors the server's lower(trim(contact_email)) — must match so
+    the prefix join lands."""
+    db = _make_db(tmp_path, [("  Jane@Example.COM  ", "Jane")])
+    idx = iv.build_email_hash_index(str(db))
+    expected = _sha256_hex("jane@example.com")
+    assert expected in idx
+    assert idx[expected] == {"email": "jane@example.com", "name": "Jane"}
+
+
+def test_build_email_hash_index_handles_missing_db(tmp_path):
+    """Missing DB → empty dict, not raise. CLI keeps emitting the table
+    with '<unknown prefix=…>' placeholders."""
+    assert iv.build_email_hash_index(str(tmp_path / "nope.db")) == {}
+
+
+# ---- print_human ---------------------------------------------------------
+
+def test_print_human_handles_empty_window():
+    """Smoke: empty input still produces readable output, no crash."""
+    attribution = {"rows": [], "anonymous_count": 0, "anonymous_builds": {}}
+    buf = io.StringIO()
+    with redirect_stdout(buf):
+        iv.print_human(attribution, "30 days ago", "fellows-pwa")
+    out = buf.getvalue()
+    assert "installed-versions" in out
+    assert "no attributed" in out
+
+
+def test_print_human_flags_stuck_users(tmp_path):
+    """The STUCK marker is the load-bearing call-out — make sure it
+    actually appears for an install/seen mismatch."""
+    email = "stuck@example.com"
+    h = _sha256_hex(email)
+    prefix = h[:12]
+    db = _make_db(tmp_path, [(email, "Stuck")])
+    hash_index = iv.build_email_hash_index(str(db))
+    entries = [
+        _send_evt(prefix, "tok_s_s_s_s_", "2026-04-23T10:00:00Z"),
+        _verify_evt("tok_s_s_s_s_", "2026-04-23-af63655", "iPhone",
+                    "2026-04-23T10:00:30Z"),
+        _boot_evt(prefix, "2026-04-23-af63655", "iPhone",
+                  "2026-05-09T08:00:00Z"),  # same build — NOT stuck
+    ]
+    attribution = iv.attribute(iv.collect(entries), hash_index)
+    buf = io.StringIO()
+    with redirect_stdout(buf):
+        iv.print_human(attribution, "30 days ago", "fellows-pwa")
+    assert "STUCK" not in buf.getvalue()
+
+    # Now flip seen to a newer build → should be marked stuck.
+    entries[-1] = _boot_evt(prefix, "2026-05-12-newer", "iPhone",
+                            "2026-05-12T08:00:00Z")
+    attribution = iv.attribute(iv.collect(entries), hash_index)
+    buf = io.StringIO()
+    with redirect_stdout(buf):
+        iv.print_human(attribution, "30 days ago", "fellows-pwa")
+    assert "STUCK" in buf.getvalue()
+
+
+def test_print_human_surfaces_anonymous_boots():
+    attribution = {
+        "rows": [],
+        "anonymous_count": 5,
+        "anonymous_builds": {"2026-05-12-abc": 4, "2026-05-08-xyz": 1},
+    }
+    buf = io.StringIO()
+    with redirect_stdout(buf):
+        iv.print_human(attribution, "30 days ago", "fellows-pwa")
+    out = buf.getvalue()
+    assert "5 events" in out or "Anonymous boots" in out
+    assert "2026-05-12-abc" in out
+    assert "2026-05-08-xyz" in out
+
+
+# ---- end-to-end through main(--json) -------------------------------------
+
+def test_main_json_emits_stable_schema(tmp_path, monkeypatch, capsys):
+    """End-to-end smoke: --json output carries the documented top-level
+    keys. We stub journal_entries and build_email_hash_index so the
+    test doesn't depend on the droplet."""
+    email = "jane@example.com"
+    h = _sha256_hex(email)
+    prefix = h[:12]
+
+    entries = [
+        _send_evt(prefix, "tok_e2e_aaaa", "2026-05-01T10:00:00Z"),
+        _verify_evt("tok_e2e_aaaa", "2026-05-01-x", "ua",
+                    "2026-05-01T10:00:30Z"),
+        _boot_evt(prefix, "2026-05-08-y", "ua", "2026-05-08T08:00:00Z"),
+    ]
+    monkeypatch.setattr(iv, "journal_entries", lambda unit, since: entries)
+    db = _make_db(tmp_path, [(email, "Jane")])
+    monkeypatch.setattr(
+        iv, "build_email_hash_index",
+        lambda path=iv.FELLOWS_DB_PATH: iv.build_email_hash_index.__wrapped__(str(db))
+        if hasattr(iv.build_email_hash_index, "__wrapped__")
+        else _real_index(db),
+    )
+    # The above monkeypatch trick is fragile; simpler: just override
+    # FELLOWS_DB_PATH to point at our tmp DB.
+    monkeypatch.setattr(iv, "FELLOWS_DB_PATH", str(db))
+    monkeypatch.setattr(
+        iv, "build_email_hash_index", lambda path=str(db): _real_index(db)
+    )
+
+    rc = iv.main(["--json", "--since", "30 days ago"])
+    assert rc == 0
+    captured = capsys.readouterr()
+    payload = json.loads(captured.out)
+    assert payload["unit"] == "fellows-pwa"
+    assert payload["since"] == "30 days ago"
+    assert isinstance(payload["rows"], list)
+    assert payload["rows"][0]["email"] == "jane@example.com"
+
+
+def _real_index(db_path):
+    """Helper for the monkeypatch above — calls the real builder against
+    a known-good DB path without recursing through the monkeypatched
+    binding."""
+    conn = sqlite3.connect(str(db_path))
+    try:
+        conn.row_factory = sqlite3.Row
+        cur = conn.execute(
+            "SELECT name, lower(trim(contact_email)) AS email "
+            "FROM fellows WHERE contact_email IS NOT NULL "
+            "AND trim(contact_email) != ''"
+        )
+        out = {}
+        for row in cur.fetchall():
+            email = row["email"]
+            if email:
+                out[hashlib.sha256(email.encode("utf-8")).hexdigest()] = {
+                    "email": email, "name": row["name"] or ""
+                }
+        return out
+    finally:
+        conn.close()


### PR DESCRIPTION
## Summary

Phase C of install-version telemetry — the operator-visible deliverable. \`just installed-versions\` joins the events from PR A (\`event=verify_token\`, #148) and PR B (\`event=client_error kind=boot\`, #150) into a single table that answers \"what build did each fellow install on, what build is their PWA running right now, and who's stuck on a stale shell?\"

Closes the [A→B→C plan](./plans/install_version_telemetry.md). The script is what tomorrow's Janine-on-iOS triage runs against.

## What ships

- \`scripts/installed_versions.py\` (new) — stdlib-only journald reader + join, deployable to \`/opt/fellows/bin/installed_versions\` alongside \`prod_stats\`.
- \`tests/test_installed_versions.py\` (new) — 23 unit tests, pure fixture-driven (no real journalctl/SSH). Added to \`just test-fast\`.
- \`ansible/roles/fellows_app/tasks/main.yml\` — copy task mirroring the existing \`prod_stats\` install.
- \`justfile\` — \`installed-versions [SINCE]\` recipe (default 30 days).
- \`docs/justfile.md\` — full recipe description + SSH env-var table updated.
- \`docs/email_gate.md\` § Operator triage — linked from the existing triage section.

## Sample output

\`\`\`
== installed-versions — since 30 days ago (plaintext; confidential) ==
  unit: fellows-pwa

  2 attributed fellows, most-recent activity first:

  rich@example.com  (Rich)  ⚠ STUCK
    installed: 2026-04-01-old             2026-04-01  ua: Mac OS X 14
    seen:      2026-05-12-newest          2026-05-12  ua: Mac OS X 14  (displayMode=browser-tab provider=api+idb)
  janine@janineedge.com  (Janine Edge)
    installed: 2026-04-23-af63655         2026-04-23  ua: Mozilla/5.0 (iPhone; CPU iPhone OS 16_3 like Mac OS X)
    seen:      2026-04-23-af63655         2026-05-09  ua: Mozilla/5.0 (iPhone; CPU iPhone OS 16_3 like Mac OS X)  (displayMode=standalone provider=worker)

-- Anonymous boots (no gate submit in localStorage): 1 event --
  2026-05-12-newest                1
\`\`\`

The \`⚠ STUCK\` flag is the load-bearing diagnostic — it means the install build differs from the currently-running build, i.e. the SW update path didn't take for that user. That's the exact symptom Janine triggered this whole effort with.

## Join semantics

- \`installed_build\`: from the most recent \`event=verify_token result=ok\`. Joined back to email via \`token_prefix\` → \`event=send_unlock_email result=sent\` → \`email_hash_prefix\`.
- \`seen_build\`: from the most recent \`event=client_error\` whose first inner event has \`kind=boot\`, keyed by \`lastSubmitHashPrefix\` (= \`email_hash_prefix\`).
- Both prefix-match \`sha256(lower(trim(contact_email)))\` against the rows in \`/opt/fellows/deploy/dist/fellows.db\` — same scheme \`prod_stats.py:build_email_hash_index\` uses.
- Anonymous boots (no \`lastSubmitHashPrefix\` — Clear-App-Cache'd, never gated) are histogrammed at the bottom by build label.

## Test plan

- [x] Unit: \`tests/test_installed_versions.py\` 23/23 green; covers the three event kinds, the most-recent-wins rules, the install-only / boot-only / unknown-prefix rows, anonymous-boot histogram, sort order, the STUCK flag, and CLI \`--json\` shape.
- [x] Full unit suite: \`tests/test_installed_versions.py\` + \`test_prod_stats.py\` + \`test_client_error_sanitizer.py\` + \`test_magic_link_auth.py\` + \`test_deploy_auth_round_trip.py\` 138/138 green.
- [ ] **Maintainer manual QA after deploy**:
  1. \`just ship\` — picks up the new \`installed_versions\` binary via the existing fellows_app role.
  2. \`just installed-versions '7 days ago'\` — confirm the binary is in place and journald scan completes (initially most rows will show \`installed: —\` because PR A's \`verify_token\` events only exist from PR #148 onward; \`seen:\` will populate as users open the app after PR #150).
  3. After a few days of natural traffic, re-run and confirm at least one fully-attributed row with both \`installed_build\` and \`seen_build\` set — that's the proof the end-to-end pipeline works.

## What this closes

The original triage question: \"what build is Janine's PWA actually running?\" — answerable in one command going forward. Pre-instrumentation installs (~all current installed users) remain forensically opaque until they next open the app (boot beacon fires) or click a fresh magic link (verify_token fires); then they populate.

Related: #147 (data retention docs — what the server keeps + user-side removal).

🤖 Generated with [Claude Code](https://claude.com/claude-code)