### PR TITLE
docs(users-manual): match download bullet to merged save-dialog UX

### DIFF
--- a/docs/users_manual.md
+++ b/docs/users_manual.md
@@ -114,9 +114,10 @@ the data file lives in a private storage area your browser manages.
 What you *can* do is download and restore your data file
 (`relationships.db`) from inside the app. Here's how:
 
-- **Download a backup.** Settings → *Download a copy of
-  relationships.db*. Save the file somewhere you'll remember
-  (Downloads is a good default).
+- **Download a backup.** Settings → *⬇ Download my user data*. Your
+  browser asks you where to save it (Chrome / Edge / Brave on desktop,
+  share sheet on iOS / Android) or drops it into your Downloads folder
+  (Safari / Firefox).
 - **Restore from a backup.** Settings → *Restore from backup →
   Restore from a file* → pick the `.db` file you downloaded earlier.
   The current data is captured into the auto-backup list first, so


### PR DESCRIPTION
## Summary

- Tiny follow-up to #158 + #159: the *Where your data is stored* section (added in #158) had a *"Downloads is a good default"* hint that became inaccurate once #159 made `showSaveFilePicker` the desktop-Chromium download path (user now picks the location explicitly).
- One bullet edit, no code change.

## What changed

- **`docs/users_manual.md`** — the *Download a backup* bullet in *Where your data is stored* now mirrors the per-browser story already in *Settings → Your saved data → Download my user data*:
  - Chrome / Edge / Brave on desktop → native save dialog (you pick).
  - iOS / Android → OS share sheet (you pick).
  - Safari / Firefox → Downloads folder.
- Also fixes the button-label reference (the bullet said *"Download a copy of relationships.db"*, which is the hint text; the button label is *"⬇ Download my user data"*).

## Test plan

- [x] Diff is a single bullet replacement.
- [x] Reads consistently with the *Settings* section copy below it.

## Manual QA

- [ ] Skim the *Where your data is stored* section in rendered markdown; flow should match what users actually see when they click *⬇ Download my user data*.

🤖 Generated with [Claude Code](https://claude.com/claude-code)