### PR TITLE
docs(pna-spec): flesh out the 5 remaining typed contracts (private/shared DB, client-errors, transport, distribution-auth)

### DIFF
--- a/docs/pna_toolkit/spec/contracts/client-errors-payload.schema.json
+++ b/docs/pna_toolkit/spec/contracts/client-errors-payload.schema.json
@@ -1,7 +1,86 @@
 {
   "$schema": "https://json-schema.org/draft/2020-12/schema",
   "$id": "https://pna-spec.example/v0.1/client-errors-payload.schema.json",
-  "title": "Sanitized error sink payload",
-  "description": "Debug contract: the body of POSTs to the sanitized error sink. Placeholder — to be drafted in step 5. See ../../../_pna_triage.md § Part 1 — Debug contract § Sanitized error sink and the kind= enum allowlist.",
-  "type": "object"
+  "title": "Debug contract — sanitized error sink payload",
+  "description": "Sub-contract DB-4 from `_pna_triage.md` Part 4. Body schema for `POST /api/client-errors` (or the substrate-equivalent unauthenticated sink). The endpoint is unauthenticated by design — its job is to capture diagnostics from users who couldn't pass the auth gate — so the privacy boundary is load-bearing: only what's defined here is allowed to flow into the maintainer's structured log. Anything outside this schema MUST be silently dropped server-side (per DB-4 'always 204; events typed via a kind= enum allowlist; free-text fields sanitized server-side. Privacy boundary is *server-side*, not trusted to the client'). Adding new event kinds — and only new kinds — is the only widening lever (DB-5). For the full free-text sanitization rules (email redaction, slug/token redaction in hash routes, query-string drop, length caps), see the conforming implementation at `deploy/client_error_sanitizer.py` and `docs/email_gate.md` § Client error reporting.\n\nv0.1 size caps (operational, not strict spec): 16 KB body cap (enforced by the Distribution slot's POST handler — see DI-5); 20 events per POST; 500 chars per `msg`; 200 chars per `extra`; 240 chars each for `ua`, `route`; 64 chars for `build`.",
+  "type": "object",
+  "required": ["events"],
+  "additionalProperties": false,
+  "properties": {
+    "events": {
+      "type": "array",
+      "minItems": 0,
+      "maxItems": 20,
+      "items": { "$ref": "#/$defs/Event" },
+      "description": "Up to 20 typed events per POST. Events beyond the cap are dropped server-side. Order is preserved."
+    },
+    "ua": {
+      "type": "string",
+      "maxLength": 240,
+      "description": "User-Agent header value, length-capped. Deliberately NOT sanitized further (UA is the highest-signal triage field; some browsers encode device names — accepted tradeoff)."
+    },
+    "route": {
+      "type": "string",
+      "maxLength": 240,
+      "description": "Workspace route at the moment the error was captured. Server-side sanitization: query strings dropped; `#/fellow/<slug>` and `#/unlock/<token>` redacted to `<redacted>`; group IDs (`#/groups/<id>`) preserved (integers, not PII)."
+    },
+    "build": {
+      "type": "string",
+      "maxLength": 64,
+      "description": "Workspace-side build label (AC-15). Helps correlate the report to a specific deployed version."
+    },
+    "displayMode": {
+      "type": "string",
+      "enum": ["standalone", "browser-tab"],
+      "description": "How the workspace is currently rendered. Only the two values above are accepted; anything else is dropped."
+    },
+    "online": {
+      "type": "boolean",
+      "description": "navigator.onLine snapshot at capture time. Browser-PNA-specific; native PNAs may omit."
+    },
+    "lastSubmitHashPrefix": {
+      "type": "string",
+      "pattern": "^[0-9a-f]{12}$",
+      "description": "12 hex chars from sha256(user_identifier). Non-reversible correlator that ties this report to a recent auth event (the same prefix appears in the Distribution slot's send-unlock journald event). Must match the pattern exactly; anything else is dropped."
+    }
+  },
+  "$defs": {
+    "Event": {
+      "type": "object",
+      "required": ["kind"],
+      "additionalProperties": false,
+      "description": "One captured event. Free-text fields (`msg`, `extra`) are sanitized server-side per the rules in `deploy/client_error_sanitizer.py`. Adding a new `kind` value is the only allowed widening of the privacy boundary (DB-5).",
+      "properties": {
+        "kind": {
+          "type": "string",
+          "enum": [
+            "http",
+            "sw",
+            "window.error",
+            "unhandledrejection",
+            "console.error",
+            "install",
+            "worker",
+            "boot"
+          ],
+          "description": "Event category. The allowlist is normative — a caller cannot smuggle e.g. `kind=admin_command`. v0.1 reserves: `http` (failed HTTP responses surfaced by the workspace), `sw` (service-worker lifecycle errors in browser PNAs), `window.error` / `unhandledrejection` / `console.error` (top-level error capture), `install` (install-funnel telemetry: beforeinstallprompt fired/never-arrived, button clicked, accept/dismiss outcome, app installed, iOS Safari advisory), `worker` (OPFS worker spawn / init-handshake outcomes — browser-PNA-specific; substrate-equivalent in native PNAs), `boot` (once-per-page-load beacon carrying the running build_label)."
+        },
+        "ts": {
+          "type": "string",
+          "maxLength": 32,
+          "description": "ISO-8601 timestamp. Server clips length only; does not parse."
+        },
+        "msg": {
+          "type": "string",
+          "maxLength": 500,
+          "description": "Primary message body. Server-side sanitization: emails → `<email>`; `#/fellow/<slug>` and `#/unlock/<token>` → `<redacted>`; query strings dropped; truncated to 500 chars."
+        },
+        "extra": {
+          "type": "string",
+          "maxLength": 200,
+          "description": "Supplementary context. Same sanitization as `msg`, truncated to 200 chars."
+        }
+      }
+    }
+  }
 }

--- a/docs/pna_toolkit/spec/contracts/distribution-auth.openapi.yaml
+++ b/docs/pna_toolkit/spec/contracts/distribution-auth.openapi.yaml
@@ -1,13 +1,343 @@
-# Distribution slot's auth/install/error endpoints.
-# Placeholder — to be drafted in step 5.
-# See ../../../_pna_triage.md § Part 1 — Distribution § Auth contract.
+# Distribution slot — auth, install, and sanitized-error endpoints.
+#
+# Sub-contracts DI-3 (auth) and DI-4 (anti-enum + rate limit) from
+# `_pna_triage.md` Part 4, plus the DB-4 sanitized error sink that
+# Distribution hosts (the sink lives at the Distribution boundary
+# because it must be reachable by users who failed the auth gate).
+#
+# Scope: ONLY the auth/install/error surfaces. Read endpoints for the
+# Shared DB (/api/fellows/*, /api/search, /api/stats etc.) are NOT
+# pinned here — they're flavor-specific to the Shared schema and live in
+# the implementation's own API docs. The endpoints below are what the
+# Distribution slot itself is responsible for.
+#
+# AC-bearing properties this contract enforces:
+#   - AC-2 (no SaaS surface): the only POSTs accepted are the four below.
+#     No /api/groups, /api/settings, or per-user RW endpoints.
+#   - AC-5 (stale session never locks out): /api/auth/status is
+#     unauthenticated; clients use it to detect 401 fallback.
+#   - AC-8 (anti-enumeration + abuse-bounded analytics): send-unlock,
+#     client-errors, and logout always return success status; verify-token
+#     returns distinct "expired" vs "invalid" error strings (intentional
+#     — UX disambiguates the gate banner; not exploitable for enumeration
+#     because tokens are unguessable).
+#   - AC-15 (build label tied to source revision): auth/status carries
+#     build + buildGitSha so the workspace's drift check and diag panel
+#     can surface server-vs-client skew.
+#   - DB-4 (sanitized error sink): /api/client-errors body conforms to
+#     client-errors-payload.schema.json; server returns 204 always.
 
 openapi: 3.1.0
 info:
-  title: PNA Distribution Auth API
+  title: PNA Distribution slot — auth + error endpoints
   version: 0.1.0
   description: |
-    Placeholder. The full surface covers /api/auth/status, /api/send-unlock,
-    /api/verify-token, /api/logout, and /api/client-errors per
-    _pna_triage.md § Distribution and § Debug contract.
-paths: {}
+    Canonical surface for the Distribution slot's auth, install, and
+    sanitized-error endpoints. v0.1 reference implementation:
+    `deploy/server.py` in fellows_local_db. The implementation may host
+    additional endpoints (Shared DB reads, build metadata, health check);
+    those are flavor-specific and documented per implementation.
+
+    Authentication mechanism: magic-link delivered out-of-band (email,
+    SMS, or any other side channel the distribution operator configures).
+    A session cookie issued by /api/verify-token authorizes subsequent
+    reads; logout revokes it.
+
+servers:
+  - url: https://example.invalid
+    description: Replaced with the deployed origin (e.g., fellows.globaldonut.com).
+
+components:
+  securitySchemes:
+    sessionCookie:
+      type: apiKey
+      in: cookie
+      name: pna_session
+      description: |
+        HMAC-signed, version-prefixed session cookie. HttpOnly; Secure;
+        SameSite=Lax. Issued by /api/verify-token; cleared by /api/logout.
+        Carries `token_issued_at` and `session_id`; the server's
+        in-memory revocation registry refuses replays after logout. Cookie
+        name is implementation-specific (`fellows_session` in
+        fellows_local_db); workspaces read the name from configuration.
+
+  schemas:
+    AuthStatus:
+      type: object
+      required:
+        - authEnabled
+        - authenticated
+        - hasSessionCookie
+        - installRecentlyAllowed
+      properties:
+        authEnabled:
+          type: boolean
+          description: |
+            True iff this distribution has auth wired up. Dev / open
+            distributions return false; gated distributions return true.
+        authenticated:
+          type: boolean
+          description: |
+            True iff the request carried a valid session cookie that the
+            server's revocation registry accepts.
+        hasSessionCookie:
+          type: boolean
+          description: |
+            True iff the request carried *some* session cookie value
+            (even an invalid one). Lets the workspace distinguish "no
+            cookie set" from "cookie present but bad" for diagnostics.
+        installRecentlyAllowed:
+          type: boolean
+          description: |
+            True iff the session's `token_issued_at` is within a short
+            implementation-defined window (DI-2). Drives the workspace's
+            "you can install the PWA now" affordance without re-requiring
+            a fresh magic-link verification.
+        build:
+          type: string
+          description: |
+            ISO-8601 timestamp of the server's current build. Used by
+            workspace drift check (AC-15). Optional — present when the
+            server has BUILD_META.
+        buildGitSha:
+          type: string
+          description: |
+            Short SHA of the server's current build. Used by workspace
+            drift check (AC-15). Optional.
+
+    SendUnlockRequest:
+      type: object
+      required: [email]
+      additionalProperties: false
+      properties:
+        email:
+          type: string
+          format: email
+          description: |
+            User-supplied email address. The server hashes this for
+            rate-limiting + journald correlation; HMAC-checks against
+            the allowlist; never logs the raw value.
+
+    SendUnlockResponse:
+      type: object
+      required: [sent]
+      additionalProperties: false
+      properties:
+        sent:
+          type: boolean
+          description: |
+            **Always true** (DI-4 anti-enumeration). The server returns
+            `{sent: true}` for unknown emails, rate-limited emails,
+            unparseable emails, and successful sends alike. The actual
+            outcome is in the server's journald log, not the HTTP body.
+
+    VerifyTokenRequest:
+      type: object
+      required: [token]
+      additionalProperties: false
+      properties:
+        token:
+          type: string
+          minLength: 1
+          description: Magic-link token, opaque to the client.
+
+    VerifyTokenSuccess:
+      type: object
+      required: [ok]
+      additionalProperties: false
+      properties:
+        ok:
+          type: boolean
+          enum: [true]
+
+    VerifyTokenFailure:
+      type: object
+      required: [ok, error]
+      additionalProperties: false
+      properties:
+        ok:
+          type: boolean
+          enum: [false]
+        error:
+          type: string
+          enum: [expired, invalid, server_misconfigured]
+          description: |
+            Discriminator the workspace uses to render specific gate-banner
+            copy ("link expired" vs "link invalid"). Distinct strings here
+            are intentional and AC-8-compatible: tokens are unguessable, so
+            distinguishing expired-vs-invalid doesn't enable enumeration.
+
+    LogoutResponse:
+      type: object
+      required: [ok]
+      additionalProperties: false
+      properties:
+        ok:
+          type: boolean
+          enum: [true]
+
+    ClientErrorsPayload:
+      $ref: ./client-errors-payload.schema.json
+
+paths:
+  /api/auth/status:
+    get:
+      summary: Probe the auth state of the current request.
+      description: |
+        Unauthenticated. The workspace probes this on every non-standalone
+        load to decide which boot flow to enter (directory mode vs gate).
+        Always returns 200; the response distinguishes "auth not wired
+        up" (`authEnabled: false`) from "wired up but you're not
+        authenticated" (`authEnabled: true && authenticated: false`).
+      responses:
+        '200':
+          description: Auth status snapshot.
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/AuthStatus'
+
+  /api/send-unlock:
+    post:
+      summary: Request a magic-link to the supplied email.
+      description: |
+        Unauthenticated. Server checks the email against the in-memory
+        allowlist (HMAC of the configured allowed-emails set), rate-limits
+        by sha256(email), and sends the magic-link via the configured
+        out-of-band channel (Postmark in fellows_local_db). **Always
+        returns 200 `{sent: true}`** (AC-8 / DI-4) regardless of the
+        actual outcome — the real outcome is logged to journald.
+
+        Hard request-body cap: 16 KB (enforced by the Distribution slot's
+        POST handler — DI-5). The body schema is tiny so the cap is
+        primarily about /api/client-errors.
+      requestBody:
+        required: true
+        content:
+          application/json:
+            schema:
+              $ref: '#/components/schemas/SendUnlockRequest'
+      responses:
+        '200':
+          description: |
+            Always returned, regardless of whether the email was sent.
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/SendUnlockResponse'
+        '413':
+          description: Request body exceeds the 16 KB cap.
+
+  /api/verify-token:
+    post:
+      summary: Exchange a magic-link token for a session cookie.
+      description: |
+        Unauthenticated. The workspace POSTs the token from the magic
+        link's URL fragment. On success the server issues an HMAC-signed
+        session cookie (HttpOnly; Secure; SameSite=Lax) via Set-Cookie
+        and returns `{ok: true}`. On failure returns 401 with a
+        discriminated error string.
+
+        Tokens are single-use (`consume_token`) — a successful verify
+        marks the token consumed regardless of subsequent failures. The
+        revocation registry keys the issued cookie's `session_id` so
+        logout (or the maintainer's manual revocation) takes effect
+        across all clients holding the same cookie.
+      requestBody:
+        required: true
+        content:
+          application/json:
+            schema:
+              $ref: '#/components/schemas/VerifyTokenRequest'
+      responses:
+        '200':
+          description: Token verified; session cookie issued via Set-Cookie.
+          headers:
+            Set-Cookie:
+              schema:
+                type: string
+              description: |
+                HMAC-signed session cookie. HttpOnly; Secure; SameSite=Lax.
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/VerifyTokenSuccess'
+        '401':
+          description: |
+            Token failed verification. `error: expired` and `error:
+            invalid` are distinct strings (intentional UX disambiguation
+            — see VerifyTokenFailure schema).
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/VerifyTokenFailure'
+        '500':
+          description: |
+            Server-side misconfiguration (session secret missing). Workspace
+            renders a maintainer-contact banner.
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/VerifyTokenFailure'
+
+  /api/logout:
+    post:
+      summary: Clear the session cookie and revoke its session_id.
+      description: |
+        Idempotent. The server clears the cookie via Set-Cookie regardless
+        of whether the caller had a valid session — DI-4 prohibits the
+        endpoint from revealing whether the caller was authenticated.
+        When the cookie is well-formed, the server also revokes the
+        cookie's `session_id` from its in-memory registry so the same
+        cookie value cannot be replayed even if captured from a network
+        log later. Always returns 200.
+      security:
+        - {}
+        - sessionCookie: []
+      responses:
+        '200':
+          description: Session cleared (whether or not it existed).
+          headers:
+            Set-Cookie:
+              schema:
+                type: string
+              description: Cookie cleared (`Max-Age=0`).
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/LogoutResponse'
+
+  /api/client-errors:
+    post:
+      summary: Sanitized client-error sink.
+      description: |
+        DB-4 sanitized error sink, hosted at the Distribution boundary so
+        users who failed the auth gate can still report problems.
+        Unauthenticated. Hard 16 KB body cap (DI-5). Per-IP rate limit
+        (DI-4) using the same bucket as /api/send-unlock.
+
+        **Always returns 204** (DI-4 / DB-4 anti-oracle). Malformed
+        bodies, rate-limited callers, schema-failing payloads — all
+        silently dropped. The only persistence is the structured journald
+        event the server writes after sanitizing (`event=client_error`).
+
+        Payload schema in `client-errors-payload.schema.json`. The server
+        MUST sanitize before logging (email redaction, slug/token
+        redaction in hash routes, query-string drop, hard length caps);
+        see the reference implementation at
+        `deploy/client_error_sanitizer.py`. The schema is the wire
+        contract; the sanitizer is the server's defense in depth.
+      requestBody:
+        required: true
+        content:
+          application/json:
+            schema:
+              $ref: '#/components/schemas/ClientErrorsPayload'
+      responses:
+        '204':
+          description: |
+            Always returned, regardless of whether the payload was
+            actually logged. The server MUST NOT distinguish accepted
+            from dropped payloads in the response.
+        '413':
+          description: Request body exceeds the 16 KB cap.

--- a/docs/pna_toolkit/spec/contracts/private-db.schema.sql
+++ b/docs/pna_toolkit/spec/contracts/private-db.schema.sql
@@ -1,7 +1,122 @@
--- Private schema interface: canonical SQL DDL for a conforming Private DB.
--- Placeholder — to be drafted in step 5.
--- See ../../../_pna_triage.md § Part 1 — Private schema and § Part 4 — PR-1 through PR-5.
+-- Private schema interface — canonical SQL DDL for a conforming Private DB.
 --
--- Will define: groups, group_members, record_tags, record_notes, settings
--- (workspace_id, key, value) composite PK, opt-in record_comms_history.
--- PRAGMA foreign_keys=ON per connection; PRAGMA user_version for migrations.
+-- Sub-contracts PR-1 through PR-5 from `_pna_triage.md` Part 4. The Private DB
+-- holds user-authored relationship data (groups, tags, notes, settings,
+-- optional comms history); it is read-write from the workspace and is the
+-- store that AC-1 promises to keep local-only.
+--
+-- This DDL is the spec-generic shape. Implementations may rename for
+-- ergonomics (fellows_local_db calls record-keyed tables `fellow_*` and uses
+-- a simpler `settings(key, value)` without the workspace partition); the
+-- spec-target shape is below.
+--
+-- PRAGMAs that MUST run per connection (PR-3):
+--   PRAGMA foreign_keys = ON;
+--   PRAGMA user_version = <SCHEMA_VERSION>;   -- bumped on schema migrations
+--
+-- Idempotency note (PR-5): every CREATE below uses `IF NOT EXISTS` so a
+-- restore from an older backup gains any newer tables on next boot without
+-- a manual migration step. The same bootstrap script runs on cold-start and
+-- on restore.
+
+-- PR-1: groups — user-curated subsets of Shared DB records.
+CREATE TABLE IF NOT EXISTS groups (
+    id          INTEGER PRIMARY KEY,
+    name        TEXT NOT NULL,
+    note        TEXT NOT NULL DEFAULT '',
+    created_at  TEXT NOT NULL,                  -- ISO-8601
+    updated_at  TEXT NOT NULL                   -- ISO-8601; drives list ordering
+);
+
+-- PR-1: group_members — joins a group to Shared DB records via record_id.
+-- ON DELETE CASCADE ensures deleting a group removes its members (PRAGMA
+-- foreign_keys=ON is required per PR-3 or the cascade is silently inert).
+--
+-- fellows_local_db naming: this column is `fellow_record_id` in the live
+-- schema; the spec-generic column name is `record_id`. The shape and PK
+-- semantics are identical.
+CREATE TABLE IF NOT EXISTS group_members (
+    group_id    INTEGER NOT NULL REFERENCES groups(id) ON DELETE CASCADE,
+    record_id   TEXT NOT NULL,
+    PRIMARY KEY (group_id, record_id)
+);
+
+CREATE INDEX IF NOT EXISTS idx_group_members_group ON group_members(group_id);
+
+-- PR-1: record_tags — per-record tags. fellows_local_db naming: `fellow_tags`
+-- with `fellow_record_id`.
+CREATE TABLE IF NOT EXISTS record_tags (
+    record_id   TEXT NOT NULL,
+    tag         TEXT NOT NULL,
+    created_at  TEXT NOT NULL,
+    PRIMARY KEY (record_id, tag)
+);
+
+CREATE INDEX IF NOT EXISTS idx_record_tags_tag ON record_tags(tag);
+
+-- PR-1: record_notes — per-record freeform notes. fellows_local_db naming:
+-- `fellow_notes` with `fellow_record_id`.
+CREATE TABLE IF NOT EXISTS record_notes (
+    record_id   TEXT PRIMARY KEY,
+    body        TEXT NOT NULL,
+    updated_at  TEXT NOT NULL
+);
+
+-- PR-1: settings — key/value bag partitioned by workspace_id.
+--
+-- Single-workspace PNAs use the empty string as workspace_id (default).
+-- Multi-workspace PNAs (per the "one origin, many workspaces" decision in
+-- _pna_triage.md Part 3) use their workspace's id so each workspace has
+-- its own settings namespace.
+--
+-- fellows_local_db is single-workspace today and uses a simpler
+-- `settings(key TEXT PRIMARY KEY, value TEXT)` table — the spec-generic
+-- composite-PK shape below is the forward-compatible target. A schema
+-- migration can extend the existing settings table by adding workspace_id
+-- with a default of '' to preserve all existing rows.
+CREATE TABLE IF NOT EXISTS settings (
+    workspace_id    TEXT NOT NULL DEFAULT '',
+    key             TEXT NOT NULL,
+    value           TEXT,
+    PRIMARY KEY (workspace_id, key)
+);
+
+-- PR-2: record_comms_history — opt-in log of outreach launched from the
+-- workspace.
+--
+-- **Disabled by default.** The workspace MUST NOT write to this table
+-- unless `settings.value WHERE workspace_id='' AND key='comms_history_enabled'`
+-- is the literal string '1'. The user has full read / edit / delete
+-- control over the rows; they live in the Private DB and are protected by
+-- AC-1 (never leave the device).
+--
+-- `transport` records which Communications transport launched the outreach
+-- (e.g., 'mailto', 'signal'). `direction` is 'outbound' for messages the
+-- user sent and 'inbound' for messages the user manually logs as received.
+-- `summary` is user-editable shorthand; the message body itself is NOT
+-- stored — that's the responsibility of the user's mail/messaging client.
+CREATE TABLE IF NOT EXISTS record_comms_history (
+    id          INTEGER PRIMARY KEY,
+    record_id   TEXT NOT NULL,
+    transport   TEXT NOT NULL,                  -- e.g., 'mailto', 'signal'
+    direction   TEXT NOT NULL,                  -- 'outbound' | 'inbound'
+    occurred_at TEXT NOT NULL,                  -- ISO-8601
+    summary     TEXT NOT NULL DEFAULT ''        -- user-editable shorthand
+);
+
+CREATE INDEX IF NOT EXISTS idx_record_comms_history_record
+    ON record_comms_history(record_id);
+
+-- PR-4 (durability) and PR-5 (backup/restore conformance) are operational
+-- properties, not table shapes. They appear in this contract as comments:
+--
+-- PR-4: The Private DB is never replaced on app update. It survives Clear
+-- App Cache. It is wiped only by Reset Everything (the workspace's
+-- explicit-user-choice nuclear path; ST-10 implements the wipe in browser
+-- PNAs).
+--
+-- PR-5: Auto-backups + user-supplied restores are part of the Storage
+-- slot's contract (ST-6, ST-7). This DDL is idempotent so a restore from
+-- an older backup gains any newer tables on next boot without a manual
+-- migration step. Schema migrations beyond CREATE-IF-NOT-EXISTS will
+-- branch on `PRAGMA user_version`.

--- a/docs/pna_toolkit/spec/contracts/shared-db.schema.sql
+++ b/docs/pna_toolkit/spec/contracts/shared-db.schema.sql
@@ -1,7 +1,117 @@
--- Shared schema interface: canonical SQL DDL for a conforming Shared DB.
--- Placeholder — to be drafted in step 5.
--- See ../../../_pna_triage.md § Part 1 — Shared schema and § Part 4 — SH-1 through SH-6.
+-- Shared schema interface — canonical SQL DDL for a conforming Shared DB.
 --
--- Will define: primary record table (record_id, slug, name, app-defined display
--- columns, extra_json), optional FTS5 virtual table, optional per-record asset
--- URL convention, sourced-provenance column for multi-source PNAs.
+-- Sub-contracts SH-1 through SH-6 from `_pna_triage.md` Part 4. The Shared
+-- DB holds mirrored contact data — read-only inside the PNA, written only
+-- by the Ingestion slot. AC-17 (mirrored data is sourced) and AC-10
+-- (opt-in non-destructive re-imports with orphan preview) apply.
+--
+-- This DDL is the spec-generic shape — implementations supply app-specific
+-- display columns and decide whether to ship the optional FTS5 index.
+-- The contract pins three things:
+--   (1) the primary record table's core column set (SH-1)
+--   (2) the read-only enforcement mechanism (SH-4) — at JOIN time, not DDL
+--   (3) the asset-URL convention when one is used (SH-3)
+--
+-- Naming note: the spec uses the table name `records`; specializations may
+-- rename. fellows_local_db's specialization calls it `fellows`. The
+-- column names below (record_id, slug, name, extra_json) are normative
+-- across all Shared DBs.
+
+-- SH-1: Primary record table.
+--
+-- Required columns:
+--   record_id   TEXT  PRIMARY KEY     — opaque, STABLE across re-mirrors.
+--                                      This is the join key from the
+--                                      Private DB; AC-10's orphan-preview
+--                                      depends on stability for the set
+--                                      difference to be meaningful.
+--   slug        TEXT  NOT NULL UNIQUE — display URL key; deterministic
+--                                      from `name`. SH-3's optional asset
+--                                      URL convention keys on this.
+--   name        TEXT  NOT NULL        — display label; what orphan-preview
+--                                      surfaces to the user.
+--   extra_json  TEXT                  — JSON-encoded overflow for any
+--                                      source-specific keys not in the
+--                                      app-defined explicit columns. The
+--                                      workspace merges these into per-
+--                                      record API responses without per-
+--                                      field schema knowledge.
+--
+-- Plus zero or more app-defined display columns. fellows_local_db ships
+-- 17 explicit display columns (name, bio_tagline, fellow_type, cohort,
+-- contact_email, …); see fellows_local_db's Architecture.md § Database
+-- Schema for the full list. Other PNAs will have wildly different display
+-- columns; that's expected and not constrained by the spec.
+CREATE TABLE IF NOT EXISTS records (
+    record_id   TEXT PRIMARY KEY,
+    slug        TEXT NOT NULL,
+    name        TEXT NOT NULL,
+    extra_json  TEXT,
+    -- app-defined display columns go here (workspace-rendered fields)
+    --   e.g. bio_tagline TEXT,
+    --        contact_email TEXT,
+    --        image_url TEXT,
+    --        ...
+    -- SH-6: Multi-source PNAs add a provenance column. Single-source PNAs
+    -- (Directory Archive flavors) may omit it. fellows_local_db is
+    -- single-source today; AC-PRM-B's draft multi-source contract will
+    -- formalize the per-field provenance shape for PRM-flavor PNAs.
+    --   source TEXT,
+    -- SH-3 optional asset URL convention is OUT of the SQL — see comment
+    -- below.
+    UNIQUE (slug)
+);
+
+-- SH-2: Optional FTS5 virtual table.
+--
+-- When a PNA wants full-text search across the Shared DB, the spec
+-- recommends FTS5 with external content (`content='records'`,
+-- `content_rowid='rowid'`) so the index stays in sync with the primary
+-- table without per-row triggers being a hand-maintained burden. Which
+-- columns to index is app-specific; fellows_local_db indexes name,
+-- bio_tagline, cohort, fellow_type, search_tags, key_links.
+--
+-- CLI / native PNAs may use a different search engine (Tantivy, ripgrep
+-- shelling out, …); the contract names the FTS5 path as the recommended
+-- default for SQLite-substrate PNAs, not a mandate.
+--
+--   CREATE VIRTUAL TABLE IF NOT EXISTS records_fts USING fts5(
+--       name,
+--       /* app-defined searchable columns */,
+--       content='records',
+--       content_rowid='rowid'
+--   );
+
+-- SH-3: Optional per-record asset URL convention.
+--
+-- When a PNA serves per-record binary assets (profile photos, attachment
+-- previews, etc.), the convention is to make them slug-keyed and content-
+-- addressable so they're cacheable, immutable, and never include the
+-- record_id (which may be opaque). The path lives on the workspace /
+-- distribution side, not in the Shared DB — but the SLUG is what binds
+-- them, so it goes here as documentation.
+--
+-- fellows_local_db convention: `/images/<slug>.{jpg,png}`. Alphanumeric-
+-- fuzzy fallback in the server handler covers slug-vs-filename drift.
+
+-- SH-4: Read-only enforcement.
+--
+-- The Shared DB is read-only at runtime. Implementations MUST enforce
+-- this at the storage substrate level when joining from the Private DB:
+--
+--   ATTACH DATABASE 'file:.../shared.db?mode=ro' AS shared;
+--
+-- For browser PNAs using OPFS, the dedicated worker (Storage slot) opens
+-- the file with the equivalent read-only flag at SAH-pool import. Any
+-- stray write into the attached namespace raises `OperationalError` —
+-- the read-only-ness is not just an app-layer convention.
+--
+-- The only writer is the Ingestion slot's atomic-swap pipeline (SH-5).
+
+-- SH-5: Atomic re-import semantics with orphan preview (AC-10).
+--
+-- Implemented by ST-8 (worker-rpc-protocol.schema.json:op_previewSharedDbSwap
+-- → op_applySharedDbSwap). The DDL above is what an ingested fresh DB
+-- must conform to; the orchestration (stage, validate via PRAGMA
+-- quick_check, compute affected Private DB references, surface them to
+-- the user before commit, atomic swap) is in the Storage slot.

--- a/docs/pna_toolkit/spec/contracts/transport-interface.d.ts
+++ b/docs/pna_toolkit/spec/contracts/transport-interface.d.ts
@@ -1,7 +1,188 @@
-// Communications slot: the transport interface every comms transport implements.
-// Placeholder — to be drafted in step 5.
-// See ../../../_pna_triage.md § Part 1 — Communications § Contract and § Part 4 — CO-1 through CO-6.
+// Communications slot — the transport interface every comms transport
+// implements. Sub-contracts CO-1 through CO-6 from `_pna_triage.md` Part 4.
+//
+// A Transport is a pluggable outreach mechanism — mailto, signal-cli, a
+// Matrix bridge, a future P2P pubkey-based channel. The workspace surfaces
+// the user's configured transports and lets the user pick per outreach
+// (AC-16). The transport's only job is to launch the user's external
+// client (or in-bundle handler) with the composed payload pre-populated —
+// it MUST NOT send autonomously, and it MUST NOT read message content
+// (AC-18). The workspace shows the full payload to the user before any
+// transport is launched (AC-19); the transport sees what the user already
+// approved.
+//
+// CO-3 (transport eligibility, AC-18) is enforced by the workspace's
+// transport-registration logic: a candidate Transport whose mechanism
+// could read message contents is refused at register time. The interface
+// below describes the runtime contract; the eligibility check is a build-
+// time / registration-time decision on top of it.
+//
+// CO-6: This interface is for *workspace-launched* user outreach. The
+// distribution-mechanism's auth-link transport (Postmark in
+// fellows_local_db's magic-link distribution flavor) is governed by the
+// Distribution slot's contracts, NOT by this interface. They look similar
+// — both deliver bytes to a user — but their AC sets and trust postures
+// are different.
 
+/**
+ * The fixed v0.1 action enum (CO-2). New action values can be added with
+ * toolkit version bumps; transports are free to canHandle() a subset.
+ *
+ * - `email_one` — one recipient, visible To.
+ * - `email_group_cc` — multiple recipients, visible Cc.
+ * - `email_group_bcc` — multiple recipients, blind Bcc (privacy-preserving
+ *   for group sends; the recommended default for >1 recipients).
+ * - `direct_message_one` — one recipient via a DM channel (Signal, Matrix DM,
+ *   etc.). Format depends on the transport's protocol.
+ * - `share_link_one` — share a single URL to one recipient.
+ * - `share_link_group` — share a single URL to multiple recipients.
+ */
+export type TransportAction =
+  | "email_one"
+  | "email_group_cc"
+  | "email_group_bcc"
+  | "direct_message_one"
+  | "share_link_one"
+  | "share_link_group";
+
+/**
+ * Static description a transport publishes about itself. The workspace
+ * uses this to render the user's transport-picker (the "reach out via …"
+ * menu) and to record which transport launched a given outreach in the
+ * optional `record_comms_history` Private DB table (PR-2).
+ */
+export interface TransportDescriptor {
+  /**
+   * Stable identifier. Used as the key the user's transport-preference
+   * settings are stored under and as the `transport` value in
+   * `record_comms_history`. Snake-case ASCII.
+   * Examples: `"mailto"`, `"signal_cli"`, `"matrix"`.
+   */
+  id: string;
+
+  /** Human-readable label shown in the workspace's transport-picker. */
+  name: string;
+
+  /**
+   * Optional self-reported security tier for UI sorting / labeling. The
+   * workspace MAY use this to order the picker (more-secure first) and to
+   * render a small badge ("encrypted in protocol"). NOT used as a gate —
+   * AC-18 eligibility is enforced at registration time, not via this
+   * advisory field.
+   */
+  secureLevel?: "plaintext" | "in-transit" | "end-to-end";
+
+  /**
+   * Optional human-readable note shown alongside the transport in the
+   * picker (e.g., "requires Signal Desktop installed", "uses your default
+   * mail client"). UI-only.
+   */
+  note?: string;
+}
+
+/**
+ * Result of a launch call. Returned to the workspace so it can surface
+ * outcome to the user and (when comms history is enabled — PR-2) record
+ * the outreach.
+ */
+export interface LaunchResult {
+  /**
+   * `true` when the external client / handler was successfully invoked.
+   * `false` when the transport refused (e.g., no recipients, payload
+   * exceeded the transport's hard limit) — the workspace surfaces
+   * `error` to the user.
+   */
+  ok: boolean;
+
+  /** Human-readable error message when `ok === false`. */
+  error?: string;
+
+  /**
+   * Transport-specific structured metadata for diagnostics or history —
+   * e.g., `{ mailto_url_byte_length: 1487, recipient_count: 5 }` for the
+   * mailto transport. The workspace MAY persist this into
+   * `record_comms_history.summary` (or a transport-specific extension);
+   * the spec does not pin the shape.
+   */
+  meta?: Record<string, unknown>;
+}
+
+/**
+ * Payload passed to `launch()`. Shape is action-dependent; the workspace
+ * has already validated and shown it to the user (AC-19) before calling.
+ */
+export interface LaunchPayload {
+  /** Visible primary recipients. May be empty for BCC-only group sends. */
+  to?: string[];
+
+  /** Carbon-copied recipients. */
+  cc?: string[];
+
+  /** Blind-carbon-copied recipients. */
+  bcc?: string[];
+
+  /** Subject (email-style transports) / title (link-share transports). */
+  subject?: string;
+
+  /** Message body. */
+  body?: string;
+
+  /** URL to share (used by `share_link_*` actions). */
+  url?: string;
+
+  /**
+   * Transport-specific extension fields. The workspace pre-shows these to
+   * the user (AC-19); transports MUST NOT add fields here that the
+   * workspace didn't surface.
+   */
+  extras?: Record<string, unknown>;
+}
+
+/**
+ * CO-1: the interface every Communications transport implements.
+ *
+ * The workspace registers configured transports at startup (each
+ * registration is gated on AC-18 eligibility — mechanism cannot read
+ * message contents). At outreach time the workspace:
+ *
+ *   1. Asks each registered transport whether it `canHandle(action)`.
+ *   2. Shows the user a picker of the transports that returned `true`.
+ *   3. The user composes / reviews the full payload (AC-19).
+ *   4. The workspace calls `launch(action, payload)` on the chosen
+ *      transport.
+ *   5. On `ok: true`, optionally records the outreach in
+ *      `record_comms_history` if PR-2 is enabled.
+ *
+ * Transports MUST be stateless across calls. State that persists across
+ * outreaches (per-recipient nicknames, address-book mappings) lives in
+ * the Private DB, not in the transport.
+ */
 export interface Transport {
-  // TODO: canHandle(action), launch(action, payload), descriptor()
+  /**
+   * Returns true when this transport can handle the given action.
+   * The workspace calls this to populate the user's transport-picker.
+   * Cheap; must not perform I/O.
+   */
+  canHandle(action: TransportAction): boolean;
+
+  /**
+   * Launch the user's external client (or in-bundle handler) with the
+   * composed payload pre-populated. The transport MUST NOT send
+   * autonomously — opening a URL, spawning a process, or invoking the
+   * OS's share sheet is acceptable; transmitting the payload itself
+   * is not (AC-18).
+   *
+   * The workspace has already shown the user the full payload (AC-19);
+   * the transport's job is to hand it off.
+   *
+   * Returns a Promise so transports that need an async handshake (e.g.,
+   * checking that `signal-cli` is reachable) can resolve when ready.
+   */
+  launch(action: TransportAction, payload: LaunchPayload): Promise<LaunchResult>;
+
+  /**
+   * Static self-description. Stable across calls. Used by the workspace
+   * for picker rendering and history attribution.
+   */
+  descriptor(): TransportDescriptor;
 }


### PR DESCRIPTION
## Summary

Completes step 5 of `_pna_triage.md`'s plan for everything except the two MCP placeholders (Ingestion + Diagnostics — they wait on first reference implementations). All five files were 7–13-line stubs before this PR; they now carry full normative shape.

| File | Sub-contracts | Source-mapped against |
|---|---|---|
| `private-db.schema.sql` | PR-1 through PR-5 | `app/relationships.py:SCHEMA_SQL` (spec-generic table/column names; flavor notes for fellows_local_db's `fellow_tags` / `fellow_notes` / single-PK `settings`). Adds opt-in `record_comms_history` from PR-2. |
| `shared-db.schema.sql` | SH-1 through SH-6 | `docs/Architecture.md § Database Schema` (spec-generic `records` table; fellows-flavor calls it `fellows`). FTS5 + asset-URL convention documented in comments as optional flavor extensions. |
| `client-errors-payload.schema.json` | DB-4 | `deploy/client_error_sanitizer.py` — accept-listed top-level keys, 20-event cap, `kind` enum allowlist, length caps + pattern on `lastSubmitHashPrefix`. |
| `transport-interface.d.ts` | CO-1 through CO-6 | `_pna_triage.md` Part 4 (CO- decomposition). Defines `TransportAction` enum, `LaunchPayload` / `LaunchResult` / `TransportDescriptor` shapes, plus the three-method `Transport` interface. AC-18 documented as a registration-time check; AC-19 as a workspace responsibility above the interface. |
| `distribution-auth.openapi.yaml` | DI-3, DI-4, DB-4 (host) | `deploy/server.py` auth handlers. OpenAPI 3.1 fragment for `/api/auth/status`, `/api/send-unlock`, `/api/verify-token`, `/api/logout`, `/api/client-errors`. AC-8 anti-enumeration baked into response shapes (always-`{sent: true}` / always-204). |

## What remains in `spec/contracts/` after this lands

| File | Status |
|---|---|
| `mcp-ingestion.schema.json` | placeholder; awaits first Ingestion-exposing reference implementation |
| `mcp-diagnostics.schema.json` | placeholder; awaits first Diagnostics-exposing reference implementation |

That's it. Every other contract slot is filled.

## Test plan

- [ ] `python3 -c "import json; json.load(open(...))"` passes for the JSON Schema files (client-errors-payload, and the previously-merged MCP + worker schemas).
- [ ] `python -c "import yaml; yaml.safe_load(open('docs/pna_toolkit/spec/contracts/distribution-auth.openapi.yaml'))"` parses.
- [ ] `sqlite3 :memory: < docs/pna_toolkit/spec/contracts/private-db.schema.sql` runs without error (the DDL is idempotent CREATE IF NOT EXISTS).
- [ ] Spot-check `private-db.schema.sql` against `app/relationships.py:SCHEMA_SQL` — the spec's `record_id` should map cleanly to fellows's `fellow_record_id`; the spec's composite-PK `settings(workspace_id, key, value)` is a forward-compatible extension of fellows's `settings(key, value)`.
- [ ] Spot-check `distribution-auth.openapi.yaml` against `deploy/server.py:_handle_send_unlock` and `_handle_verify_token` — request bodies, response shapes, and the discriminated 401 error strings should match.
- [ ] Spot-check `client-errors-payload.schema.json` against `deploy/client_error_sanitizer.py` — `kind` enum, length caps, `lastSubmitHashPrefix` pattern.

After this lands: `_pna_triage.md` step 5 (typed contracts) is complete. Steps 6 (Architecture.md rewrite as spec-conformance layer), 7 (repo-root `llms.txt`), 8 (demote secondary docs to annexes) remain.

🤖 Generated with [Claude Code](https://claude.com/claude-code)