### PR TITLE
docs(arch): rewrite Architecture.md as fellows's PNA-spec specialization layer

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -1,6 +1,6 @@
 # CLAUDE.md
 
-Read README.md for project setup, API docs, and test commands. Read docs/Architecture.md for system design and database schema.
+Read README.md for project setup, API docs, and test commands. Read docs/Architecture.md for fellows_local_db's specialization and PNA-spec conformance (axis picks, fellows-specific schema, HTTP routes, debug placeholders); docs/Architecture.md cross-links into docs/pna_toolkit/ for the universal PNA architecture.
 
 ## Constraints
 

--- a/README.md
+++ b/README.md
@@ -57,7 +57,7 @@ The github tree is clean of PII.  Still, treat the contents of your app as confi
 
 ## Architecture
 
-See `[docs/Architecture.md](docs/Architecture.md)` for system design, data flow, and schema.
+See `[docs/Architecture.md](docs/Architecture.md)` for fellows_local_db's specialization-and-conformance layer (axis picks, schema, HTTP routes, debug placeholders). The universal PNA architecture it cross-links into lives in `[docs/pna_toolkit/](docs/pna_toolkit/)` — `PNA_Spec.md`, `axes.md`, `use_cases.md`, and the typed contracts under `spec/contracts/`.
 
 The origin of this app was [prt](https://github.com/richbodo/prt) and the next version of prt that will be able to build apps like this is [personal_network_toolkit](https://github.com/richbodo/personal_network_toolkit)
 

--- a/docs/Architecture.md
+++ b/docs/Architecture.md
@@ -1,298 +1,108 @@
-# Architecture
+# Architecture (fellows_local_db)
 
-## Design constraint: local-only, not SaaS
+This document is fellows_local_db's **specialization-and-conformance layer**: it declares which version of the PNA Spec this repo conforms to, names the axis picks fellows has made, and catalogs the fellows-specific values that the spec leaves to each implementation (HTTP routes, schema, worker constants, debug placeholders, distribution tunables).
 
-**This app is single-user and local-only by design. It must never become a SaaS.** The PWA + magic-link distribution exists so a fellow can pull down the bundle and contact DB once, then run the app indefinitely against that local copy. Production is a delivery channel, not a service.
+Universal PNA architecture — vocabulary, goals, the two-store ownership split, the worker-owned-OPFS rule, the version-handshake contract, the universal ACs — lives in [`./pna_toolkit/PNA_Spec.md`](./pna_toolkit/PNA_Spec.md). This file does not restate it.
 
-Operationally that means server contact is restricted to two responsibilities:
+---
 
-1. **Authorize a download** (magic-link gate, allowlist check, session cookie) so the bundle and `fellows.db` only reach EHF fellows.
-2. **Serve fresh bytes on update** (new bundle when the SHA changes; re-imported `fellows.db` only when its content SHA changes, gated by `fellows_db_sha` in `/build-meta.json`).
+## Spec conformance
 
-Everything else runs on the device:
+**Spec-Version:** [0.1 (draft)](./pna_toolkit/CHANGELOG.md)
+**Use case:** [Directory Archive](./pna_toolkit/use_cases.md#directory-archive)
 
-- **No per-user resources on the server.** `deploy/server.py` does not implement `/api/groups` or `/api/settings` — the dev server's routes for those exist only for the local round-trip. The canonical store for user-authored data is OPFS (`relationships.db`).
-- **Stale-session must not lock users out of cached data.** A 401 on `/api/fellows` falls back to the IndexedDB cache; the directory, search, and profile views keep working. See `email_gate.md` invariant 10.
-- **No server-side persistence of anything user-authored.** No backups of `relationships.db`, no server-stored notes, no shared groups, no cross-device sync. The unauthenticated client-error sink (`/api/client-errors`) is the only structured journald write driven by client behavior, and it is sanitized to remove identifiers.
+### Flavor — fellows's six axis picks
 
-What this rules out as features, even when individually attractive: cross-device sync, "share this group with another fellow", an admin console, server-side activity history, analytics beyond the install-funnel events already documented in `email_gate.md`. Adding any per-user RW endpoint on prod is the bright line that turns this from a delivery channel into a SaaS — don't cross it without a deliberate change to this section.
+| Axis | Pick | Why |
+|---|---|---|
+| [Distribution](./pna_toolkit/axes.md#distribution) | `web-bundle-with-magic-link` | EHF-allowlisted PWA; multiple fellows install from one origin behind a magic-link gate. |
+| [Storage substrate](./pna_toolkit/axes.md#storage-substrate) | `opfs-sqlite-wasm` | Browser-only deployment; sqlite3.wasm in a dedicated worker with OPFS-SAH-Pool VFS. |
+| [Ingestion shape](./pna_toolkit/axes.md#ingestion-shape) | `single-source-static-mirror` | One source (Knack JSON dump); no dedup; opt-in user-driven re-import. |
+| [Workspace shell](./pna_toolkit/axes.md#workspace-shell) | `vanilla-js-spa` | Single-IIFE `app/static/app.js`; hash routing; no framework, no bundler. |
+| [Comms transport set](./pna_toolkit/axes.md#comms-transport-set) | `mailto-only` | `mailto:` (+ `tel:`) today; Signal planned. |
+| [MCP-exposure](./pna_toolkit/axes.md#mcp-exposure) | `shared+private+comms` | `mcp_servers/` ships three stdio MCP servers for Claude Desktop and similar clients. |
 
-The architectural decisions below — separate `relationships.db` file, `ATTACH DATABASE ?mode=ro`, OPFS in both standalone and browser-tab modes, the unsupported-browser panel for missing OPFS — all flow from this constraint.
+### Universal ACs
 
-## Tech Stack
+All universal ACs from [`./pna_toolkit/PNA_Spec.md#universal-architectural-commitments`](./pna_toolkit/PNA_Spec.md#universal-architectural-commitments) apply — that's the definition of *universal*. The list (AC-1, AC-4, AC-6, AC-7, AC-9, AC-10, AC-11, AC-15, AC-16, AC-17, AC-18, AC-19, AC-PRM-A, AC-PRM-D, AC-MCP-A, AC-MCP-B) is the canonical reference.
 
-- **Server**: Python stdlib `http.server` — single file, no framework
-- **Cross-origin isolation**: Both servers send `Cross-Origin-Opener-Policy: same-origin` and `Cross-Origin-Embedder-Policy: require-corp`. **Required** — the OPFS-SAH-Pool VFS that backs `relationships.db` and `fellows.db` in the browser gates `SharedArrayBuffer` / `Atomics` on `crossOriginIsolated=true`. A reverse proxy that strips these headers makes the worker silently fall back to the `api+idb` provider; the symptom is "Settings has no backup/restore section," diagnosable via `?diag=1` showing `dataProvider.kind: api+idb` instead of `worker`.
-- **Strict CSP + adjacent hardening**: Both servers send `Content-Security-Policy: default-src 'self'; script-src 'self' 'wasm-unsafe-eval'; worker-src 'self'; connect-src 'self'; img-src 'self' data:; style-src 'self'; font-src 'self'; object-src 'none'; base-uri 'self'; frame-ancestors 'none';` plus `Permissions-Policy` (geolocation/camera/mic/payment/sensors/USB/etc. all `=()`), `Cross-Origin-Resource-Policy: same-origin`, `Referrer-Policy: strict-origin-when-cross-origin`, and `X-Content-Type-Options: nosniff`. The CSP is the load-bearing one — without it a single XSS exfiltrates the entire OPFS to an attacker-controlled origin. `'wasm-unsafe-eval'` is the modern carve-out for the `sqlite3.wasm` runtime. The dev and prod headers must stay byte-identical so a CSP-incompatible pattern can't slip past local development. The HSTS header is added by Caddy at the edge (`ansible/roles/caddy/templates/Caddyfile.j2`) rather than by the Python server.
-- **Subresource Integrity (SRI)**: `index.html` carries SHA-384 `integrity=` attributes on both `<script src>` tags (`app.js` and `vendor/jspdf-...js`). `build/build_pwa.py:stamp_sri_attributes` computes the hashes at build time over the post-build-label-stamped bytes; the dev server (`app/server.py`) performs the same substitution at request time so dev and prod produce byte-identical integrity values. Browser refuses to execute a script whose fetched bytes don't match — defense-in-depth on top of `script-src 'self'`. The service worker itself isn't covered (`navigator.serviceWorker.register` doesn't accept an integrity option); that gap is the motivation for the out-of-band signed bundles still in the security backlog.
-- **Database**: SQLite3 with FTS5 full-text search
-- **Frontend**: Vanilla JS SPA with hash routing, no build step
-- **Data source**: JSON dump from EHF wiki, imported via build script
-- **Tests**: pytest for database and HTTP API tests; Playwright for browser e2e. Venv, dev dependencies, Playwright browsers, building `app/fellows.db`, and commands (including freeing port 8765) are documented in the root **README.md**.
+### Flavor-derived ACs triggered by fellows's picks
 
-## Data Flow
+Cross-referenced to [`./pna_toolkit/axes.md`](./pna_toolkit/axes.md):
 
-```
-JSON source data                   Build script                          SQLite DB
-knack_api_detail_dump.json  →  restore_from_knack_scrapefile.py  →  fellows.db
-                                                                         ↓
-Browser (vanilla JS SPA)  ←  HTTP API (server.py)  ←  SQL queries
-```
+| AC | Triggered by | Fellows's realization |
+|---|---|---|
+| AC-2 (no SaaS surface) | `dist:web-bundle-with-magic-link` | `deploy/server.py` ships no per-user RW endpoints; the dev server's retired `/api/groups` and `/api/settings` were the only ones that ever existed (Phase 1 cutover). |
+| AC-3 (single OPFS owner) | `storage:opfs-sqlite-wasm` | `app/static/vendor/sqlite-worker.js` is the sole context that calls `navigator.storage.getDirectory` or opens a `FileSystemSyncAccessHandle`. |
+| AC-5 (stale session never locks users out of cache) | `dist:web-bundle-with-magic-link` (auth-gated) | Three-tier `window.__dataProvider` hot-swaps from `worker` → `api+idb` on 401/403 mid-boot; the cached directory stays readable. |
+| AC-8 (anti-enumeration + abuse-bounded analytics) | `dist:web-bundle-with-magic-link` + `debug:has-error-sink` | `deploy/server.py`'s auth endpoints return neutral payloads with per-IP rate limits; the `/api/client-errors` sink doubles as the analytics pipe via `kind=` allowlist. See [`./email_gate.md`](./email_gate.md). |
+| AC-12 (capability detection inside worker) | `storage:opfs-sqlite-wasm` | Worker `init` reports `opfsCapable`; main thread reads the field and renders the unsupported-browser panel rather than UA-sniffing. |
+| AC-13 (COOP/COEP required) | `storage:opfs-sqlite-wasm` + `dist:web-served` | Both dev and prod servers send `Cross-Origin-Opener-Policy: same-origin` + `Cross-Origin-Embedder-Policy: require-corp`. Caddy preserves them at the edge. |
+| AC-14 (SW never owns SQLite) | `dist:web-bundle-with-magic-link` (PWA) | `app/static/sw.js` is app-shell + update detection only; `/fellows.db` is explicitly bypassed in the fetch handler. |
 
-### Build Phase
+### MCP-related ACs activated by `mcp-exposure:shared+private+comms`
 
-`build/restore_from_knack_scrapefile.py` reads the Knack API detail dump (with a fallback read of the list-view `raw_dump` for a few fields), deduplicates slugs, detects grey-diamond placeholder avatars by MD5, and writes two tables:
+- **AC-MCP-A** active — the Private Data Ops server returns Private DB rows; cloud AI clients require per-call consent. See [`mcp_servers/README.md`](../mcp_servers/README.md) § Cloud LLM caveat.
+- **AC-MCP-B** active — Communications is exposed; `mcp_servers/comms.py` stages outreach (returns a `mailto:` URL) and never fires the transport directly.
 
-- **`fellows`** — 17 explicit TEXT columns + `extra_json` TEXT for overflow fields
-- **`fellows_fts`** — FTS5 virtual table (external content) indexing name, bio_tagline, cohort, fellow_type, search_tags, key_links
+### ACs that are vacuous in fellows's flavor
 
-The explicit columns cover the fields needed for display and filtering. Any JSON keys not in that list are serialized into `extra_json`, which `row_to_fellow()` in the server merges back into the API response. This means the API returns all original fields without needing schema changes for every new field.
+For a reader auditing conformance: AC-PRM-B and AC-PRM-C don't apply (fellows is single-source and uses OPFS, not native SQLite). Picks fellows did not take on other axes (e.g. `ingestion:multi-source-merge-with-dedup`, `storage:native-sqlite-via-filesystem`) carry their own flavor-derived ACs in [`./pna_toolkit/axes.md`](./pna_toolkit/axes.md); none fire here.
 
-### Runtime
+---
 
-The server opens a new SQLite connection per request (no connection pool — unnecessary at local scale). Responses are JSON for API routes and raw bytes for static files and images.
+## HTTP API
 
-**HTTP API.** The dev server (`app/server.py`) exposes the table below. The production server (`deploy/server.py`) adds magic-link auth (`/api/send-unlock`, `/api/verify-token`, `/api/logout`), the unauthenticated client-error sink (`/api/client-errors`), build/diagnostics endpoints (`/healthz`, `/build-meta.json`, `/api/debug/diagnostics`), and gates directory `/api/*` paths behind a valid session cookie. The allowlist is built in memory at startup by HMAC-ing every distinct `contact_email` from `fellows.db` (`FELLOWS_ALLOWLIST_HMAC_KEY` env var); no `allowed_emails.json` artifact ships in `dist/`. The behavioral spec for the auth flow + client-error sanitization is [`email_gate.md`](email_gate.md).
+Read-only fellow data (served from `app/fellows.db`):
 
 | Method | Path | Purpose |
 |---|---|---|
-| GET | `/api/fellows` | Minimal list (record_id / slug / name / has_contact_email) for instant directory render. |
+| GET | `/api/fellows` | Minimal list (`record_id`, `slug`, `name`, `has_contact_email`) for instant directory render. |
 | GET | `/api/fellows?full=1` | Full fellow rows (phase 2 of the two-phase load). |
 | GET | `/api/fellows/<slug>` | One fellow by `slug` or `record_id`. |
 | GET | `/api/search?q=…` | FTS5 search across name / bio / cohort / fellow_type / search_tags / key_links. |
 | GET | `/api/stats` | Aggregates for the About page: total, breakdowns by fellow_type / cohort / region, field completeness. |
-| GET | `/api/auth/status` | Stub in dev (auth disabled). Real shape comes from `deploy/server.py`. |
-| POST | `/api/client-errors` | Unauthenticated client-error sink. Always 204. Sanitized + rate-limited; logs `event=client_error` to journald. Schema + privacy boundary: [`email_gate.md` § Client error reporting](email_gate.md#client-error-reporting). Dev stub mirrors prod for round-trip. |
 | GET | `/fellows.db` | Raw SQLite snapshot for the PWA's OPFS bootstrap. |
-| GET | `/images/<slug>.{jpg,png}` | Profile image; alphanumeric-fallback filename match. |
+| GET | `/images/<slug>.{jpg,png}` | Profile image; alphanumeric-fuzzy filename fallback. |
 | GET | `/` and other static paths | App shell from `app/static/`. |
 
-`/api/stats` is heavier than a simple row fetch (region split + field-completeness pass over `extra_json` via `json_extract`); still fine at local scale. Per-user state (groups, settings, tags, notes) does not appear above — `/api/groups` and `/api/settings` were retired in Phase 1 of the local-first worker plan; see [Persistence and upgrades](#persistence-and-upgrades) and [Worker-owned OPFS](#worker-owned-opfs).
+Production-only routes (added by `deploy/server.py`; conform to the Distribution slot's auth contract in [`./pna_toolkit/spec/contracts/distribution-auth.openapi.yaml`](./pna_toolkit/spec/contracts/distribution-auth.openapi.yaml)):
 
-### Persistence and upgrades
+| Method | Path | Purpose |
+|---|---|---|
+| GET | `/api/auth/status` | Never gated; returns `{authEnabled, authenticated, hasSessionCookie, installRecentlyAllowed, build, buildGitSha}`. |
+| POST | `/api/send-unlock` | Anti-enum, always 200; rate-limited per email-hash. |
+| POST | `/api/verify-token` | 200 + Set-Cookie on success; 401 with distinct `expired`/`invalid` strings otherwise. |
+| POST | `/api/logout` | Idempotent, always 200. |
+| POST | `/api/client-errors` | Unauthenticated client-error sink. Always 204. Sanitized + rate-limited; logs `event=client_error` to journald. Dev stub mirrors prod for round-trip. Schema in [`./pna_toolkit/spec/contracts/client-errors-payload.schema.json`](./pna_toolkit/spec/contracts/client-errors-payload.schema.json); privacy boundary detailed in [`./email_gate.md` § Client error reporting](./email_gate.md#client-error-reporting). |
+| GET | `/healthz` | Liveness probe. |
+| GET | `/build-meta.json` | Build label + git SHA + `fellows_db_sha` for SW drift-check. |
+| GET | `/api/debug/diagnostics` | Operator diagnostics blob. |
 
-User-authored data (groups, tags, notes, settings) lives in
-`app/relationships.db`, a separate SQLite file from `fellows.db`.
-Cross-DB joins happen inside the dedicated worker, attached once per
-worker `init` via `ATTACH DATABASE 'fellows.db' AS f ?mode=ro` — *not*
-per request. The `?mode=ro` suffix enforces read-only access at the
-SQLite level; any stray write into `f.*` raises `OperationalError`.
-(Pre-Phase-1 the dev server did per-request ATTACHes for `/api/groups`
-and friends; those routes are retired and the worker now does it once
-per session.) `relationships.db`
-is durable across both app updates and Clear App Cache; `fellows.db`
-is re-imported **on user request** when its server-reported content SHA
-differs from the SHA recorded in OPFS-side `fellows.db.meta.json` —
-the boot path is install-only and never auto-refreshes a returning
-visitor. The user-driven swap path lives on the About page (*Update
-directory data*) and is gated by a pre-swap impact preview that lists
-any group members who would no longer have a profile after the
-update. See `plans/opt_in_directory_data_updates.md` for the policy
-and `plans/local_first_worker_architecture.md` for the underlying
-SHA-keyed-refresh mechanism (now wrapped behind the opt-in UI).
+The server opens a new SQLite connection per request (no pool; unnecessary at local scale). `/api/stats` is heavier than a simple row fetch (region split + field-completeness pass over `extra_json` via `json_extract`); still fine at local scale.
 
-In the browser this lives in OPFS (`sqlite3.wasm` + `relationships.db`
-+ `fellows.db` + `fellows.db.meta.json`) in **both** standalone PWA mode
-and browser-tab mode. Neither the production server nor the dev server
-exposes per-user state HTTP routes — `/api/groups` and `/api/settings`
-were retired in Phase 1 and OPFS is the only canonical store. When a
-visitor's browser can't run OPFS (older Safari, missing
-`FileSystemSyncAccessHandle`, insecure context), the worker reports
-`opfsCapable: false` during init and the page surfaces an
-unsupported-browser panel via `renderLocalDataUnavailablePanel()` — see
-[`docs/browser_support.md`](browser_support.md).
+The Two-Phase Load pattern (`/api/fellows` then `/api/fellows?full=1` in the background, falling back to `/api/fellows/<slug>` if the user clicks before phase 2 completes) is a Workspace concern; the route names are fellows specifics.
 
-The full state-survival matrix (which storage layers survive which
-events, plus the standard upgrade flow) lives in
-[`docs/persistence_and_upgrades.md`](persistence_and_upgrades.md).
-Read that when adding a feature that touches storage, or when
-triaging a "why did my X disappear?" report.
+---
 
-### Worker-owned OPFS
+## Cross-origin and CSP headers
 
-A single dedicated worker
-(`app/static/vendor/sqlite-worker.js`) owns every OPFS handle and
-every `sqlite3.wasm` instance. The main thread is an RPC client: it
-posts `{id, op, args}` messages and awaits `{id, ok, result|error}`
-responses. The same worker handles both `relationships.db`
-(read-write user-authored data) and `fellows.db` (read-only contact
-data, re-imported only when its server-reported content SHA in
-`/build-meta.json:fellows_db_sha` differs from the SHA recorded in
-worker-owned `fellows.db.meta.json`). No other context — not the main
-thread, not the service worker, not a future render worker — is
-permitted to call `navigator.storage.getDirectory` or open a
-`FileSystemSyncAccessHandle`.
+Both servers send (must be preserved by Caddy at the edge):
 
-This single-owner rule lets us reason about the database without
-worrying about cross-context coordination, and makes the SAH-pool's
-per-file serialization a non-issue: there is exactly one opener.
+- `Cross-Origin-Opener-Policy: same-origin` + `Cross-Origin-Embedder-Policy: require-corp` — AC-13 prerequisite for OPFS-SAH-Pool.
+- `Cross-Origin-Resource-Policy: same-origin`, `Referrer-Policy: strict-origin-when-cross-origin`, `X-Content-Type-Options: nosniff`.
+- A strict Content-Security-Policy: `default-src 'self'; script-src 'self' 'wasm-unsafe-eval'; worker-src 'self'; connect-src 'self'; img-src 'self' data:; style-src 'self'; font-src 'self'; object-src 'none'; base-uri 'self'; frame-ancestors 'none';`
+- A locked-down `Permissions-Policy` (geolocation / camera / microphone / payment / sensors / USB / etc. all `=()`).
 
-**Why a worker rather than the main thread.** Real-browser evidence
-(Safari, intermittent Firefox, vanilla Chrome 147 — see PRs #95–#99)
-shows the main-thread OPFS path is the brittle layer. Several
-browser configurations strip
-`FileSystemFileHandle.prototype.createSyncAccessHandle` from the
-main-thread prototype while still exposing it inside dedicated
-workers. The worker context is also easier to keep network-free and
-gate-aware: the worker's `init` op does sqlite3 init, OPFS attach,
-and the auto-backup pass with no HTTP traffic, while a separate
-page-driven `ensureFellowsDb` op covers the bundle fetch only after
-the gate decision tree resolves to directory mode.
+HSTS is added by Caddy (`ansible/roles/caddy/templates/Caddyfile.j2`), not the Python server.
 
-**Compatibility gates between page and worker.** Two narrow,
-worker-internal constants govern whether a mismatched page may
-mutate state:
+**Subresource Integrity (SRI):** `index.html` carries SHA-384 `integrity=` attributes on both `<script src>` tags. `build/build_pwa.py:stamp_sri_attributes` computes the hashes at build time over the post-build-label-stamped bytes; the dev server (`app/server.py`) performs the same substitution at request time so dev and prod produce byte-identical integrity values. The service worker itself isn't covered — that gap is the motivation for the signed-bundle work tracked separately.
 
-- `WORKER_RPC_VERSION` — bumped only when the request/response
-  shape of any RPC changes.
-- `RELATIONSHIPS_SCHEMA_VERSION` — same value as
-  `relationships.db`'s `PRAGMA user_version` (currently `1`); bumped
-  only on schema migrations.
+---
 
-The page reads both during the worker `init` handshake and refuses
-mutating RPCs (`createGroup`, `setSetting`,
-`importRelationshipsBytes`, …) on mismatch. Reads still work so the
-user can browse cached data while the service worker's existing
-"New version available — Reload" banner does its job. The build
-label is **not** consulted for this gate — see [the plan's "Why
-build label is not the gate" section](../plans/local_first_worker_architecture.md#why-build-label-is-not-the-gate).
+## Shared DB schema (`fellows.db`)
 
-**Cross-DB joins still happen, but in the worker.** What the dev
-server used to do via `ATTACH DATABASE 'fellows.db' AS f ?mode=ro`
-on a per-request basis, the worker now does once per init. The
-read-only enforcement at the SQLite layer is preserved.
-
-**Capability detection runs in the worker.** When OPFS or
-`FileSystemSyncAccessHandle` is unavailable (older Safari, missing
-SAH, insecure context), the worker reports `opfsCapable: false`
-during `init`; the main thread reads that field and surfaces the
-unsupported-browser panel via `renderLocalDataUnavailablePanel()`.
-See [`docs/browser_support.md`](browser_support.md).
-
-### Non-goals (worker-owned OPFS)
-
-Bright lines for the codebase, not just the plan:
-
-- **The service worker never owns a SQLite DB.** SW lifecycle
-  (idle eviction, multi-instance, restart on push) is hostile to
-  storage ownership. SW is app-shell + update detection only.
-- **No parallel main-thread OPFS access.** After the Phase 1
-  cutover, opening OPFS from anywhere other than the dedicated
-  worker is a bug.
-- **No server-side per-user state.** Production never gains
-  `/api/groups`, `/api/settings`, server-side `relationships.db`
-  storage, server-side backup, cross-device sync, or admin views.
-  The dev-server routes for groups/settings (`app/server.py`) are
-  retired in Phase 1 — they were only ever a dev-round-trip
-  scaffold and become dead code once the worker is sole owner.
-- **No silent cross-device sync substrate.** Any future sync
-  becomes an explicit, opt-in feature with its own design doc.
-- **No multi-tab concurrent ownership.** OPFS sync access handles
-  serialize per file; two tabs both opening `relationships.db`
-  race on the SAH. Today's behavior — second tab fails to acquire
-  — is preserved. A graceful "another instance is open" UI is a
-  follow-up, not a goal.
-
-## Workspace data providers (three tiers, mid-boot hot-swap)
-
-The workspace's data layer is a tiered abstraction with three
-implementations and an explicit fall-through path. The active
-provider is the runtime contract every render path consults; it's
-exposed at `window.__dataProvider` for tests and diagnostics.
-
-The tiers, in preference order:
-
-1. **`worker`** — happy path. RPC into the dedicated OPFS-owning
-   worker (see [Worker-owned OPFS](#worker-owned-opfs)). Full reads +
-   writes on both `relationships.db` and `fellows.db` (the latter
-   read-only).
-2. **`api+idb`** — auth-failure / OPFS-incapable fallback. Directory
-   reads come from `/api/fellows` when the session is valid, or from
-   the IndexedDB cache populated by a prior successful boot when it
-   isn't (per [`email_gate.md` invariant 10](email_gate.md)). Writes
-   to relationship-shaped methods (`createGroup`, `setSetting`, …)
-   reject with `localDataUnavailableError` so render paths catch it
-   and surface the unsupported-browser panel.
-3. **`api`** — deepest fallback. Same as `api+idb` without the
-   IndexedDB layer. Used in environments without IndexedDB (rare)
-   and as the dev passthrough.
-
-**Hot-swap on auth failure.** `bootDirectoryAsApp` starts with the
-worker provider; if the worker's `ensureFellowsDb` returns 401 / 403
-(stale session), the boot path swaps to `api+idb` mid-flight without
-unwinding. The worker process stays alive (it still owns OPFS;
-`clearEverything` reaches it through `warmWorker.rpc` for the wipe).
-The build badge flips to `server: offline · using cache`. The user
-keeps browsing the cached directory until they explicitly re-authenticate
-via `/?gate=1`.
-
-This is what makes "stale session must not lock users out of cached
-data" testable: a 401 on `/api/fellows` doesn't propagate as a boot
-failure; it transparently routes through the IDB cache.
-
-## Boot orchestration (named marks + watchdog + slow-boot persistence)
-
-The workspace runs a watchdog (default 20s) over a sequence of named
-boot phase marks: `script_start`, `pick_provider_start`,
-`worker_init_done`, `provider_ready`, `get_list_done`, `get_full_done`,
-`image_prewarm_done`, `summary`. If `get_list_done` doesn't arrive in
-time, a recovery panel (`#boot-stuck-panel`) renders naming the last
-completed mark — diagnostic enough that a stuck-boot report identifies
-which phase stalled before any backtrace. Same recovery affordances as
-the boot-error panel: Reload, Clear App Cache & Reload, send a bug
-report.
-
-Slow boots persist to localStorage:
-
-- **Trigger:** total >3000 ms or any single phase >2000 ms.
-- **Storage key:** `fellows_last_slow_boot`. Single record, overwritten
-  on each new slow boot. Survives Clear App Cache by being preserved
-  alongside `fellows_authenticated_once`.
-- **Surface:** the `?diag=1` panel shows it under "Last slow boot
-  recorded" on the next session. A regression captured one session
-  is readable in the next without depending on the user keeping the
-  slow tab open.
-
-`bootMarks` is exposed at `window.__bootMarks` for e2e tests; the
-chronological trace is at `window.__bootDebugLines`. Both are
-read-only by convention.
-
-## Two-Phase Load
-
-The frontend uses two sequential fetches to minimize time-to-interactive:
-
-1. `GET /api/fellows` — returns only `record_id`, `slug`, `name`. The directory renders immediately from this.
-2. `GET /api/fellows?full=1` — returns all fields for all fellows. Fetched in the background after the directory is visible. Results are cached in a `Map` keyed by slug.
-
-When a user clicks a fellow before phase 2 completes, the app falls back to `GET /api/fellows/<slug>` for that single record.
-
-## Frontend Routing
-
-Hash-based SPA routing with no history API and no router library. Defined in `route()` in `app/static/app.js`.
-
-| Route | Purpose |
-|---|---|
-| `#/` (default; empty or unmatched hash) | Directory. Two-phase load: minimal list, then full rows in the background. |
-| `#/about` | About page. Loads fellowship statistics via `GET /api/stats`; links out to the user guide. |
-| `#/fellow/<slug>` | Fellow detail. Resolves from the in-memory cache or `GET /api/fellows/<slug>`. |
-| `#/groups` | Groups index — saved groups with member counts. |
-| `#/groups/<id>` | Group detail. Action bar (Contact / Export / Edit), member list, inline note editor. |
-| `#/groups/<id>/directory` | Visual portrait directory for the group; click a portrait → `#/fellow/<slug>`. |
-| `#/edit/<id>` | Edit-mode entry. Re-uses the right-rail composer against an existing group; auto-saves on toggle, "Cancel edits" reverts to the entry snapshot. |
-| `#/settings` | Settings page. The user's "me" email used for export `mailto:?to=…`; auto-captured from the magic-link gate, persisted to `relationships.settings` and mirrored to localStorage on boot. |
-
-User-facing screen behavior, navigation, and UX flows live in [`users_manual.md`](users_manual.md). Treat the user guide as the source of truth for UI/UX from a user's perspective and keep it in sync when the UI changes.
-
-## Manifest gotchas
-
-`app/static/manifest.webmanifest` is intentionally minimal: `id`, `start_url`, and `scope` all `=/`; three icons (`any`, `any`, `maskable`); no `related_applications`, no `share_target`. Two reasons not to add either casually:
-
-- **`related_applications`** — if a stale or wrong app ID lands here, Android's WebAPK pipeline tries to verify it against the Play Store and fails with the cryptic "Older Version of Android" install error. Don't add unless we actually ship a Play Store companion.
-- **`share_target` with `method: "POST"`** — some Samsung/Chromium WebAPK servers reject POST share targets and the install silently fails. If a future feature needs a share target, use `method: "GET"`.
-
-## Database Schema
-
-Produced by `build/restore_from_knack_scrapefile.py` (matches `sqlite3 app/fellows.db ".schema"` for the app-defined objects). Slug uniqueness is enforced with an index rather than an inline `UNIQUE` column constraint.
+Specializes the [Shared schema](./pna_toolkit/spec/contracts/shared-db.schema.sql) — record_id / slug / name / extra_json plus app-defined display columns. fellows renames the spec's `records` table to `fellows` (spec-allowed; see the contract's naming note).
 
 ```sql
 CREATE TABLE fellows (
@@ -313,7 +123,7 @@ CREATE TABLE fellows (
     ethnicity TEXT,
     primary_citizenship TEXT,
     global_regions_currently_based_in TEXT,
-    extra_json TEXT            -- JSON object of all other fields
+    extra_json TEXT            -- JSON object of all other source fields
 );
 
 CREATE UNIQUE INDEX idx_fellows_slug ON fellows(slug);
@@ -330,11 +140,19 @@ CREATE VIRTUAL TABLE fellows_fts USING fts5(
 );
 ```
 
-FTS5 also creates internal shadow tables (`fellows_fts_data`, `fellows_fts_idx`, etc.); those are SQLite-managed and not altered by hand.
+> **Drift from spec form:** the spec contract enforces `slug` uniqueness with a table constraint (`UNIQUE (slug)`); fellows uses a separate `CREATE UNIQUE INDEX`. Functionally equivalent — both enforce the same contract at the SQLite level.
 
-### `relationships.db`
+The 17 explicit columns are the fellows-specific app-defined display columns. Source-specific fields not in this list are serialized into `extra_json`, which `row_to_fellow()` in `app/fellows_queries.py` merges back into the API response. FTS5 also creates internal shadow tables (`fellows_fts_data`, `fellows_fts_idx`, etc.); those are SQLite-managed and not altered by hand.
 
-User-authored data. Created on first access by `app.relationships.open_db()`; the same schema is mirrored in the PWA via `RELATIONSHIPS_SCHEMA_SQL` in `app/static/app.js` so the OPFS-backed sqlite3.wasm path matches the dev server. ATTACHed read-only as `f` against `fellows.db` for cross-DB joins (e.g. resolving member names on `GET /api/groups/<id>`); any stray write to `f.*` raises `OperationalError`.
+**Per-record asset URL convention:** `/images/<slug>.{jpg,png}` — alphanumeric-only fuzzy fallback in the server handler covers slug-vs-filename drift. Asset URLs are slug-keyed, immutable, and cacheable; they're separate from the database. See SH-3 in the [Shared schema contract](./pna_toolkit/spec/contracts/shared-db.schema.sql).
+
+**Build pipeline:** `build/restore_from_knack_scrapefile.py` reads the Knack API detail dump (with a fallback read of the list-view `raw_dump` for a few fields), deduplicates slugs, detects grey-diamond placeholder avatars by MD5, and writes both tables. See [`./data_provenance.md`](./data_provenance.md) for the full data pipeline.
+
+---
+
+## Private DB schema (`relationships.db`)
+
+Specializes the [Private schema](./pna_toolkit/spec/contracts/private-db.schema.sql). Created on first access by `app.relationships.open_db()`; the same DDL is mirrored in the PWA via `RELATIONSHIPS_SCHEMA_SQL` in `app/static/app.js` so the OPFS-backed sqlite3.wasm path matches the dev server.
 
 ```sql
 CREATE TABLE groups (
@@ -353,7 +171,6 @@ CREATE TABLE group_members (
 
 CREATE INDEX idx_group_members_group ON group_members(group_id);
 
--- Reserved for tag/note CRUD UI (designed once, surfaced incrementally).
 CREATE TABLE fellow_tags (
     fellow_record_id TEXT NOT NULL,
     tag TEXT NOT NULL,
@@ -369,15 +186,166 @@ CREATE TABLE fellow_notes (
     updated_at TEXT NOT NULL
 );
 
--- Single key/value bag (e.g. `self_email` override for export `mailto:?to=…`).
 CREATE TABLE settings (
     key TEXT PRIMARY KEY,
     value TEXT
 );
 ```
 
-`PRAGMA user_version` is set to `SCHEMA_VERSION` (currently `1`) at bootstrap so future migrations can branch on it. The file is gitignored, per-user, and durable across both app updates and Clear App Cache — see [`persistence_and_upgrades.md`](persistence_and_upgrades.md) for the full state-survival matrix.
+`PRAGMA user_version = 1` at bootstrap; `PRAGMA foreign_keys = ON` per connection (without it the `ON DELETE CASCADE` is silently inert).
+
+> **Drift notes vs the spec contract:**
+>
+> - **Column rename.** Spec calls the Private-DB FK column `record_id`; fellows uses `fellow_record_id` for in-app ergonomics. Spec-allowed specialization; same shape and same PK semantics.
+> - **Table renames.** Spec uses `record_tags` and `record_notes`; fellows uses `fellow_tags` and `fellow_notes` (same reason).
+> - **Settings PK.** Spec uses composite `(workspace_id, key)`; fellows is single-workspace and uses a simpler `key TEXT PRIMARY KEY`. A future schema migration can add `workspace_id` with default `''` to converge on the spec shape without losing rows.
+> - **`record_comms_history` absent.** Spec attests this as an opt-in PR-2 table (disabled by default). Fellows doesn't ship it yet; when comms-history capture is added, it will conform to PR-2.
+
+**Durability (per PR-4):** `relationships.db` is gitignored, per-user, never replaced on app update, survives Clear App Cache, and is wiped only by Reset Everything (the workspace's explicit-user-choice nuclear path). Auto-backup, restore, and the OPFS-vs-IndexedDB-vs-cookie state-survival matrix live in [`./persistence_and_upgrades.md`](./persistence_and_upgrades.md).
+
+---
+
+## Worker constants (fellows's version-handshake values)
+
+The spec's [AC-4 versioned cross-boundary handshake](./pna_toolkit/PNA_Spec.md#universal-architectural-commitments) is parameterized; fellows pins:
+
+- `WORKER_RPC_VERSION = 2` (bumped only when the request/response shape of any RPC changes; gates mutating ops on mismatch)
+- `RELATIONSHIPS_SCHEMA_VERSION = 1` (mirrors `PRAGMA user_version`; bumped only on schema migrations)
+- Worker file path: `app/static/vendor/sqlite-worker.js`
+
+The page reads both during the worker `init` handshake (the handshake shape itself is specified in [`./pna_toolkit/spec/contracts/worker-init-handshake.schema.json`](./pna_toolkit/spec/contracts/worker-init-handshake.schema.json) and the RPC envelope in [`./pna_toolkit/spec/contracts/worker-rpc-protocol.schema.json`](./pna_toolkit/spec/contracts/worker-rpc-protocol.schema.json)) and refuses mutating RPCs on mismatch. Reads still work, so the user can browse cached data while the SW's "New version available — Reload" banner does its job. Build label is **not** consulted for this gate.
+
+---
+
+## Data provider abstraction
+
+The Workspace slot's data provider has three tiers per AC-5; in fellows the active provider is exposed at `window.__dataProvider` for tests and diagnostics:
+
+1. `worker` — happy path. RPC into the OPFS-owning worker.
+2. `api+idb` — auth-failure / OPFS-incapable fallback. Directory reads come from `/api/fellows` when the session is valid, or from the IndexedDB cache populated by a prior successful boot when it isn't.
+3. `api` — deepest fallback. Same as `api+idb` without IDB; used in environments without IndexedDB.
+
+`bootDirectoryAsApp` starts with the worker provider; if the worker's `ensureFellowsDb` returns 401/403 (stale session), the boot path swaps to `api+idb` mid-flight. The worker process stays alive (it still owns OPFS; `clearEverything` reaches it through `warmWorker.rpc` for the wipe). The build badge flips to `server: offline · using cache`.
+
+---
+
+## Boot orchestration
+
+Specializes AC-7's self-service field-debug substrate. Fellows pins:
+
+- **Phase marks** (eight, in order): `script_start`, `pick_provider_start`, `worker_init_done`, `provider_ready`, `get_list_done`, `get_full_done`, `image_prewarm_done`, `summary`.
+- **Watchdog timeout:** 20 seconds. If `get_list_done` doesn't arrive in time, the recovery panel (`#boot-stuck-panel`) renders naming the last completed mark.
+- **Slow-boot persistence:** total >3000 ms or any single phase >2000 ms writes a record to `localStorage['fellows_last_slow_boot']`. Survives Clear App Cache. Surfaced under "Last slow boot recorded" in the `?diag=1` panel on the next session.
+- **E2E test seams:** `window.__bootMarks` (read-only) and `window.__bootDebugLines` (chronological trace).
+
+---
+
+## Frontend routing
+
+Hash-based SPA routing with no history API and no router library, defined in `route()` in `app/static/app.js`. Specializes the Workspace slot's routing sub-contract.
+
+| Route | Purpose |
+|---|---|
+| `#/` (default; empty or unmatched hash) | Directory. Two-phase load: minimal list, then full rows in the background. Filter state persists in a query suffix on the hash (`#/?cohort=2020`), read on every `route()` call by `applyFiltersToHash` / `readFiltersFromHash`. |
+| `#/about` | About page. Loads fellowship statistics via `GET /api/stats`; links out to the user guide. |
+| `#/fellow/<slug>` | Fellow detail. Resolves from the in-memory cache or `GET /api/fellows/<slug>`. |
+| `#/groups` | Groups index — saved groups with member counts. |
+| `#/groups/<id>` | Group detail. Action bar (Contact / Export / Edit), member list, inline note editor. |
+| `#/groups/<id>/directory` | Visual portrait directory for the group; click a portrait → `#/fellow/<slug>`. |
+| `#/edit/<id>` | Edit-mode entry. Re-uses the right-rail composer against an existing group; auto-saves on toggle, "Cancel edits" reverts to the entry snapshot. |
+| `#/settings` | Settings page. The user's "me" email used for export `mailto:?to=…`; auto-captured from the magic-link gate, persisted to `relationships.settings` and mirrored to localStorage on boot. |
+
+User-facing screen behavior, navigation, and UX flows live in [`./users_manual.md`](./users_manual.md). Treat the user guide as the source of truth for UI/UX from a user's perspective and keep it in sync when the UI changes.
+
+A `window.ai` natural-language search affordance is behind a capability gate; when present, it's wired into the directory route's filter pipeline.
+
+---
+
+## Debug substitutions and addresses
+
+Specializes the Debug contract. fellows pins:
+
+- **Build-label format:** `<YYYY-MM-DD>-<short-sha>`.
+- **Placeholders substituted at build + serve time:** `__FELLOWS_UI_DIAG__`, `__CACHE_VERSION__` (in `app.js`, `sw.js`, `vendor/sqlite-worker.js`).
+- **Sanitized error sink:** `POST /api/client-errors` (16 KB body cap; per-IP rate limit; always 204; `kind=` enum allowlist).
+- **Bug-report `mailto:` target:** `richbodo@gmail.com`.
+- **Force-gate URL:** `/?gate=1` (AC-6's realization for SPA shells; doesn't bypass auth — only the UI decision tree).
+- **In-app diagnostics URL:** `/?diag=1`.
+
+---
+
+## Distribution flavor specifics (magic-link PWA)
+
+Specializes the Distribution slot. Auth-endpoint shapes are in [`./pna_toolkit/spec/contracts/distribution-auth.openapi.yaml`](./pna_toolkit/spec/contracts/distribution-auth.openapi.yaml); the behavioral decision tree and the operator runbook live in the annexes.
+
+Fellows pins:
+
+- `TOKEN_TTL = 30 min`, `INSTALL_WINDOW = 30 min`, `SESSION_MAX_AGE = 7 days`.
+- Session cookie: HttpOnly, HMAC-signed, **v2 format** (v1 rejected on sight post-deploy).
+- Token re-consume grace window: ~60 s — defends against bfcache, iOS back-button, email-side link scanners.
+- Allowlist built in memory at startup by HMAC-ing each `contact_email` row in `fellows.db` with `FELLOWS_ALLOWLIST_HMAC_KEY`. No `allowed_emails.json` artifact ships in `dist/`.
+- Six-step browser-mode decision tree (see [`./email_gate.md`](./email_gate.md) for the full table).
+- Persistence marker (per WS persistence-marker contract): `localStorage['fellows_authenticated_once']` is the one localStorage key preserved across the workspace's Clear App Cache affordance.
+
+### PWA manifest gotchas
+
+`app/static/manifest.webmanifest` is intentionally minimal: `id`, `start_url`, `scope` all `=/`; three icons (`any`, `any`, `maskable`). Two specific things to keep out, per the Distribution slot's PWA contract:
+
+- **`related_applications`** — a stale or wrong app ID here triggers Android's WebAPK pipeline to verify against the Play Store and fail with a cryptic "Older Version of Android" install error.
+- **`share_target` with `method: "POST"`** — some Samsung/Chromium WebAPK servers reject POST share targets and the install silently fails. If a future feature needs a share target, use `method: "GET"`.
+
+---
+
+## MCP servers
+
+Fellows attests `mcp-exposure:shared+private+comms`. Three stdio MCP servers ship today, all read-only or stage-only (no writes, no transports fired from inside the MCP process); their typed tool surfaces live in `./pna_toolkit/spec/contracts/`.
+
+| Server | Source | Contract | Tools |
+|---|---|---|---|
+| Shared Data Ops | `mcp_servers/shared_data_ops.py` | [`mcp-shared-data-ops.schema.json`](./pna_toolkit/spec/contracts/mcp-shared-data-ops.schema.json) | `search_fellows`, `get_fellow`, `list_fellows`, `get_directory_stats` |
+| Private Data Ops | `mcp_servers/private_data_ops.py` | [`mcp-private-data-ops.schema.json`](./pna_toolkit/spec/contracts/mcp-private-data-ops.schema.json) | `list_groups`, `find_group`, `get_group_members` |
+| Communications | `mcp_servers/comms.py` | [`mcp-comms.schema.json`](./pna_toolkit/spec/contracts/mcp-comms.schema.json) | `stage_email`, `get_staged` |
+
+Per AC-MCP-B, `stage_email` returns a `mailto:` URL with a staging ID; the user's mail client launches the transport when the user clicks. The server never invokes a transport. Per AC-MCP-A, the Private Data Ops server returns Private DB rows and so requires per-call consent when wired to a cloud AI client; see [`../mcp_servers/README.md`](../mcp_servers/README.md) § Cloud LLM caveat.
+
+Ingestion and Diagnostics MCP servers are not yet built; their spec contracts are placeholders pending first reference implementations.
+
+The `mcp_servers/` directory is the project's one exception to the stdlib-only constraint — it depends on the official `mcp` SDK, isolated in `mcp_servers/.venv`. It imports from `app/` only via pure-logic helpers (e.g. `app/fellows_queries.py`).
+
+---
+
+## Operator concerns
+
+Production-side, fellows-specific operator concerns (out of spec scope):
+
+- **Deployment, systemd hardening, droplet topology** — [`./DevOps.md`](./DevOps.md).
+- **Magic-link operator runbook (Postmark, env file, journald schema)** — [`./email_system_management.md`](./email_system_management.md).
+- **Data pipeline + recovery paths** — [`./data_provenance.md`](./data_provenance.md).
+- **Ansible specifics (tags, galaxy install, troubleshooting)** — [`../ansible/README.md`](../ansible/README.md).
+
+---
+
+## Annexes
+
+Architecture-adjacent docs that specialize one part of the spec or operator surface in depth:
+
+| Annex | Specializes |
+|---|---|
+| [`./email_gate.md`](./email_gate.md) | Distribution slot — magic-link auth flow, decision tree, client-error sanitization. |
+| [`./persistence_and_upgrades.md`](./persistence_and_upgrades.md) | Storage slot — state-survival matrix across Clear App Cache / Reset Everything / app update; auto-backup; restore. |
+| [`./browser_support.md`](./browser_support.md) | Storage slot — capability detection inside the worker, required versions, unsupported-browser surfacing (AC-12). |
+| [`./data_provenance.md`](./data_provenance.md) | Ingestion slot — column-by-column source mapping; backup/restore workflow; recovery paths. |
+
+---
 
 ## Roadmap
 
-See ROADMAP.md
+See [`../ROADMAP.md`](../ROADMAP.md).
+
+<!--
+Cross-link migration: when the PNA toolkit `git mv`s out of this repo to its
+own `personal_network_toolkit` repository (per `_pna_triage.md` § Next steps
+item 9), do a single replace in this file: `./pna_toolkit/` → the toolkit
+repo's URL prefix. All other relative links (`./email_gate.md`, etc.) stay
+fellows-repo-local.
+-->


### PR DESCRIPTION
## Summary

- Completes step #6 of `docs/_pna_triage.md`. `Architecture.md` becomes fellows's specialization-and-conformance layer rather than a mixed generic+specific doc.
- Adds a top-of-doc **Spec conformance** section declaring `Spec-Version: 0.1`, the Directory Archive use case, fellows's six axis picks, and the seven flavor-derived ACs that fire (AC-2/3/5/8/12/13/14) plus the two MCP ACs activated by `shared+private+comms` exposure (AC-MCP-A/B).
- Deletes universal prose now restated in `docs/pna_toolkit/PNA_Spec.md`; replaces it with cross-links. Keeps every fellows-specific fact verbatim (HTTP routes, fellows.db / relationships.db DDL with inline drift notes, worker constants, boot orchestration, hash routes, debug placeholders, magic-link tunables, MCP server attestation).
- `CLAUDE.md` + `README.md` get one-line updates so AIs starting on `main` read Architecture.md's new role and find the universal spec via cross-link.

Net: Architecture.md drops from 502 → 351 lines (~30% smaller) without losing fellows-specific content.

## What this PR doesn't do (separate follow-ups)

- **Step #7 — repo-root `llms.txt`.** Separate PR. Depends on this PR's new structure being on `main`.
- **Step #8 — annex demotion preamble.** This PR *names* `email_gate.md` / `persistence_and_upgrades.md` / `browser_support.md` / `data_provenance.md` as annexes in Architecture.md, but doesn't modify the four files themselves.
- **Sub-contract numbering migration.** WS-/ST-/DB-* sub-contract IDs still live in `_pna_triage.md`; Architecture.md cites ACs and slot names rather than sub-contract IDs.
- **MCP Ingestion + Diagnostics contracts.** Still spec placeholders pending first reference implementations; not a regression.

## Test plan (manual QA — no test suite touched; docs-only change)

- [ ] Render the new `docs/Architecture.md` on the PR view; verify the section table of contents reads as intended (Spec conformance → HTTP API → Cross-origin and CSP headers → Shared DB schema → Private DB schema → Worker constants → Data provider abstraction → Boot orchestration → Frontend routing → Debug substitutions → Distribution flavor specifics → MCP servers → Operator concerns → Annexes → Roadmap).
- [ ] Click each `./pna_toolkit/...` link in the rendered doc. Each should resolve to an existing file and (where anchored) an existing heading. Key anchors to confirm: `PNA_Spec.md#universal-architectural-commitments`, `axes.md#distribution`, `axes.md#storage-substrate`, `axes.md#ingestion-shape`, `axes.md#workspace-shell`, `axes.md#comms-transport-set`, `axes.md#mcp-exposure`, `use_cases.md#directory-archive`.
- [ ] Click each `./<annex>.md` link (`email_gate.md`, `persistence_and_upgrades.md`, `browser_support.md`, `data_provenance.md`, `DevOps.md`, `email_system_management.md`, `data_provenance.md`, `users_manual.md`). All four annexes + the operator-concern docs should exist.
- [ ] Verify the six axis picks listed in *Spec conformance* match `docs/pna_toolkit/axes.md`'s `Attested in [fellows_local_db]` attestations. Expected count: 6 (one per axis); `grep -c "Attested in \[fellows_local_db\]" docs/pna_toolkit/axes.md` confirms.
- [ ] Verify flavor-derived ACs listed (AC-2, AC-3, AC-5, AC-8, AC-12, AC-13, AC-14) match the entries triggered by fellows's picks per `axes.md`'s `Triggered flavor-derived ACs` tables.
- [ ] DDL copy-pasteable: paste the `CREATE TABLE fellows` + `CREATE VIRTUAL TABLE fellows_fts` blocks into `sqlite3`; same for the five `relationships.db` blocks. Both should round-trip without syntax errors.
- [ ] Spot-check implementation assertions:
  - `WORKER_RPC_VERSION = 2` per `grep WORKER_RPC_VERSION app/static/vendor/sqlite-worker.js`.
  - `RELATIONSHIPS_SCHEMA_VERSION = 1` per same file.
  - MCP exposure: `ls mcp_servers/` shows `shared_data_ops.py`, `private_data_ops.py`, `comms.py`.
  - localStorage keys: `grep -n "fellows_authenticated_once\|fellows_last_slow_boot" app/static/app.js` finds both.
- [ ] No universal AC prose accidentally duplicated: `grep -E "two-store ownership split|single OPFS owner|versioned cross-boundary handshake|always-reachable diagnostic escape" docs/Architecture.md` should only return cross-references / AC names + fellows's realization, never the universal definitions.
- [ ] Run `claude` once on this branch to confirm the updated `CLAUDE.md` line 3 doesn't break Claude Code's bootstrap read.
- [ ] No regression in repo tests is expected (docs-only); CI's standard pass is sufficient.

🤖 Generated with [Claude Code](https://claude.com/claude-code)