### PR TITLE
fix(backup): native save dialog on desktop; honest status; cancel-aware reset

### DIFF
--- a/app/static/app.js
+++ b/app/static/app.js
@@ -2134,8 +2134,12 @@
       var ts = new Date().toISOString().replace(/[:.]/g, '-');
       var filename = 'relationships-' + ts + '.db';
       var blob = new Blob([bytes], { type: 'application/octet-stream' });
-      return downloadBlob(blob, filename).then(function () {
-        return { filename: filename, byteLength: bytes.byteLength };
+      return downloadBlob(blob, filename).then(function (result) {
+        return {
+          outcome: (result && result.outcome) || 'fallback',
+          filename: (result && result.filename) || filename,
+          byteLength: bytes.byteLength
+        };
       });
     });
   }
@@ -2200,9 +2204,33 @@
                 promptStatus.textContent =
                   'No saved data on this device — nothing to back up. Continuing.';
               }
-            } else if (promptStatus) {
-              promptStatus.textContent =
-                'Saved ' + result.filename + ' (' + result.byteLength + ' bytes). Continuing.';
+              closePrompt();
+              destructiveConfirmAndReset();
+              return;
+            }
+            if (result.outcome === 'cancelled') {
+              // User dismissed the save dialog — treat as backing out.
+              // Don't proceed to the destructive confirm; let them
+              // pick again or hit Skip explicitly.
+              downloadBtn.disabled = false;
+              downloadBtn.textContent = '⬇ Download backup & continue';
+              if (promptStatus) {
+                promptStatus.textContent =
+                  'Save cancelled — pick again, or use Skip to reset without saving.';
+              }
+              return;
+            }
+            if (promptStatus) {
+              if (result.outcome === 'picker') {
+                promptStatus.textContent =
+                  'Saved as ' + result.filename + ' (' + result.byteLength + ' bytes). Continuing.';
+              } else if (result.outcome === 'share') {
+                promptStatus.textContent =
+                  'Saved via the share sheet (' + result.byteLength + ' bytes). Continuing.';
+              } else {
+                promptStatus.textContent =
+                  'Saved ' + result.filename + ' to your Downloads folder (' + result.byteLength + ' bytes). Continuing.';
+              }
             }
             closePrompt();
             destructiveConfirmAndReset();
@@ -7306,15 +7334,48 @@
       "</svg>"
     );
 
-  /** Trigger a Blob download. On mobile (iOS 16.4+, modern Android),
-   *  prefer the share sheet — gives the user Save to Files / AirDrop /
-   *  Mail. Desktop always uses <a download>: on macOS Chrome PWA the
-   *  share sheet has no Save-to-Downloads entry, just AirDrop/Messages.
-   *  If share() rejects (Chromium's file-share allowlist excludes
-   *  text/html, which surfaced as "permission denied" on Android too),
-   *  fall back to <a download> — but skip the fallback on AbortError,
-   *  which is the user dismissing the sheet. */
+  /** Trigger a Blob download. Returns a Promise that resolves to an
+   *  outcome object so callers can render a status message tied to
+   *  *how* the file got saved:
+   *
+   *    {outcome: 'picker',    filename: <chosen name>}    — user picked
+   *                                                         via the
+   *                                                         showSaveFilePicker
+   *                                                         native dialog
+   *    {outcome: 'share',     filename: <suggested name>} — mobile share
+   *                                                         sheet save
+   *    {outcome: 'fallback',  filename: <suggested name>} — <a download>
+   *                                                         (goes to the
+   *                                                         browser's
+   *                                                         Downloads folder)
+   *    {outcome: 'cancelled', filename: <suggested name>} — user dismissed
+   *                                                         the picker /
+   *                                                         share sheet
+   *
+   *  Decision tree:
+   *    - **Desktop** (any non-mobile UA) with `showSaveFilePicker` →
+   *      native Save As dialog. User picks name + location explicitly.
+   *      The old behavior (invisible `<a download>` click) silently lost
+   *      files inside installed PWAs on Chrome — the file lands in a
+   *      PWA-context path that's not the user's Downloads folder, with
+   *      no save dialog and no recoverable feedback. This is the fix.
+   *    - **Mobile** (iOS 16.4+, modern Android) with `navigator.canShare`
+   *      for files → OS share sheet. Includes Save to Files / Save to
+   *      Drive destinations; the mobile-native way to choose a location.
+   *      iOS / Android PWAs have no Downloads folder concept, so an
+   *      `<a download>` fallback there is even less reliable than on
+   *      desktop.
+   *    - **Everything else** (Safari, Firefox, older browsers,
+   *      capability rejections) → `<a download>`. Both Safari and
+   *      Firefox handle this correctly, landing the file in the user's
+   *      Downloads folder with a visible banner.
+   */
   function downloadBlob(blob, filename) {
+    function isMobileUA() {
+      var ua = navigator.userAgent || '';
+      return /iPad|iPhone|iPod|Android/.test(ua) ||
+             (navigator.platform === 'MacIntel' && navigator.maxTouchPoints > 1);
+    }
     function triggerAnchorDownload() {
       return new Promise(function (resolve) {
         var url = URL.createObjectURL(blob);
@@ -7327,25 +7388,60 @@
         setTimeout(function () {
           try { document.body.removeChild(a); } catch (e) {}
           try { URL.revokeObjectURL(url); } catch (e) {}
-          resolve();
+          resolve({ outcome: 'fallback', filename: filename });
         }, 100);
       });
     }
+
+    // Desktop with the File System Access API → native Save As dialog.
+    if (!isMobileUA() && typeof window.showSaveFilePicker === 'function') {
+      return Promise.resolve().then(function () {
+        return window.showSaveFilePicker({
+          suggestedName: filename,
+          types: [{
+            description: 'SQLite database',
+            accept: { 'application/octet-stream': ['.db'] }
+          }]
+        });
+      }).then(function (handle) {
+        return handle.createWritable().then(function (writable) {
+          return writable.write(blob).then(function () {
+            return writable.close();
+          });
+        }).then(function () {
+          return { outcome: 'picker', filename: handle.name };
+        });
+      }).catch(function (err) {
+        if (err && err.name === 'AbortError') {
+          return { outcome: 'cancelled', filename: filename };
+        }
+        // Real failure (permission denied, write error, etc.) — fall
+        // back to the anchor path so the user still gets the file.
+        try { console.warn('[Fellows] showSaveFilePicker failed; falling back:', err); } catch (e) {}
+        return triggerAnchorDownload();
+      });
+    }
+
+    // Mobile share sheet — only when the OS supports file shares
+    // and accepts this MIME. canShare guards both.
     try {
-      var ua = navigator.userAgent || '';
-      var isMobile = /iPad|iPhone|iPod|Android/.test(ua) ||
-                     (navigator.platform === 'MacIntel' && navigator.maxTouchPoints > 1);
-      if (isMobile && navigator.canShare && typeof File === 'function') {
+      if (isMobileUA() && navigator.canShare && typeof File === 'function') {
         var file = new File([blob], filename, { type: blob.type || 'application/octet-stream' });
         if (navigator.canShare({ files: [file] })) {
           return navigator.share({ files: [file], title: filename })
+            .then(function () {
+              return { outcome: 'share', filename: filename };
+            })
             .catch(function (err) {
-              if (err && err.name === 'AbortError') return;
+              if (err && err.name === 'AbortError') {
+                return { outcome: 'cancelled', filename: filename };
+              }
               return triggerAnchorDownload();
             });
         }
       }
     } catch (e) { /* fall through to <a download> */ }
+
     return triggerAnchorDownload();
   }
 
@@ -8009,10 +8105,21 @@
             var ts = new Date().toISOString().replace(/[:.]/g, '-');
             var filename = 'relationships-' + ts + '.db';
             var blob = new Blob([bytes], { type: 'application/octet-stream' });
-            return downloadBlob(blob, filename).then(function () {
-              if (downloadStatus) {
+            return downloadBlob(blob, filename).then(function (result) {
+              if (!downloadStatus) return;
+              var savedName = (result && result.filename) || filename;
+              var size = bytes.byteLength;
+              if (result && result.outcome === 'cancelled') {
+                downloadStatus.textContent = 'Cancelled — no file saved.';
+              } else if (result && result.outcome === 'picker') {
                 downloadStatus.textContent =
-                  'Downloaded ' + filename + ' (' + bytes.byteLength + ' bytes).';
+                  'Saved as ' + savedName + ' (' + size + ' bytes).';
+              } else if (result && result.outcome === 'share') {
+                downloadStatus.textContent =
+                  'Saved via the share sheet (' + size + ' bytes).';
+              } else {
+                downloadStatus.textContent =
+                  'Saved ' + savedName + ' to your browser\'s Downloads folder (' + size + ' bytes).';
               }
             });
           })

--- a/docs/users_manual.md
+++ b/docs/users_manual.md
@@ -257,9 +257,12 @@ action as the detail page.
   other place the app addresses something *to you*. Auto-captured from
   your magic link, so most people never need to touch this.
 - **Your saved data → Download my user data** — saves all your groups,
-  notes, tags, and settings to a single `.db` file. The app also
-  auto-snapshots the same file before every upgrade and keeps the
-  newest 3.
+  notes, tags, and settings to a single `.db` file. Your browser
+  opens its native save dialog (Chrome / Edge / Brave on desktop) or
+  share sheet (iOS / Android) so **you choose where the file goes**;
+  on Safari and Firefox the file lands in your Downloads folder. The
+  app also auto-snapshots the same file before every upgrade and
+  keeps the newest 3.
 - **Restore from backup → Restore from a file** — replace your current
   saved data with a previously downloaded `.db`. The app shows a
   confirmation summary ("4 groups, 12 notes → 7 groups, 23 notes —


### PR DESCRIPTION
## Summary

- Fixes a silent-success bug reported during MCP-demo prep: Settings → ⬇ Download my user data on an installed Chrome PWA on macOS said *"Downloaded relationships-….db (NNNN bytes)"* but the file was nowhere — not in `~/Downloads`, no save dialog, no downloads shelf in the PWA window.
- Root cause: `downloadBlob()` used an invisible `<a download>` click on all non-mobile paths. Inside standalone-display PWA windows on Chrome that's unreliable — the file lands in a PWA-context path that isn't the user's Downloads folder, and the PWA chrome has no visible save affordance.
- Fix: prefer `window.showSaveFilePicker()` (File System Access API) on desktop when available. Native macOS Save As dialog → user explicitly chooses name + location. **The user cannot not know where the file went, because they typed/clicked it themselves.**

## What changed

- **`app/static/app.js` — `downloadBlob()` rewritten.** New decision tree:
  - Desktop Chrome / Edge / Brave → `showSaveFilePicker` (native Save As dialog).
  - Desktop Safari / Firefox → `<a download>` fallback (these handle it correctly, file goes to `~/Downloads` with a visible banner).
  - iOS / Android (capable) → `navigator.share({files})` share sheet (Save to Files / Save to Drive — mobile-native way to pick a destination, no Downloads folder concept).
  - Anywhere else / capability rejections → `<a download>` fallback.
  Returns a structured outcome `{outcome: 'picker'|'share'|'fallback'|'cancelled', filename}` so callers can render an honest status message.
- **`app/static/app.js` — Settings click handler.** Status line now matches the actual outcome:
  - picker → *"Saved as `<chosen name>` (NNN bytes)."*
  - share → *"Saved via the share sheet (NNN bytes)."*
  - fallback → *"Saved `<name>` to your browser's Downloads folder (NNN bytes)."*
  - cancelled → *"Cancelled — no file saved."*
- **`app/static/app.js` — Reset Everything `Download backup & continue`.** Same outcome branching, plus a small safety improvement: a `cancelled` outcome no longer proceeds to the destructive confirm. The user dismissed the save dialog → they backed out of the reset. Buttons re-enable; status reads *"Save cancelled — pick again, or use Skip to reset without saving."*
- **`docs/users_manual.md` — Settings download bullet.** Now explains the three location stories (native dialog on Chromium desktop, share sheet on mobile, Downloads folder on Safari/Firefox) so users know what to expect per browser.

## Test plan

Automated:

- [x] `just test-fast` — 86 passing (no regressions; Playwright doesn't cover this flow today).
- [x] `node --check app/static/app.js` — parses cleanly.

Manual — desktop Chrome PWA on macOS (the originally-broken case):

- [x] Settings → Download my user data — native Save As dialog appears, defaulting to `relationships-<timestamp>.db`. User picks location and saves. Status: *"Saved as relationships-….db (NNNN bytes)."* File is at the chosen location. *(Verified by maintainer.)*

## Manual QA for the maintainer

Paths the maintainer hasn't yet exercised:

- [ ] **Desktop Chrome PWA — cancel path.** Settings → Download my user data → hit *Cancel* in the Save As dialog. Status: *"Cancelled — no file saved."* Button re-enables. No phantom file appears.
- [ ] **Reset Everything — cancel path.** Clear app data → *Reset everything* → *Save a backup first?* → *⬇ Download backup & continue* → hit *Cancel* in the save dialog. Destructive confirm must NOT fire. Status: *"Save cancelled — pick again, or use Skip to reset without saving."*
- [ ] **Desktop Safari.** Settings → Download my user data — file lands in `~/Downloads` via Safari's native UI. Status: *"Saved relationships-….db to your browser's Downloads folder (NNNN bytes)."*
- [ ] **Desktop Firefox.** Same as Safari path.
- [ ] **iOS PWA.** Install via Share → Add to Home Screen. Settings → Download my user data — OS share sheet opens with *Save to Files* near the top. Pick a destination, save. Status: *"Saved via the share sheet (NNNN bytes)."*
- [ ] **Android PWA.** Same flow; share sheet should include *Save to Drive* / *Files by Google* destinations.

If the iOS/Android share sheet doesn't appear at all (rather than appearing and being acceptable), that's a separate bug worth filing — the share-sheet branch is gated on `navigator.canShare({files: [file]})` returning true; if that returns false on a modern device, the fallback will still trigger but the UX will be worse.

## Cross-PR note

#TBD-mcp-private-data-ops added a *Where your data is stored* section to `users_manual.md` with a *"Downloads is a good default"* hint that becomes slightly stale once this PR's picker forces an explicit save location on Chromium desktop. Small follow-up edit after both PRs merge.

## Related

- Reported during the MCP-demo prep (#TBD-mcp-private-data-ops).
- No tracked-issue link; documented inline.

🤖 Generated with [Claude Code](https://claude.com/claude-code)