### PR TITLE
docs(pna-spec): draft worker-side contracts (ST-2 init handshake + ST-3 RPC protocol)

### DIFF
--- a/docs/pna_toolkit/spec/contracts/worker-init-handshake.schema.json
+++ b/docs/pna_toolkit/spec/contracts/worker-init-handshake.schema.json
@@ -1,7 +1,87 @@
 {
   "$schema": "https://json-schema.org/draft/2020-12/schema",
   "$id": "https://pna-spec.example/v0.1/worker-init-handshake.schema.json",
-  "title": "Worker init handshake",
-  "description": "Storage slot: the blob returned by the dedicated worker's first 'init' RPC. Placeholder — to be drafted in step 5. See ../../../_pna_triage.md § Part 1 — Storage § Worker init contract.",
-  "type": "object"
+  "title": "Storage slot — init handshake",
+  "description": "Sub-contract ST-2 from the Storage slot. The first RPC across the Storage boundary must be `op='init'`, and the response carries the handshake blob defined here. Three things land in this single message: (1) the version pair that AC-4 enforces (workerRpcVersion + schemaVersion — page refuses mutating RPCs on mismatch, reads still work); (2) the capability flag AC-12 reads (opfsCapable — substrate-equivalent capability for non-browser PNAs); (3) the inventory the page needs to decide directory-mode vs distribution-gate (hasSharedDb, hasPrivateDb). Capability detection MUST happen inside this op, not on the page (AC-12 — browsers lie about main-thread support; the worker is the only context where the answer is reliable). The init response is wrapped by the standard RPC envelope from worker-rpc-protocol.schema.json — `ok` in the envelope indicates success/failure; the InitResult below is what the envelope's `result` field carries on success. Init failures surface via the envelope's error path, notably with `errorCode: 'OWNERSHIP_CONFLICT'` when AC-11 fires (multi-tab access conflict).\n\nNaming note (v0.1): the spec uses the generic field names `hasSharedDb` and `hasPrivateDb`, matching PNA_Spec.md vocabulary. fellows_local_db's worker today emits `hasFellowsDb` and `hasRelationshipsDb` instead — a flavor-specific divergence pre-dating the spec. Implementations conforming to v0.1 should use the generic names; aligning fellows_local_db's field names is a clean-up task tracked in `_pna_triage.md`.",
+  "type": "object",
+  "required": ["request", "response"],
+  "properties": {
+    "request": { "$ref": "#/$defs/InitRequest" },
+    "response": { "$ref": "#/$defs/InitResult" }
+  },
+  "$defs": {
+    "InitRequest": {
+      "type": "object",
+      "description": "The page's first message across the Storage boundary. Wrapped by the worker-rpc-protocol envelope; only the op-specific shape is defined here. v0.1 takes no args.",
+      "required": ["op"],
+      "additionalProperties": false,
+      "properties": {
+        "op":   { "const": "init" },
+        "args": {
+          "type": "object",
+          "description": "v0.1: no init args. Future spec versions may add bootstrap flags (e.g. a 'skipAutoBackup' switch for test runners).",
+          "additionalProperties": false,
+          "properties": {}
+        }
+      }
+    },
+    "InitResult": {
+      "type": "object",
+      "description": "The handshake blob the Storage slot returns on successful init. Carried in the envelope's `result` field. Page reads `workerRpcVersion` + `schemaVersion` and gates mutating RPCs on match (AC-4); reads `opfsCapable` to trigger the unsupported-browser panel (AC-12); reads `hasSharedDb` / `hasPrivateDb` to decide whether a cold-start cohort fetch is needed.",
+      "required": [
+        "ok",
+        "workerRpcVersion",
+        "schemaVersion",
+        "buildLabel",
+        "opfsCapable",
+        "hasSharedDb",
+        "hasPrivateDb",
+        "poolFiles",
+        "trace"
+      ],
+      "additionalProperties": true,
+      "properties": {
+        "ok": {
+          "const": true,
+          "description": "Always `true` in a successful InitResult. Redundant with the envelope's `ok: true` but documents the shape carried in the wire bytes today."
+        },
+        "workerRpcVersion": {
+          "type": "integer",
+          "minimum": 1,
+          "description": "Storage-side RPC protocol version. Bumped only when the request/response shape of any op changes incompatibly. The page bakes in an EXPECTED_WORKER_RPC_VERSION constant and refuses mutating RPCs on mismatch (AC-4). fellows_local_db currently emits `2`."
+        },
+        "schemaVersion": {
+          "type": "integer",
+          "minimum": 1,
+          "description": "Private DB schema version. Same value as `PRAGMA user_version` on the Private DB; bumped only on schema migrations. Mutation gate is AND'd with workerRpcVersion — both must match for the page to mutate. fellows_local_db currently emits `1`."
+        },
+        "buildLabel": {
+          "type": "string",
+          "description": "Worker-side build label, substituted at build *and* serve time (AC-15). Tied to source revision. Format is implementation-specific (e.g. `<YYYY-MM-DD>-<short-sha>` in fellows_local_db). NOT used as the AC-4 gate — the version integer pair is. Surfaced in diagnostics and bug reports for correlation with CI/server logs."
+        },
+        "opfsCapable": {
+          "type": "boolean",
+          "description": "True iff the Storage slot successfully installed its persistent storage substrate (OPFS-SAH-Pool for browser PNAs; equivalent capability check for CLI/native PNAs — e.g., the SQLite file path is writable). False here triggers the unsupported-browser / substrate-unavailable panel on the page (AC-12). UA-parsing on the page is permitted for messaging only, never for gating."
+        },
+        "hasSharedDb": {
+          "type": "boolean",
+          "description": "True iff a Shared DB is already on disk and was opened during init. False means cold-start — the page issues a separate `ensureSharedDb` op (gated on the distribution-mode decision tree) to fetch + import. Init itself MUST NOT make network calls."
+        },
+        "hasPrivateDb": {
+          "type": "boolean",
+          "description": "True iff the Private DB exists and was opened during init. Schema bootstrap (CREATE IF NOT EXISTS + PRAGMA user_version) runs on the same path so this is `true` on first-ever boot too, once the schema lands."
+        },
+        "poolFiles": {
+          "type": "array",
+          "items": { "type": "string" },
+          "description": "Inventory of files the storage substrate currently manages — typically the SAH-pool's capacity files for browser PNAs, or the on-disk DB filenames for native PNAs. Diagnostic surface; not load-bearing for any AC. Empty when introspection isn't supported by the substrate."
+        },
+        "trace": {
+          "type": "array",
+          "items": { "type": "string" },
+          "description": "Snapshot of the worker-side boot trace (timestamped strings) up to the init return. Diagnostic surface — bug reports include it. The page-side equivalent (window.__bootDebugLines / window.__bootMarks) is the workspace-side complement."
+        }
+      }
+    }
+  }
 }

--- a/docs/pna_toolkit/spec/contracts/worker-rpc-protocol.schema.json
+++ b/docs/pna_toolkit/spec/contracts/worker-rpc-protocol.schema.json
@@ -1,7 +1,419 @@
 {
   "$schema": "https://json-schema.org/draft/2020-12/schema",
   "$id": "https://pna-spec.example/v0.1/worker-rpc-protocol.schema.json",
-  "title": "Worker RPC protocol envelope",
-  "description": "Storage slot: the request/response envelope for page<->worker RPC ({id, op, args} <-> {id, ok, result|error}). Placeholder — to be drafted in step 5. See ../../../_pna_triage.md § Part 1 — Storage § RPC protocol.",
-  "type": "object"
+  "title": "Storage slot — RPC protocol",
+  "description": "Sub-contract ST-3 from the Storage slot. Defines the request/response envelope across the Storage boundary plus the input/output shape of the AC-load-bearing ops. The envelope is what every implementation must conform to; the op catalog below is the v0.1 minimum surface — implementations expose additional ops (CRUD on Private DB tables, reads on the Shared DB, auto-backup management, diagnostics) under the same envelope, and those flavor-specific ops are documented per implementation rather than pinned here.\n\nThe ops pinned here are the ones that enforce or surface an architectural commitment, so the spec contract is what an auditor reads to confirm AC compliance:\n- `init` — the version handshake (AC-4) and capability flag (AC-12); shape lives in worker-init-handshake.schema.json.\n- `compareSharedDbSha`, `previewSharedDbSwap`, `applySharedDbSwap`, `cancelSharedDbSwap` — the staged Shared-DB swap dance that AC-10 (opt-in non-destructive re-imports of the Shared store) hinges on.\n- `wipeAll` — the Reset Everything nuclear path (ST-10).\n- `getOpfsInventory`, `getVersions` — the diagnostic surface (ST-11) used by `?diag=1` and bug reports.\n\nFan-in dispatch: a single Storage boundary handles concurrent in-flight RPCs by correlating `id`. The implementation tracks pending RPCs in a sequence-numbered Map and rejects all pending entries on `worker.onerror` (or substrate-equivalent fatal-error signal) with a synthetic error so callers can fall back instead of hanging.\n\nNaming note (v0.1): the spec uses generic op names (`compareSharedDbSha`, `previewSharedDbSwap`, …). fellows_local_db's worker today uses fellows-specific names (`compareFellowsDbSha`, `previewFellowsDbSwap`, …) — a flavor-specific divergence pre-dating the spec; aligning op names is tracked in `_pna_triage.md`. Implementations conforming to v0.1 should use the generic names.",
+  "type": "object",
+  "required": ["envelope", "errorCodes", "ops"],
+  "properties": {
+    "envelope": {
+      "type": "object",
+      "required": ["request", "response"],
+      "properties": {
+        "request":  { "$ref": "#/$defs/WorkerRpcRequest" },
+        "response": { "$ref": "#/$defs/WorkerRpcResponse" }
+      }
+    },
+    "errorCodes": { "$ref": "#/$defs/NormativeErrorCodes" },
+    "ops": {
+      "type": "object",
+      "description": "AC-load-bearing op catalog. Each entry pins the op's input args + output result. The envelope wraps every entry uniformly.",
+      "required": [
+        "init",
+        "compareSharedDbSha",
+        "previewSharedDbSwap",
+        "applySharedDbSwap",
+        "cancelSharedDbSwap",
+        "wipeAll",
+        "getOpfsInventory",
+        "getVersions"
+      ],
+      "additionalProperties": false,
+      "properties": {
+        "init":                { "$ref": "#/$defs/op_init" },
+        "compareSharedDbSha":  { "$ref": "#/$defs/op_compareSharedDbSha" },
+        "previewSharedDbSwap": { "$ref": "#/$defs/op_previewSharedDbSwap" },
+        "applySharedDbSwap":   { "$ref": "#/$defs/op_applySharedDbSwap" },
+        "cancelSharedDbSwap":  { "$ref": "#/$defs/op_cancelSharedDbSwap" },
+        "wipeAll":             { "$ref": "#/$defs/op_wipeAll" },
+        "getOpfsInventory":    { "$ref": "#/$defs/op_getOpfsInventory" },
+        "getVersions":         { "$ref": "#/$defs/op_getVersions" }
+      }
+    }
+  },
+  "$defs": {
+    "WorkerRpcRequest": {
+      "type": "object",
+      "description": "Message sent from the workspace (page / CLI shell / native UI) to the Storage boundary. The `id` is opaque and unique-per-pending-request; the implementation uses it to correlate the response back to the awaiting caller.",
+      "required": ["id", "op"],
+      "additionalProperties": false,
+      "properties": {
+        "id": {
+          "type": ["string", "integer"],
+          "description": "Caller-chosen correlation handle. Stable for the lifetime of one RPC. The implementation's pending-Map keys on this value."
+        },
+        "op": {
+          "type": "string",
+          "minLength": 1,
+          "description": "Op name. v0.1 normative ops are catalogued in `ops` above; flavor-specific ops MUST use distinct names and are documented per implementation."
+        },
+        "args": {
+          "description": "Op-specific arguments. Shape pinned by the matching `ops.<name>.input` schema. Absent or `{}` for ops that take no args.",
+          "default": {}
+        }
+      }
+    },
+    "WorkerRpcResponse": {
+      "oneOf": [
+        { "$ref": "#/$defs/WorkerRpcSuccessResponse" },
+        { "$ref": "#/$defs/WorkerRpcErrorResponse" }
+      ]
+    },
+    "WorkerRpcSuccessResponse": {
+      "type": "object",
+      "description": "Response shape on success. `result` is op-specific and conforms to `ops.<name>.output`.",
+      "required": ["id", "ok", "result"],
+      "additionalProperties": false,
+      "properties": {
+        "id": { "type": ["string", "integer"] },
+        "ok": { "const": true },
+        "result": {
+          "description": "Op-specific payload."
+        }
+      }
+    },
+    "WorkerRpcErrorResponse": {
+      "type": "object",
+      "description": "Response shape on failure. `error` is the human-readable message. The optional taxonomy fields below let the workspace render specific UI (multi-tab panel vs unsupported-browser panel vs auth fallback) without parsing free-text. `errorCode` is the normative classification — see `errorCodes` for the v0.1 allowlist of AC-bearing codes.",
+      "required": ["id", "ok", "error"],
+      "additionalProperties": false,
+      "properties": {
+        "id":    { "type": ["string", "integer"] },
+        "ok":    { "const": false },
+        "error": {
+          "type": "string",
+          "description": "Human-readable error message. Always present, even when `errorCode` is set."
+        },
+        "errorName": {
+          "type": ["string", "null"],
+          "description": "Underlying exception name when available (e.g., `NoModificationAllowedError`, `DOMException`). Diagnostic surface; not load-bearing for any AC."
+        },
+        "errorCode": {
+          "type": ["string", "null"],
+          "description": "Normative classification. v0.1 reserves the codes in `errorCodes` (see schema's root `errorCodes` def) for AC-bearing failures; implementations MAY add op-specific codes alongside (e.g., fellows_local_db emits `staging_id_mismatch`, `fellows_db_fetch_http`, `no_local_fellows_db`). The reserved codes carry consistent AC semantics across all conforming implementations; the op-specific ones do not."
+        },
+        "httpStatus": {
+          "type": ["integer", "null"],
+          "description": "When the underlying failure was an HTTP response (e.g., the cohort fetch returned 401/403/500), the status is surfaced here so the workspace's hot-swap path (AC-5) can distinguish stale-session 401 from server-down 5xx."
+        },
+        "meta": {
+          "description": "Op-specific structured context. Examples: ensureSharedDb attaches the post-failure meta blob (last_failure_at, last_failure_reason) so the page can render a soft warning without a second RPC roundtrip. Free-form by design."
+        },
+        "stack": {
+          "type": ["string", "null"],
+          "description": "Underlying exception stack trace when available. Diagnostic surface for bug reports; never surfaced as part of normal UI."
+        }
+      }
+    },
+    "NormativeErrorCodes": {
+      "type": "object",
+      "description": "v0.1 normative `errorCode` allowlist. The codes here are reserved across all conforming implementations — their semantics are tied to ACs, and workspaces are entitled to dispatch UI specifically on them. Implementations MAY add additional codes for op-specific failures, but additions MUST NOT collide with these names and MUST NOT change their AC meaning. Future spec versions may extend this set.",
+      "required": ["OWNERSHIP_CONFLICT", "VERSION_MISMATCH", "LOCAL_DATA_UNAVAILABLE", "NOT_FOUND", "INTERNAL"],
+      "additionalProperties": false,
+      "properties": {
+        "OWNERSHIP_CONFLICT": {
+          "type": "string",
+          "description": "AC-11: Another instance of the PNA holds the storage substrate. Browser PNAs: a second tab acquired the OPFS SAH pool. CLI/native PNAs: a second process holds the SQLite file lock. Workspace MUST render a specific 'another instance is open' panel (WS-6), not a generic 'unsupported' panel."
+        },
+        "VERSION_MISMATCH": {
+          "type": "string",
+          "description": "AC-4: The workspace's expected workerRpcVersion or schemaVersion doesn't match what the Storage slot emitted in the init handshake. Mutating ops MUST be refused with this code; reads MAY still be served. The standard remediation is the workspace's update banner (e.g., the service worker's 'New version available — Reload' affordance for browser PNAs)."
+        },
+        "LOCAL_DATA_UNAVAILABLE": {
+          "type": "string",
+          "description": "The Storage slot can't currently serve the requested data — substrate failure (AC-12 negative), version-skew refusal (AC-4 mutation gate), or capability gap. The workspace catches this code and surfaces the appropriate failure panel (WS-6) rather than a generic error. In hot-swap mode (AC-5 fallback to api+idb), the data provider catches this same code on mutating Private-DB ops and refuses with a localDataUnavailableError to the calling render path."
+        },
+        "NOT_FOUND": {
+          "type": "string",
+          "description": "The requested record/group/setting/staging slot doesn't exist. Distinct from INTERNAL: NOT_FOUND is a normal flow outcome (lookup by id that doesn't resolve), not an error condition."
+        },
+        "INTERNAL": {
+          "type": "string",
+          "description": "Catch-all for unexpected Storage-slot failures that don't map to a more specific code. Workspaces typically surface this as 'something went wrong, please reload' and include the `meta` + `stack` fields in the bug-report payload (AC-7)."
+        }
+      }
+    },
+    "op_init": {
+      "type": "object",
+      "description": "ST-2 init handshake. Full request + response shapes live in [`worker-init-handshake.schema.json`](./worker-init-handshake.schema.json). First op across the Storage boundary; mandatory; failure-mode for AC-11 (OWNERSHIP_CONFLICT) and AC-12 (opfsCapable=false).",
+      "required": ["input", "output"],
+      "properties": {
+        "input":  { "$ref": "./worker-init-handshake.schema.json#/$defs/InitRequest" },
+        "output": { "$ref": "./worker-init-handshake.schema.json#/$defs/InitResult" }
+      }
+    },
+    "op_compareSharedDbSha": {
+      "type": "object",
+      "description": "Step 1 of the AC-10 opt-in swap dance. Cheap read: compare the locally-recorded Shared DB content SHA against the server-reported one. Does NOT fetch the Shared DB; no network call on the Storage side. `dataUpdateAvailable: null` distinguishes 'couldn't check' (server unreachable, no serverSha passed) from 'up to date' (false) and 'update available' (true). fellows_local_db's op name: `compareFellowsDbSha`.",
+      "required": ["input", "output"],
+      "properties": {
+        "input": {
+          "type": "object",
+          "additionalProperties": false,
+          "properties": {
+            "serverSha": {
+              "type": ["string", "null"],
+              "description": "Server-reported Shared DB content SHA, typically pulled from `/build-meta.json` (browser PNAs) or an equivalent metadata endpoint. Null when the workspace couldn't fetch it."
+            }
+          }
+        },
+        "output": {
+          "type": "object",
+          "required": ["hasSharedDb", "localSha", "serverSha", "fetchedAt", "dataUpdateAvailable"],
+          "additionalProperties": false,
+          "properties": {
+            "hasSharedDb":          { "type": "boolean" },
+            "localSha":             { "type": ["string", "null"] },
+            "serverSha":            { "type": ["string", "null"], "description": "Echo of the input serverSha." },
+            "fetchedAt":            { "type": ["string", "null"], "description": "ISO-8601 timestamp of the last successful Shared DB import." },
+            "dataUpdateAvailable":  { "type": ["boolean", "null"], "description": "true = local differs from server; false = match; null = couldn't determine (no serverSha or no local Shared DB)." }
+          }
+        }
+      }
+    },
+    "op_previewSharedDbSwap": {
+      "type": "object",
+      "description": "Step 2 of the AC-10 swap dance. Fetches a new Shared DB into a staging slot (separate from the live slot, so the live Shared DB stays serving reads), validates it (PRAGMA quick_check + zero-row guard), then computes the orphan-preview: which group members would no longer resolve in the staged DB. Returns an opaque `stagingId` the workspace must echo back to applySharedDbSwap or cancelSharedDbSwap. A previous pending swap is implicitly discarded if this op is called again. fellows_local_db's op name: `previewFellowsDbSwap`.",
+      "required": ["input", "output"],
+      "properties": {
+        "input": {
+          "type": "object",
+          "additionalProperties": false,
+          "properties": {
+            "serverSha": {
+              "type": ["string", "null"],
+              "description": "Server-reported Shared DB content SHA (hint for trace logging; not strictly required for the swap)."
+            }
+          }
+        },
+        "output": {
+          "type": "object",
+          "required": ["stagingId", "newSha", "affectedGroups"],
+          "additionalProperties": false,
+          "properties": {
+            "stagingId": {
+              "type": "string",
+              "description": "Opaque per-session staging handle. Required input to applySharedDbSwap. A stale handle (page reloaded, worker restarted) makes applySharedDbSwap fail with op-specific code `staging_id_mismatch`."
+            },
+            "newSha": {
+              "type": "string",
+              "description": "Content SHA of the staged bytes."
+            },
+            "affectedGroups": {
+              "type": "array",
+              "items": { "$ref": "#/$defs/AffectedMember" },
+              "description": "Private DB rows that reference Shared DB records no longer present in the staged bytes. Empty when nothing would be orphaned. Workspace MUST render this preview before the user confirms (AC-10)."
+            }
+          }
+        }
+      }
+    },
+    "op_applySharedDbSwap": {
+      "type": "object",
+      "description": "Step 3 of the AC-10 swap dance. Promotes the staging slot's bytes to the live Shared DB slot atomically (close live handle → import staged bytes → open new handle → update meta). Caller MUST pass the `stagingId` from previewSharedDbSwap; a stale id is refused with op-specific code `staging_id_mismatch`. fellows_local_db's op name: `applyFellowsDbSwap`.",
+      "required": ["input", "output"],
+      "properties": {
+        "input": {
+          "type": "object",
+          "required": ["stagingId"],
+          "additionalProperties": false,
+          "properties": {
+            "stagingId": { "type": "string" }
+          }
+        },
+        "output": {
+          "type": "object",
+          "required": ["ok", "newSha", "meta"],
+          "additionalProperties": false,
+          "properties": {
+            "ok":     { "const": true },
+            "newSha": { "type": "string" },
+            "meta":   { "$ref": "#/$defs/SharedDbMeta" }
+          }
+        }
+      }
+    },
+    "op_cancelSharedDbSwap": {
+      "type": "object",
+      "description": "Cancellation path for the AC-10 swap dance. Lenient on stagingId — even a stale id clears the pending swap (the intent 'don't apply' is unambiguous). The user-driven 'Cancel' button in the swap dialog binds to this op. fellows_local_db's op name: `cancelFellowsDbSwap`.",
+      "required": ["input", "output"],
+      "properties": {
+        "input": {
+          "type": "object",
+          "additionalProperties": false,
+          "properties": {
+            "stagingId": {
+              "type": ["string", "null"],
+              "description": "Best-effort. Mismatch or absence is logged but does not fail the cancel."
+            }
+          }
+        },
+        "output": {
+          "type": "object",
+          "required": ["ok"],
+          "additionalProperties": false,
+          "properties": {
+            "ok": { "const": true }
+          }
+        }
+      }
+    },
+    "op_wipeAll": {
+      "type": "object",
+      "description": "ST-10 nuclear reset. Closes both DB handles, tears down the storage substrate (browser PNAs: `removeVfs()` + iterate OPFS root removing every entry; native PNAs: substrate-equivalent), and returns an inventory of what was removed. The Storage slot is unusable post-wipe; the workspace MUST reload after the response. Pure read of OPFS / disk; no network. The workspace's Reset Everything button binds to this op.",
+      "required": ["input", "output"],
+      "properties": {
+        "input": {
+          "type": "object",
+          "additionalProperties": false,
+          "properties": {}
+        },
+        "output": {
+          "type": "object",
+          "required": ["removedVfs", "rootEntriesRemoved", "rootEntriesFailed"],
+          "additionalProperties": false,
+          "properties": {
+            "removedVfs": {
+              "type": "boolean",
+              "description": "True iff the substrate VFS was successfully torn down. False indicates partial wipe — `rootEntriesRemoved` may still list entries the substrate-agnostic cleanup pass removed."
+            },
+            "rootEntriesRemoved": {
+              "type": "array",
+              "items": { "type": "string" },
+              "description": "Names of OPFS-root (or disk-equivalent) entries successfully removed in the cleanup pass."
+            },
+            "rootEntriesFailed": {
+              "type": "array",
+              "items": { "$ref": "#/$defs/RemovalFailure" },
+              "description": "Entries the cleanup pass tried but failed to remove. Diagnostic; the workspace should still proceed to reload."
+            }
+          }
+        }
+      }
+    },
+    "op_getOpfsInventory": {
+      "type": "object",
+      "description": "ST-11 diagnostic read. Snapshot of every entry at OPFS root (browser PNAs) or the substrate-equivalent storage root, plus the SAH-pool slot inventory. Used by the `?diag=1` panel post-Phase-1 so the maintainer can see exactly what's on disk without main-thread substrate access. Pure read; no writes, no fetches. The name reflects browser-PNA heritage; native-PNA implementations may rename this op to `getStorageInventory` in a future spec version.",
+      "required": ["input", "output"],
+      "properties": {
+        "input": {
+          "type": "object",
+          "additionalProperties": false,
+          "properties": {}
+        },
+        "output": {
+          "type": "object",
+          "required": ["root", "poolFiles"],
+          "additionalProperties": false,
+          "properties": {
+            "root": {
+              "type": "array",
+              "items": { "$ref": "#/$defs/StorageEntry" },
+              "description": "Entries at OPFS root or the substrate-equivalent. Sorted by name for stable diagnostic output."
+            },
+            "poolFiles": {
+              "type": "array",
+              "items": { "type": "string" },
+              "description": "Slot inventory inside the substrate's container (the SAH-pool's opaque files for browser PNAs; empty when not applicable). Same value as init's `poolFiles` snapshot — kept available here so a long-running session can re-read."
+            }
+          }
+        }
+      }
+    },
+    "op_getVersions": {
+      "type": "object",
+      "description": "ST-11 diagnostic read. Same version pair the init handshake returned, made re-readable so a long-running workspace can verify the Storage slot is still the same generation without re-issuing init. Pure read.",
+      "required": ["input", "output"],
+      "properties": {
+        "input": {
+          "type": "object",
+          "additionalProperties": false,
+          "properties": {}
+        },
+        "output": {
+          "type": "object",
+          "required": ["workerRpcVersion", "schemaVersion", "buildLabel"],
+          "additionalProperties": false,
+          "properties": {
+            "workerRpcVersion": { "type": "integer", "minimum": 1 },
+            "schemaVersion":    { "type": "integer", "minimum": 1 },
+            "buildLabel":       { "type": "string" }
+          }
+        }
+      }
+    },
+    "AffectedMember": {
+      "type": "object",
+      "description": "One Private DB row whose Shared DB reference would no longer resolve after a staged swap. Returned in previewSharedDbSwap's affectedGroups list so the workspace can render the orphan-preview that AC-10 requires before the user commits.",
+      "required": ["recordId", "groups"],
+      "additionalProperties": false,
+      "properties": {
+        "recordId": {
+          "type": "string",
+          "description": "The Private DB row's reference into the Shared DB — would-be-orphaned by the swap."
+        },
+        "name": {
+          "type": ["string", "null"],
+          "description": "Display name resolved from the *currently live* Shared DB (so the workspace shows 'Alice Smith' instead of a bare record_id). Null when the live DB doesn't carry a name field for this record."
+        },
+        "groups": {
+          "type": "array",
+          "items": {
+            "type": "object",
+            "required": ["id", "name"],
+            "additionalProperties": false,
+            "properties": {
+              "id":   { "type": "integer", "description": "Private DB group id." },
+              "name": { "type": "string",  "description": "Private DB group name." }
+            }
+          },
+          "minItems": 1
+        }
+      }
+    },
+    "SharedDbMeta": {
+      "type": "object",
+      "description": "Storage-side metadata blob about the live Shared DB. Used by AC-10 swap flow + diagnostics. Stored as a sibling file at OPFS root in browser PNAs (e.g., `fellows.db.meta.json`); substrate-equivalent in native PNAs.",
+      "required": ["sha", "fetched_at"],
+      "additionalProperties": false,
+      "properties": {
+        "sha":                  { "type": "string", "description": "Content SHA of the live Shared DB bytes." },
+        "fetched_at":           { "type": "string", "description": "ISO-8601 timestamp of when this DB was imported." },
+        "last_failure_at":      { "type": ["string", "null"], "description": "ISO-8601 timestamp of the last ensureSharedDb failure, or null." },
+        "last_failure_reason":  { "type": ["string", "null"], "description": "Human-readable description of the last failure, or null. Surfaced as a soft warning on the About page." }
+      }
+    },
+    "RemovalFailure": {
+      "type": "object",
+      "description": "One entry the wipeAll cleanup pass failed to remove. Diagnostic only — wipeAll proceeds past failures.",
+      "required": ["name", "error"],
+      "additionalProperties": false,
+      "properties": {
+        "name":  { "type": "string" },
+        "error": { "type": "string" }
+      }
+    },
+    "StorageEntry": {
+      "type": "object",
+      "description": "One entry under the storage substrate's root (OPFS root for browser PNAs; a directory listing for native PNAs).",
+      "required": ["name", "kind"],
+      "additionalProperties": false,
+      "properties": {
+        "name":         { "type": "string" },
+        "kind":         { "type": "string", "enum": ["file", "directory"] },
+        "size":         { "type": "integer", "minimum": 0, "description": "Bytes, when introspectable. Files only." },
+        "lastModified": { "type": "integer", "minimum": 0, "description": "Unix epoch ms, when introspectable. Files only." }
+      }
+    }
+  }
 }


### PR DESCRIPTION
## Summary

Fills two of the eight remaining placeholders in `docs/pna_toolkit/spec/contracts/`. These are the AC-4 load-bearing surfaces for the Storage slot:

- **`worker-init-handshake.schema.json` (ST-2)** — `InitRequest` + `InitResult` shapes. `InitResult` pins `workerRpcVersion` + `schemaVersion` (AC-4 mutation gate), `opfsCapable` (AC-12 capability-detection-inside-worker), `hasSharedDb` / `hasPrivateDb` (cold-start vs warm-boot decision), plus `poolFiles` + `trace` (ST-11 diagnostics).
- **`worker-rpc-protocol.schema.json` (ST-3)** — the `{id, op, args}` ↔ `{id, ok, result|error}` envelope plus the full error taxonomy. **Normative errorCode allowlist**: `OWNERSHIP_CONFLICT` (AC-11), `VERSION_MISMATCH` (AC-4), `LOCAL_DATA_UNAVAILABLE` (AC-5/AC-12), `NOT_FOUND`, `INTERNAL`. AC-load-bearing ops with full input/output: `init`, the AC-10 swap dance (`compareSharedDbSha` → `previewSharedDbSwap` → `applySharedDbSwap` / `cancelSharedDbSwap`), `wipeAll` (ST-10), `getOpfsInventory` + `getVersions` (ST-11).

Both use spec-generic names (`hasSharedDb`, `compareSharedDbSha`); a flavor note in each schema's `description` records that fellows_local_db's worker currently emits the fellows-specific names (`hasFellowsDb`, `compareFellowsDbSha`). Aligning fellows_local_db with the spec's generic names is a v0.1 cleanup item.

Source-mapped against `app/static/vendor/sqlite-worker.js` — every shape was derived from the actual `handlers.*` implementations, not invented from prose.

## Test plan

- [ ] Both schemas parse as valid JSON Schema (Draft 2020-12) — `python3 -c "import json; json.load(open(...))"` passes for both.
- [ ] Spot-check `InitResult` fields against `handlers.init`'s return at `app/static/vendor/sqlite-worker.js:602-613` (modulo the documented `hasSharedDb`/`hasFellowsDb` flavor rename).
- [ ] Spot-check `op_compareSharedDbSha`, `op_previewSharedDbSwap`, `op_applySharedDbSwap`, `op_cancelSharedDbSwap` outputs against `handlers.compareFellowsDbSha`, `handlers.previewFellowsDbSwap`, `handlers.applyFellowsDbSwap`, `handlers.cancelFellowsDbSwap`.
- [ ] Confirm the `NormativeErrorCodes` enum covers the five AC-bearing codes and the description correctly notes that op-specific codes (`staging_id_mismatch`, `no_local_fellows_db`, etc.) are permitted alongside.

## Remaining contract work

| File | Status |
|---|---|
| `shared-db.schema.sql` | placeholder; transcription of `fellows.db` DDL from `build/restore_from_knack_scrapefile.py` |
| `private-db.schema.sql` | placeholder; transcription of `relationships.db` DDL from `app/relationships.py` |
| `transport-interface.d.ts` | placeholder; small TypeScript declaration for the Comms transport interface |
| `distribution-auth.openapi.yaml` | placeholder; OpenAPI fragment for `/api/auth/*` + `/api/client-errors` (drawn from `deploy/server.py`) |
| `client-errors-payload.schema.json` | placeholder; transcription from `deploy/client_error_sanitizer.py` |
| `mcp-ingestion.schema.json` | placeholder; awaits first Ingestion-exposing PNA |
| `mcp-diagnostics.schema.json` | placeholder; awaits first Diagnostics-exposing PNA |

🤖 Generated with [Claude Code](https://claude.com/claude-code)