### PR TITLE
fix(dev): just / run.sh prefer .venv/bin/python over system python3

### DIFF
--- a/docs/justfile.md
+++ b/docs/justfile.md
@@ -271,6 +271,16 @@ Export them or inline: `FELLOWS_BASE_URL=https://staging.example.com just smoke`
 - **Recipes are idempotent where the underlying script is.** `setup` checks
   for `.venv` before creating; `db-rebuild` always snapshots first;
   `serve` detects a running server and no-ops.
+- **Python invocations prefer the venv.** A top-of-file `python` variable
+  resolves to `.venv/bin/python` when present (post `just setup`) and
+  falls back to system `python3` otherwise. Every recipe that runs a
+  Python script (`serve-fg`, `build`, `db-rebuild`, `images-fetch`, …)
+  uses `{{python}}`, so dev-only deps like `cryptography` (added in
+  PR #146 for SW bundle-signing in dev) are picked up automatically
+  after setup — no `source .venv/bin/activate` needed. `run.sh` does
+  the same selection in shell. The `keygen` and `sign` recipes use
+  `{{venv}}/bin/python` explicitly because they *require* the venv
+  (`cryptography` is mandatory there, not optional).
 - **Production recipes are identified by the `prod-` prefix** so a careless
   tab-complete doesn't fire something destructive. The one exception is
   `smoke` (it's read-only and hits prod by default).

--- a/justfile
+++ b/justfile
@@ -8,6 +8,15 @@ db_backup  := "app/fellows.db.backup.2026-04-08"
 port       := "8765"
 venv       := ".venv"
 pytest     := venv / "bin/pytest"
+# Pick the venv's Python when it's been materialised by `just setup`,
+# fall back to system `python3` (fresh clone, pre-setup). Evaluated at
+# parse time on every `just` invocation, so the first run after setup
+# automatically switches over — no shell re-source needed. Recipes
+# that historically used bare `python3` (serve-fg, build, db-*, etc.)
+# silently picked up system Python and missed venv-installed deps
+# like `cryptography` (added in PR #146 for SW signature verify); this
+# variable removes that footgun without forcing users to `source .venv/bin/activate`.
+python     := `if [ -x .venv/bin/python ]; then echo .venv/bin/python; else echo python3; fi`
 host       := env_var_or_default("FELLOWS_HOST", "fellows.globaldonut.com")
 ssh_port   := env_var_or_default("FELLOWS_SSH_PORT", "52221")
 ssh_user   := env_var_or_default("FELLOWS_SSH_USER", "rsb")
@@ -34,7 +43,7 @@ setup:
     {{venv}}/bin/playwright install chromium
     ansible-galaxy collection install -r ansible/collections/requirements.yml -p ansible/collections
     if [ ! -f {{db}} ]; then
-        python3 build/restore_from_knack_scrapefile.py
+        {{venv}}/bin/python build/restore_from_knack_scrapefile.py
     fi
     echo "Setup complete."
 
@@ -79,7 +88,7 @@ serve:
 # Start dev server in foreground (Ctrl-C to stop).
 [group('dev')]
 serve-fg:
-    python3 app/server.py
+    {{python}} app/server.py
 
 # Stop the background dev server.
 [group('dev')]
@@ -129,18 +138,18 @@ serve-lan:
 # Canonical rebuild from Knack dump (auto-backup first).
 [group('db')]
 db-rebuild: data-backup
-    python3 build/restore_from_knack_scrapefile.py
+    {{python}} build/restore_from_knack_scrapefile.py
     @just db-stats
 
 # Bytewise-diff app/fellows.db against the Apr 8 reference backup.
 [group('db')]
 db-verify:
-    python3 build/diff_fellows_db.py {{db}} {{db_backup}}
+    {{python}} build/diff_fellows_db.py {{db}} {{db_backup}}
 
 # Bytewise-diff app/fellows.db against OTHER.
 [group('db')]
 db-diff other:
-    python3 build/diff_fellows_db.py {{db}} {{other}}
+    {{python}} build/diff_fellows_db.py {{db}} {{other}}
 
 # Row / email / image counts.
 [group('db')]
@@ -162,12 +171,12 @@ db-open:
 # Download missing profile images from Knack S3.
 [group('db')]
 images-fetch:
-    python3 build/fetch_missing_images.py
+    {{python}} build/fetch_missing_images.py
 
 # Print what images WOULD be fetched (--dry-run).
 [group('db')]
 images-fetch-dry:
-    python3 build/fetch_missing_images.py --dry-run
+    {{python}} build/fetch_missing_images.py --dry-run
 
 
 # ---- backup / restore ----------------------------------------------------
@@ -249,7 +258,7 @@ test-mobile-promote:
 # Assemble deploy/dist/ (runs build/build_pwa.py).
 [group('build')]
 build:
-    python3 build/build_pwa.py
+    {{python}} build/build_pwa.py
 
 # Generate the prod ECDSA P-256 signing keypair (one-time, per maintainer).
 # Prompts for a passphrase, writes ~/.fellows/signing-key.enc.pem, prints

--- a/run.sh
+++ b/run.sh
@@ -12,6 +12,15 @@ cd "$(dirname "$0")"
 PIDFILE=".server.pid"
 PORT=8765
 DB="app/fellows.db"
+# Prefer the venv's Python when `just setup` has been run. Bare `python3`
+# (system) won't see dev-only deps like `cryptography` (needed for SW
+# bundle-signing in dev — added in PR #146). Falls back to system
+# `python3` when the venv isn't materialised yet (fresh clone).
+if [ -x ".venv/bin/python" ]; then
+  PY=".venv/bin/python"
+else
+  PY="python3"
+fi
 
 server_pid() {
   # Return PID if server is running on our port, empty otherwise
@@ -52,9 +61,9 @@ do_start() {
   fi
   if [ ! -f "$DB" ]; then
     echo "Database not found. Building from JSON..."
-    python3 build/restore_from_knack_scrapefile.py
+    "$PY" build/restore_from_knack_scrapefile.py
   fi
-  python3 app/server.py &
+  "$PY" app/server.py &
   echo $! > "$PIDFILE"
   echo "Server started (PID $!) at http://localhost:$PORT/"
   sleep 1
@@ -73,7 +82,7 @@ do_status() {
 do_reset() {
   echo "Rebuilding database..."
   do_stop
-  python3 build/restore_from_knack_scrapefile.py
+  "$PY" build/restore_from_knack_scrapefile.py
   do_start
 }
 


### PR DESCRIPTION
## Summary

\`just serve-fg\` and friends invoked bare \`python3\` (system), bypassing the venv that \`just setup\` populates. PR #146 (signed bundles) added a runtime import of \`cryptography\` inside \`app/server.py:_dev_sign_bytes\` — that import is in \`requirements-dev.txt\` and lands in \`.venv\`, so system Python doesn't see it and the SW's bundle-verify code path crashes with \`ModuleNotFoundError\` on the first request that exercises it. Reported live this morning.

## The fix

Introduce a top-of-file \`python\` variable in \`justfile\` that auto-detects:

\`\`\`just
python := \`if [ -x .venv/bin/python ]; then echo .venv/bin/python; else echo python3; fi\`
\`\`\`

Evaluated at parse time on every \`just\` invocation — first run after \`just setup\` picks up the venv automatically, no \`source .venv/bin/activate\` ritual. Threaded through every recipe that runs a Python script (\`serve-fg\`, \`build\`, \`db-rebuild\`, \`db-verify\`, \`db-diff\`, \`images-fetch\`, \`images-fetch-dry\`, and \`setup\`'s post-bootstrap DB build). \`run.sh\` does the equivalent selection in shell at script start (\`$PY\`) so \`just serve\` / \`restart\` / \`reset\` get the same treatment.

Out of scope (already correct):

- \`keygen\` and \`sign\` recipes already used \`{{venv}}/bin/python\` explicitly — kept as-is because \`cryptography\` is *mandatory* there, not optional. A missing venv should fail loud, not silently fall back to system Python.
- \`python3 -m venv\` in \`setup\` itself stays bare — bootstrap runs before the venv exists.

## Smoke

Before: \`just serve-fg\` then any SW manifest-sig fetch → \`ModuleNotFoundError: No module named 'cryptography'\` traceback in the server log.

After:
\`\`\`
$ just serve-fg
.venv/bin/python app/server.py
Server at http://localhost:8765/
$ curl -sI http://localhost:8765/manifest.sig
HTTP/1.0 200 OK
\`\`\`
89 bytes of real signature, no traceback.

## Test plan

- [x] \`just --evaluate python\` → \`.venv/bin/python\` (when venv present)
- [x] \`just serve-fg\` invokes \`.venv/bin/python app/server.py\`
- [x] \`GET /manifest.sig\` returns 200 with bytes (was 500 before)
- [x] Unit suite (\`test_installed_versions\` + \`test_magic_link_auth\` + \`test_database\`): 66/66 green
- [ ] **Maintainer manual QA on a fresh clone**: \`just setup && just serve-fg\` — confirm the recipe still works end-to-end on a workstation that's never had cryptography on system Python.

🤖 Generated with [Claude Code](https://claude.com/claude-code)