### PR TITLE
feat(lock): opt-in 'Lock my user data' — phase 1 (crypto primitives)

### DIFF
--- a/app/static/app.js
+++ b/app/static/app.js
@@ -37,7 +37,7 @@
   // app/static/vendor/sqlite-worker.js (`WORKER_RPC_VERSION`,
   // `RELATIONSHIPS_SCHEMA_VERSION`). See plans/local_first_worker_architecture.md
   // §"Why build label is not the gate".
-  var EXPECTED_WORKER_RPC_VERSION = 2;
+  var EXPECTED_WORKER_RPC_VERSION = 3;
   var EXPECTED_RELATIONSHIPS_SCHEMA_VERSION = 1;
 
   // Thrown by mutating dataProvider methods when the worker reports a

--- a/app/static/vendor/sqlite-worker.js
+++ b/app/static/vendor/sqlite-worker.js
@@ -362,15 +362,38 @@ async function _opfsRemoveEntry(name) {
   }
 }
 
+// Lists all backup files at OPFS root — both plaintext
+// `relationships.db.bak.<ISO>` AND encrypted siblings
+// `relationships.db.bak.<ISO>.locked`. Filename order is alphabetic,
+// which interleaves chronologically by ISO timestamp (plain sorts
+// before its .locked sibling for the same ts, but in steady state we
+// only ever have one of the two per timestamp). Excludes .locked.new
+// and .tmp orphans — those are residue from interrupted ops and are
+// init-cleaned, not user-visible.
+//
+// Used by _rotateRelationshipsBackups (newest-5-of-any-kind policy)
+// and the listRelationshipsBackups RPC.
 async function listRelationshipsBackups() {
   try {
     var root = await _opfsRoot();
     var out = [];
     for await (var entry of root.values()) {
-      if (entry.kind === 'file' && entry.name.indexOf(BACKUP_PREFIX) === 0) {
-        var f = await entry.getFile();
-        out.push({ name: entry.name, size: f.size, lastModified: f.lastModified });
-      }
+      if (entry.kind !== 'file') continue;
+      var nm = entry.name;
+      if (nm.indexOf(BACKUP_PREFIX) !== 0) continue;
+      if (nm.length > LOCKED_NEW_SUFFIX.length &&
+          nm.slice(-LOCKED_NEW_SUFFIX.length) === LOCKED_NEW_SUFFIX) continue;
+      if (nm.length > TMP_SUFFIX.length &&
+          nm.slice(-TMP_SUFFIX.length) === TMP_SUFFIX) continue;
+      var f = await entry.getFile();
+      var isLocked = nm.length > LOCKED_SUFFIX.length &&
+                     nm.slice(-LOCKED_SUFFIX.length) === LOCKED_SUFFIX;
+      out.push({
+        name: nm,
+        size: f.size,
+        lastModified: f.lastModified,
+        encrypted: isLocked
+      });
     }
     out.sort(function (a, b) { return a.name < b.name ? -1 : a.name > b.name ? 1 : 0; });
     return out;
@@ -706,16 +729,7 @@ async function maybeBackupRelationshipsDb() {
   if (!bytes || !bytes.byteLength) {
     return { backedUp: false, reason: 'empty file' };
   }
-  var ts = new Date().toISOString().replace(/[:.]/g, '-');
-  var backupName = BACKUP_PREFIX + ts;
-  try { await _opfsWriteBinary(backupName, bytes); }
-  catch (e) {
-    trace('backup: write failed: ' + (e && e.message || e));
-    return { backedUp: false, reason: 'write failed' };
-  }
-  await _rotateRelationshipsBackups();
-  trace('backup: wrote ' + backupName + ' (' + bytes.byteLength + ' bytes)');
-  return { backedUp: true, name: backupName, size: bytes.byteLength };
+  return await _writeBackupBytesLockAware(bytes, 'backup');
 }
 
 async function snapshotRelationshipsDbToBackup() {
@@ -728,13 +742,55 @@ async function snapshotRelationshipsDbToBackup() {
   try { bytes = poolUtil.exportFile(RELATIONSHIPS_DB_SLOT); }
   catch (e) { return { backedUp: false, reason: 'export failed: ' + (e && e.message || e) }; }
   if (!bytes || !bytes.byteLength) return { backedUp: false, reason: 'empty file' };
+  return await _writeBackupBytesLockAware(bytes, 'snapshot');
+}
+
+// Common write-and-rotate logic shared by maybeBackupRelationshipsDb
+// (init/unlock-time, debounced) and snapshotRelationshipsDbToBackup
+// (pre-restore, forced). The lock-aware split is here so both call
+// sites pick up encryption automatically.
+//
+// Policy:
+//   - !lockEnabled                           → write plaintext .bak.<ISO>
+//   - lockEnabled && lockKey cached          → write .bak.<ISO>.locked
+//   - lockEnabled && lockKey NOT cached      → skip (can't encrypt and
+//                                                won't write plaintext;
+//                                                stale-unlocked state)
+async function _writeBackupBytesLockAware(plainBytes, opLabel) {
   var ts = new Date().toISOString().replace(/[:.]/g, '-');
-  var backupName = BACKUP_PREFIX + ts;
-  try { await _opfsWriteBinary(backupName, bytes); }
-  catch (e) { return { backedUp: false, reason: 'write failed: ' + (e && e.message || e) }; }
+  var plainName = BACKUP_PREFIX + ts;
+
+  if (lockEnabled) {
+    if (!lockKey) {
+      trace(opLabel + ': skipped (lock enabled, no cached key)');
+      return { backedUp: false, reason: 'lock-no-key' };
+    }
+    var envelope;
+    try {
+      envelope = await _lockBlobBytes(lockKey, plainBytes, lockSalt, lockIters);
+    } catch (e) {
+      trace(opLabel + ': encrypt failed: ' + ((e && e.message) || e));
+      return { backedUp: false, reason: 'encrypt failed' };
+    }
+    var lockedName = plainName + LOCKED_SUFFIX;
+    try { await _opfsWriteLockedFile(lockedName, envelope); }
+    catch (e) {
+      trace(opLabel + ': write failed: ' + ((e && e.message) || e));
+      return { backedUp: false, reason: 'write failed' };
+    }
+    await _rotateRelationshipsBackups();
+    trace(opLabel + ': wrote ' + lockedName + ' (encrypted, ' + envelope.byteLength + ' bytes)');
+    return { backedUp: true, name: lockedName, size: envelope.byteLength, encrypted: true };
+  }
+
+  try { await _opfsWriteBinary(plainName, plainBytes); }
+  catch (e) {
+    trace(opLabel + ': write failed: ' + ((e && e.message) || e));
+    return { backedUp: false, reason: 'write failed' };
+  }
   await _rotateRelationshipsBackups();
-  trace('snapshot: wrote ' + backupName + ' (' + bytes.byteLength + ' bytes)');
-  return { backedUp: true, name: backupName, size: bytes.byteLength };
+  trace(opLabel + ': wrote ' + plainName + ' (' + plainBytes.byteLength + ' bytes)');
+  return { backedUp: true, name: plainName, size: plainBytes.byteLength, encrypted: false };
 }
 
 // ===== fellows.db.meta.json (freshness sidecar) =============================
@@ -913,15 +969,16 @@ handlers.init = async function () {
   try { initialPoolFiles = poolUtil.getFileNames(); } catch (e) {}
   var plaintextInPool = initialPoolFiles.indexOf(RELATIONSHIPS_DB_SLOT) !== -1;
 
-  // Auto-backup: skip when locked (no key to encrypt with — Phase 3
-  // will lock-aware this) and also when stale-unlocked (a plaintext
-  // .bak.<ISO> would defeat the lock the user enabled). Leaves the
-  // backup chain untouched until lock() or disableLock() runs.
-  if (lockEnabled) {
-    trace('backup: skipped (lock enabled — Phase 3 will revisit)');
-  } else {
-    await maybeBackupRelationshipsDb();
-  }
+  // Auto-backup. maybeBackupRelationshipsDb itself is lock-aware (Phase 3):
+  //   - lock disabled                          → plaintext .bak.<ISO>
+  //   - lock enabled + cached key              → encrypted .bak.<ISO>.locked
+  //   - lock enabled + no cached key (init)    → skipped (no key yet);
+  //                                              the unlock RPC fires a
+  //                                              backup after caching the
+  //                                              key, so freshness is
+  //                                              preserved across the
+  //                                              locked/unlocked cycle.
+  await maybeBackupRelationshipsDb();
 
   var hasRelationshipsDb = false;
   if (lockEnabled && !plaintextInPool) {
@@ -1139,19 +1196,62 @@ handlers.listRelationshipsBackups = async function () {
   // Sequential — staging slot is shared across inspects.
   for (var i = 0; i < raw.length; i++) {
     var entry = raw[i];
+    var encrypted = !!entry.encrypted;
     try {
       var bytes = await _opfsReadBinary(entry.name);
+      // .locked: decrypt with cached lockKey if available, else mark
+      // encrypted-without-counts (Settings can still surface the entry
+      // — it just can't show row counts without unlocking first).
+      if (encrypted) {
+        if (!lockKey) {
+          out.push({
+            name: entry.name, size: entry.size, lastModified: entry.lastModified,
+            counts: null, encrypted: true,
+            invalid: false, error: null
+          });
+          continue;
+        }
+        var parsed;
+        try { parsed = _parseLockEnvelope(bytes); }
+        catch (pe) {
+          out.push({
+            name: entry.name, size: entry.size, lastModified: entry.lastModified,
+            counts: null, encrypted: true,
+            invalid: true, error: 'Corrupt lock envelope: ' + ((pe && pe.message) || pe)
+          });
+          continue;
+        }
+        var plainBuf;
+        try {
+          plainBuf = await crypto.subtle.decrypt(
+            { name: 'AES-GCM', iv: parsed.iv }, lockKey, parsed.ciphertext
+          );
+        } catch (de) {
+          // The cached key didn't decrypt this envelope — most likely a
+          // backup encrypted with a previous password that
+          // changePassphrase missed (shouldn't happen post-PR but defensive).
+          out.push({
+            name: entry.name, size: entry.size, lastModified: entry.lastModified,
+            counts: null, encrypted: true,
+            invalid: true, error: 'Could not decrypt with current password.'
+          });
+          continue;
+        }
+        bytes = new Uint8Array(plainBuf);
+      }
       var insp = await inspectBytes(bytes);
       out.push({
         name: entry.name, size: entry.size, lastModified: entry.lastModified,
         counts: insp.valid ? insp.counts : null,
+        encrypted: encrypted,
         invalid: !insp.valid,
         error: insp.valid ? null : insp.error
       });
     } catch (e) {
       out.push({
         name: entry.name, size: entry.size, lastModified: entry.lastModified,
-        counts: null, invalid: true, error: (e && e.message) || String(e)
+        counts: null, encrypted: encrypted,
+        invalid: true, error: (e && e.message) || String(e)
       });
     }
   }
@@ -1162,13 +1262,17 @@ handlers.restoreRelationshipsBackup = async function (args) {
   if (!poolUtil) throw new Error('pool util unavailable');
   _requireRelDb();
   var name = args && args.name;
-  // Phase 2: refuse .locked backups. Phase 3 will teach this handler to
-  // decrypt with the cached lockKey before importing.
-  if (name && name.length > LOCKED_SUFFIX.length &&
-      name.slice(-LOCKED_SUFFIX.length) === LOCKED_SUFFIX) {
+  var isLocked = name && name.length > LOCKED_SUFFIX.length &&
+                 name.slice(-LOCKED_SUFFIX.length) === LOCKED_SUFFIX;
+
+  // .locked restore needs the cached key. Stale-unlocked state (locked
+  // enabled, key not cached) gets LockStateError; page-side UI surfaces
+  // "unlock first to restore an encrypted backup."
+  if (isLocked && !lockKey) {
     throw _lockError('LockStateError',
-      'Restoring encrypted backups is not supported yet (Phase 3 follow-up).');
+      'Cannot restore an encrypted backup without an unlocked session. Unlock first.');
   }
+
   var backups = await listRelationshipsBackups();
   var match = null;
   for (var i = 0; i < backups.length; i++) {
@@ -1176,6 +1280,23 @@ handlers.restoreRelationshipsBackup = async function (args) {
   }
   if (!match) throw new Error('Backup not found: ' + name);
   var bytes = await _opfsReadBinary(name);
+
+  if (isLocked) {
+    var parsed;
+    try { parsed = _parseLockEnvelope(bytes); }
+    catch (pe) { throw _lockError('LockEnvelopeError', (pe && pe.message) || String(pe)); }
+    var plainBuf;
+    try {
+      plainBuf = await crypto.subtle.decrypt(
+        { name: 'AES-GCM', iv: parsed.iv }, lockKey, parsed.ciphertext
+      );
+    } catch (de) {
+      throw _lockError('LockEnvelopeError',
+        'Backup ' + name + ' could not be decrypted with the current password.');
+    }
+    bytes = new Uint8Array(plainBuf);
+  }
+
   return await handlers.importRelationshipsBytes({ bytes: bytes });
 };
 
@@ -1243,9 +1364,12 @@ handlers.enableLock = async function (args) {
     throw new Error('enableLock: live DB is empty');
   }
 
-  // Encrypt every plaintext backup before the live DB — oldest first
-  // (per the plan). Each envelope gets a fresh IV; salt/iters identical
-  // across all files written here.
+  // Encrypt EVERY plaintext backup before touching the live DB —
+  // oldest first. Even if a prior crash left >BACKUP_KEEP plaintext
+  // files lying around, we encrypt them all: the user's promise was
+  // "encrypt my data," not "encrypt some of my data." Rotation prunes
+  // afterwards. Each envelope gets a fresh IV; salt/iters are identical
+  // across all files so a single unlock derives one key for all.
   var backupSet = await _listAllRelationshipsBackups();
   var plaintextBackups = backupSet.plain;
   for (var i = 0; i < plaintextBackups.length; i++) {
@@ -1269,6 +1393,13 @@ handlers.enableLock = async function (args) {
   }
   try { poolUtil.unlink(RELATIONSHIPS_DB_SLOT); }
   catch (e) { trace('enableLock: poolUtil.unlink failed: ' + ((e && e.message) || e)); }
+
+  // Now prune to BACKUP_KEEP newest. Done AFTER encryption so we never
+  // delete a plaintext backup before its .locked sibling is committed
+  // — if rotation runs in the middle of encryption and the user is at
+  // >5 files, we'd lose data. Encrypt-everything-then-rotate keeps the
+  // invariant "encryption never loses a backup."
+  await _rotateRelationshipsBackups();
 
   // Per the plan, enableLock leaves the worker in the locked state.
   // The page reloads → unlock card → user re-enters the password they
@@ -1326,6 +1457,16 @@ handlers.unlock = async function (args) {
   lockSalt = parsed.salt;
   lockIters = parsed.iters;
   trace('unlock: success');
+
+  // Now that we have a key, run the same debounced auto-backup pass
+  // that init runs for unlocked-no-lock sessions. Without this, a
+  // locked-then-unlocked session would never get fresh backups —
+  // they'd freeze at whatever the user had when they enabled lock.
+  // Non-fatal: failures get logged via bootTrace and the unlock still
+  // succeeds.
+  try { await maybeBackupRelationshipsDb(); }
+  catch (e) { trace('unlock: post-unlock backup failed: ' + ((e && e.message) || e)); }
+
   return {
     ok: true,
     counts: {

--- a/app/static/vendor/sqlite-worker.js
+++ b/app/static/vendor/sqlite-worker.js
@@ -43,7 +43,12 @@ importScripts('./sqlite3.js');
 // arg and SHA-keyed refresh semantics. Page bumps its expected value in
 // lockstep; a stale page paired with this worker (or vice versa) refuses
 // mutations and waits for the SW's "New version available" reload banner.
-var WORKER_RPC_VERSION = 2;
+//
+// v3 (lock-my-user-data Phase 2): adds the lock-orchestration RPCs
+// (getLockState, enableLock, unlock, lock, changePassphrase, disableLock)
+// and structured error names (WrongPassphraseError, LockEnvelopeError,
+// LockStateError, DataLockedError) that the page UI routes on.
+var WORKER_RPC_VERSION = 3;
 
 // Same value as relationships.db's PRAGMA user_version. Bumped only on
 // schema migrations. Mirrored from app/relationships.py:SCHEMA_VERSION.
@@ -169,6 +174,16 @@ var FELLOWS_META_FILE = 'fellows.db.meta.json';
 
 var REQUIRED_RESTORE_TABLES = ['groups', 'group_members', 'fellow_tags', 'fellow_notes', 'settings'];
 
+// Lock-feature file names (OPFS root). See plans/lock_my_user_data.md.
+// The live DB's encrypted blob and each backup's .locked sibling all live
+// at OPFS root, not inside the SAH pool — the pool is for sqlite-wasm-
+// managed slots, and the .locked envelopes are plain files we read/write
+// directly via FileSystemFileHandle.
+var LOCKED_DB_NAME = 'relationships.db.locked';
+var LOCKED_SUFFIX = '.locked';
+var LOCKED_NEW_SUFFIX = '.locked.new';
+var TMP_SUFFIX = '.tmp';
+
 // ===== State ================================================================
 
 var sqlite3 = null;
@@ -182,6 +197,26 @@ var bootTrace = [];
 // stagingId that the page must echo back. Bytes live in the staging
 // slot, not in JS memory.
 var pendingFellowsDbSwap = null;
+
+// ===== Lock state ===========================================================
+//
+// Steady-state invariants:
+//   lockEnabled === true  iff  /relationships.db.locked exists on init
+//   relDb !== null         iff  /relationships.db plaintext is in SAH pool
+//   lockKey !== null       iff  caller proved they hold the passphrase
+//                               this session (via enableLock or unlock)
+//
+// Three observable states (see plans/lock_my_user_data.md):
+//   disabled         : lockEnabled=false, relDb open, lockKey=null
+//   enabled+locked   : lockEnabled=true,  relDb=null,  lockKey=null
+//   enabled+unlocked : lockEnabled=true,  relDb open,  lockKey=(non-null
+//                      this session, null after a reload that found both
+//                      plaintext and .locked on disk)
+
+var lockEnabled = false;
+var lockKey = null;
+var lockSalt = null;   // Uint8Array — needed by changePassphrase to verify old
+var lockIters = null;  // int        — same; mirrors envelope header field
 
 function trace(msg) { bootTrace.push(new Date().toISOString() + ' ' + String(msg)); }
 
@@ -354,6 +389,139 @@ async function _rotateRelationshipsBackups() {
       trace('backup: rotate removeEntry failed for ' + oldest.name);
     }
   }
+}
+
+// ===== Lock orchestration helpers ===========================================
+//
+// Used by enableLock / unlock / lock / changePassphrase / disableLock to
+// move bytes around OPFS root with crash-safe two-step writes.
+// See plans/lock_my_user_data.md § "Two-pass write for multi-file ops."
+
+async function _opfsRename(fromName, toName) {
+  var root = await _opfsRoot();
+  var fh = await root.getFileHandle(fromName);
+  if (typeof fh.move === 'function') {
+    await fh.move(toName);
+    return;
+  }
+  // Fallback for browsers without FileSystemFileHandle.move():
+  // copy bytes to the target name, then remove source. Not atomic, but
+  // init-time orphan cleanup of `.locked.new` covers the half-finished
+  // case on next boot.
+  var f = await fh.getFile();
+  var bytes = new Uint8Array(await f.arrayBuffer());
+  await _opfsWriteBinary(toName, bytes);
+  await root.removeEntry(fromName);
+}
+
+async function _opfsHasEntry(name) {
+  try {
+    var root = await _opfsRoot();
+    await root.getFileHandle(name);
+    return true;
+  } catch (e) { return false; }
+}
+
+// Write encrypted bytes to OPFS via the two-step .new-then-rename
+// pattern. Used by enableLock, lock, changePassphrase. Verifies the
+// bytes round-trip an envelope header parse before committing.
+async function _opfsWriteLockedFile(finalName, envelopeBytes) {
+  var newName = finalName + '.new';
+  await _opfsWriteBinary(newName, envelopeBytes);
+  // Sanity-check the file landed parseably before renaming over the
+  // previous .locked. We don't decrypt — just verify the envelope header
+  // makes sense, which catches truncated writes and bit-flips.
+  var readback = await _opfsReadBinary(newName);
+  _parseLockEnvelope(readback); // throws on corrupt
+  await _opfsRename(newName, finalName);
+}
+
+// Init-time cleanup: remove orphan .locked.new and .tmp files at OPFS
+// root. These can only exist when a prior operation was interrupted
+// between writing the .new file and renaming it — the old .locked is
+// still intact, so the orphan is always safe to delete.
+async function _cleanupLockOrphans() {
+  try {
+    var root = await _opfsRoot();
+    var orphans = [];
+    for await (var entry of root.values()) {
+      if (entry.kind !== 'file') continue;
+      var nm = entry.name;
+      if (nm.length > LOCKED_NEW_SUFFIX.length &&
+          nm.slice(-LOCKED_NEW_SUFFIX.length) === LOCKED_NEW_SUFFIX) {
+        orphans.push(nm);
+      } else if (nm.length > TMP_SUFFIX.length &&
+                 nm.slice(-TMP_SUFFIX.length) === TMP_SUFFIX) {
+        orphans.push(nm);
+      }
+    }
+    for (var i = 0; i < orphans.length; i++) {
+      try {
+        await root.removeEntry(orphans[i]);
+        trace('lock: cleaned orphan ' + orphans[i]);
+      } catch (e) {}
+    }
+  } catch (e) {}
+}
+
+// List backup files at OPFS root, split into plaintext and .locked
+// subsets. Both prefixes are `relationships.db.bak.<ISO>`; the .locked
+// variant has the LOCKED_SUFFIX appended. Excludes .new / .tmp orphans.
+async function _listAllRelationshipsBackups() {
+  var plain = [], locked = [];
+  try {
+    var root = await _opfsRoot();
+    for await (var entry of root.values()) {
+      if (entry.kind !== 'file') continue;
+      var nm = entry.name;
+      if (nm.indexOf(BACKUP_PREFIX) !== 0) continue;
+      // Skip orphans.
+      if (nm.length > LOCKED_NEW_SUFFIX.length &&
+          nm.slice(-LOCKED_NEW_SUFFIX.length) === LOCKED_NEW_SUFFIX) continue;
+      if (nm.length > TMP_SUFFIX.length &&
+          nm.slice(-TMP_SUFFIX.length) === TMP_SUFFIX) continue;
+      var f = await entry.getFile();
+      var info = { name: nm, size: f.size, lastModified: f.lastModified };
+      if (nm.length > LOCKED_SUFFIX.length &&
+          nm.slice(-LOCKED_SUFFIX.length) === LOCKED_SUFFIX) {
+        locked.push(info);
+      } else {
+        plain.push(info);
+      }
+    }
+    plain.sort(function (a, b) { return a.name < b.name ? -1 : a.name > b.name ? 1 : 0; });
+    locked.sort(function (a, b) { return a.name < b.name ? -1 : a.name > b.name ? 1 : 0; });
+  } catch (e) {}
+  return { plain: plain, locked: locked };
+}
+
+// Structured error factory — the dispatcher already forwards
+// `errorName` to the page in the {ok: false, errorName} response.
+function _lockError(name, message) {
+  var err = new Error(message);
+  err.name = name;
+  return err;
+}
+
+// Maps WebCrypto's atomic GCM auth-tag failure ('OperationError') to our
+// structured WrongPassphraseError; rethrows anything else. Use inside a
+// try/catch around `crypto.subtle.decrypt`.
+function _mapDecryptError(e, contextLabel) {
+  if (e && (e.name === 'OperationError' || /OperationError/.test(String(e)))) {
+    return _lockError('WrongPassphraseError', contextLabel || 'Wrong password.');
+  }
+  return e;
+}
+
+// Throws if the worker can't currently serve a relDb read. Distinguishes
+// the lock-enabled case (DataLockedError → page routes to unlock card)
+// from generic "relDb not open" (a real bug or pre-init call).
+function _requireRelDb() {
+  if (relDb) return;
+  if (lockEnabled) {
+    throw _lockError('DataLockedError', 'Data is locked — call unlock first.');
+  }
+  throw new Error('relationships db not open');
 }
 
 // ===== Lock crypto (envelope v1) ============================================
@@ -726,20 +894,53 @@ handlers.init = async function () {
   var sentinelRemoved = await _opfsRemoveEntry(LEGACY_SENTINEL);
   if (sentinelRemoved) trace('cleanup: removed legacy ' + LEGACY_SENTINEL);
 
-  // Auto-backup runs before opening relationships.db for app use, so the
-  // snapshot reflects the user's last-saved state, not anything mutated
-  // this session. Failure is non-fatal — logged via bootTrace.
-  await maybeBackupRelationshipsDb();
+  // Lock-orphan cleanup: any *.locked.new / *.tmp files at OPFS root
+  // are residue from a prior op that crashed between the .new write
+  // and the rename. Safe to delete unconditionally — the old .locked
+  // (if any) is still intact.
+  await _cleanupLockOrphans();
+
+  // Probe lock state. .locked file presence is the canonical signal —
+  // see plans/lock_my_user_data.md § OPFS layout.
+  lockEnabled = await _opfsHasEntry(LOCKED_DB_NAME);
+  if (lockEnabled) trace('lock: enabled (' + LOCKED_DB_NAME + ' present)');
+
+  // Detect the steady-state-unlocked vs. locked split before we touch
+  // the SAH pool. We're "locked" if .locked exists AND no plaintext is
+  // in the pool; "stale-unlocked" if both exist (previous session
+  // didn't call lock() before closing — see Q2-A in the plan).
+  var initialPoolFiles = [];
+  try { initialPoolFiles = poolUtil.getFileNames(); } catch (e) {}
+  var plaintextInPool = initialPoolFiles.indexOf(RELATIONSHIPS_DB_SLOT) !== -1;
+
+  // Auto-backup: skip when locked (no key to encrypt with — Phase 3
+  // will lock-aware this) and also when stale-unlocked (a plaintext
+  // .bak.<ISO> would defeat the lock the user enabled). Leaves the
+  // backup chain untouched until lock() or disableLock() runs.
+  if (lockEnabled) {
+    trace('backup: skipped (lock enabled — Phase 3 will revisit)');
+  } else {
+    await maybeBackupRelationshipsDb();
+  }
 
   var hasRelationshipsDb = false;
-  try {
-    relDb = new poolUtil.OpfsSAHPoolDb(RELATIONSHIPS_DB_SLOT);
-    bootstrapRelationshipsSchema(relDb);
-    hasRelationshipsDb = true;
-    trace('relationships.db: open + schema OK');
-  } catch (relErr) {
-    trace('relationships.db: open failed (' + (relErr && relErr.message || relErr) + ')');
+  if (lockEnabled && !plaintextInPool) {
+    // Locked: don't create an empty SAH-pool slot that would mask the
+    // .locked file. relDb stays null until unlock() imports decrypted
+    // bytes.
+    trace('relationships.db: locked, awaiting unlock RPC');
     relDb = null;
+  } else {
+    try {
+      relDb = new poolUtil.OpfsSAHPoolDb(RELATIONSHIPS_DB_SLOT);
+      bootstrapRelationshipsSchema(relDb);
+      hasRelationshipsDb = true;
+      trace('relationships.db: open + schema OK' +
+            (lockEnabled ? ' (stale-unlocked — key not cached)' : ''));
+    } catch (relErr) {
+      trace('relationships.db: open failed (' + (relErr && relErr.message || relErr) + ')');
+      relDb = null;
+    }
   }
 
   // Open fellows.db if it's already on disk. Cold-start fetch is the
@@ -757,6 +958,10 @@ handlers.init = async function () {
     relDbOpen: hasRelationshipsDb,
     hasFellowsDb: hasFellowsDb,
     poolFiles: (function () { try { return poolUtil.getFileNames(); } catch (e) { return []; } })(),
+    // Lock state surfaced in the handshake so the page can route the
+    // boot flow into the unlock card before calling any relDb ops.
+    lockEnabled: lockEnabled,
+    lockLocked: lockEnabled && relDb === null,
     trace: bootTrace.slice()
   };
 };
@@ -764,7 +969,7 @@ handlers.init = async function () {
 // ----- Relationships (groups + settings) ------------------------------------
 
 handlers.listGroups = async function () {
-  if (!relDb) throw new Error('relationships db not open');
+  _requireRelDb();
   return dbSelectAll(
     relDb,
     'SELECT g.id, g.name, g.note, g.created_at, g.updated_at, ' +
@@ -776,7 +981,7 @@ handlers.listGroups = async function () {
 };
 
 handlers.getGroup = async function (args) {
-  if (!relDb) throw new Error('relationships db not open');
+  _requireRelDb();
   var id = args && args.id;
   var row = dbSelectOne(relDb, 'SELECT * FROM groups WHERE id = ?', [id]);
   if (!row) return null;
@@ -790,7 +995,7 @@ handlers.getGroup = async function (args) {
 };
 
 handlers.createGroup = async function (data) {
-  if (!relDb) throw new Error('relationships db not open');
+  _requireRelDb();
   var name = data && data.name;
   var note = (data && typeof data.note === 'string') ? data.note : '';
   var ids = dedupeRecordIds(data && data.fellow_record_ids);
@@ -813,7 +1018,7 @@ handlers.createGroup = async function (data) {
 };
 
 handlers.updateGroup = async function (args) {
-  if (!relDb) throw new Error('relationships db not open');
+  _requireRelDb();
   var id = args && args.id;
   var patch = (args && args.patch) || {};
   var existing = dbSelectOne(relDb, 'SELECT 1 AS x FROM groups WHERE id = ?', [id]);
@@ -842,7 +1047,7 @@ handlers.updateGroup = async function (args) {
 };
 
 handlers.deleteGroup = async function (args) {
-  if (!relDb) throw new Error('relationships db not open');
+  _requireRelDb();
   var id = args && args.id;
   var existing = dbSelectOne(relDb, 'SELECT 1 AS x FROM groups WHERE id = ?', [id]);
   if (!existing) return false;
@@ -865,7 +1070,7 @@ handlers.getSettings = async function () {
 };
 
 handlers.setSetting = async function (args) {
-  if (!relDb) throw new Error('relationships db not open');
+  _requireRelDb();
   var key = args && args.key;
   var value = args && args.value;
   if (value === null || value === undefined || value === '') {
@@ -884,6 +1089,7 @@ handlers.setSetting = async function (args) {
 
 handlers.exportRelationshipsBytes = async function () {
   if (!poolUtil) throw new Error('pool util unavailable');
+  _requireRelDb();
   return poolUtil.exportFile(RELATIONSHIPS_DB_SLOT);
 };
 
@@ -904,6 +1110,7 @@ handlers.countRelationships = async function () {
 
 handlers.importRelationshipsBytes = async function (args) {
   if (!poolUtil) throw new Error('pool util unavailable');
+  _requireRelDb();
   var bytes = args && args.bytes;
   var inspection = await inspectBytes(bytes);
   if (!inspection.valid) {
@@ -953,7 +1160,15 @@ handlers.listRelationshipsBackups = async function () {
 
 handlers.restoreRelationshipsBackup = async function (args) {
   if (!poolUtil) throw new Error('pool util unavailable');
+  _requireRelDb();
   var name = args && args.name;
+  // Phase 2: refuse .locked backups. Phase 3 will teach this handler to
+  // decrypt with the cached lockKey before importing.
+  if (name && name.length > LOCKED_SUFFIX.length &&
+      name.slice(-LOCKED_SUFFIX.length) === LOCKED_SUFFIX) {
+    throw _lockError('LockStateError',
+      'Restoring encrypted backups is not supported yet (Phase 3 follow-up).');
+  }
   var backups = await listRelationshipsBackups();
   var match = null;
   for (var i = 0; i < backups.length; i++) {
@@ -962,6 +1177,375 @@ handlers.restoreRelationshipsBackup = async function (args) {
   if (!match) throw new Error('Backup not found: ' + name);
   var bytes = await _opfsReadBinary(name);
   return await handlers.importRelationshipsBytes({ bytes: bytes });
+};
+
+// ----- Lock orchestration ---------------------------------------------------
+//
+// See plans/lock_my_user_data.md. State machine:
+//
+//   disabled              ──enableLock──>  enabled+locked
+//   enabled+locked        ──unlock──────>  enabled+unlocked  (cached key)
+//   enabled+unlocked      ──lock────────>  enabled+locked
+//   enabled+unlocked      ──changePass──>  enabled+unlocked  (new cached key)
+//   enabled+unlocked      ──disableLock──> disabled
+//
+// All RPCs in this section gate on `lockEnabled` to refuse no-op
+// transitions (e.g. unlock when not enabled) with LockStateError.
+// Wrong-passphrase failures (WebCrypto OperationError) get rewrapped as
+// WrongPassphraseError so the page can route on the structured name.
+
+handlers.getLockState = async function () {
+  var out = {
+    enabled: lockEnabled,
+    locked: lockEnabled && relDb === null,
+    hasKey: lockKey !== null,
+    formatVersion: null,
+    kdfId: null,
+    iters: null
+  };
+  if (!lockEnabled) return out;
+  // Read the v1 header without decrypting (magic + version + kdf id +
+  // iters is plaintext). Surfaces envelope corruption so the page can
+  // offer Reset Everything.
+  try {
+    var bytes = await _opfsReadBinary(LOCKED_DB_NAME);
+    var hdr = _parseLockEnvelope(bytes);
+    out.formatVersion = hdr.version;
+    out.kdfId = hdr.kdfId;
+    out.iters = hdr.iters;
+  } catch (e) {
+    out.envelopeError = (e && e.message) || String(e);
+  }
+  return out;
+};
+
+handlers.enableLock = async function (args) {
+  if (lockEnabled) {
+    throw _lockError('LockStateError', 'Lock is already enabled.');
+  }
+  var passphrase = args && args.passphrase;
+  if (!passphrase || typeof passphrase !== 'string') {
+    throw _lockError('LockStateError', 'enableLock requires a passphrase.');
+  }
+  if (!poolUtil) throw new Error('pool util unavailable');
+
+  // One salt + iter count for every file written by this op — a future
+  // unlock derives one key that decrypts all of them.
+  var salt = _lockRandomBytes(LOCK_SALT_LEN);
+  var iters = LOCK_KDF_ITERS_V1;
+  var key = await _deriveLockKey(passphrase, salt, iters);
+
+  // Snapshot live plaintext from the SAH pool.
+  var livePlain;
+  try { livePlain = poolUtil.exportFile(RELATIONSHIPS_DB_SLOT); }
+  catch (e) { throw new Error('enableLock: exportFile failed: ' + ((e && e.message) || e)); }
+  if (!livePlain || !livePlain.byteLength) {
+    throw new Error('enableLock: live DB is empty');
+  }
+
+  // Encrypt every plaintext backup before the live DB — oldest first
+  // (per the plan). Each envelope gets a fresh IV; salt/iters identical
+  // across all files written here.
+  var backupSet = await _listAllRelationshipsBackups();
+  var plaintextBackups = backupSet.plain;
+  for (var i = 0; i < plaintextBackups.length; i++) {
+    var bk = plaintextBackups[i];
+    var bkBytes = await _opfsReadBinary(bk.name);
+    var bkEnvelope = await _lockBlobBytes(key, bkBytes, salt, iters);
+    await _opfsWriteLockedFile(bk.name + LOCKED_SUFFIX, bkEnvelope);
+    try { await (await _opfsRoot()).removeEntry(bk.name); }
+    catch (e) { trace('enableLock: removeEntry failed for ' + bk.name + ': ' + ((e && e.message) || e)); }
+    trace('enableLock: encrypted ' + bk.name);
+  }
+
+  // Live DB: write .locked first, then close handle and unlink the
+  // SAH-pool slot. If the unlink fails the state is still consistent —
+  // next init sees both files and treats it as stale-unlocked.
+  var liveEnvelope = await _lockBlobBytes(key, livePlain, salt, iters);
+  await _opfsWriteLockedFile(LOCKED_DB_NAME, liveEnvelope);
+  if (relDb) {
+    try { relDb.close(); } catch (e) {}
+    relDb = null;
+  }
+  try { poolUtil.unlink(RELATIONSHIPS_DB_SLOT); }
+  catch (e) { trace('enableLock: poolUtil.unlink failed: ' + ((e && e.message) || e)); }
+
+  // Per the plan, enableLock leaves the worker in the locked state.
+  // The page reloads → unlock card → user re-enters the password they
+  // just typed in the set-up modal. (Self-teaching steady-state demo.)
+  lockEnabled = true;
+  lockKey = null;
+  lockSalt = null;
+  lockIters = null;
+  trace('enableLock: complete');
+  return { ok: true, encryptedBackups: plaintextBackups.length };
+};
+
+handlers.unlock = async function (args) {
+  if (!lockEnabled) {
+    throw _lockError('LockStateError', 'unlock called but lock is not enabled.');
+  }
+  var passphrase = args && args.passphrase;
+  if (!passphrase || typeof passphrase !== 'string') {
+    throw _lockError('LockStateError', 'unlock requires a passphrase.');
+  }
+  if (!poolUtil) throw new Error('pool util unavailable');
+
+  var envelope;
+  try { envelope = await _opfsReadBinary(LOCKED_DB_NAME); }
+  catch (e) { throw _lockError('LockEnvelopeError', 'Could not read .locked file: ' + ((e && e.message) || e)); }
+  var parsed;
+  try { parsed = _parseLockEnvelope(envelope); }
+  catch (e) { throw _lockError('LockEnvelopeError', (e && e.message) || String(e)); }
+
+  var key = await _deriveLockKey(passphrase, parsed.salt, parsed.iters);
+  var plainBuf;
+  try {
+    plainBuf = await crypto.subtle.decrypt(
+      { name: 'AES-GCM', iv: parsed.iv }, key, parsed.ciphertext
+    );
+  } catch (e) {
+    throw _mapDecryptError(e, 'Wrong password.');
+  }
+  var plainBytes = new Uint8Array(plainBuf);
+
+  // If plaintext isn't already in the SAH pool (true `locked` state),
+  // import the just-decrypted bytes. In the stale-unlocked path the
+  // pool slot already exists — we just cache the key and leave it.
+  var poolFiles = [];
+  try { poolFiles = poolUtil.getFileNames(); } catch (e) {}
+  if (poolFiles.indexOf(RELATIONSHIPS_DB_SLOT) === -1) {
+    poolUtil.importDb(RELATIONSHIPS_DB_SLOT, plainBytes);
+  }
+  if (!relDb) {
+    relDb = new poolUtil.OpfsSAHPoolDb(RELATIONSHIPS_DB_SLOT);
+    bootstrapRelationshipsSchema(relDb);
+  }
+
+  lockKey = key;
+  lockSalt = parsed.salt;
+  lockIters = parsed.iters;
+  trace('unlock: success');
+  return {
+    ok: true,
+    counts: {
+      groups: dbSelectOne(relDb, 'SELECT COUNT(*) AS n FROM groups', null).n,
+      members: dbSelectOne(relDb, 'SELECT COUNT(*) AS n FROM group_members', null).n,
+      tags: dbSelectOne(relDb, 'SELECT COUNT(*) AS n FROM fellow_tags', null).n,
+      notes: dbSelectOne(relDb, 'SELECT COUNT(*) AS n FROM fellow_notes', null).n,
+      settings: dbSelectOne(relDb, 'SELECT COUNT(*) AS n FROM settings', null).n
+    }
+  };
+};
+
+handlers.lock = async function () {
+  if (!lockEnabled) {
+    throw _lockError('LockStateError', 'lock called but lock is not enabled.');
+  }
+  if (!lockKey) {
+    // Stale-unlocked: cached key is missing (reload after an unlocked
+    // session that never called lock()). Page-side UI prompts for the
+    // passphrase and calls unlock() first to cache the key, then lock().
+    throw _lockError('LockStateError',
+      'Cannot lock — no cached key. Unlock first, then lock.');
+  }
+  if (!relDb) {
+    throw _lockError('LockStateError', 'lock called but relDb is not open.');
+  }
+  if (!poolUtil) throw new Error('pool util unavailable');
+
+  var livePlain = poolUtil.exportFile(RELATIONSHIPS_DB_SLOT);
+  var envelope = await _lockBlobBytes(lockKey, livePlain, lockSalt, lockIters);
+  await _opfsWriteLockedFile(LOCKED_DB_NAME, envelope);
+
+  try { relDb.close(); } catch (e) {}
+  relDb = null;
+  try { poolUtil.unlink(RELATIONSHIPS_DB_SLOT); }
+  catch (e) { trace('lock: poolUtil.unlink failed: ' + ((e && e.message) || e)); }
+
+  lockKey = null;
+  lockSalt = null;
+  lockIters = null;
+  trace('lock: complete');
+  return { ok: true };
+};
+
+handlers.changePassphrase = async function (args) {
+  if (!lockEnabled) {
+    throw _lockError('LockStateError', 'changePassphrase called but lock is not enabled.');
+  }
+  var oldPass = args && args.oldPassphrase;
+  var newPass = args && args.newPassphrase;
+  if (!oldPass || typeof oldPass !== 'string' ||
+      !newPass || typeof newPass !== 'string') {
+    throw _lockError('LockStateError',
+      'changePassphrase requires oldPassphrase and newPassphrase.');
+  }
+
+  // Verify oldPass via the live .locked, regardless of whether we have
+  // a cached key — the explicit confirmation is the point.
+  var liveEnvelope = await _opfsReadBinary(LOCKED_DB_NAME);
+  var liveParsed;
+  try { liveParsed = _parseLockEnvelope(liveEnvelope); }
+  catch (e) { throw _lockError('LockEnvelopeError', (e && e.message) || String(e)); }
+  var oldKey = await _deriveLockKey(oldPass, liveParsed.salt, liveParsed.iters);
+  var livePlain;
+  try {
+    livePlain = new Uint8Array(await crypto.subtle.decrypt(
+      { name: 'AES-GCM', iv: liveParsed.iv }, oldKey, liveParsed.ciphertext
+    ));
+  } catch (e) {
+    throw _mapDecryptError(e, 'Wrong current password.');
+  }
+
+  // Decrypt every .locked backup with the old key.
+  var backupSet = await _listAllRelationshipsBackups();
+  var lockedBackups = backupSet.locked;
+  var backupPlaintexts = [];
+  for (var i = 0; i < lockedBackups.length; i++) {
+    var lb = lockedBackups[i];
+    var lbBytes = await _opfsReadBinary(lb.name);
+    var lbParsed;
+    try { lbParsed = _parseLockEnvelope(lbBytes); }
+    catch (pe) {
+      throw _lockError('LockEnvelopeError',
+        'Backup ' + lb.name + ' has a corrupt envelope: ' + ((pe && pe.message) || pe));
+    }
+    var lbPlain;
+    try {
+      lbPlain = new Uint8Array(await crypto.subtle.decrypt(
+        { name: 'AES-GCM', iv: lbParsed.iv }, oldKey, lbParsed.ciphertext
+      ));
+    } catch (e2) {
+      throw _lockError('LockEnvelopeError',
+        'Backup ' + lb.name + ' could not be decrypted with the current password.');
+    }
+    backupPlaintexts.push({ name: lb.name, plain: lbPlain });
+  }
+
+  // Derive new key with a fresh salt + same iter count.
+  var newSalt = _lockRandomBytes(LOCK_SALT_LEN);
+  var newIters = LOCK_KDF_ITERS_V1;
+  var newKey = await _deriveLockKey(newPass, newSalt, newIters);
+
+  // Two-pass write: every new envelope lands at *.locked.new before
+  // any rename. A crash before the rename phase leaves old .locked
+  // files intact + .locked.new orphans that init cleans up. A crash
+  // mid-rename leaves mixed keys — known v1 limitation (Q1-A in plan).
+  var newLiveEnvelope = await _lockBlobBytes(newKey, livePlain, newSalt, newIters);
+  await _opfsWriteBinary(LOCKED_DB_NAME + '.new', newLiveEnvelope);
+  _parseLockEnvelope(await _opfsReadBinary(LOCKED_DB_NAME + '.new'));
+
+  var pendingRenames = [];
+  for (var j = 0; j < backupPlaintexts.length; j++) {
+    var bp = backupPlaintexts[j];
+    var env = await _lockBlobBytes(newKey, bp.plain, newSalt, newIters);
+    var newName = bp.name + '.new';
+    await _opfsWriteBinary(newName, env);
+    _parseLockEnvelope(await _opfsReadBinary(newName));
+    pendingRenames.push({ from: newName, to: bp.name });
+  }
+
+  // Rename phase.
+  await _opfsRename(LOCKED_DB_NAME + '.new', LOCKED_DB_NAME);
+  for (var k = 0; k < pendingRenames.length; k++) {
+    await _opfsRename(pendingRenames[k].from, pendingRenames[k].to);
+  }
+
+  lockKey = newKey;
+  lockSalt = newSalt;
+  lockIters = newIters;
+  trace('changePassphrase: complete (' + (1 + pendingRenames.length) + ' files re-keyed)');
+  return { ok: true, rekeyedCount: 1 + pendingRenames.length };
+};
+
+handlers.disableLock = async function (args) {
+  if (!lockEnabled) {
+    throw _lockError('LockStateError', 'disableLock called but lock is not enabled.');
+  }
+  var passphrase = args && args.passphrase;
+  if (!passphrase || typeof passphrase !== 'string') {
+    throw _lockError('LockStateError', 'disableLock requires a passphrase.');
+  }
+  if (!poolUtil) throw new Error('pool util unavailable');
+
+  // Verify passphrase against live .locked (gives us plaintext bytes
+  // for free, useful when relDb is currently null).
+  var liveEnvelope = await _opfsReadBinary(LOCKED_DB_NAME);
+  var liveParsed;
+  try { liveParsed = _parseLockEnvelope(liveEnvelope); }
+  catch (e) { throw _lockError('LockEnvelopeError', (e && e.message) || String(e)); }
+  var key = await _deriveLockKey(passphrase, liveParsed.salt, liveParsed.iters);
+  var livePlain;
+  try {
+    livePlain = new Uint8Array(await crypto.subtle.decrypt(
+      { name: 'AES-GCM', iv: liveParsed.iv }, key, liveParsed.ciphertext
+    ));
+  } catch (e) {
+    throw _mapDecryptError(e, 'Wrong password.');
+  }
+
+  // Decrypt every .locked backup.
+  var backupSet = await _listAllRelationshipsBackups();
+  var lockedBackups = backupSet.locked;
+  var decryptedBackups = [];
+  for (var i = 0; i < lockedBackups.length; i++) {
+    var lb = lockedBackups[i];
+    var lbBytes = await _opfsReadBinary(lb.name);
+    var lbParsed;
+    try { lbParsed = _parseLockEnvelope(lbBytes); }
+    catch (pe) {
+      throw _lockError('LockEnvelopeError',
+        'Backup ' + lb.name + ' has a corrupt envelope: ' + ((pe && pe.message) || pe));
+    }
+    var lbPlain;
+    try {
+      lbPlain = new Uint8Array(await crypto.subtle.decrypt(
+        { name: 'AES-GCM', iv: lbParsed.iv }, key, lbParsed.ciphertext
+      ));
+    } catch (e2) {
+      throw _lockError('LockEnvelopeError',
+        'Backup ' + lb.name + ' could not be decrypted.');
+    }
+    decryptedBackups.push({
+      lockedName: lb.name,
+      plainName: lb.name.slice(0, -LOCKED_SUFFIX.length),
+      plain: lbPlain
+    });
+  }
+
+  // Two-pass: write all plaintext .tmp targets first.
+  for (var j = 0; j < decryptedBackups.length; j++) {
+    var bp = decryptedBackups[j];
+    await _opfsWriteBinary(bp.plainName + TMP_SUFFIX, bp.plain);
+  }
+  // Rename phase + cleanup of .locked sources.
+  var root = await _opfsRoot();
+  for (var m = 0; m < decryptedBackups.length; m++) {
+    var bp2 = decryptedBackups[m];
+    await _opfsRename(bp2.plainName + TMP_SUFFIX, bp2.plainName);
+    try { await root.removeEntry(bp2.lockedName); } catch (e3) {}
+  }
+
+  // Live DB: import the freshly-decrypted plaintext if not already in
+  // the SAH pool, then remove the live .locked file.
+  var poolFiles = [];
+  try { poolFiles = poolUtil.getFileNames(); } catch (e) {}
+  if (poolFiles.indexOf(RELATIONSHIPS_DB_SLOT) === -1) {
+    poolUtil.importDb(RELATIONSHIPS_DB_SLOT, livePlain);
+  }
+  if (!relDb) {
+    relDb = new poolUtil.OpfsSAHPoolDb(RELATIONSHIPS_DB_SLOT);
+    bootstrapRelationshipsSchema(relDb);
+  }
+  try { await root.removeEntry(LOCKED_DB_NAME); } catch (e) {}
+
+  lockEnabled = false;
+  lockKey = null;
+  lockSalt = null;
+  lockIters = null;
+  trace('disableLock: complete (' + decryptedBackups.length + ' backups decrypted)');
+  return { ok: true, decryptedBackups: decryptedBackups.length };
 };
 
 // ----- fellows.db query handlers (sole local read source post-cutover) ------

--- a/app/static/vendor/sqlite-worker.js
+++ b/app/static/vendor/sqlite-worker.js
@@ -356,6 +356,154 @@ async function _rotateRelationshipsBackups() {
   }
 }
 
+// ===== Lock crypto (envelope v1) ============================================
+//
+// Opt-in encryption-at-rest for relationships.db + its OPFS backups.
+// See plans/lock_my_user_data.md.
+//
+// Phase 1: pure crypto primitives — no OPFS reads/writes, no RPCs that
+// touch live state. The OPFS-orchestration RPCs (enableLock, unlock,
+// lock, changePassphrase, disableLock) and the lock-in-progress recovery
+// land in Phase 2 and rely on the round-trip behavior of these helpers.
+//
+// Envelope layout:
+//
+//   Offset    Length    Field
+//   0         8         Magic: "EHFLOCK\0"
+//   8         1         Format version (= 1)
+//   9         1         KDF id          (= 1 → PBKDF2-SHA256)
+//   10        4         KDF iterations  (uint32 big-endian, = 600000 for v1)
+//   14        2         Salt length     (uint16 big-endian, = 16 for v1)
+//   16        <Slen>    Salt
+//   16+Slen   12        AES-GCM IV (96-bit nonce)
+//   28+Slen   <rest>    AES-GCM ciphertext (plaintext + 16-byte auth tag)
+//
+// WebCrypto appends the 128-bit GCM auth tag to the ciphertext, so a
+// wrong password fails decrypt atomically with OperationError. No
+// separate verifier blob is needed.
+//
+// Header is fixed-shape so envelope v2 (e.g. Argon2id once vendored) can
+// land without breaking v1 readers: bump LOCK_FORMAT_VERSION, branch on
+// the KDF id field, leave v1 unchanged.
+
+var LOCK_MAGIC = new Uint8Array([0x45, 0x48, 0x46, 0x4c, 0x4f, 0x43, 0x4b, 0x00]); // "EHFLOCK\0"
+var LOCK_FORMAT_VERSION = 1;
+var LOCK_KDF_PBKDF2_SHA256 = 1;
+var LOCK_KDF_ITERS_V1 = 600000;
+var LOCK_SALT_LEN = 16;
+var LOCK_IV_LEN = 12;
+var LOCK_HEADER_BASE_LEN = 8 + 1 + 1 + 4 + 2; // magic + version + kdf + iters + saltLen
+
+function _lockRandomBytes(n) {
+  var b = new Uint8Array(n);
+  crypto.getRandomValues(b);
+  return b;
+}
+
+// Derive a non-extractable AES-GCM key from the passphrase. The key
+// itself never leaves WebCrypto; callers hold an opaque CryptoKey
+// handle. PBKDF2-SHA256 is in WebCrypto natively — no vendored dep.
+async function _deriveLockKey(passphrase, salt, iters) {
+  var passBytes = new TextEncoder().encode(passphrase);
+  var baseKey = await crypto.subtle.importKey(
+    'raw', passBytes, { name: 'PBKDF2' }, false, ['deriveKey']
+  );
+  return await crypto.subtle.deriveKey(
+    { name: 'PBKDF2', salt: salt, iterations: iters, hash: 'SHA-256' },
+    baseKey,
+    { name: 'AES-GCM', length: 256 },
+    false,
+    ['encrypt', 'decrypt']
+  );
+}
+
+// Pack a v1 envelope from an already-derived key + plaintext. Returns
+// Uint8Array. The salt + iters are stored in the header so
+// unlockBlobWithPassphrase can rederive without external state.
+async function _lockBlobBytes(key, plainBytes, salt, iters) {
+  var iv = _lockRandomBytes(LOCK_IV_LEN);
+  var ctBuf = await crypto.subtle.encrypt(
+    { name: 'AES-GCM', iv: iv }, key, plainBytes
+  );
+  var ct = new Uint8Array(ctBuf);
+  var headerLen = LOCK_HEADER_BASE_LEN + salt.length + LOCK_IV_LEN;
+  var out = new Uint8Array(headerLen + ct.length);
+  var dv = new DataView(out.buffer);
+  out.set(LOCK_MAGIC, 0);
+  dv.setUint8(8, LOCK_FORMAT_VERSION);
+  dv.setUint8(9, LOCK_KDF_PBKDF2_SHA256);
+  dv.setUint32(10, iters >>> 0, false); // big-endian
+  dv.setUint16(14, salt.length, false);
+  out.set(salt, 16);
+  out.set(iv, 16 + salt.length);
+  out.set(ct, headerLen);
+  return out;
+}
+
+// Parse a v1 envelope without decrypting. Returns the header fields +
+// ciphertext slice. Throws on malformed input — DOES NOT throw on a
+// wrong-passphrase ciphertext (the auth-tag check happens during
+// decrypt). Callers should treat a parse error as "this is not a lock
+// envelope" and a decrypt OperationError as "wrong passphrase."
+function _parseLockEnvelope(bytes) {
+  if (!bytes || bytes.byteLength < LOCK_HEADER_BASE_LEN + LOCK_IV_LEN) {
+    throw new Error('Lock envelope too short.');
+  }
+  for (var i = 0; i < LOCK_MAGIC.length; i++) {
+    if (bytes[i] !== LOCK_MAGIC[i]) throw new Error('Not a lock envelope.');
+  }
+  var dv = new DataView(bytes.buffer, bytes.byteOffset, bytes.byteLength);
+  var version = dv.getUint8(8);
+  if (version !== LOCK_FORMAT_VERSION) {
+    throw new Error('Unsupported lock format version: ' + version);
+  }
+  var kdfId = dv.getUint8(9);
+  if (kdfId !== LOCK_KDF_PBKDF2_SHA256) {
+    throw new Error('Unsupported KDF id: ' + kdfId);
+  }
+  var iters = dv.getUint32(10, false);
+  var saltLen = dv.getUint16(14, false);
+  if (saltLen === 0 || saltLen > 256) {
+    throw new Error('Invalid salt length: ' + saltLen);
+  }
+  var fixedHeader = LOCK_HEADER_BASE_LEN + saltLen + LOCK_IV_LEN;
+  if (bytes.byteLength < fixedHeader) {
+    throw new Error('Lock envelope truncated header.');
+  }
+  return {
+    version: version,
+    kdfId: kdfId,
+    iters: iters,
+    salt: bytes.slice(16, 16 + saltLen),
+    iv: bytes.slice(16 + saltLen, 16 + saltLen + LOCK_IV_LEN),
+    ciphertext: bytes.slice(fixedHeader)
+  };
+}
+
+// Encrypt plainBytes with passphrase. Fresh random salt + iv per call,
+// so encrypting the same plaintext twice yields different envelopes.
+async function lockBlobWithPassphrase(passphrase, plainBytes) {
+  var salt = _lockRandomBytes(LOCK_SALT_LEN);
+  var iters = LOCK_KDF_ITERS_V1;
+  var key = await _deriveLockKey(passphrase, salt, iters);
+  return await _lockBlobBytes(key, plainBytes, salt, iters);
+}
+
+// Decrypt a v1 envelope with passphrase. Returns Uint8Array on success.
+// Throws:
+//   - Error("Not a lock envelope.") / similar — malformed input.
+//   - OperationError (name === 'OperationError') — wrong passphrase or
+//     ciphertext corruption. WebCrypto's GCM auth-tag check is the
+//     verifier; no per-envelope password hash is needed.
+async function unlockBlobWithPassphrase(passphrase, envelope) {
+  var parsed = _parseLockEnvelope(envelope);
+  var key = await _deriveLockKey(passphrase, parsed.salt, parsed.iters);
+  var plainBuf = await crypto.subtle.decrypt(
+    { name: 'AES-GCM', iv: parsed.iv }, key, parsed.ciphertext
+  );
+  return new Uint8Array(plainBuf);
+}
+
 // ===== Auto-backup (debounced per-boot) =====================================
 
 // Per Phase 0 Q-C: trigger flips from "build-SHA differs" to "newest
@@ -1499,6 +1647,77 @@ handlers.getOpfsInventory = async function () {
   var poolFiles = [];
   try { poolFiles = poolUtil.getFileNames(); } catch (e2) {}
   return { root: rootEntries, poolFiles: poolFiles };
+};
+
+// ----- Lock crypto self-test -----------------------------------------------
+//
+// Round-trip smoke test for the lock-envelope primitives. Doesn't touch
+// OPFS, doesn't mutate any worker state. Stays in the worker as a
+// permanent cheap sanity check — the OPFS-orchestration RPCs (Phase 2+)
+// rely on this behavior being correct, and an e2e test that drives this
+// RPC catches WebCrypto / envelope-format regressions in isolation.
+//
+// Reached from a test via window.__dataProvider._rpc.call('__lockSelfTest').
+
+handlers.__lockSelfTest = async function () {
+  var plain = new TextEncoder().encode(
+    'lock-self-test: ' + new Date().toISOString()
+  );
+  var pass = 'correct horse battery staple';
+  var wrong = 'wrong horse battery staple';
+
+  var envelope = await lockBlobWithPassphrase(pass, plain);
+
+  // Envelope must start with the magic.
+  for (var i = 0; i < LOCK_MAGIC.length; i++) {
+    if (envelope[i] !== LOCK_MAGIC[i]) {
+      return { ok: false, error: 'envelope missing EHFLOCK magic at byte ' + i };
+    }
+  }
+
+  // Right passphrase round-trips to identical bytes.
+  var dec = await unlockBlobWithPassphrase(pass, envelope);
+  if (dec.length !== plain.length) {
+    return { ok: false, error: 'round-trip length mismatch: ' + dec.length + ' vs ' + plain.length };
+  }
+  for (var j = 0; j < plain.length; j++) {
+    if (dec[j] !== plain[j]) {
+      return { ok: false, error: 'round-trip byte mismatch at ' + j };
+    }
+  }
+
+  // Wrong passphrase MUST fail atomically (auth-tag check). WebCrypto
+  // surfaces this as a DOMException with name === 'OperationError'.
+  var wrongErrName = null;
+  try {
+    await unlockBlobWithPassphrase(wrong, envelope);
+    return { ok: false, error: 'wrong passphrase did not throw' };
+  } catch (e) {
+    wrongErrName = (e && e.name) || (e && e.message) || String(e);
+  }
+
+  // Header readback exposes the v1 parameters so tests can assert them
+  // without re-parsing the envelope themselves.
+  var parsed;
+  try { parsed = _parseLockEnvelope(envelope); }
+  catch (pe) {
+    return { ok: false, error: 'envelope re-parse failed: ' + ((pe && pe.message) || pe) };
+  }
+
+  return {
+    ok: true,
+    envelopeLen: envelope.length,
+    plainLen: plain.length,
+    wrongPassphraseErrorName: wrongErrName,
+    header: {
+      formatVersion: parsed.version,
+      kdfId: parsed.kdfId,
+      iters: parsed.iters,
+      saltLen: parsed.salt.length,
+      ivLen: parsed.iv.length,
+      ciphertextLen: parsed.ciphertext.length
+    }
+  };
 };
 
 // ===== Dispatcher ===========================================================

--- a/plans/lock_my_user_data.md
+++ b/plans/lock_my_user_data.md
@@ -107,29 +107,64 @@ separate "verifier" blob — the GCM tag is the verifier.
 This avoids a separate "lock enabled" sentinel that could disagree with
 the actual file state.
 
-## Lock-in-progress recovery
+## Lock-in-progress recovery and crash safety
 
-A naïve lock sequence (`encrypt all → delete all plaintext`) can leave
-half-encrypted state on crash. Order matters because a backup ciphertext
-must replace its plaintext atomically before we delete the source.
+### State observability vs. transition crash (Q2-A)
 
-**Lock sequence (worker):**
-1. For each `relationships.db.bak.<ISO>` (oldest first):
-   - Read plaintext, encrypt, write `relationships.db.bak.<ISO>.locked`.
-   - Read back, decrypt-and-verify (auth tag check).
-   - `removeEntry` the plaintext.
-2. Export live `relationships.db` from the SAH pool, encrypt, write
-   `relationships.db.locked` at OPFS root.
-3. Read back, decrypt-and-verify.
-4. Close `relDb` handle, `removeEntry` the SAH-pool slot.
+A subtle but load-bearing observation: **the on-disk state "both
+`.locked` and plaintext exist for the same logical file" is
+indistinguishable between a `lock()` that crashed mid-flight and a
+session that legitimately ended in `enabled+unlocked` without the
+user clicking Lock Now.** Both produce identical OPFS inventories.
 
-**Boot-time recovery:** on `init`, if both plaintext and `.locked`
-siblings exist for the same logical file (e.g. `bak.2026-05-13T...`
-*and* `bak.2026-05-13T....locked`), trust the `.locked` (it survived
-crash + auth-tag verifies) and delete the plaintext. If the `.locked`
-exists but auth tag fails on the resume check, log + leave both in
-place; the user sees an unlock failure with a diagnostic message and
-can use **Reset Everything**.
+For v1 we adopt the simpler interpretation: **don't try to
+distinguish.** Both states boot as `enabled+unlocked`. The user sees
+the 🔓 Lock chip in the topbar (the awareness affordance) and can
+click it to re-lock. Init does *not* run a recovery pass that tries
+to "finish" a crashed lock.
+
+**Follow-up:** crash-scenario testing for the lock/unlock/change/disable
+operations needs a definitive harness — Playwright can drop a page mid-
+operation but reproducing a worker crash mid-RPC is harder. Tracked as
+an open follow-up against the Phase 7 test surface.
+
+### Two-pass write for multi-file ops (Q1-A)
+
+`changePassphrase` and `disableLock` touch every `.locked` file at
+once (live DB + up to 5 backups = 6 files). OPFS has no batch rename,
+so a crash mid-operation could split files between two states. v1
+mitigates by **writing all new envelopes first, then deleting old
+artifacts only after every new file is verified.**
+
+**Lock-sequence primitive (used by `enableLock`, `lock`, and
+`changePassphrase`'s write phase):**
+1. Encrypt plaintext to envelope bytes (in memory).
+2. Write to `<name>.locked.new` at OPFS root.
+3. Read bytes back and parse the envelope header (magic +
+   format-version sanity check — no decrypt needed).
+4. Rename `.locked.new` → `.locked` via
+   `FileSystemFileHandle.move()` when available; fall back to "write
+   to final name, then delete `.new`" for older browsers.
+5. After the rename, delete the source plaintext (only relevant for
+   `enableLock` / `lock` — the previous `.locked` is overwritten by
+   step 4).
+
+**Init-time orphan cleanup:** worker `init` scans OPFS root and
+removes any `*.locked.new` and `*.tmp` files. These can only exist
+when a prior operation was interrupted between steps 2 and 4 — the
+old `.locked` is still intact, so the orphan is safe to delete.
+
+## Structured error names
+
+Worker handlers throw `Error` with these `.name` values; the dispatcher
+forwards `errorName` to the page, which routes accordingly:
+
+| `errorName` | When | Page UI response |
+|---|---|---|
+| `WrongPassphraseError` | `unlock` / `changePassphrase` / `disableLock` got the wrong passphrase (WebCrypto's `OperationError` wrapped). | Show "Wrong password." on the same input. |
+| `LockEnvelopeError` | `.locked` file unparseable (corrupt magic / version / length). | Surface "Locked file appears corrupt — Reset Everything to recover." |
+| `LockStateError` | RPC called in an incompatible state (e.g. `enableLock` while already enabled, `lock` while no key cached). | Bug indicator; log + show diagnostic. Should not be reachable in normal UI. |
+| `DataLockedError` | Any `relDb`-touching RPC (`listGroups`, `createGroup`, …) called while in `enabled+locked` state. | Route to "Unlock to view" panel; offer the unlock card. |
 
 ## Worker RPCs
 

--- a/plans/lock_my_user_data.md
+++ b/plans/lock_my_user_data.md
@@ -1,8 +1,37 @@
 # Lock My User Data — opt-in encryption-at-rest for `relationships.db`
 
-**Status:** plan, not yet implemented. Tier 2 #3 of the security review
-(`security_review/2026-05-08_local_vs_saas_risk.md`), following SRI (PR
-#143) and signed bundles (PR #146).
+**Status:** in flight on branch `feat/lock-my-data`, PR
+[#155](https://github.com/richbodo/fellows_local_db/pull/155). Tier 2
+#3 of the security review
+(`security_review/2026-05-08_local_vs_saas_risk.md`), following SRI
+(PR #143) and signed bundles (PR #146).
+
+## Implementation status
+
+| Phase | Status | Notes / commits on `feat/lock-my-data` |
+|---|---|---|
+| 1 — Crypto primitives + envelope | ✅ shipped | `d0e11d3` — `lockBlobWithPassphrase` / `unlockBlobWithPassphrase` + `__lockSelfTest` RPC + `tests/e2e/test_lock_crypto.py` |
+| 2 — Worker orchestration RPCs | ✅ shipped | `503e976` — `getLockState`, `enableLock`, `unlock`, `lock`, `changePassphrase`, `disableLock`; `WORKER_RPC_VERSION` and `EXPECTED_WORKER_RPC_VERSION` bumped 2→3 in lockstep; `tests/e2e/test_lock_rpcs.py` |
+| 3 — Backup encryption + rotation | ✅ shipped | `2568880` — `maybeBackupRelationshipsDb` lock-aware; `unlock` triggers a post-cache backup pass; `listRelationshipsBackups`/`restoreRelationshipsBackup` handle `.locked` entries; rotation is newest-5-of-any-kind; `tests/e2e/test_lock_backups.py` |
+| 4 — Settings UI + topbar chips | 🟡 next | See § Phase 4 pickup details |
+| 5 — Locked-boot UX | ⏳ | See § Locked-boot UX |
+| 6 — Diagnostics + docs | ⏳ | `users_manual.md`, `persistence_and_upgrades.md`, `Architecture.md`, `SECURITY.md` |
+| 7 — Full e2e cycle tests | ⏳ | Combined enable→reload→unlock→edit→lock→disable cycle; cross-browser smoke |
+
+**Full regression after each shipped phase:** 452 passed, 12 skipped, 0
+failures.
+
+**Where the worker-side contract is** (what Phase 4 consumes):
+- Worker RPCs reachable from page via
+  `window.__dataProvider._rpc.call(opName, args)`. Direct route used by
+  the e2e tests; Phase 4 will wrap the lock-specific ops in
+  `createWorkerDataProvider` to match the existing wrapper shape.
+- `init` handshake now returns `lockEnabled` and `lockLocked` booleans.
+  Phase 4/5 read these to choose the boot route (directory vs. unlock
+  card).
+- Structured error names (`WrongPassphraseError`, `LockEnvelopeError`,
+  `LockStateError`, `DataLockedError`) reach the page via `e.name` on
+  rejected RPCs — see § Structured error names.
 
 **Scope:** user-driven, opt-in app-layer encryption of the user-authored
 `relationships.db` and its OPFS backups. `fellows.db` is *not* encrypted
@@ -349,29 +378,123 @@ Per CLAUDE.md convention ("UI/UX changes belong in `docs/users_manual.md`"):
 
 ## Implementation phases (one PR; phased commits)
 
-1. **Crypto primitives + envelope.** Module-local `lockCrypto.js`-shape
-   helpers inside `vendor/sqlite-worker.js` (we don't add a new vendored
-   file): `deriveKey(passphrase, salt, iters)`, `encryptBlob(key, plain)`,
-   `decryptBlob(key, blob)`, header pack/unpack. Unit-style tests via a
-   tiny e2e Playwright test that drives the worker's RPCs.
-2. **Worker RPCs.** `getLockState`, `enableLock`, `unlock`, `lock`,
-   `changePassphrase`, `disableLock`. Lock-in-progress recovery on
-   `init`.
-3. **Backup encryption.** Extend `maybeBackupRelationshipsDb` +
-   `snapshotRelationshipsDbToBackup` to honor lock state.
-4. **Settings UI.** Three-state panel + four modals (enable, change,
-   disable, unlock-when-already-on-settings).
-5. **Locked-boot UX.** Unlock card before `bootDirectoryAsApp`'s normal
-   route dispatch; browse-directory-only mode; topbar Unlock button on
-   locked routes.
-6. **Diagnostics + docs.** `?diag=1` rows, `users_manual.md` section,
-   `persistence_and_upgrades.md` table rows, `Architecture.md` note,
-   `SECURITY.md` row.
-7. **E2E tests.** Enable → reload → unlock-gate → wrong-passphrase →
-   right-passphrase → directory-only escape → unlock from gate →
-   change-passphrase → disable. Verify on-disk `.locked` files via the
-   worker RPC (we can't poke OPFS directly from the test runner, but
-   `getLockState` + `listRelationshipsBackups` cover it).
+Implementation status table is at the top of the file. Phase-by-phase
+detail below; phases 1–3 are shipped, the rest are the pickup spec.
+
+### Phase 4 — Settings UI + topbar chips (next)
+
+**Hook points in `app/static/app.js`:**
+
+| Location | What lands here |
+|---|---|
+| `createWorkerDataProvider` (~3518) | Add six wrapper methods: `getLockState`, `enableLock(passphrase)`, `unlock(passphrase)`, `lock()`, `changePassphrase(oldP, newP)`, `disableLock(passphrase)`. Each is a thin `rpc.call('opName', args)` — no `refuseIfVersionSkew` gate (the version check happened at init handshake; if it failed the page is in api+idb fallback and these methods aren't reachable). |
+| `renderSettingsPage` (~7900) | Append a `<div class="settings-section settings-lock-section">` after the existing `settings-export-section`. Renders one of three states from `getLockState()`. Markup uses `class` only — no inline styles (CSP). |
+| Topbar render path | Add a chip slot read from `getLockState()` on every route render. (Find existing topbar — it's the title strip with the build badge; grep for `header-bar` or `app-header` to locate.) |
+
+**dataProvider wrapper shape (drop in to `createWorkerDataProvider`):**
+```js
+getLockState: function () { return rpc.call('getLockState'); },
+enableLock: function (passphrase) { return rpc.call('enableLock', { passphrase: passphrase }); },
+unlock:     function (passphrase) { return rpc.call('unlock',     { passphrase: passphrase }); },
+lock:       function ()           { return rpc.call('lock'); },
+changePassphrase: function (oldP, newP) {
+  return rpc.call('changePassphrase', { oldPassphrase: oldP, newPassphrase: newP });
+},
+disableLock: function (passphrase) { return rpc.call('disableLock', { passphrase: passphrase }); },
+```
+
+**Settings panel — three rendered states, decided by `await getLockState()`:**
+
+1. `enabled === false` → "Lock my saved data: off" + **Set up locking…**
+   button. Click opens the two-step honesty-first modal (copy already
+   written below).
+2. `enabled === true && locked === false` → status row + three buttons.
+   Status copy depends on `hasKey`:
+   - `hasKey === true` → "Lock is set up. Your data is currently unlocked
+     in this session."
+   - `hasKey === false` (stale-unlocked from a prior session) → "Lock
+     is set up. Your data is currently unlocked. Click **Lock now** to
+     encrypt it." Lock now in this state opens a password prompt first
+     (since we need to derive the key); the prompt calls `unlock(p)`
+     then `lock()` in sequence.
+3. `enabled === true && locked === true` → unreachable: route is gated
+   behind Phase 5's unlock card.
+
+**Decision: topbar chip behavior.** Click → **immediately call `lock()`**;
+no confirm modal. Rationale: locking is *reversible* (user unlocks
+again), the user already opted in by enabling, and a confirm modal on
+every lock would train them to dismiss it. The Settings *Lock now*
+button stays identical — same RPC, no confirm.
+
+**Decision: "Set up locking…" submit reloads the page.** After
+`enableLock` resolves, call `location.reload()` so the user lands on
+the boot unlock card. Self-demos the steady-state and gives password
+managers a chance to capture the credential they just saw.
+
+**Decision: per-modal autocomplete attributes:**
+- Set-up modal new password: `autocomplete="new-password"` (both fields).
+- Change-password modal old field: `autocomplete="current-password"`;
+  new fields: `autocomplete="new-password"`.
+- Disable modal: `autocomplete="current-password"`.
+- Phase 5's boot unlock card: `autocomplete="current-password"`.
+
+**Decision: error display.** Inline below the password field — never a
+modal-on-modal. Map errorName → user-facing copy:
+| `errorName` | Copy |
+|---|---|
+| `WrongPassphraseError` | "Wrong password." |
+| `LockEnvelopeError` | "Your locked data appears damaged. Use **Reset everything** to start over." |
+| `LockStateError` | "Couldn't complete this action. Reload and try again." |
+| `DataLockedError` | (shouldn't surface in Settings — Settings is unreachable when locked.) |
+
+**Cleanup of stale references:** `renderSettingsPage` mentions "auto-
+snapshots ... rotated to keep the newest 3" in its existing copy
+(app.js:7928). The actual rotation is 5 (BACKUP_KEEP). This copy was
+already stale before Phase 4; fix it as part of Phase 4 since we're
+touching the same function.
+
+### Phase 5 — Locked-boot UX
+
+**Hook point:** `bootDirectoryAsApp` (~9232). Read
+`provider.getLockState()` (or just `provider._init.lockLocked`) before
+the normal route dispatch. If locked, render the unlock card and
+return early.
+
+**`__lockedMode` flag** (page-side window prop):
+- Set to `"directory-only"` when user clicks Browse directory only.
+- Read by `route()` (~6528) for `#/groups`, `#/groups/<id>`,
+  `#/edit/<id>`, `#/settings` → render the small "Locked — Unlock to
+  view." panel + topbar 🔒 Unlock chip.
+- Cleared when `unlock()` succeeds (returns to normal routing).
+
+**Unlock card markup** lives in a new `renderLockUnlockCard()` function
+called by `bootDirectoryAsApp`. Copy + structure already specified in
+§ Locked-boot UX above.
+
+### Phase 6 — Diagnostics + docs
+
+- `?diag=1` panel rows (rendered from `getLockState()`): "Lock enabled:
+  yes/no", "Currently locked: yes/no", "Lock format: v1 (PBKDF2-SHA256,
+  600000 iters)".
+- `docs/users_manual.md` § "Locking your saved data" — enable, lock,
+  unlock, change, disable. Mirror the honesty-first set-up modal copy.
+- `docs/persistence_and_upgrades.md` storage-layer table — add rows for
+  `relationships.db.locked` (worker, doesn't auto-clear on Clear App
+  Cache) and `relationships.db.bak.<ISO>.locked`.
+- `docs/Architecture.md` § Worker-owned OPFS — note the lock RPCs and
+  the v1 envelope.
+- `SECURITY.md` § Defensive controls — add app-layer-encryption row.
+
+### Phase 7 — Full e2e cycle tests
+
+The shipped tests cover state machine + crypto + backups in isolation.
+Phase 7 adds the user-flow cycle:
+- Enable from Settings → page reloads → unlock card shows → wrong
+  password → right password → land in directory → mutate groups → click
+  Lock now in topbar → unlock card shows → unlock → change-password →
+  reload → unlock with new → disable → fully plaintext access.
+- Cross-browser smoke (Firefox / WebKit) for the WebCrypto + OPFS
+  `move()` paths. Document any browser-specific quirks discovered.
 
 ## Open follow-ups (NOT in v1)
 

--- a/plans/lock_my_user_data.md
+++ b/plans/lock_my_user_data.md
@@ -1,0 +1,363 @@
+# Lock My User Data — opt-in encryption-at-rest for `relationships.db`
+
+**Status:** plan, not yet implemented. Tier 2 #3 of the security review
+(`security_review/2026-05-08_local_vs_saas_risk.md`), following SRI (PR
+#143) and signed bundles (PR #146).
+
+**Scope:** user-driven, opt-in app-layer encryption of the user-authored
+`relationships.db` and its OPFS backups. `fellows.db` is *not* encrypted
+— it's shared directory data, gated by the magic link.
+
+**Non-scope:**
+- Forced passphrase at install. This is "I'm being paranoid right now,"
+  not "everyone always."
+- Auto-lock on tab-hidden / quit timers / `pagehide`. v1 is **manual
+  lock only** — the user clicks **Lock now** in Settings (or the topbar
+  chip) to encrypt. This is the conscious trade-off: the user is
+  **aware** of every lock transition rather than having silent ones.
+  The silent-failure gap (forgetting to click Lock Now before closing
+  the tab leaves that session's data plaintext on disk until the next
+  explicit lock) is filed as issue
+  [#154](https://github.com/richbodo/fellows_local_db/issues/154) for
+  follow-up design — addressing it well needs a separate conversation
+  about how to message the transition to the user.
+- Passphrase recovery. Forgotten passphrase = effectively wiped; the
+  user's recovery path is **Reset Everything** (already shipped). This
+  is honest scoping, not a gap.
+- `fellows.db` encryption.
+
+## Threat model — what this defends, what it does not
+
+**Defends against:**
+- A discarded or stolen device read offline (drive imaging, OPFS file
+  extraction).
+- A drive image taken while the OS is locked.
+
+**Does NOT defend against:**
+- Live malware on the unlocked OS — the encryption key is in worker
+  memory while unlocked.
+- Shoulder-surfing / screen capture while unlocked.
+- Weak passphrases. The KDF makes offline cracking expensive but not
+  infeasible against `password123`.
+- A forgotten passphrase. There is no recovery.
+
+This boundary lives in user-facing copy on the Settings panel and in
+`docs/users_manual.md` § Updates → Lock my user data.
+
+## Crypto primitives
+
+- **KDF:** PBKDF2-SHA256, 600 000 iterations (OWASP 2023 PBKDF2-SHA256
+  recommendation), 16-byte random salt per file format version. WebCrypto
+  native — no new vendored dependency. Format header carries the KDF id
+  + iteration count + salt so a future migration to Argon2id (vendored
+  wasm) lands without breaking existing locked DBs.
+- **Cipher:** AES-256-GCM with 96-bit random IV per ciphertext (a
+  different IV for every locked file even though the key is shared).
+  128-bit auth tag, the WebCrypto default.
+- **Key material:** the derived `CryptoKey` is non-extractable and lives
+  only in worker memory. The user's plaintext passphrase string is
+  zeroed (best-effort — JS doesn't guarantee zeroing) and the reference
+  dropped as soon as the key is derived. The main thread never holds the
+  derived key.
+
+## Locked-file envelope (`v1`)
+
+Self-describing binary blob, written as one OPFS file. The format is
+versioned so v2 (e.g. Argon2id) can land later.
+
+```
+Offset  Length    Field
+0       8         Magic: "EHFLOCK\0"   (so a misfiled blob is diagnosable)
+8       1         Format version       (= 1)
+9       1         KDF id               (1 = PBKDF2-SHA256)
+10      4         KDF iterations       (uint32 big-endian; = 600000 for v1)
+14      2         Salt length          (uint16 big-endian; = 16 for PBKDF2)
+16      <Slen>    Salt bytes
+16+Slen 12        AES-GCM IV (96-bit nonce)
+28+Slen <rest>    AES-GCM ciphertext (plaintext bytes + 16-byte auth tag)
+```
+
+The auth tag is part of the ciphertext per WebCrypto convention; a wrong
+passphrase fails decrypt atomically with `OperationError`. There is no
+separate "verifier" blob — the GCM tag is the verifier.
+
+## OPFS layout
+
+**Unlocked (today's layout):**
+```
+/relationships.db                  (SAH-pool slot, live RW)
+/relationships.db.bak.<ISO>        (OPFS root, plaintext)
+/fellows.db                        (read-only, never touched by lock)
+/fellows.db.meta.json
+```
+
+**Locked:**
+```
+/relationships.db.locked           (OPFS root, encrypted blob)
+/relationships.db.bak.<ISO>.locked (OPFS root, each backup individually encrypted)
+/fellows.db                        (unchanged)
+/fellows.db.meta.json
+```
+
+**Lock-state detection** is by file presence:
+- `.locked` siblings present → locked (or lock-in-progress, see below).
+- Plaintext `relationships.db` in SAH pool present → unlocked.
+- Neither → first install.
+
+This avoids a separate "lock enabled" sentinel that could disagree with
+the actual file state.
+
+## Lock-in-progress recovery
+
+A naïve lock sequence (`encrypt all → delete all plaintext`) can leave
+half-encrypted state on crash. Order matters because a backup ciphertext
+must replace its plaintext atomically before we delete the source.
+
+**Lock sequence (worker):**
+1. For each `relationships.db.bak.<ISO>` (oldest first):
+   - Read plaintext, encrypt, write `relationships.db.bak.<ISO>.locked`.
+   - Read back, decrypt-and-verify (auth tag check).
+   - `removeEntry` the plaintext.
+2. Export live `relationships.db` from the SAH pool, encrypt, write
+   `relationships.db.locked` at OPFS root.
+3. Read back, decrypt-and-verify.
+4. Close `relDb` handle, `removeEntry` the SAH-pool slot.
+
+**Boot-time recovery:** on `init`, if both plaintext and `.locked`
+siblings exist for the same logical file (e.g. `bak.2026-05-13T...`
+*and* `bak.2026-05-13T....locked`), trust the `.locked` (it survived
+crash + auth-tag verifies) and delete the plaintext. If the `.locked`
+exists but auth tag fails on the resume check, log + leave both in
+place; the user sees an unlock failure with a diagnostic message and
+can use **Reset Everything**.
+
+## Worker RPCs
+
+Added to `app/static/vendor/sqlite-worker.js`. All mutating ops require
+WORKER_RPC_VERSION + RELATIONSHIPS_SCHEMA_VERSION match (per the
+existing guard pattern):
+
+| RPC | Inputs | Outputs | Notes |
+|---|---|---|---|
+| `getLockState` | — | `{enabled, locked, kdf, iters, formatVersion}` | Read-only. Safe to call before unlock. Reads file presence; doesn't decrypt anything. |
+| `enableLock` | `{passphrase}` | `{ok: true}` | Derives key, encrypts live DB + all backups, deletes plaintext. Errors if already enabled. Closes `relDb` — caller should `unlock` to resume. |
+| `unlock` | `{passphrase}` | `{ok: true, counts}` | Decrypts `.db.locked` → SAH pool → opens `relDb`. Backup `.locked` files stay encrypted until used (lazy). Wrong passphrase → throws `wrong-passphrase` error. |
+| `lock` | — | `{ok: true}` | Re-encrypts live DB + any new backups created since unlock; deletes plaintext. Errors if not currently unlocked. |
+| `changePassphrase` | `{oldPassphrase, newPassphrase}` | `{ok: true}` | Verifies old, derives new key + new salt, re-encrypts every `.locked` file with the new key. All-or-nothing: write new files alongside, verify all, then delete old. |
+| `disableLock` | `{passphrase}` | `{ok: true}` | Decrypts every `.locked` file → plaintext OPFS files → deletes ciphertext. Future backups are plaintext. |
+
+The `CryptoKey` lives in worker module scope as `lockKey`; cleared on
+`lock` and `disableLock`.
+
+## Discoverability — out of the way by default
+
+The feature must not get in the way of users who don't want it. Concretely:
+
+- **No boot-time prompt, banner, or toast** advertises the feature.
+  Users who never enable it see the app exactly as they do today.
+- **No code path even runs.** WebCrypto calls, lock-state probes, and
+  the unlock card are entered only when a "lock is enabled" marker is
+  present (see § OPFS layout — file-presence detection).
+- **One entry point: `#/settings`.** A single closed section sits below
+  *Your saved data*. Users who don't read Settings don't discover it
+  until they go looking.
+
+## Settings UI (main thread)
+
+New panel on `#/settings`, after the existing "Your saved data" section.
+Three states:
+
+1. **Disabled** (default — what every non-user sees forever).
+   - Header: **Lock my saved data**.
+   - One-line copy: "Encrypt your groups, notes, and tags with a
+     password you choose. Off by default."
+   - Button: **Set up locking…** → "honesty-first" modal (next subsection).
+
+2. **Enabled, currently unlocked** (after the user has set it up).
+   - Status row: **"Lock is set up. Your data is currently unlocked."**
+     (load-bearing copy: the user is aware that "set up" ≠ "encrypted
+     right now").
+   - Buttons: **Lock now**, **Change password…**, **Turn off locking…**.
+   - **Lock now** → `lock` RPC → page re-renders into locked-boot UX
+     (next section).
+   - **Change password** → modal: current password + new + confirm new.
+   - **Turn off locking** → modal: current password + plain-language
+     copy ("This decrypts your saved data and returns it to its
+     unencrypted state on this device.").
+
+3. **Enabled, currently locked.** The Settings route is gated behind
+   the unlock card; this state isn't reachable on the panel itself.
+
+### The set-up modal (honesty-first)
+
+Two steps, single modal. Step 1 is plain-language acknowledgement of
+the trade-off **before** any password field appears.
+
+**Step 1 — "Before you turn this on"**
+
+> **Before you turn this on**
+>
+> Locking encrypts your saved groups, notes, and tags so that if someone
+> steals or images this device, they can't read them.
+>
+> It does **not** protect against malware running on this device, or
+> against someone using the device while it's unlocked.
+>
+> **There is no password recovery.** If you forget your password, your
+> saved data is gone. Your only option will be to reset everything. The
+> fellow directory itself is not affected.
+>
+> It's a good idea to store this password in a password manager — like
+> Google Password Manager, 1Password, Bitwarden, or a local password
+> database that you back up — rather than relying on memory.
+>
+> ☐ I understand there is no password recovery.
+>
+> [ Cancel ]  [ Continue ]
+
+**Step 2 — password entry**
+
+- `Password` (type=password, autocomplete=new-password) with a
+  "Show password" toggle.
+- `Confirm password`.
+- No strength meter (theater; the KDF is the real defense).
+- Submit → `enableLock` RPC (encrypts live DB + any existing backups in
+  place, deletes plaintext) → immediately reloads into the locked-boot
+  flow so the very next thing the user sees is the unlock card. This
+  self-demos the steady-state: "ah, *this* is what happens every time I
+  open the app from now on."
+
+## Locked-boot UX
+
+When `getLockState().locked === true` on app boot, `bootDirectoryAsApp`
+takes the "**unlock gate with browse-directory-only escape hatch**"
+branch:
+
+- A full-page unlock card renders before any route handler runs:
+  - Title: "Your saved data is locked"
+  - Password input (autofocus, `type=password`,
+    `autocomplete=current-password` so password managers can fill it)
+    with a "Show password" toggle.
+  - Primary button: **Unlock my data**.
+  - Secondary link: **Browse directory only** → boots into a degraded
+    mode (next bullet).
+  - Footer link: **Forgot password? Reset everything** → routes through
+    the existing destructive-action confirm dialog with its current
+    copy. Same affordance the user already knows.
+- "Browse directory only" mode:
+  - `window.__lockedMode = "directory-only"` flag set; `lockKey` stays
+    `null` in the worker.
+  - `#/`, `#/about`, `#/fellow/<slug>` render normally from `fellows.db`.
+  - `#/groups`, `#/groups/<id>`, `#/edit/<id>`, `#/settings` render a
+    small panel: "Locked — Unlock your saved data to view." with an
+    **Unlock** button that re-opens the unlock card.
+  - The topbar gains a discreet **🔒 Unlock** chip on locked-mode
+    routes only; clicking it re-opens the unlock card.
+- Wrong-password error in the card: "Wrong password." No counter, no
+  delay, no progressive lockout — the KDF cost is the rate limit.
+
+Slow-boot watchdog already covers stuck-PWA cases (`bootMarks`); a
+locked-state boot adds a `lock_gate_shown` mark.
+
+## Topbar awareness chips
+
+Because v1 is manual-lock-only, users must be **aware** of which state
+they're in. Two narrow topbar affordances cover this without
+introducing noise for non-users:
+
+- **Disabled lock (default).** No chip. Nothing in the topbar.
+- **Enabled + currently unlocked.** A small **🔓 Lock** chip in the
+  topbar's right corner. Click → confirm modal "Lock now?" → `lock`
+  RPC → page re-renders to the unlock card. This is the same action
+  as the Settings *Lock now* button, surfaced where the user already
+  is.
+- **Enabled + currently locked (directory-only mode).** A small
+  **🔒 Unlock** chip in the same place. Click → unlock card.
+
+Chips are only rendered when `getLockState().enabled === true`. Users
+who never enable lock never see them.
+
+## Backup behavior
+
+- When lock is **disabled**: today's behavior. Auto-backup at boot
+  (debounced 1h), keep newest 5, all plaintext.
+- When lock is **enabled and unlocked**: same rotation cadence, but
+  `maybeBackupRelationshipsDb` encrypts the snapshot before writing
+  `relationships.db.bak.<ISO>.locked`. The 5-newest rotation is by
+  `.locked` filename suffix-stripped timestamp.
+- When lock is **enabled and locked**: no auto-backup. The plaintext
+  `relationships.db` doesn't exist; we have no key to make new backups
+  with.
+- On `enableLock`: any existing plaintext backups get encrypted in-place
+  (the lock sequence above handles this).
+- On `disableLock`: every `.locked` backup gets decrypted to plaintext.
+
+## Diagnostics (`?diag=1`)
+
+Add to the diagnostics panel:
+- `Lock enabled: yes/no`
+- `Currently locked: yes/no`
+- `Lock format: v1 (PBKDF2-SHA256, 600000 iters)`
+- Backup list shows `.locked` suffix where present.
+
+## Documentation
+
+Per CLAUDE.md convention ("UI/UX changes belong in `docs/users_manual.md`"):
+- New § "Locking your saved data" in `docs/users_manual.md` covering
+  enable / unlock / lock / change-passphrase / disable + the threat-
+  model boundary.
+- `docs/persistence_and_upgrades.md` storage-layer table gains rows for
+  `relationships.db.locked` and `relationships.db.bak.<ISO>.locked`.
+- `docs/Architecture.md` § Worker-owned OPFS notes the lock RPCs.
+- `SECURITY.md` defensive-controls table gains a row for app-layer
+  encryption of `relationships.db`.
+
+## Implementation phases (one PR; phased commits)
+
+1. **Crypto primitives + envelope.** Module-local `lockCrypto.js`-shape
+   helpers inside `vendor/sqlite-worker.js` (we don't add a new vendored
+   file): `deriveKey(passphrase, salt, iters)`, `encryptBlob(key, plain)`,
+   `decryptBlob(key, blob)`, header pack/unpack. Unit-style tests via a
+   tiny e2e Playwright test that drives the worker's RPCs.
+2. **Worker RPCs.** `getLockState`, `enableLock`, `unlock`, `lock`,
+   `changePassphrase`, `disableLock`. Lock-in-progress recovery on
+   `init`.
+3. **Backup encryption.** Extend `maybeBackupRelationshipsDb` +
+   `snapshotRelationshipsDbToBackup` to honor lock state.
+4. **Settings UI.** Three-state panel + four modals (enable, change,
+   disable, unlock-when-already-on-settings).
+5. **Locked-boot UX.** Unlock card before `bootDirectoryAsApp`'s normal
+   route dispatch; browse-directory-only mode; topbar Unlock button on
+   locked routes.
+6. **Diagnostics + docs.** `?diag=1` rows, `users_manual.md` section,
+   `persistence_and_upgrades.md` table rows, `Architecture.md` note,
+   `SECURITY.md` row.
+7. **E2E tests.** Enable → reload → unlock-gate → wrong-passphrase →
+   right-passphrase → directory-only escape → unlock from gate →
+   change-passphrase → disable. Verify on-disk `.locked` files via the
+   worker RPC (we can't poke OPFS directly from the test runner, but
+   `getLockState` + `listRelationshipsBackups` cover it).
+
+## Open follow-ups (NOT in v1)
+
+- **Auto-lock on tab close.** Filed as
+  [#154](https://github.com/richbodo/fellows_local_db/issues/154).
+  Needs a separate design conversation about how to message the
+  silent transition to the user before it can land.
+- **Argon2id migration (envelope v2).** Format header is already
+  versioned; ship when vendoring a wasm Argon2 build is worthwhile.
+- **Encrypted-bundle download.** Settings' "Download my user data" today
+  emits plaintext bytes. When lock is enabled, the download should be
+  the `.locked` envelope (already on disk) — trivial follow-up but adds
+  UX questions about labeling.
+
+## Pointers
+
+- Worker file: `app/static/vendor/sqlite-worker.js`
+- Main-thread Settings rendering: `app/static/app.js`
+- Existing export/import seam: `handlers.exportRelationshipsBytes` /
+  `handlers.importRelationshipsBytes`
+- Backup rotation: `listRelationshipsBackups`,
+  `maybeBackupRelationshipsDb`, `snapshotRelationshipsDbToBackup`
+- Memory: `~/.claude/.../memory/project_lock_my_data.md`
+- Predecessor work: PR #143 (SRI), PR #146 (signed bundles)

--- a/tests/e2e/test_lock_backups.py
+++ b/tests/e2e/test_lock_backups.py
@@ -1,0 +1,298 @@
+"""Lock-aware backup behavior (Phase 3 of plans/lock_my_user_data.md).
+
+What this pins:
+  - enableLock encrypts every existing plaintext backup, even when the
+    backup count exceeds BACKUP_KEEP (no plaintext gets dropped during
+    the encryption transition).
+  - maybeBackupRelationshipsDb honors lock state: encrypts when lockKey
+    is cached, skips when lock is enabled and no key cached, writes
+    plaintext when lock disabled.
+  - The unlock RPC triggers a fresh backup so locked-then-unlocked
+    sessions stay current.
+  - listRelationshipsBackups surfaces .locked entries with
+    encrypted: true. Counts are populated when the session has a
+    cached key, null otherwise.
+  - restoreRelationshipsBackup decrypts .locked entries when unlocked
+    and refuses them with LockStateError when locked.
+  - Rotation counts plain + .locked together (newest BACKUP_KEEP of
+    any kind).
+"""
+from __future__ import annotations
+
+import pytest
+
+
+# Shared helpers — duplicated rather than imported to keep test files
+# self-contained. If a third lock test file gets added, factor out to
+# a conftest helper.
+_WAIT_FOR_DP = """
+async () => {
+  for (var i = 0; i < 200; i++) {
+    if (window.__dataProvider && typeof window.__dataProvider.listGroups === 'function') {
+      return window.__dataProvider.kind || 'unknown';
+    }
+    await new Promise(function (r) { setTimeout(r, 50); });
+  }
+  throw new Error('window.__dataProvider not ready after 10s');
+}
+"""
+
+
+def _wait_for_dp(page):
+    return page.evaluate(_WAIT_FOR_DP)
+
+
+def _rpc(page, op, args=None):
+    if args is None:
+        return page.evaluate(
+            "(op) => window.__dataProvider._rpc.call(op)",
+            op,
+        )
+    return page.evaluate(
+        "(p) => window.__dataProvider._rpc.call(p.op, p.args)",
+        {"op": op, "args": args},
+    )
+
+
+def _rpc_expect_error(page, op, args):
+    return page.evaluate(
+        """async (p) => {
+          try {
+            await window.__dataProvider._rpc.call(p.op, p.args);
+            return { thrown: false };
+          } catch (e) {
+            return { thrown: true, name: e.name, message: e.message };
+          }
+        }""",
+        {"op": op, "args": args},
+    )
+
+
+@pytest.fixture
+def lock_clean_page(standalone_page, base_url_fixture):
+    """Fresh OPFS state per test. wipeAll + reload before yield."""
+    page = standalone_page
+    page.goto(base_url_fixture + "/", wait_until="domcontentloaded")
+    _wait_for_dp(page)
+    _rpc(page, "wipeAll")
+    page.reload(wait_until="domcontentloaded")
+    _wait_for_dp(page)
+    yield page
+    try:
+        _rpc(page, "wipeAll")
+    except Exception:
+        pass
+
+
+def _seed_group(page, name="Seed", note=""):
+    full = page.evaluate("() => window.__dataProvider.getFull()")
+    rid = full[0]["record_id"]
+    return page.evaluate(
+        "(p) => window.__dataProvider.createGroup(p)",
+        {"name": name, "fellow_record_ids": [rid], "note": note},
+    )
+
+
+def _reload_for_init_backup(page, base_url):
+    """Reload the page so init's auto-backup pass fires against the
+    existing SAH-pool slot. Returns after dataProvider is ready again."""
+    page.reload(wait_until="domcontentloaded")
+    _wait_for_dp(page)
+
+
+# ----- enableLock encrypts existing plaintext backups -----------------------
+
+def test_enable_lock_encrypts_existing_plaintext_backup(
+    lock_clean_page, base_url_fixture,
+):
+    # Create data + reload so init's maybeBackupRelationshipsDb writes a
+    # plaintext backup (relationships.db slot is in the pool by then).
+    _seed_group(lock_clean_page, "Pre-lock", note="will be encrypted")
+    _reload_for_init_backup(lock_clean_page, base_url_fixture)
+
+    before = _rpc(lock_clean_page, "listRelationshipsBackups")
+    plain_before = [b for b in before if not b.get("encrypted")]
+    assert plain_before, f"expected ≥1 plaintext backup pre-lock, got {before}"
+
+    result = _rpc(lock_clean_page, "enableLock", {"passphrase": "pw"})
+    assert result["ok"] is True
+    assert result["encryptedBackups"] == len(plain_before)
+
+    after = _rpc(lock_clean_page, "listRelationshipsBackups")
+    plain_after = [b for b in after if not b.get("encrypted")]
+    locked_after = [b for b in after if b.get("encrypted")]
+    assert plain_after == [], f"plaintext backups should be gone: {plain_after}"
+    assert len(locked_after) >= len(plain_before)
+
+
+# ----- unlock invokes the backup-decision pass ------------------------------
+
+def test_unlock_invokes_backup_pass(lock_clean_page, base_url_fixture):
+    """unlock must call maybeBackupRelationshipsDb so locked-then-unlocked
+    sessions get fresh backups. We can't assert "new file written" because
+    BACKUP_DEBOUNCE_MS = 1h and the just-encrypted .locked from enableLock
+    is too fresh — debounce correctly skips. The observable signal is the
+    trace line: either "backup: wrote ..." or "backup: skipped (debounced)".
+    """
+    _seed_group(lock_clean_page, "Trace probe")
+    _reload_for_init_backup(lock_clean_page, base_url_fixture)
+    _rpc(lock_clean_page, "enableLock", {"passphrase": "pw"})
+    # Reload → fresh trace, locked state, no key cached.
+    _reload_for_init_backup(lock_clean_page, base_url_fixture)
+
+    _rpc(lock_clean_page, "unlock", {"passphrase": "pw"})
+
+    trace_lines = _rpc(lock_clean_page, "getTrace")
+    # Look for a backup decision line emitted AFTER "unlock: success".
+    seen_unlock = False
+    backup_after_unlock = False
+    for line in trace_lines:
+        if "unlock: success" in line:
+            seen_unlock = True
+        elif seen_unlock and "backup: " in line:
+            backup_after_unlock = True
+            break
+    assert seen_unlock, f"expected unlock: success in trace, got {trace_lines}"
+    assert backup_after_unlock, \
+        f"expected a backup: trace line after unlock, got {trace_lines}"
+
+
+# ----- listRelationshipsBackups: counts depend on key availability ----------
+
+def test_locked_backup_counts_visible_when_unlocked(
+    lock_clean_page, base_url_fixture,
+):
+    _seed_group(lock_clean_page, "Has Counts")
+    _reload_for_init_backup(lock_clean_page, base_url_fixture)
+
+    _rpc(lock_clean_page, "enableLock", {"passphrase": "pw"})
+    _rpc(lock_clean_page, "unlock", {"passphrase": "pw"})
+
+    entries = _rpc(lock_clean_page, "listRelationshipsBackups")
+    locked = [e for e in entries if e.get("encrypted")]
+    assert locked, entries
+    # At least one .locked entry should have decryptable counts now that
+    # we have the cached key.
+    has_counts = [e for e in locked if e.get("counts") is not None]
+    assert has_counts, f"expected non-null counts on .locked entries when unlocked, got {locked}"
+    sample = has_counts[0]["counts"]
+    assert sample["groups"] >= 1
+
+
+def test_locked_backup_counts_null_when_locked(
+    lock_clean_page, base_url_fixture,
+):
+    _seed_group(lock_clean_page, "Hidden Counts")
+    _reload_for_init_backup(lock_clean_page, base_url_fixture)
+
+    _rpc(lock_clean_page, "enableLock", {"passphrase": "pw"})
+    # NOTE: no unlock → lockKey is null.
+
+    entries = _rpc(lock_clean_page, "listRelationshipsBackups")
+    locked = [e for e in entries if e.get("encrypted")]
+    assert locked, entries
+    for entry in locked:
+        assert entry["counts"] is None, \
+            f"expected counts:null when locked but got {entry}"
+
+
+# ----- restoreRelationshipsBackup on .locked entries ------------------------
+
+def test_restore_encrypted_backup_when_unlocked_round_trips(
+    lock_clean_page, base_url_fixture,
+):
+    # Seed group A, reload to backup, then mutate to group B, restore from
+    # the encrypted backup, verify only A remains.
+    _seed_group(lock_clean_page, "Group A")
+    _reload_for_init_backup(lock_clean_page, base_url_fixture)
+
+    _rpc(lock_clean_page, "enableLock", {"passphrase": "pw"})
+    _rpc(lock_clean_page, "unlock", {"passphrase": "pw"})
+
+    # Mutate: rename group, add a different group
+    groups = lock_clean_page.evaluate("() => window.__dataProvider.listGroups()")
+    a_id = next(g["id"] for g in groups if g["name"] == "Group A")
+    lock_clean_page.evaluate(
+        "(args) => window.__dataProvider.updateGroup(args.id, args.patch)",
+        {"id": a_id, "patch": {"name": "Group A mutated"}},
+    )
+    _seed_group(lock_clean_page, "Group B")
+
+    # Pick the oldest .locked backup (which should hold pre-mutation state).
+    entries = _rpc(lock_clean_page, "listRelationshipsBackups")
+    locked_entries = sorted(
+        [e for e in entries if e.get("encrypted")],
+        key=lambda e: e["name"],
+    )
+    assert locked_entries, entries
+    target = locked_entries[0]["name"]
+
+    result = _rpc(
+        lock_clean_page, "restoreRelationshipsBackup",
+        {"name": target},
+    )
+    assert result["counts"]["groups"] == 1  # pre-mutation: just Group A
+
+    restored = lock_clean_page.evaluate(
+        "() => window.__dataProvider.listGroups()"
+    )
+    names = [g["name"] for g in restored]
+    assert names == ["Group A"], names
+
+
+def test_restore_encrypted_backup_when_locked_throws_lock_state(
+    lock_clean_page, base_url_fixture,
+):
+    _seed_group(lock_clean_page, "Locked Restore Target")
+    _reload_for_init_backup(lock_clean_page, base_url_fixture)
+
+    _rpc(lock_clean_page, "enableLock", {"passphrase": "pw"})
+    # Reload → real locked state (no key cached). restore should refuse.
+    _reload_for_init_backup(lock_clean_page, base_url_fixture)
+
+    entries = _rpc(lock_clean_page, "listRelationshipsBackups")
+    locked = [e for e in entries if e.get("encrypted")]
+    assert locked
+    err = _rpc_expect_error(
+        lock_clean_page, "restoreRelationshipsBackup",
+        {"name": locked[0]["name"]},
+    )
+    assert err["thrown"] is True
+    # Locked state → relDb is null → _requireRelDb fires first with
+    # DataLockedError, before the locked-suffix branch's LockStateError.
+    # Either is correct (both mean "unlock first"); pin DataLockedError
+    # since that's the actual current path.
+    assert err["name"] == "DataLockedError"
+
+
+# ----- Rotation counts plain + .locked together -----------------------------
+
+def test_rotation_keeps_newest_five_of_any_kind(
+    lock_clean_page, base_url_fixture,
+):
+    """The encryption pass must not lose a backup, but after encryption
+    completes, rotation prunes to BACKUP_KEEP=5 newest. We can't easily
+    inject pre-crash plaintext-overflow state from a black-box test, but
+    we can verify the rotation invariant holds: after enableLock with N
+    plaintext backups, we end up with min(N, 5) .locked entries.
+    """
+    # Force 3 plaintext backups by repeated reload (each init writes one,
+    # debounced at 1h — so consecutive reloads in <1h would skip). The
+    # debounce is the live constraint here, so we accept ≥1 plaintext
+    # backup as proof rotation considered the file.
+    _seed_group(lock_clean_page, "Rotation seed")
+    _reload_for_init_backup(lock_clean_page, base_url_fixture)
+    pre = _rpc(lock_clean_page, "listRelationshipsBackups")
+    plain_pre = [b for b in pre if not b.get("encrypted")]
+    assert plain_pre, "no plaintext backup landed pre-enable"
+
+    _rpc(lock_clean_page, "enableLock", {"passphrase": "pw"})
+    post = _rpc(lock_clean_page, "listRelationshipsBackups")
+    plain_post = [b for b in post if not b.get("encrypted")]
+    locked_post = [b for b in post if b.get("encrypted")]
+    # No plaintext should remain; total backups ≤ BACKUP_KEEP (5).
+    assert plain_post == []
+    assert len(locked_post) <= 5
+    # And the encrypted count should match (or exceed: rotation prunes
+    # excess) the pre-existing plaintext count.
+    assert len(locked_post) >= 1

--- a/tests/e2e/test_lock_crypto.py
+++ b/tests/e2e/test_lock_crypto.py
@@ -1,0 +1,49 @@
+"""Lock crypto envelope smoke test (Phase 1 of plans/lock_my_user_data.md).
+
+Drives the worker's __lockSelfTest RPC, which round-trips a known plaintext
+through lockBlobWithPassphrase + unlockBlobWithPassphrase and asserts:
+
+  - envelope starts with the EHFLOCK magic
+  - right passphrase decrypts to identical bytes
+  - wrong passphrase fails with WebCrypto's OperationError
+  - header parameters match the v1 spec (kdf id, iter count, lengths)
+
+The OPFS-touching RPCs (enableLock, unlock, lock, changePassphrase,
+disableLock) and the locked-boot UX land in later phases; this test is
+the foundation that proves the crypto layer is sound in isolation.
+"""
+from __future__ import annotations
+
+
+def test_lock_self_test_roundtrip(worker_data):
+    result = worker_data.page.evaluate(
+        "() => window.__dataProvider._rpc.call('__lockSelfTest')"
+    )
+    assert result.get("ok") is True, result
+    assert result["plainLen"] > 0
+    # Header: 8 magic + 1 version + 1 kdfId + 4 iters + 2 saltLen
+    #         + 16 salt + 12 iv = 44 fixed bytes;
+    # ciphertext = plaintext + 16-byte GCM auth tag.
+    expected_envelope_len = 44 + result["plainLen"] + 16
+    assert result["envelopeLen"] == expected_envelope_len, result
+
+    header = result["header"]
+    assert header["formatVersion"] == 1
+    assert header["kdfId"] == 1  # PBKDF2-SHA256
+    assert header["iters"] == 600000
+    assert header["saltLen"] == 16
+    assert header["ivLen"] == 12
+    assert header["ciphertextLen"] == result["plainLen"] + 16
+
+
+def test_lock_wrong_passphrase_is_operation_error(worker_data):
+    result = worker_data.page.evaluate(
+        "() => window.__dataProvider._rpc.call('__lockSelfTest')"
+    )
+    assert result.get("ok") is True, result
+    # WebCrypto's GCM auth-tag failure surfaces as a DOMException with
+    # name === 'OperationError'. We rely on this distinction in Phase 2's
+    # `unlock` RPC to differentiate "wrong passphrase" from "envelope is
+    # corrupt" — if browsers ever changed the name, that branch would
+    # silently mis-handle the case, so we pin it here.
+    assert result["wrongPassphraseErrorName"] == "OperationError", result

--- a/tests/e2e/test_lock_rpcs.py
+++ b/tests/e2e/test_lock_rpcs.py
@@ -1,0 +1,321 @@
+"""Lock orchestration RPCs (Phase 2 of plans/lock_my_user_data.md).
+
+Drives the worker's lock state machine directly via
+window.__dataProvider._rpc.call(...). The page-side Settings UI lands
+in Phase 4; these tests pin the contract the UI will eventually
+consume.
+
+State machine under test:
+    disabled        ── enableLock ──>  enabled+locked
+    enabled+locked  ── unlock     ──>  enabled+unlocked (cached key)
+    enabled+unlocked ── lock      ──>  enabled+locked
+    enabled+unlocked ── changePass ─>  enabled+unlocked (new cached key)
+    enabled+unlocked ── disableLock ─> disabled
+
+Structured errors pinned:
+    WrongPassphraseError   — wrong password on unlock / change / disable
+    LockStateError         — RPC called in incompatible state
+    LockEnvelopeError      — corrupt .locked file
+    DataLockedError        — relDb-touching RPC called while locked
+"""
+from __future__ import annotations
+
+import pytest
+
+
+_WAIT_FOR_DP = """
+async () => {
+  for (var i = 0; i < 200; i++) {
+    if (window.__dataProvider && typeof window.__dataProvider.listGroups === 'function') {
+      return window.__dataProvider.kind || 'unknown';
+    }
+    await new Promise(function (r) { setTimeout(r, 50); });
+  }
+  throw new Error('window.__dataProvider not ready after 10s');
+}
+"""
+
+
+def _wait_for_dp(page):
+    return page.evaluate(_WAIT_FOR_DP)
+
+
+def _rpc(page, op, args=None):
+    if args is None:
+        return page.evaluate(
+            "(op) => window.__dataProvider._rpc.call(op)",
+            op,
+        )
+    return page.evaluate(
+        "(p) => window.__dataProvider._rpc.call(p.op, p.args)",
+        {"op": op, "args": args},
+    )
+
+
+def _rpc_expect_error(page, op, args):
+    """Call an RPC, catch the rejection in JS, return {name, message}."""
+    return page.evaluate(
+        """async (p) => {
+          try {
+            await window.__dataProvider._rpc.call(p.op, p.args);
+            return { thrown: false };
+          } catch (e) {
+            return { thrown: true, name: e.name, message: e.message };
+          }
+        }""",
+        {"op": op, "args": args},
+    )
+
+
+@pytest.fixture
+def lock_clean_page(standalone_page, base_url_fixture):
+    """Fresh OPFS state per test. Wipes everything via wipeAll + reloads,
+    then yields the page. Teardown wipes again so the next test starts
+    clean.
+    """
+    page = standalone_page
+    page.goto(base_url_fixture + "/", wait_until="domcontentloaded")
+    _wait_for_dp(page)
+    # Wipe any leftover state from prior tests (or prior runs).
+    _rpc(page, "wipeAll")
+    page.reload(wait_until="domcontentloaded")
+    _wait_for_dp(page)
+    yield page
+    # Best-effort teardown. wipeAll nulls poolUtil; the next test's
+    # fixture entry reloads, so leaving the page broken is fine.
+    try:
+        _rpc(page, "wipeAll")
+    except Exception:
+        pass
+
+
+# ----- getLockState ---------------------------------------------------------
+
+def test_get_lock_state_default(lock_clean_page):
+    state = _rpc(lock_clean_page, "getLockState")
+    assert state["enabled"] is False
+    assert state["locked"] is False
+    assert state["hasKey"] is False
+    assert state["formatVersion"] is None
+    assert state["kdfId"] is None
+    assert state["iters"] is None
+
+
+# ----- enableLock -----------------------------------------------------------
+
+def test_enable_lock_transitions_to_locked(lock_clean_page):
+    full = lock_clean_page.evaluate("() => window.__dataProvider.getFull()")
+    rid = full[0]["record_id"]
+    lock_clean_page.evaluate(
+        "(p) => window.__dataProvider.createGroup(p)",
+        {"name": "Locked Group", "fellow_record_ids": [rid], "note": "secret"},
+    )
+
+    result = _rpc(lock_clean_page, "enableLock", {"passphrase": "correct-horse"})
+    assert result["ok"] is True
+
+    state = _rpc(lock_clean_page, "getLockState")
+    assert state["enabled"] is True
+    assert state["locked"] is True
+    assert state["hasKey"] is False
+    assert state["formatVersion"] == 1
+    assert state["kdfId"] == 1
+    assert state["iters"] == 600000
+
+
+def test_enable_lock_when_already_enabled_throws(lock_clean_page):
+    _rpc(lock_clean_page, "enableLock", {"passphrase": "pw"})
+    err = _rpc_expect_error(
+        lock_clean_page, "enableLock", {"passphrase": "pw"}
+    )
+    assert err["thrown"] is True
+    assert err["name"] == "LockStateError"
+
+
+# ----- DataLockedError on relDb-touching ops --------------------------------
+
+def test_listgroups_while_locked_throws_data_locked_error(lock_clean_page):
+    _rpc(lock_clean_page, "enableLock", {"passphrase": "pw"})
+    err = _rpc_expect_error(lock_clean_page, "listGroups", None)
+    assert err["thrown"] is True
+    assert err["name"] == "DataLockedError"
+
+
+def test_creategroup_while_locked_throws_data_locked_error(lock_clean_page):
+    _rpc(lock_clean_page, "enableLock", {"passphrase": "pw"})
+    err = _rpc_expect_error(
+        lock_clean_page, "createGroup",
+        {"name": "Should not exist", "fellow_record_ids": []},
+    )
+    assert err["thrown"] is True
+    assert err["name"] == "DataLockedError"
+
+
+# ----- unlock ---------------------------------------------------------------
+
+def test_unlock_with_right_passphrase_restores_data(lock_clean_page):
+    full = lock_clean_page.evaluate("() => window.__dataProvider.getFull()")
+    rid = full[0]["record_id"]
+    lock_clean_page.evaluate(
+        "(p) => window.__dataProvider.createGroup(p)",
+        {"name": "Confidential", "fellow_record_ids": [rid]},
+    )
+
+    _rpc(lock_clean_page, "enableLock", {"passphrase": "pw1"})
+    assert _rpc(lock_clean_page, "getLockState")["locked"] is True
+
+    result = _rpc(lock_clean_page, "unlock", {"passphrase": "pw1"})
+    assert result["ok"] is True
+    assert result["counts"]["groups"] == 1
+
+    state = _rpc(lock_clean_page, "getLockState")
+    assert state["enabled"] is True
+    assert state["locked"] is False
+    assert state["hasKey"] is True
+
+    groups = lock_clean_page.evaluate("() => window.__dataProvider.listGroups()")
+    assert len(groups) == 1
+    assert groups[0]["name"] == "Confidential"
+
+
+def test_unlock_wrong_passphrase_throws_wrong_passphrase_error(lock_clean_page):
+    _rpc(lock_clean_page, "enableLock", {"passphrase": "right"})
+    err = _rpc_expect_error(
+        lock_clean_page, "unlock", {"passphrase": "wrong"}
+    )
+    assert err["thrown"] is True
+    assert err["name"] == "WrongPassphraseError"
+
+    state = _rpc(lock_clean_page, "getLockState")
+    assert state["locked"] is True
+
+
+def test_unlock_when_not_enabled_throws_lock_state_error(lock_clean_page):
+    err = _rpc_expect_error(
+        lock_clean_page, "unlock", {"passphrase": "anything"}
+    )
+    assert err["thrown"] is True
+    assert err["name"] == "LockStateError"
+
+
+# ----- lock -----------------------------------------------------------------
+
+def test_lock_re_encrypts_session_changes(lock_clean_page):
+    _rpc(lock_clean_page, "enableLock", {"passphrase": "pw"})
+    _rpc(lock_clean_page, "unlock", {"passphrase": "pw"})
+
+    lock_clean_page.evaluate(
+        "() => window.__dataProvider.setSetting('marker', 'after-unlock')"
+    )
+
+    result = _rpc(lock_clean_page, "lock")
+    assert result["ok"] is True
+
+    state = _rpc(lock_clean_page, "getLockState")
+    assert state["locked"] is True
+    assert state["hasKey"] is False
+
+    _rpc(lock_clean_page, "unlock", {"passphrase": "pw"})
+    val = lock_clean_page.evaluate(
+        "() => window.__dataProvider.getSetting('marker')"
+    )
+    assert val == "after-unlock"
+
+
+def test_lock_without_cached_key_throws_lock_state_error(lock_clean_page):
+    _rpc(lock_clean_page, "enableLock", {"passphrase": "pw"})
+    # Do not unlock; cached key is null.
+    err = _rpc_expect_error(lock_clean_page, "lock", None)
+    assert err["thrown"] is True
+    assert err["name"] == "LockStateError"
+
+
+# ----- changePassphrase -----------------------------------------------------
+
+def test_change_passphrase_old_stops_working_new_works(lock_clean_page):
+    _rpc(lock_clean_page, "enableLock", {"passphrase": "old-pw"})
+    _rpc(lock_clean_page, "unlock", {"passphrase": "old-pw"})
+
+    result = _rpc(
+        lock_clean_page, "changePassphrase",
+        {"oldPassphrase": "old-pw", "newPassphrase": "new-pw"},
+    )
+    assert result["ok"] is True
+    assert result["rekeyedCount"] >= 1  # at least the live DB
+
+    # Lock + unlock with new passphrase
+    _rpc(lock_clean_page, "lock")
+    unlock_result = _rpc(lock_clean_page, "unlock", {"passphrase": "new-pw"})
+    assert unlock_result["ok"] is True
+
+    # Lock + try old passphrase — must fail
+    _rpc(lock_clean_page, "lock")
+    err = _rpc_expect_error(
+        lock_clean_page, "unlock", {"passphrase": "old-pw"}
+    )
+    assert err["name"] == "WrongPassphraseError"
+
+
+def test_change_passphrase_wrong_old_throws(lock_clean_page):
+    _rpc(lock_clean_page, "enableLock", {"passphrase": "real"})
+    _rpc(lock_clean_page, "unlock", {"passphrase": "real"})
+
+    err = _rpc_expect_error(
+        lock_clean_page, "changePassphrase",
+        {"oldPassphrase": "wrong", "newPassphrase": "new"},
+    )
+    assert err["thrown"] is True
+    assert err["name"] == "WrongPassphraseError"
+
+
+# ----- disableLock ----------------------------------------------------------
+
+def test_disable_lock_restores_plaintext_access(lock_clean_page):
+    full = lock_clean_page.evaluate("() => window.__dataProvider.getFull()")
+    rid = full[0]["record_id"]
+    lock_clean_page.evaluate(
+        "(p) => window.__dataProvider.createGroup(p)",
+        {"name": "Persisting", "fellow_record_ids": [rid]},
+    )
+
+    _rpc(lock_clean_page, "enableLock", {"passphrase": "pw"})
+    _rpc(lock_clean_page, "unlock", {"passphrase": "pw"})
+
+    result = _rpc(lock_clean_page, "disableLock", {"passphrase": "pw"})
+    assert result["ok"] is True
+
+    state = _rpc(lock_clean_page, "getLockState")
+    assert state["enabled"] is False
+    assert state["locked"] is False
+
+    groups = lock_clean_page.evaluate("() => window.__dataProvider.listGroups()")
+    assert any(g["name"] == "Persisting" for g in groups)
+
+
+def test_disable_lock_wrong_passphrase_throws(lock_clean_page):
+    _rpc(lock_clean_page, "enableLock", {"passphrase": "real"})
+    _rpc(lock_clean_page, "unlock", {"passphrase": "real"})
+
+    err = _rpc_expect_error(
+        lock_clean_page, "disableLock", {"passphrase": "wrong"}
+    )
+    assert err["thrown"] is True
+    assert err["name"] == "WrongPassphraseError"
+
+
+# ----- persistence across reload --------------------------------------------
+
+def test_lock_persists_across_page_reload(lock_clean_page, base_url_fixture):
+    _rpc(lock_clean_page, "enableLock", {"passphrase": "pw"})
+
+    lock_clean_page.reload(wait_until="domcontentloaded")
+    _wait_for_dp(lock_clean_page)
+
+    state = _rpc(lock_clean_page, "getLockState")
+    assert state["enabled"] is True
+    assert state["locked"] is True
+
+    _rpc(lock_clean_page, "unlock", {"passphrase": "pw"})
+    state = _rpc(lock_clean_page, "getLockState")
+    assert state["locked"] is False
+    assert state["hasKey"] is True


### PR DESCRIPTION
Tier 2 #3 of the security review (`security_review/2026-05-08_local_vs_saas_risk.md`), following SRI (#143) and signed bundles (#146). Opt-in, user-driven encryption-at-rest for `relationships.db` and its OPFS backups. `fellows.db` is not encrypted — it's shared directory data gated by the magic link.

**Draft** — this PR will accumulate further phases as commits.

## Design

Full design doc shipped in this PR at [`plans/lock_my_user_data.md`](../blob/feat/lock-my-data/plans/lock_my_user_data.md). Key decisions:

- **PBKDF2-SHA256 / AES-GCM via WebCrypto.** No new vendored deps. 600k iterations (OWASP 2023). 16-byte random salt + 12-byte random IV per envelope. Wrong passphrase fails atomically with `OperationError`.
- **Manual Lock Now only.** v1 ships a button in Settings (and a topbar lock chip) — no auto-lock on tab-hidden / `pagehide` / timers. The user is **aware** of every lock transition. The silent-failure gap is filed as #154 for separate design.
- **Out-of-the-way discoverability.** Users who never enable lock see the app exactly as today — no banners, no nudges, no boot-path changes. One entry point: a closed section on `#/settings`.
- **Locked-boot UX:** unlock card with a *Browse directory only* escape and a *Forgot password? Reset everything* footer link. `fellows.db` views always work.
- **v1 scope:** set-up + unlock + lock + change password + disable. Auto-lock-on-close is #154.

## What's in this PR so far

| Commit | Phase | Summary |
|---|---|---|
| `a843723` | — | Plan doc at `plans/lock_my_user_data.md` |
| `d0e11d3` | 1 | Worker-internal lock envelope primitives + `__lockSelfTest` RPC + e2e round-trip test |

## Remaining phases (will land on this branch as further commits)

- **Phase 2** — OPFS-orchestration RPCs (`getLockState`, `enableLock`, `unlock`, `lock`, `changePassphrase`, `disableLock`) + lock-in-progress recovery on worker `init`.
- **Phase 3** — Backup encryption (`maybeBackupRelationshipsDb` honors lock state; `enableLock` encrypts existing backups in place; `disableLock` decrypts them).
- **Phase 4** — Settings UI: three-state panel + four modals (honesty-first set-up, change, disable, unlock-while-on-settings). Topbar lock/unlock chips.
- **Phase 5** — Locked-boot UX: unlock card before route dispatch, browse-directory-only mode.
- **Phase 6** — Diagnostics rows in `?diag=1`, `docs/users_manual.md` § Locking your saved data, `docs/persistence_and_upgrades.md` storage-layer table additions, `docs/Architecture.md` worker-RPC note, `SECURITY.md` defensive-controls row.
- **Phase 7** — End-to-end test coverage for the full enable / lock / unlock / wrong-password / directory-only / change-password / disable cycle.

## Test plan

**Automated (already green for what's shipped):**
- [x] `tests/e2e/test_lock_crypto.py` — round-trip + wrong-passphrase + envelope header fields
- [x] No regression in `tests/e2e/test_worker_rpc.py`, `tests/test_database.py`, `tests/test_api.py`
- [ ] (Future phase 7) full e2e cycle for enable → reload → unlock-gate → wrong-passphrase → right-passphrase → directory-only escape → unlock-from-gate → change-passphrase → disable

**Manual QA for the maintainer (do not merge before all of these pass):**
- [ ] Open the app on a fresh profile. Confirm Settings shows the new "Lock my saved data" section closed-by-default, no other surface mentions it.
- [ ] Confirm the boot path is byte-for-byte unchanged for a user who never enables lock (compare directory render time + boot trace to a build of `main`).
- [ ] Enable lock with a known password. Verify the next reload presents the unlock card. Verify "Browse directory only" works without password (`#/`, `#/about`, `#/fellow/<slug>` render; `#/groups`, `#/settings` show the locked panel).
- [ ] Wrong-password path: confirm error copy is "Wrong password." (no counter, no lockout).
- [ ] Unlock with right password → Settings/Groups become available, topbar chip flips to 🔓 Lock.
- [ ] Click Lock Now → page reloads to unlock card.
- [ ] Change password → verify old password no longer works, new password works.
- [ ] Disable lock → confirm `relationships.db` is back as plaintext (check via `?diag=1` panel) and any prior `.locked` backups are gone.
- [ ] Forgot-password recovery: Reset Everything from the unlock card → returns to email gate as first-time visitor.
- [ ] Cross-browser: smoke the unlock card + round-trip on Chromium, Firefox (DOM exception name parity), WebKit (Safari OPFS path).

## Related

- Plan: `plans/lock_my_user_data.md`
- Memory (design preferences): `~/.claude/.../memory/project_lock_my_data.md`
- Auto-lock-on-close follow-up: #154
- Predecessors: #143 (SRI), #146 (signed bundles)

🤖 Generated with [Claude Code](https://claude.com/claude-code)