### PR TITLE
feat(mcp): Private Data Ops + Communications MCP servers

### DIFF
--- a/docs/users_manual.md
+++ b/docs/users_manual.md
@@ -103,6 +103,48 @@ directory.
 
 ---
 
+## Where your data is stored
+
+Your groups, notes, and settings live **inside your browser**. They
+stay there — never sent to any server, never visible to other apps
+or websites on your device.
+
+There's no folder on your disk you can browse to or back up by hand;
+the data file lives in a private storage area your browser manages.
+What you *can* do is download and restore your data file
+(`relationships.db`) from inside the app. Here's how:
+
+- **Download a backup.** Settings → *Download a copy of
+  relationships.db*. Save the file somewhere you'll remember
+  (Downloads is a good default).
+- **Restore from a backup.** Settings → *Restore from backup →
+  Restore from a file* → pick the `.db` file you downloaded earlier.
+  The current data is captured into the auto-backup list first, so
+  a wrong restore is one click away from being undone.
+- **Auto-backups happen on their own.** While you work, the app
+  periodically snapshots your data. Pick one with Settings →
+  *Restore from backup → Recent auto-backups*.
+
+**What clearing does** (see *Clearing app data* below for the full
+breakdown): **Clear App Cache** keeps your data and auto-backups.
+**Reset Everything** wipes both — that's why it pops up a *Save a
+backup first?* dialog. Download a backup yourself first if you want
+a copy you control.
+
+**Phone gotchas.** On **Android**, *Clear Storage* for the browser
+in Android Settings wipes everything this app has saved, including
+the auto-backups. On **iOS**, *Settings → Safari → Clear History and
+Website Data* does the same. Both bypass the app's own confirm
+dialogs — download a backup yourself before doing either.
+
+**Switching browsers or devices.** Your data doesn't follow the
+browser — the new browser starts empty. Download a backup in the
+source browser, move the file across (AirDrop, email-to-yourself,
+USB, cloud drive), then use *Restore from a file* in the new
+browser to carry your groups, notes, and settings over.
+
+---
+
 ## The directory
 
 ![Directory page during a search; the visible-count line tracks how many

--- a/justfile
+++ b/justfile
@@ -285,6 +285,35 @@ shared-data-ops:
 test-shared-data-ops:
     {{mcp_pytest}} tests/test_shared_data_ops.py -v
 
+rel_db     := "app/relationships.db"
+
+# Run the Private Data Ops MCP server over stdio against relationships.db
+# (RO) with fellows.db ATTACHed (RO). See `shared-data-ops` recipe header
+# for the same note about test harnesses vs. real Claude Desktop use.
+[group('mcp')]
+private-data-ops:
+    {{mcp_python}} mcp_servers/private_data_ops.py --db {{rel_db}} --fellows-db {{db}}
+
+# Run the Communications MCP server (stage-only, in-memory). Pure stdio
+# server; no DB. See mcp_servers/README.md for Claude Desktop wiring.
+[group('mcp')]
+comms:
+    {{mcp_python}} mcp_servers/comms.py
+
+# Run the Private Data Ops MCP server's unit tests.
+[group('mcp')]
+test-private-data-ops:
+    {{mcp_pytest}} tests/test_private_data_ops.py -v
+
+# Run the Communications MCP server's unit tests.
+[group('mcp')]
+test-comms:
+    {{mcp_pytest}} tests/test_comms.py -v
+
+# Run every MCP server's tests at once.
+[group('mcp')]
+test-mcp: test-shared-data-ops test-private-data-ops test-comms
+
 
 # ---- build / deploy ------------------------------------------------------
 

--- a/mcp_servers/README.md
+++ b/mcp_servers/README.md
@@ -5,22 +5,23 @@ fellows_local_db**, so an AI client — Claude Desktop, Cursor, an
 Ollama-backed local agent — can act on the directory and on your saved
 relationships on your behalf.
 
-Concretely: ask Claude *"who in my fellowship works on climate in
-Auckland?"* and get a grounded answer drawn from real records. Or, when
-the other servers ship, *"draft a follow-up email to my Brisbane
-meetup group"* and have Claude stage the outreach for you to confirm.
+Flagship demo: ask Claude Desktop *"compose an email to the climate
+group in my fellows database, invite them to meet Thursday NZ time at
+1pm — don't send, just stage it for review"* and have it find the
+group, look up everyone's email, draft the body, and hand you back a
+`mailto:` URL that opens in your mail client with the composition
+pre-populated. You review and click send.
 
 ## What's here
 
-The PNA architecture defines four canonical MCP servers, each
-automating a different part of the app. Only Shared Data Ops ships
-today; the other three are scoped here so you know what's coming.
+The PNA architecture defines four canonical MCP servers. Three ship
+today; Diagnostics is scoped here so you know what's coming.
 
 | Server | Status | What it automates |
 |---|---|---|
 | **Shared Data Ops** (`shared_data_ops.py`) | v1 — ships now | Read-only access to the **Shared DB** (`fellows.db`). Search, filter, look up fellows, read directory stats. |
-| **Private Data Ops** | not yet built | Access to the **Private DB** (`relationships.db`): your groups, tags, notes, settings. Reads + writes. Requires a workspace bridge because the Private DB lives in OPFS, owned by the browser tab. |
-| **Communications** | not yet built | Drafts outreach (mailto, exports, etc.) and *stages* it. The MCP server never actually sends — the workspace launches transports only after you confirm. |
+| **Private Data Ops** (`private_data_ops.py`) | v1 — ships now | Read-only access to **groups** in the **Private DB** (`relationships.db`). List groups, find by name, fetch members joined to `fellows.db`. Tags/notes deferred — users aren't writing those at scale yet. |
+| **Communications** (`comms.py`) | v1 — ships now | Stage outreach as a `mailto:` URL. **Server stages; mail client launches.** No transports fired from inside the MCP process (per AC-MCP-B). |
 | **Diagnostics** | not yet built | Read-only access to build label, versions, boot timings, sanitized error events. Useful for AI-assisted bug triage. |
 
 The architectural plan for all four is in `docs/_pna_triage.md` (search
@@ -31,21 +32,30 @@ for "four canonical MCP servers" and `AC-MCP-A` / `AC-MCP-B`).
 The app distinguishes **Shared data** (the fellows directory — name,
 bio, region, contact email, mobile number) from **Private data**
 (your groups, tags, notes — never on any server, never shared).
-**Shared Data Ops returns Shared data.** It does not touch your
-Private data; that's the future Private Data Ops server, which will
-carry stronger consent gates (see *Cloud LLM caveat* below). Within
-those bounds, any MCP client you wire up will see the same fellow
-records you can see by opening the app.
+**Shared Data Ops returns Shared data.** **Private Data Ops returns
+Private data.** **Communications returns neither — it operates on
+recipients/text you (or the AI) hand it.** All three are read-only or
+stage-only — no MCP tool in this directory writes to the Private DB
+or fires a transport. Any MCP client you wire up will see the same
+fellow records and the same groups you can see by opening the app.
 
-## Shared Data Ops — install and run
+Important — Cloud LLMs touching Private data: see *Cloud LLM caveat*
+below. The short version is **wire these up to a local model** when
+possible.
 
-### Prerequisites
+## Prerequisites
 
 - `fellows.db` built locally (`just db-rebuild` from the repo root, or
   `python build/restore_from_knack_scrapefile.py`).
+- `relationships.db` — automatically created on first dev-server boot,
+  but for the demo to be interesting you want **fresh data from your
+  installed PWA**: open the app → Settings → *Download a backup* →
+  save the file as `app/relationships.db` (overwrite any existing
+  one). The dev-server's on-disk DB diverges from your PWA's OPFS DB
+  over time; the backup is the bridge.
 - Python 3.10+.
 
-### Install
+## Install (one venv covers all three servers)
 
 From the repo root:
 
@@ -61,7 +71,7 @@ python3 -m venv mcp_servers/.venv
 mcp_servers/.venv/bin/pip install -r mcp_servers/requirements.txt
 ```
 
-### Wire up Claude Desktop
+## Wire up Claude Desktop
 
 Edit `~/Library/Application Support/Claude/claude_desktop_config.json`
 (macOS). Easiest path: open Claude Desktop → Settings → Developer →
@@ -70,6 +80,9 @@ doesn't exist; if it does already exist (Claude Desktop writes
 `preferences` here in normal use), add the `mcpServers` block at the
 top level alongside whatever's already there — don't nest it inside
 `preferences`.
+
+Paste **all three entries together** — same venv, same install
+ceremony, three independent stdio servers:
 
 ```json
 {
@@ -81,6 +94,22 @@ top level alongside whatever's already there — don't nest it inside
         "--db",
         "/absolute/path/to/fellows_local_db/app/fellows.db"
       ]
+    },
+    "private-data-ops": {
+      "command": "/absolute/path/to/fellows_local_db/mcp_servers/.venv/bin/python",
+      "args": [
+        "/absolute/path/to/fellows_local_db/mcp_servers/private_data_ops.py",
+        "--db",
+        "/absolute/path/to/fellows_local_db/app/relationships.db",
+        "--fellows-db",
+        "/absolute/path/to/fellows_local_db/app/fellows.db"
+      ]
+    },
+    "comms": {
+      "command": "/absolute/path/to/fellows_local_db/mcp_servers/.venv/bin/python",
+      "args": [
+        "/absolute/path/to/fellows_local_db/mcp_servers/comms.py"
+      ]
     }
   }
 }
@@ -89,15 +118,16 @@ top level alongside whatever's already there — don't nest it inside
 **Fully quit Claude Desktop** (⌘Q — closing the window isn't enough;
 the menu bar entry must disappear) and relaunch. Then:
 
-1. Open Settings → Developer → *Local MCP servers*. `shared-data-ops`
-   should appear there. If the panel still says "No servers added,"
-   the config didn't parse — most likely a JSON syntax error or
-   `mcpServers` was nested under `preferences`.
-2. Start a new chat and try a sanity prompt:
-   - *"How many fellows are in the directory?"* → fires `get_directory_stats`.
-   - *"Find fellows working on climate."* → fires `search_fellows`.
-   - *"Who is `<known name>`?"* → fires `get_fellow`.
-   - *"List NZ Investor fellows."* → fires `list_fellows` with a `fellow_type` filter.
+1. Open Settings → Developer → *Local MCP servers*. All three should
+   appear. If the panel still says "No servers added," the config
+   didn't parse — most likely a JSON syntax error or `mcpServers` was
+   nested under `preferences`.
+2. Start a new chat and try sanity prompts:
+   - *"How many fellows are in the directory?"* → fires `shared-data-ops` `get_directory_stats`.
+   - *"List my groups."* → fires `private-data-ops` `list_groups`.
+   - *"Find the climate group."* → fires `private-data-ops` `find_group`.
+   - *"Who's in the climate action group?"* → fires `private-data-ops` `get_group_members`, which joins to `fellows.db` for names + emails in one round-trip.
+   - **Flagship**: *"Compose an email to the climate action group inviting them to meet Thursday NZ time at 1pm. Don't send — stage it."* → fires all three servers in turn (find_group → get_group_members → stage_email).
 
 First-run UX: Claude Desktop prompts for approval the first time the
 model invokes each tool, and the model may try a couple of generic
@@ -107,21 +137,22 @@ re-prompt.
 
 To verify a tool actually fired (vs. the model answering from
 training), tail `~/Library/Logs/Claude/mcp*.log` — each invocation
-writes a JSON-RPC frame. The clearest A/B test is to disable the
+writes a JSON-RPC frame. The clearest A/B test is to disable a
 server in Settings → Developer, ask the same question, and compare
 the answer.
 
-### Run it standalone (without an MCP client)
+### Run a server standalone (without an MCP client)
 
 ```bash
-just shared-data-ops
+just shared-data-ops      # against app/fellows.db
+just private-data-ops     # against app/relationships.db + app/fellows.db
+just comms                # no DB; pure stdio staging server
 ```
 
-That runs `mcp_servers/shared_data_ops.py` against `app/fellows.db` over
-stdio. On its own this just waits for JSON-RPC frames on stdin — useful
-for piping into a protocol test harness, not for interactive use.
+Each just blocks waiting for JSON-RPC frames on stdin — useful for
+piping into a protocol test harness, not for interactive use.
 
-## Cloud LLM caveat
+## Cloud LLM caveat (read this if your MCP client is hosted)
 
 The four canonical servers' privacy posture is set by **architectural
 commitment AC-MCP-A** (see `docs/_pna_triage.md`): MCP tools that
@@ -130,51 +161,82 @@ the consuming AI client is a cloud-hosted LLM (Claude API direct,
 OpenAI API, etc.). Local clients (Claude Desktop running a local
 model, Cursor + Ollama) are the default green path.
 
-**Shared Data Ops does not return Private DB rows, so AC-MCP-A doesn't
-strictly apply.** But the practical concern remains: if you wire this
-server up to a cloud-hosted AI client, fellow contact data (emails,
-mobile numbers, bios) crosses the network to that provider when you
-run queries. The data is data you already have access to as a fellow,
-but you'd be choosing to disclose it to a third party.
+**Private Data Ops returns Private DB rows.** Anytime an MCP client
+calls `list_groups`, `find_group`, or `get_group_members`, the
+contents of your `relationships.db` (group names, member record_ids,
+and joined fellow details) flow to that client. If the client is
+hosted (Claude Desktop with the Anthropic-hosted model, ChatGPT
+desktop, etc.), the data crosses the network to the provider.
 
-For v1 the server does not detect or gate cloud clients. The MCP
-transport is stdio-only, which usually means a local process is the
-client — but Claude Desktop's stdio MCP server can still send
-extracted text to Anthropic's API for the model to consume. Today's
-position is: **document the boundary, trust the user's choice**,
-revisit if the future Private Data Ops server lands. There's an open
-issue tracking the proper consent UX once it's needed
-(see `docs/_pna_triage.md` § AC-MCP-A and the issue tracker).
+**Shared Data Ops** and **Communications** don't return Private DB
+rows, so AC-MCP-A doesn't strictly apply to them — but Shared Data
+Ops still exposes fellow contact info, and Communications stages
+text the AI client composed (which already saw the underlying data
+to compose it). The full data flow matters more than the per-server
+posture.
 
-## Configuration
+For v1, none of the three servers detects or gates cloud clients.
+The MCP transport is stdio-only, which usually means a *local
+process* is the client — but a stdio MCP client (Claude Desktop in
+its default config) still sends extracted tool output to its
+upstream model. Today's position is: **document the boundary,
+trust the user's choice**. Wire the servers up to a local model
+(Claude Desktop + a locally-served model, Cursor + Ollama) for the
+green-path posture. The proper consent UX lands when the spec's
+typed contracts land (`docs/pna_toolkit/spec/contracts/mcp-*.schema.json`).
 
-`shared_data_ops.py` resolves the DB path in this order:
+## Per-server configuration
+
+### Shared Data Ops
+
+Path resolution:
 
 1. `--db /path/to/fellows.db` CLI flag.
 2. `FELLOWS_DB_PATH` environment variable.
 3. `<repo>/app/fellows.db` relative to the script (works in-repo).
 
-The DB is always opened with SQLite's `mode=ro` URI flag — even a
-buggy tool can't mutate the snapshot.
+DB opened with `mode=ro` — even a buggy tool can't mutate the snapshot.
 
-Logs go to stderr (stdio is reserved for JSON-RPC frames). Use
-`--verbose` for noisier output when debugging tool routing.
+### Private Data Ops
+
+Path resolution (two DBs, both opened RO):
+
+| Source | Relationships DB | Fellows DB |
+|---|---|---|
+| CLI flag | `--db` | `--fellows-db` |
+| Env var | `FELLOWS_RELATIONSHIPS_DB_PATH` | `FELLOWS_DB_PATH` |
+| Default | `<repo>/app/relationships.db` | `<repo>/app/fellows.db` |
+
+Both DBs opened with `mode=ro`. `fellows.db` is `ATTACH`ed as `f` once
+per connection so a single SQL query gets group_members + fellow
+display fields in one round-trip.
+
+### Communications
+
+No DB, no config beyond `--verbose`. Staged compositions live in
+process memory only; nothing on disk. Process restart clears them.
+
+All three servers log to stderr (stdio is reserved for JSON-RPC
+frames). Use `--verbose` for noisier output when debugging tool
+routing.
 
 ## Why a separate venv
 
 `mcp_servers/` is the only Python code in this repo allowed
 non-stdlib runtime dependencies. The main app (`app/server.py`,
 `deploy/server.py`) is strictly stdlib-only per `CLAUDE.md`. Keeping
-the MCP server's deps in `mcp_servers/.venv` preserves that
-boundary.
+the MCP server deps in `mcp_servers/.venv` preserves that boundary —
+and one venv covers all three servers.
 
 ## Tests
 
 ```bash
-just test-shared-data-ops
+just test-mcp                 # all three servers
+just test-shared-data-ops     # individually
+just test-private-data-ops
+just test-comms
 ```
 
-Runs `tests/test_shared_data_ops.py` against the live `fellows.db`
-using `mcp_servers/.venv/bin/pytest`. The same file lives in
+Each runs via `mcp_servers/.venv/bin/pytest`. The same files live in
 `tests/`; when run via the project `.venv` (which doesn't have the
-`mcp` SDK), it skips cleanly.
+`mcp` SDK), they skip cleanly.

--- a/mcp_servers/comms.py
+++ b/mcp_servers/comms.py
@@ -1,0 +1,271 @@
+#!/usr/bin/env python3
+"""Communications MCP server — stage outreach for workspace-mediated launch.
+
+Exposes two tools to AI clients (Claude Desktop, Cursor, mcp-cli, local
+Ollama agents):
+
+- stage_email   Build a mailto: URL + a full payload preview from a draft
+                composition. Returns a staging_id, the URL, and a warnings
+                list (URL-length issues, missing recipients, etc.).
+- get_staged    Echo a previously staged composition by id (in-memory).
+
+Architectural posture (AC-MCP-B — see ../docs/_pna_triage.md):
+**The MCP server proposes; the workspace disposes.** This server never
+launches a transport itself. It returns a mailto: URL that the user's
+mail client (acting as the workspace for this outreach) opens with the
+composition pre-populated. The user reviews and clicks send.
+
+AC-18 (transport eligibility): mailto: passes — the mechanism can't read
+message content, and the downstream mail client is the user's choice.
+AC-19 (user-visible payload before send): the `preview` field exposes
+recipients + subject + body explicitly so the AI client can show the
+full composition to the user before they open the link.
+
+State posture: staged compositions live in-memory only. Process exit
+clears them. The server intentionally writes nothing to disk — no logs
+of who you emailed, no draft persistence. That's the workspace's job
+(see PR-2 `record_comms_history` in the spec — opt-in, off by default).
+"""
+
+import argparse
+import logging
+import os
+import secrets
+import sys
+import threading
+from pathlib import Path
+from urllib.parse import quote
+
+from mcp.server.fastmcp import FastMCP
+
+log = logging.getLogger("comms")
+
+mcp = FastMCP("comms")
+
+# Recommended ceiling for mailto: URL length. RFC doesn't set one; practical
+# clients vary. macOS Mail.app and Apple Mail on iOS handle ~8 KB; Outlook
+# starts dropping characters past ~2 KB; Gmail web "send via mailto" caps near
+# ~2 KB. Pick the conservative number and warn above it.
+MAILTO_URL_WARN_BYTES = 2000
+
+# In-memory staging table. Cleared at process exit; nothing on disk.
+_STAGED: dict[str, dict] = {}
+_STAGED_LOCK = threading.Lock()
+# Cap to keep memory bounded across a long-running session.
+_STAGED_MAX = 100
+
+
+def _new_staging_id() -> str:
+    """16-char URL-safe random id. Opaque to the client."""
+    return secrets.token_urlsafe(12)[:16]
+
+
+def _clean_email(addr: str) -> str:
+    """Strip whitespace; pass-through otherwise. Validation is the mail
+    client's job — we don't want to reject things the user might fix in their
+    composer (e.g., "Jane <jane@x>" address-list syntax).
+    """
+    return (addr or "").strip()
+
+
+def _dedupe_emails(addrs):
+    """Strip empties, dedupe case-insensitively, preserve order."""
+    seen = set()
+    out = []
+    for a in addrs or ():
+        c = _clean_email(a)
+        if not c:
+            continue
+        key = c.lower()
+        if key in seen:
+            continue
+        seen.add(key)
+        out.append(c)
+    return out
+
+
+def _build_mailto(to: list, cc: list, bcc: list, subject: str, body: str) -> str:
+    """Compose a mailto: URL per RFC 6068.
+
+    Header values are percent-encoded. Multiple recipients are joined with
+    commas. ``to`` is part of the URL path; ``cc``, ``bcc``, ``subject``,
+    ``body`` are header parameters.
+    """
+    path = ",".join(quote(addr, safe="@") for addr in to)
+    params = []
+    if cc:
+        params.append(("cc", ",".join(cc)))
+    if bcc:
+        params.append(("bcc", ",".join(bcc)))
+    if subject:
+        params.append(("subject", subject))
+    if body:
+        params.append(("body", body))
+    if not params:
+        return f"mailto:{path}"
+    qs = "&".join(f"{k}={quote(v, safe='@,')}" for k, v in params)
+    return f"mailto:{path}?{qs}"
+
+
+def _store(record: dict) -> str:
+    """Insert into the in-memory staging table, evicting the oldest if full."""
+    sid = _new_staging_id()
+    with _STAGED_LOCK:
+        if len(_STAGED) >= _STAGED_MAX:
+            # Drop the oldest insertion (Python dicts preserve insertion order).
+            oldest = next(iter(_STAGED))
+            _STAGED.pop(oldest, None)
+        _STAGED[sid] = record
+    return sid
+
+
+@mcp.tool()
+def stage_email(
+    subject: str,
+    body: str,
+    to: list[str] | None = None,
+    cc: list[str] | None = None,
+    bcc: list[str] | None = None,
+) -> dict:
+    """Stage an email composition for the user to review and send.
+
+    Builds a ``mailto:`` URL that the user's mail client opens with everything
+    pre-populated. The MCP server never sends — opening the URL is what the
+    user (or the AI client on the user's behalf) does to hand the composition
+    off to the mail client.
+
+    For groups, prefer ``bcc`` over ``to`` so individual addresses aren't
+    visible in everyone's "To:" header. ``to`` may be empty if the entire
+    list is in bcc.
+
+    Recipients are de-duplicated case-insensitively. Empty addresses are
+    silently dropped (the AI may pass through fellows with no email).
+
+    Args:
+        subject: The email subject. Required (empty string allowed).
+        body: The email body. Required (empty string allowed).
+        to: Visible primary recipients. Optional; pass an empty list or
+            omit for BCC-only group sends.
+        cc: Carbon-copied recipients. Optional.
+        bcc: Blind-carbon-copied recipients. Optional.
+
+    Returns:
+        {
+          "staging_id": str,              # opaque id for get_staged
+          "mailto_url": str,              # the URL to open
+          "preview": {
+            "recipients": {
+              "to": list[str],
+              "cc": list[str],
+              "bcc": list[str],
+              "total": int,
+            },
+            "subject": str,
+            "body": str,
+            "url_byte_length": int,
+          },
+          "warnings": list[str],          # human-readable issues for the user
+        }
+    """
+    to_clean = _dedupe_emails(to)
+    cc_clean = _dedupe_emails(cc)
+    bcc_clean = _dedupe_emails(bcc)
+    subject = subject or ""
+    body = body or ""
+
+    mailto_url = _build_mailto(to_clean, cc_clean, bcc_clean, subject, body)
+    url_bytes = len(mailto_url.encode("utf-8"))
+    total = len(to_clean) + len(cc_clean) + len(bcc_clean)
+
+    warnings = []
+    if total == 0:
+        warnings.append(
+            "No recipients — the mail client will open but won't have anyone to send to."
+        )
+    if url_bytes > MAILTO_URL_WARN_BYTES:
+        warnings.append(
+            f"mailto: URL is {url_bytes} bytes; some mail clients (Outlook, "
+            f"Gmail-via-mailto) start truncating around {MAILTO_URL_WARN_BYTES} bytes. "
+            "Consider splitting the recipient list, or paste the body into the mail "
+            "composer after it opens."
+        )
+    if to_clean and total > 1 and not bcc_clean:
+        # Heuristic: a group send through To: leaks every recipient's address.
+        # Worth a nudge for the AI client to surface to the user.
+        warnings.append(
+            "Multiple recipients in `to`. Consider moving them to `bcc` so addresses "
+            "aren't visible to everyone on the thread."
+        )
+
+    preview = {
+        "recipients": {
+            "to": to_clean,
+            "cc": cc_clean,
+            "bcc": bcc_clean,
+            "total": total,
+        },
+        "subject": subject,
+        "body": body,
+        "url_byte_length": url_bytes,
+    }
+    record = {
+        "mailto_url": mailto_url,
+        "preview": preview,
+        "warnings": warnings,
+    }
+    sid = _store(record)
+    log.debug(
+        "stage_email -> sid=%s, total=%d recipients, url=%d bytes, warnings=%d",
+        sid, total, url_bytes, len(warnings),
+    )
+    return {"staging_id": sid, **record}
+
+
+@mcp.tool()
+def get_staged(staging_id: str) -> dict | None:
+    """Look up a previously staged composition by id.
+
+    Useful when the user asks "what did you draft a minute ago?" Returns null
+    when the id isn't known (process restart, eviction, or never staged).
+    Staged records live in memory only; nothing persists across restarts.
+
+    Args:
+        staging_id: The id returned by stage_email.
+
+    Returns:
+        {
+          "staging_id": str,
+          "mailto_url": str,
+          "preview": {...},
+          "warnings": list[str],
+        }
+        or null.
+    """
+    sid = (staging_id or "").strip()
+    if not sid:
+        return None
+    with _STAGED_LOCK:
+        rec = _STAGED.get(sid)
+    if rec is None:
+        return None
+    return {"staging_id": sid, **rec}
+
+
+def main(argv: list[str] | None = None) -> int:
+    parser = argparse.ArgumentParser(description="Communications MCP server.")
+    parser.add_argument("--verbose", "-v", action="store_true",
+                        help="Log tool calls and resolved args to stderr.")
+    args = parser.parse_args(argv)
+
+    logging.basicConfig(
+        stream=sys.stderr,
+        level=logging.DEBUG if args.verbose else logging.WARNING,
+        format="%(asctime)s %(name)s %(levelname)s %(message)s",
+    )
+    log.info("comms MCP server starting; stage-only, in-memory")
+    mcp.run()
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/mcp_servers/private_data_ops.py
+++ b/mcp_servers/private_data_ops.py
@@ -1,0 +1,305 @@
+#!/usr/bin/env python3
+"""Private Data Ops — read-only MCP access to the Private DB (relationships.db).
+
+Exposes three read-only tools to AI clients (Claude Desktop, Cursor, mcp-cli,
+local Ollama agents):
+
+- list_groups        All groups + member counts, newest-touched first.
+- find_group         Case-insensitive substring match on group name.
+- get_group_members  One group plus its members, joined to fellows.db for
+                     names + emails (single round-trip; AI doesn't need to
+                     chain to shared-data-ops for the common case).
+
+v1 scope: groups only. The schema also carries `fellow_tags` and `fellow_notes`,
+but users aren't yet writing those at scale (per 2026-05-14 review). Notes/tags
+land when there's usage to support.
+
+Transport: stdio (the MCP standard for desktop AI clients).
+DB access: read-only SQLite URI (mode=ro) on both relationships.db and the
+ATTACHed fellows.db. Even a buggy tool can't mutate either store.
+
+Privacy posture (AC-MCP-A — see ../docs/_pna_triage.md):
+This server *does* return Private DB rows (your groups and the fellows in them).
+Per AC-MCP-A, cloud AI clients should require explicit per-call consent before
+seeing this data. v1 does not implement that gate — it documents the boundary
+and trusts the user's choice of MCP client. Wire it up to a local model
+(Claude Desktop + local model, Cursor + Ollama) for the green-path posture.
+The proper consent UX lands when the spec's typed contracts land.
+"""
+
+import argparse
+import logging
+import os
+import sqlite3
+import sys
+from pathlib import Path
+from urllib.parse import quote
+
+REPO_ROOT = Path(__file__).resolve().parent.parent
+if str(REPO_ROOT) not in sys.path:
+    sys.path.insert(0, str(REPO_ROOT))
+
+from app.fellows_queries import row_to_fellow  # noqa: E402
+
+from mcp.server.fastmcp import FastMCP  # noqa: E402
+
+log = logging.getLogger("private-data-ops")
+
+mcp = FastMCP("private-data-ops")
+
+# Module-level paths; set by main() before mcp.run() starts the loop.
+_REL_DB_PATH: Path | None = None
+_FELLOWS_DB_PATH: Path | None = None
+
+LIST_LIMIT_DEFAULT = 100
+LIST_LIMIT_MAX = 500
+
+
+def _path_to_ro_uri(p: Path) -> str:
+    return f"file:{quote(str(p), safe='/:')}?mode=ro"
+
+
+def _open_ro() -> sqlite3.Connection:
+    """Open relationships.db RO with fellows.db ATTACHed as `f` RO.
+
+    Read-only-ness is enforced at the SQLite level (mode=ro), not just by
+    convention — accidental writes raise OperationalError.
+    """
+    if _REL_DB_PATH is None or _FELLOWS_DB_PATH is None:
+        raise RuntimeError("DB paths not configured; call main() first")
+    conn = sqlite3.connect(_path_to_ro_uri(_REL_DB_PATH), uri=True)
+    conn.row_factory = sqlite3.Row
+    conn.execute("ATTACH DATABASE ? AS f", (_path_to_ro_uri(_FELLOWS_DB_PATH),))
+    return conn
+
+
+def _to_group_summary(row: sqlite3.Row) -> dict:
+    """Shape for list/find responses — one row per group, no member list."""
+    return {
+        "group_id": row["id"],
+        "name": row["name"],
+        "note": row["note"],
+        "member_count": row["member_count"],
+        "created_at": row["created_at"],
+        "updated_at": row["updated_at"],
+    }
+
+
+def _to_member(row: sqlite3.Row) -> dict:
+    """Shape for one member of a group — record_id from Private DB + display
+    fields from fellows.db. ``contact_email`` is null when the fellow has no
+    email or when the record_id no longer resolves in the Shared DB (orphan
+    after a re-mirror, per AC-10 / SH-5).
+    """
+    return {
+        "record_id": row["record_id"],
+        "slug": row["slug"],
+        "name": row["name"],
+        "contact_email": row["contact_email"],
+        "fellow_type": row["fellow_type"],
+        "currently_based_in": row["currently_based_in"],
+    }
+
+
+@mcp.tool()
+def list_groups(limit: int = LIST_LIMIT_DEFAULT) -> dict:
+    """List all groups in the Private DB, newest-touched first.
+
+    Args:
+        limit: Max groups to return. Default 100, capped at 500.
+
+    Returns:
+        {
+          "total": int,                 # total groups (pre-limit)
+          "results": list[GroupSummary] # {group_id, name, note, member_count,
+                                        #  created_at, updated_at}
+        }
+    """
+    limit = max(1, min(int(limit), LIST_LIMIT_MAX))
+    with _open_ro() as conn:
+        total = conn.execute("SELECT COUNT(*) FROM groups").fetchone()[0]
+        cur = conn.execute(
+            """
+            SELECT g.id, g.name, g.note, g.created_at, g.updated_at,
+                   COUNT(gm.fellow_record_id) AS member_count
+            FROM groups g
+            LEFT JOIN group_members gm ON gm.group_id = g.id
+            GROUP BY g.id
+            ORDER BY g.updated_at DESC, g.id DESC
+            LIMIT ?
+            """,
+            (limit,),
+        )
+        results = [_to_group_summary(r) for r in cur.fetchall()]
+    log.debug("list_groups(limit=%d) -> total=%d, returned=%d", limit, total, len(results))
+    return {"total": total, "results": results}
+
+
+@mcp.tool()
+def find_group(name: str, limit: int = LIST_LIMIT_DEFAULT) -> dict:
+    """Find groups whose name contains the given substring (case-insensitive).
+
+    Useful when the user asks for "the climate group" — match on substring,
+    return whatever's there. If multiple match, the AI client can disambiguate
+    by showing the names or by calling get_group_members on each.
+
+    Args:
+        name: Substring to match against group names. Empty string returns
+            no results (use list_groups for that).
+        limit: Max groups to return. Default 100, capped at 500.
+
+    Returns:
+        {
+          "query": str,                 # echoed (trimmed) query
+          "total": int,                 # matches pre-limit
+          "results": list[GroupSummary] # same shape as list_groups.results
+        }
+    """
+    q = (name or "").strip()
+    if not q:
+        return {"query": "", "total": 0, "results": []}
+    limit = max(1, min(int(limit), LIST_LIMIT_MAX))
+    pattern = f"%{q}%"
+    with _open_ro() as conn:
+        total = conn.execute(
+            "SELECT COUNT(*) FROM groups WHERE name LIKE ? COLLATE NOCASE",
+            (pattern,),
+        ).fetchone()[0]
+        cur = conn.execute(
+            """
+            SELECT g.id, g.name, g.note, g.created_at, g.updated_at,
+                   COUNT(gm.fellow_record_id) AS member_count
+            FROM groups g
+            LEFT JOIN group_members gm ON gm.group_id = g.id
+            WHERE g.name LIKE ? COLLATE NOCASE
+            GROUP BY g.id
+            ORDER BY g.updated_at DESC, g.id DESC
+            LIMIT ?
+            """,
+            (pattern, limit),
+        )
+        results = [_to_group_summary(r) for r in cur.fetchall()]
+    log.debug("find_group(%r, limit=%d) -> total=%d, returned=%d", q, limit, total, len(results))
+    return {"query": q, "total": total, "results": results}
+
+
+@mcp.tool()
+def get_group_members(group_id: int) -> dict | None:
+    """Fetch one group plus its members, joined to fellows.db.
+
+    Single round-trip — the AI doesn't need to chain to shared-data-ops to
+    resolve names + emails for the common case (drafting an email to a group).
+    Members with a ``record_id`` that no longer resolves in fellows.db come
+    back with null ``name`` / ``contact_email`` (orphan after a Shared DB
+    re-mirror — see AC-10).
+
+    Args:
+        group_id: The numeric group id from list_groups / find_group.
+
+    Returns:
+        {
+          "group": GroupSummary,
+          "members": list[Member]       # {record_id, slug, name,
+                                        #  contact_email, fellow_type,
+                                        #  currently_based_in}
+        }
+        or null if no group with that id exists.
+    """
+    gid = int(group_id)
+    with _open_ro() as conn:
+        row = conn.execute(
+            """
+            SELECT g.id, g.name, g.note, g.created_at, g.updated_at,
+                   (SELECT COUNT(*) FROM group_members gm WHERE gm.group_id = g.id)
+                       AS member_count
+            FROM groups g
+            WHERE g.id = ?
+            """,
+            (gid,),
+        ).fetchone()
+        if row is None:
+            return None
+        group = _to_group_summary(row)
+        members_cur = conn.execute(
+            """
+            SELECT gm.fellow_record_id AS record_id,
+                   fl.slug AS slug,
+                   fl.name AS name,
+                   fl.contact_email AS contact_email,
+                   fl.fellow_type AS fellow_type,
+                   fl.currently_based_in AS currently_based_in
+            FROM group_members gm
+            LEFT JOIN f.fellows fl ON fl.record_id = gm.fellow_record_id
+            WHERE gm.group_id = ?
+            ORDER BY COALESCE(fl.name, gm.fellow_record_id) ASC
+            """,
+            (gid,),
+        )
+        members = [_to_member(r) for r in members_cur.fetchall()]
+    log.debug("get_group_members(%d) -> %d members", gid, len(members))
+    return {"group": group, "members": members}
+
+
+def _resolve_db_paths(rel_arg: str | None, fellows_arg: str | None) -> tuple[Path, Path]:
+    if rel_arg:
+        rel = Path(rel_arg).resolve()
+    else:
+        env = os.environ.get("FELLOWS_RELATIONSHIPS_DB_PATH")
+        rel = Path(env).resolve() if env else (REPO_ROOT / "app" / "relationships.db").resolve()
+    if fellows_arg:
+        fel = Path(fellows_arg).resolve()
+    else:
+        env = os.environ.get("FELLOWS_DB_PATH")
+        fel = Path(env).resolve() if env else (REPO_ROOT / "app" / "fellows.db").resolve()
+    return rel, fel
+
+
+def main(argv: list[str] | None = None) -> int:
+    parser = argparse.ArgumentParser(description="Private Data Ops MCP server for relationships.db.")
+    parser.add_argument(
+        "--db", default=None,
+        help="Path to relationships.db. Defaults to FELLOWS_RELATIONSHIPS_DB_PATH or <repo>/app/relationships.db.",
+    )
+    parser.add_argument(
+        "--fellows-db", default=None,
+        help="Path to fellows.db. Defaults to FELLOWS_DB_PATH or <repo>/app/fellows.db.",
+    )
+    parser.add_argument("--verbose", "-v", action="store_true",
+                        help="Log tool calls and resolved args to stderr.")
+    args = parser.parse_args(argv)
+
+    logging.basicConfig(
+        stream=sys.stderr,
+        level=logging.DEBUG if args.verbose else logging.WARNING,
+        format="%(asctime)s %(name)s %(levelname)s %(message)s",
+    )
+
+    global _REL_DB_PATH, _FELLOWS_DB_PATH
+    _REL_DB_PATH, _FELLOWS_DB_PATH = _resolve_db_paths(args.db, args.fellows_db)
+    if not _REL_DB_PATH.is_file():
+        print(f"relationships.db not found at {_REL_DB_PATH}", file=sys.stderr)
+        print("Open the app once to bootstrap it, or download a backup from", file=sys.stderr)
+        print("Settings → Restore from backup and place it at the path above.", file=sys.stderr)
+        return 1
+    if not _FELLOWS_DB_PATH.is_file():
+        print(f"fellows.db not found at {_FELLOWS_DB_PATH}", file=sys.stderr)
+        print("Run: just db-rebuild", file=sys.stderr)
+        return 1
+    try:
+        with _open_ro() as conn:
+            conn.execute("SELECT 1 FROM groups LIMIT 1").fetchone()
+            conn.execute("SELECT 1 FROM f.fellows LIMIT 1").fetchone()
+    except sqlite3.Error as e:
+        print(f"Cannot open Private/Shared DBs read-only: {e}", file=sys.stderr)
+        return 1
+
+    log.info(
+        "private-data-ops MCP server starting; rel_db=%s fellows_db=%s",
+        _REL_DB_PATH, _FELLOWS_DB_PATH,
+    )
+    mcp.run()
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/tests/test_comms.py
+++ b/tests/test_comms.py
@@ -1,0 +1,152 @@
+"""Unit tests for the Communications MCP server.
+
+Calls the underlying tool functions directly (not through the MCP protocol).
+Skips when the ``mcp`` SDK isn't installed, since the server module imports
+it at module load time. Run via ``just test-comms`` (which uses
+``mcp_servers/.venv``) or any venv with ``mcp`` available.
+"""
+from __future__ import annotations
+
+import sys
+from pathlib import Path
+from urllib.parse import unquote, urlparse, parse_qs
+
+import pytest
+
+pytest.importorskip("mcp")
+
+REPO_ROOT = Path(__file__).resolve().parent.parent
+if str(REPO_ROOT) not in sys.path:
+    sys.path.insert(0, str(REPO_ROOT))
+
+import mcp_servers.comms as srv  # noqa: E402
+
+
+def _unwrap(tool):
+    return tool.fn if hasattr(tool, "fn") else tool
+
+
+@pytest.fixture(autouse=True)
+def _clear_staging():
+    """Each test starts with an empty staging table."""
+    with srv._STAGED_LOCK:
+        srv._STAGED.clear()
+    yield
+
+
+def _parse_mailto(url):
+    """Pull recipients + headers out of a mailto: URL."""
+    assert url.startswith("mailto:")
+    parsed = urlparse(url)
+    path = parsed.path
+    to = [unquote(a) for a in path.split(",") if a]
+    qs = parse_qs(parsed.query, keep_blank_values=True)
+    return to, qs
+
+
+def test_stage_email_basic_to():
+    out = _unwrap(srv.stage_email)(
+        subject="hi",
+        body="hello there",
+        to=["a@example.com"],
+    )
+    assert "staging_id" in out and out["staging_id"]
+    assert out["preview"]["recipients"]["total"] == 1
+    to, qs = _parse_mailto(out["mailto_url"])
+    assert to == ["a@example.com"]
+    assert qs["subject"] == ["hi"]
+    assert qs["body"] == ["hello there"]
+
+
+def test_stage_email_bcc_group_send():
+    out = _unwrap(srv.stage_email)(
+        subject="Meet Thursday",
+        body="Hi all, come to the meetup",
+        bcc=["a@example.com", "b@example.com", "c@example.com"],
+    )
+    to, qs = _parse_mailto(out["mailto_url"])
+    assert to == []
+    assert qs["bcc"][0] == "a@example.com,b@example.com,c@example.com"
+    assert out["preview"]["recipients"]["bcc"] == ["a@example.com", "b@example.com", "c@example.com"]
+    assert out["preview"]["recipients"]["total"] == 3
+    # No "multiple recipients in to:" warning since none are in to.
+    assert not any("Multiple recipients in `to`" in w for w in out["warnings"])
+
+
+def test_stage_email_dedupes_case_insensitive():
+    out = _unwrap(srv.stage_email)(
+        subject="x", body="y",
+        bcc=["A@Example.com", "a@example.com", "  ", "B@example.com", "b@EXAMPLE.com"],
+    )
+    bcc = out["preview"]["recipients"]["bcc"]
+    # Originals preserved, dedupe by lowercase.
+    assert bcc == ["A@Example.com", "B@example.com"]
+
+
+def test_stage_email_warns_on_no_recipients():
+    out = _unwrap(srv.stage_email)(subject="oops", body="b")
+    assert out["preview"]["recipients"]["total"] == 0
+    assert any("No recipients" in w for w in out["warnings"])
+
+
+def test_stage_email_warns_on_multiple_to():
+    out = _unwrap(srv.stage_email)(
+        subject="x", body="y",
+        to=["a@example.com", "b@example.com"],
+    )
+    assert any("Multiple recipients in `to`" in w for w in out["warnings"])
+
+
+def test_stage_email_warns_on_long_url():
+    big_body = "x" * (srv.MAILTO_URL_WARN_BYTES + 500)
+    out = _unwrap(srv.stage_email)(
+        subject="x", body=big_body, to=["a@example.com"]
+    )
+    assert out["preview"]["url_byte_length"] > srv.MAILTO_URL_WARN_BYTES
+    assert any("URL is" in w and "bytes" in w for w in out["warnings"])
+
+
+def test_stage_email_url_encodes_special_chars():
+    out = _unwrap(srv.stage_email)(
+        subject="Re: hi & bye",
+        body="line one\nline two",
+        to=["a@example.com"],
+    )
+    # The URL must round-trip cleanly via standard parsing.
+    to, qs = _parse_mailto(out["mailto_url"])
+    assert to == ["a@example.com"]
+    assert qs["subject"] == ["Re: hi & bye"]
+    assert qs["body"] == ["line one\nline two"]
+
+
+def test_get_staged_round_trips():
+    out = _unwrap(srv.stage_email)(
+        subject="x", body="y", to=["a@example.com"]
+    )
+    sid = out["staging_id"]
+    fetched = _unwrap(srv.get_staged)(sid)
+    assert fetched is not None
+    assert fetched["staging_id"] == sid
+    assert fetched["mailto_url"] == out["mailto_url"]
+    assert fetched["preview"] == out["preview"]
+
+
+def test_get_staged_unknown_returns_none():
+    assert _unwrap(srv.get_staged)("definitely-not-real") is None
+    assert _unwrap(srv.get_staged)("") is None
+
+
+def test_staging_eviction_at_cap():
+    """Past _STAGED_MAX inserts, the oldest record is evicted."""
+    saved = srv._STAGED_MAX
+    try:
+        srv._STAGED_MAX = 3
+        a = _unwrap(srv.stage_email)(subject="1", body="b", to=["a@e.com"])["staging_id"]
+        _unwrap(srv.stage_email)(subject="2", body="b", to=["a@e.com"])
+        _unwrap(srv.stage_email)(subject="3", body="b", to=["a@e.com"])
+        _unwrap(srv.stage_email)(subject="4", body="b", to=["a@e.com"])
+        # `a` should be gone (oldest evicted when the 4th was inserted).
+        assert _unwrap(srv.get_staged)(a) is None
+        assert len(srv._STAGED) == 3
+    finally:
+        srv._STAGED_MAX = saved

--- a/tests/test_private_data_ops.py
+++ b/tests/test_private_data_ops.py
@@ -1,0 +1,175 @@
+"""Unit tests for the Private Data Ops MCP server.
+
+These call the underlying tool functions directly (not through the MCP
+protocol) against a temp relationships.db plus the live ``app/fellows.db``.
+
+Skips when the ``mcp`` SDK isn't installed, since the server module imports
+it at module load time. Run via ``just test-private-data-ops`` (which uses
+``mcp_servers/.venv``) or any venv with ``mcp`` available.
+"""
+from __future__ import annotations
+
+import sqlite3
+import sys
+import tempfile
+from pathlib import Path
+
+import pytest
+
+pytest.importorskip("mcp")
+
+REPO_ROOT = Path(__file__).resolve().parent.parent
+if str(REPO_ROOT) not in sys.path:
+    sys.path.insert(0, str(REPO_ROOT))
+
+FELLOWS_DB = REPO_ROOT / "app" / "fellows.db"
+
+if not FELLOWS_DB.is_file():
+    pytest.skip(
+        f"fellows.db not found at {FELLOWS_DB}. Run: just db-rebuild",
+        allow_module_level=True,
+    )
+
+from app.relationships import bootstrap_schema  # noqa: E402
+import mcp_servers.private_data_ops as srv  # noqa: E402
+
+
+def _unwrap(tool):
+    """Get the plain callable behind a FastMCP-decorated tool object."""
+    return tool.fn if hasattr(tool, "fn") else tool
+
+
+@pytest.fixture
+def fixture_db(tmp_path):
+    """Build a temp relationships.db with two groups and a few members.
+
+    Members are drawn from the live fellows.db so the cross-DB join in
+    get_group_members has something real to match. We pick the first three
+    fellows by name — they'll be the same on every run for a given DB build.
+    """
+    rel = tmp_path / "relationships.db"
+    conn = sqlite3.connect(rel)
+    conn.row_factory = sqlite3.Row
+    bootstrap_schema(conn)
+
+    fconn = sqlite3.connect(FELLOWS_DB)
+    fconn.row_factory = sqlite3.Row
+    fellow_ids = [
+        r["record_id"]
+        for r in fconn.execute(
+            "SELECT record_id FROM fellows ORDER BY name ASC LIMIT 3"
+        ).fetchall()
+    ]
+    fconn.close()
+    assert len(fellow_ids) == 3, "fellows.db must have at least 3 rows for tests"
+
+    now = "2026-05-14T10:00:00Z"
+    conn.execute(
+        "INSERT INTO groups(id, name, note, created_at, updated_at) VALUES (?, ?, ?, ?, ?)",
+        (1, "Climate Action Group", "Test group for climate", now, now),
+    )
+    conn.execute(
+        "INSERT INTO groups(id, name, note, created_at, updated_at) VALUES (?, ?, ?, ?, ?)",
+        (2, "Auckland Meetup", "", now, "2026-05-13T10:00:00Z"),
+    )
+    # Climate group: 2 members; Auckland: 1 member; plus 1 orphan to test the
+    # left-join branch (record_id not in fellows.db).
+    conn.executemany(
+        "INSERT INTO group_members(group_id, fellow_record_id) VALUES (?, ?)",
+        [
+            (1, fellow_ids[0]),
+            (1, fellow_ids[1]),
+            (1, "orphan-record-id-does-not-exist"),
+            (2, fellow_ids[2]),
+        ],
+    )
+    conn.commit()
+    conn.close()
+    return rel
+
+
+@pytest.fixture(autouse=True)
+def _set_db_paths(fixture_db):
+    prev_rel = srv._REL_DB_PATH
+    prev_fel = srv._FELLOWS_DB_PATH
+    srv._REL_DB_PATH = fixture_db
+    srv._FELLOWS_DB_PATH = FELLOWS_DB
+    yield
+    srv._REL_DB_PATH = prev_rel
+    srv._FELLOWS_DB_PATH = prev_fel
+
+
+def test_list_groups_returns_both_newest_first():
+    out = _unwrap(srv.list_groups)()
+    assert out["total"] == 2
+    assert [g["name"] for g in out["results"]] == ["Climate Action Group", "Auckland Meetup"]
+    climate = out["results"][0]
+    assert climate["group_id"] == 1
+    assert climate["member_count"] == 3
+    assert climate["note"] == "Test group for climate"
+
+
+def test_list_groups_respects_limit():
+    out = _unwrap(srv.list_groups)(limit=1)
+    assert out["total"] == 2          # pre-limit total
+    assert len(out["results"]) == 1
+    assert out["results"][0]["name"] == "Climate Action Group"
+
+
+def test_find_group_case_insensitive_substring():
+    out = _unwrap(srv.find_group)("climate")
+    assert out["query"] == "climate"
+    assert out["total"] == 1
+    assert out["results"][0]["name"] == "Climate Action Group"
+
+    out2 = _unwrap(srv.find_group)("CLIMATE")
+    assert out2["total"] == 1
+
+
+def test_find_group_empty_query_short_circuits():
+    assert _unwrap(srv.find_group)("") == {"query": "", "total": 0, "results": []}
+    assert _unwrap(srv.find_group)("   ")["results"] == []
+
+
+def test_find_group_no_match():
+    out = _unwrap(srv.find_group)("nonexistent")
+    assert out["total"] == 0
+    assert out["results"] == []
+
+
+def test_get_group_members_joins_fellows():
+    out = _unwrap(srv.get_group_members)(1)
+    assert out is not None
+    assert out["group"]["name"] == "Climate Action Group"
+    assert out["group"]["member_count"] == 3
+    members = out["members"]
+    assert len(members) == 3
+    # Two members resolve from fellows.db, one is orphan.
+    resolved = [m for m in members if m["name"] is not None]
+    orphans = [m for m in members if m["name"] is None]
+    assert len(resolved) == 2
+    assert len(orphans) == 1
+    assert orphans[0]["record_id"] == "orphan-record-id-does-not-exist"
+    assert orphans[0]["contact_email"] is None
+    # Resolved members carry the joined fields.
+    for m in resolved:
+        assert set(m.keys()) == {
+            "record_id", "slug", "name",
+            "contact_email", "fellow_type", "currently_based_in",
+        }
+
+
+def test_get_group_members_unknown_returns_none():
+    assert _unwrap(srv.get_group_members)(99999) is None
+
+
+def test_read_only_enforcement():
+    """A write against either DB must raise OperationalError."""
+    conn = srv._open_ro()
+    try:
+        with pytest.raises(sqlite3.OperationalError):
+            conn.execute("INSERT INTO groups(id, name, note, created_at, updated_at) VALUES (3, 'x', '', 'now', 'now')")
+        with pytest.raises(sqlite3.OperationalError):
+            conn.execute("DELETE FROM f.fellows WHERE 1=1")
+    finally:
+        conn.close()


### PR DESCRIPTION
## Summary

- Two more of the four canonical MCP servers from the PNA architecture (`docs/_pna_triage.md`), building on the Shared Data Ops server in #157. Together with that one, they enable the flagship Claude Desktop demo: *"compose an email to the climate group in my fellows database inviting them to meet Thursday NZ time at 1pm — don't send, just stage it."*
- **Private Data Ops** — RO over `relationships.db` with `fellows.db` ATTACHed (also RO). Groups-only for v1 (`list_groups`, `find_group`, `get_group_members`). Tags/notes deferred — users aren't writing those at scale yet.
- **Communications** — pure stage-only server. `stage_email` builds a `mailto:` URL + full payload preview + warnings; `get_staged` echoes by id. In-memory only, nothing on disk. **AC-MCP-B preserved: server stages, mail client launches** (the user reviews and clicks send from inside their mail composer).
- One install ceremony, three independent stdio servers (single `mcp_servers/.venv`, single JSON-config paste with three entries).

## What changed

- **New:** `mcp_servers/private_data_ops.py` — FastMCP server, stdio. RO connections to both DBs (SQLite `mode=ro` URI). `get_group_members` joins to `f.fellows` in one round-trip so the AI doesn't have to chain to `shared-data-ops` for the common group-email case.
- **New:** `mcp_servers/comms.py` — FastMCP server, stdio. `stage_email` returns `{staging_id, mailto_url, preview, warnings}`; emits warnings for no-recipients, multiple-`to:`-recipients-without-bcc, and URLs over 2 KB. RFC-6068 `mailto:` building.
- **New:** `tests/test_private_data_ops.py` (8 tests) and `tests/test_comms.py` (10 tests).
- **Modified:** `mcp_servers/README.md` — full rewrite. Three-server status table, single Claude Desktop config block with all three entries, flagship demo prompt, AC-MCP-A consent caveat now spelled out properly (Private Data Ops returns Private DB rows for the first time).
- **Modified:** `justfile` — new recipes `private-data-ops`, `comms`, `test-private-data-ops`, `test-comms`, `test-mcp` (runs all three test suites).
- **Modified:** `docs/users_manual.md` — new "Where your data is stored" section between *Where the installed app lives* and *The directory*. Surfaces a gap identified during this work: the manual told users how to install the app but not where the data lives. Covers OPFS in plain language, download / restore / auto-backup steps, what Clear App Cache vs. Reset Everything do to backups, Android Clear Storage and iOS Safari Clear History/Website Data gotchas, and carrying data across browsers/devices.

## Test plan

Automated, passing locally:

- [x] `just test-mcp` — 30 passing (12 shared + 8 private + 10 comms).
- [x] `just test-fast` — 86 passing (no regressions in the broader suite).
- [x] End-to-end smoke against the real on-disk DBs: `find_group("climate")` → 7 members joined via `fellows.db` → 479-byte `mailto:` URL with correct percent-encoding for accented chars and newlines, no warnings.

## Manual QA for the maintainer

**Before the live demo**: download a fresh copy of `relationships.db` from your installed PWA (Settings → ⬇ Download my user data) and overwrite `app/relationships.db`. The on-disk file otherwise diverges from your PWA's OPFS over time.

- [ ] `just mcp-install-deps` — same venv works for all three servers (idempotent if already done for #157).
- [ ] Paste the three-entry `mcpServers` block from `mcp_servers/README.md` into `~/Library/Application Support/Claude/claude_desktop_config.json`. **Fully quit Claude Desktop** (⌘Q) and relaunch.
- [ ] Settings → Developer → Local MCP servers — confirm `shared-data-ops`, `private-data-ops`, and `comms` all show.
- [ ] Sanity prompts (watch `~/Library/Logs/Claude/mcp*.log` to confirm tools fire):
  - *"List my groups."* → `private-data-ops` `list_groups`.
  - *"Find the climate group."* → `private-data-ops` `find_group`.
  - *"Who's in the climate action group?"* → `private-data-ops` `get_group_members` (one tool call; joined names + emails).
- [ ] **Flagship demo**: *"Compose an email to the climate action group inviting them to meet Thursday NZ time at 1pm. Don't send — stage it."* — all three servers should fire in sequence. Claude should present a preview of recipients + subject + body and hand you a `mailto:` URL. Click it → mail client opens with the composition pre-populated → review → send.
- [ ] Disable `private-data-ops` in Settings → Developer, repeat the flagship prompt. Claude should fall back to a vaguer answer or refuse the recipient lookup — proves the MCP server is doing the work.

## Cross-PR note

#TBD-backup-restore-ux refines `users_manual.md`'s download copy with the showSaveFilePicker-aware location story. After both PRs land there's a small follow-up: the *Where your data is stored* section (added here) has a "Downloads is a good default" hint that becomes inaccurate once the picker forces an explicit save location. Trivial follow-up edit after merge.

## Related

- Builds on #157 (Shared Data Ops MCP server).
- Tracked follow-up: AC-MCP-A consent gating for cloud-hosted AI clients (was deferred in #157; same posture here — Private Data Ops returns Private DB rows but doesn't yet gate cloud clients).
- Opens space for the fourth canonical MCP server (Diagnostics) and for the typed contracts in `docs/pna_toolkit/spec/contracts/` (`docs/pna-spec-triage` branch).

🤖 Generated with [Claude Code](https://claude.com/claude-code)