### PR TITLE
fix(search): fall back to cached data when /api/search 401/403s

### DIFF
--- a/app/static/app.js
+++ b/app/static/app.js
@@ -9049,7 +9049,12 @@
     var url = '/api/search?q=' + encodeURIComponent(ftsQ);
     fetch(url)
       .then(function (r) {
-        if (!r.ok) return [];
+        // Non-2xx (commonly 401/403 when the session expired, sometimes
+        // 5xx) is treated the same as a network failure: route through
+        // runLocalSearch so the cached directory still answers. Per
+        // docs/email_gate.md invariant 10, a stale session must not lock
+        // the user out of searching data they already downloaded.
+        if (!r.ok) throw new Error('search ' + r.status);
         return r.json();
       })
       .then(function (results) {

--- a/tests/e2e/test_search_offline_fallback.py
+++ b/tests/e2e/test_search_offline_fallback.py
@@ -1,0 +1,201 @@
+"""E2E: search must fall back to cached data when /api/search is gated.
+
+Companion to test_offline_only_mode.py. That suite covers the directory
+list (getList) when /fellows.db and /api/fellows both 401/403; this one
+covers search over the same cached set when /api/search also 401/403s
+(the symptom Rich hit on Android: phone in api+idb fallback, search box
+silently empty even for cached fellows).
+
+Per docs/email_gate.md invariant 10: "A stale session does not lock
+users out of cached data ... The user can still browse the directory,
+read profiles, and use the search over cached data."
+
+Pre-fix, runSearch's `.then` returned [] on `!r.ok` and rendered "No
+fellows match that search." Post-fix, runSearch falls through to
+runLocalSearch (substring filter over loadFullFellows) on a non-2xx
+response, the same way the .catch already handled network failures.
+"""
+import pytest
+from playwright.sync_api import expect
+
+from conftest import _STANDALONE_DISPLAY_INIT
+
+
+API_FELLOWS = "**/api/fellows**"
+FELLOWS_DB = "**/fellows.db"
+API_SEARCH = "**/api/search**"
+
+
+# filterFellowsLocally substring-matches across name + bio_tagline + cohort
+# + fellow_type + search_tags + currently_based_in + global_regions. Keep
+# every non-name field empty so the assertions are testing name matches
+# only — any non-empty value risks accidentally containing the query.
+_SEARCHABLE_FELLOWS = [
+    {
+        "record_id": "cached-bodo",
+        "slug": "richard_bodo",
+        "name": "Richard Bodo",
+        "bio_tagline": "",
+        "has_image": 0,
+        "has_contact_email": 1,
+        "contact_email": "richbodo@example.com",
+    },
+    {
+        "record_id": "cached-graves",
+        "slug": "richard_graves",
+        "name": "Richard Graves",
+        "bio_tagline": "",
+        "has_image": 0,
+        "has_contact_email": 1,
+        "contact_email": "graves@example.com",
+    },
+    {
+        "record_id": "cached-bird",
+        "slug": "aaron_bird",
+        "name": "Aaron Bird",
+        "bio_tagline": "",
+        "has_image": 0,
+        "has_contact_email": 1,
+        "contact_email": "aaron@example.com",
+    },
+]
+
+
+def _seed_indexeddb_with_fellows(page, fellows):
+    """Prime the fellows-local-db IndexedDB store with a known payload.
+
+    Same shape that loadFullFellows() expects: object store 'meta',
+    keyPath 'id', payload {id: 'allFellows', data: fellows}.
+    """
+    script = """
+        async (fellows) => {
+            return new Promise((resolve, reject) => {
+                const req = indexedDB.open('fellows-local-db', 1);
+                req.onupgradeneeded = () => {
+                    const db = req.result;
+                    if (!db.objectStoreNames.contains('meta')) {
+                        db.createObjectStore('meta', { keyPath: 'id' });
+                    }
+                };
+                req.onsuccess = () => {
+                    const db = req.result;
+                    const tx = db.transaction('meta', 'readwrite');
+                    tx.objectStore('meta').put({ id: 'allFellows', data: fellows });
+                    tx.oncomplete = () => { db.close(); resolve(true); };
+                    tx.onerror = () => reject(tx.error);
+                };
+                req.onerror = () => reject(req.error);
+            });
+        }
+    """
+    page.evaluate(script, fellows)
+
+
+def _make_standalone_page(context):
+    page = context.new_page()
+    page.add_init_script(_STANDALONE_DISPLAY_INIT)
+    page.add_init_script(
+        "window.localStorage.setItem('fellows_authenticated_once', '1');"
+    )
+    return page
+
+
+def _force_api_idb_fallback_with_cache(context, page, base_url):
+    """Boot a page into the api+idb fallback path with seeded IDB cache.
+
+    Mirrors the setup in test_offline_only_mode.py's cached-data test:
+    route /fellows.db and /api/fellows to 401 BEFORE first navigation, seed
+    IDB once we're on the origin, then reload to take the cache path.
+    Leaves all routes in place — the caller is responsible for unrouting.
+    """
+    context.route(
+        FELLOWS_DB,
+        lambda r: r.fulfill(status=401, body="session expired"),
+    )
+    context.route(
+        API_FELLOWS,
+        lambda r: r.fulfill(status=401, body="session expired"),
+    )
+    # Land on the origin so indexedDB is reachable, then seed it.
+    page.goto(base_url + "/", wait_until="domcontentloaded")
+    page.wait_for_function("() => !!(window.indexedDB)", timeout=5000)
+    _seed_indexeddb_with_fellows(page, _SEARCHABLE_FELLOWS)
+    # Reload so the boot path actually consumes the IDB cache.
+    page.reload(wait_until="domcontentloaded")
+    page.locator("#loading").wait_for(state="hidden", timeout=10000)
+    page.locator("#directory").wait_for(state="visible", timeout=5000)
+    # Sanity-check we landed in api+idb fallback, not the worker path.
+    # If a future change makes the worker resilient to 401 on the bytes
+    # fetch this assertion will start failing and we'll need a different
+    # repro — better to fail loudly than to test the wrong code path.
+    expect(page.locator("#build-badge-server")).to_contain_text(
+        "offline", timeout=3000
+    )
+    provider_kind = page.evaluate(
+        "() => (window.__dataProvider && window.__dataProvider.kind) || null"
+    )
+    assert provider_kind == "api+idb", (
+        f"expected api+idb fallback, got provider kind={provider_kind!r}"
+    )
+
+
+def _run_search(page, query):
+    """Type into the search input, wait past the 250 ms debounce."""
+    box = page.locator("#search-input")
+    box.fill(query)
+    # runSearch is debounced by 250 ms in app.js; give it room plus a tick
+    # for the fetch / runLocalSearch promise chain to settle.
+    page.wait_for_timeout(500)
+
+
+class TestSearchOfflineFallback:
+    """When /api/search is gated, runSearch must fall back to local cache."""
+
+    def test_search_last_name_falls_back_to_cached_data(self, context, base_url_fixture):
+        """`Bodo` over cached data finds Richard Bodo even though /api/search 401s.
+
+        Pre-fix this fails: runSearch fetches /api/search, sees !r.ok,
+        renders [] → 'No fellows match that search.' Post-fix runSearch
+        routes !r.ok through runLocalSearch, which substring-matches
+        against the IDB-cached full list.
+        """
+        page = _make_standalone_page(context)
+        try:
+            _force_api_idb_fallback_with_cache(context, page, base_url_fixture)
+            # The bug trigger: server can't answer the search either.
+            context.route(
+                API_SEARCH,
+                lambda r: r.fulfill(status=401, body="session expired"),
+            )
+            _run_search(page, "Bodo")
+            list_el = page.locator("#directory-list")
+            expect(list_el).to_contain_text("Richard Bodo", timeout=3000)
+            # Control: a fellow whose name doesn't contain the query must
+            # not appear — otherwise the "fallback" might be rendering the
+            # full list unfiltered, which would be a different bug.
+            expect(list_el).not_to_contain_text("Aaron Bird")
+        finally:
+            context.unroute(FELLOWS_DB)
+            context.unroute(API_FELLOWS)
+            context.unroute(API_SEARCH)
+            page.close()
+
+    def test_search_first_name_falls_back_to_cached_data(self, context, base_url_fixture):
+        """`Richard` returns both seeded Richards from the cache."""
+        page = _make_standalone_page(context)
+        try:
+            _force_api_idb_fallback_with_cache(context, page, base_url_fixture)
+            context.route(
+                API_SEARCH,
+                lambda r: r.fulfill(status=401, body="session expired"),
+            )
+            _run_search(page, "Richard")
+            list_el = page.locator("#directory-list")
+            expect(list_el).to_contain_text("Richard Bodo", timeout=3000)
+            expect(list_el).to_contain_text("Richard Graves")
+            expect(list_el).not_to_contain_text("Aaron Bird")
+        finally:
+            context.unroute(FELLOWS_DB)
+            context.unroute(API_FELLOWS)
+            context.unroute(API_SEARCH)
+            page.close()

--- a/tests/test_api.py
+++ b/tests/test_api.py
@@ -114,6 +114,36 @@ class TestAPI:
         names = [f.get("name") for f in data]
         assert "Aaron Bird" in names or "Aaron McDonald" in names
 
+    def test_api_search_first_name_richard(self):
+        """Whole-token first-name search hits both Richards."""
+        status, _, body = get("/api/search", query={"q": "Richard"})
+        assert status == 200
+        names = [f.get("name") for f in json.loads(body)]
+        assert "Richard Bodo" in names
+        assert "Richard Graves" in names
+
+    def test_api_search_last_name_bodo(self):
+        """Whole-token last-name search hits Richard Bodo."""
+        status, _, body = get("/api/search", query={"q": "Bodo"})
+        assert status == 200
+        names = [f.get("name") for f in json.loads(body)]
+        assert "Richard Bodo" in names
+
+    def test_api_search_partial_token_returns_empty(self):
+        """As-you-type 'Ric' / 'Bod' return [] under raw FTS5 MATCH.
+
+        Documents the real-time-search regression: the client sends the
+        in-progress input straight to fellows_fts MATCH, which requires
+        whole tokens. Until the client appends '*' for prefix matching,
+        every keystroke before a complete token shows 'no results'.
+        Pair with test_fts5_partial_token_without_prefix_glob_returns_nothing
+        in tests/test_database.py.
+        """
+        for partial in ("Ric", "Bod"):
+            status, _, body = get("/api/search", query={"q": partial})
+            assert status == 200, f"q={partial!r}"
+            assert json.loads(body) == [], f"q={partial!r}"
+
     def test_images_endpoint(self):
         status, ctype, body = get("/images/aaron_bird.jpg")
         assert status in (200, 404)

--- a/tests/test_database.py
+++ b/tests/test_database.py
@@ -32,6 +32,62 @@ def test_fts5_exists_and_matches(db):
     assert "Aaron Bird" in names or "Aaron McDonald" in names
 
 
+def test_fts5_matches_first_name_richard(db):
+    """Whole-token first-name match for 'Richard' returns the expected fellows."""
+    cur = db.execute(
+        "SELECT name FROM fellows_fts WHERE fellows_fts MATCH 'Richard'"
+    )
+    names = [r[0] for r in cur.fetchall()]
+    assert "Richard Bodo" in names
+    assert "Richard Graves" in names
+
+
+def test_fts5_matches_last_name_bodo(db):
+    """Whole-token last-name match for 'Bodo' returns Richard Bodo."""
+    cur = db.execute(
+        "SELECT name FROM fellows_fts WHERE fellows_fts MATCH 'Bodo'"
+    )
+    names = [r[0] for r in cur.fetchall()]
+    assert "Richard Bodo" in names
+
+
+def test_fts5_matches_full_name_two_tokens(db):
+    """Multi-token MATCH 'Richard Bodo' is an implicit AND and pinpoints one row."""
+    cur = db.execute(
+        "SELECT name FROM fellows_fts WHERE fellows_fts MATCH 'Richard Bodo'"
+    )
+    names = [r[0] for r in cur.fetchall()]
+    assert names == ["Richard Bodo"]
+
+
+def test_fts5_partial_token_without_prefix_glob_returns_nothing(db):
+    """As-you-type behavior: a partial token like 'Ric' returns 0 rows.
+
+    Documents the load-bearing reason real-time search appears broken:
+    FTS5 MATCH is whole-token. Without a trailing '*' the partial prefix
+    'Ric' / 'Bod' matches nothing, so every keystroke before a token is
+    complete shows 'no results'. The fix is to append '*' to the last
+    (or every) token on the client side before issuing MATCH.
+    """
+    assert (
+        db.execute(
+            "SELECT COUNT(*) FROM fellows_fts WHERE fellows_fts MATCH 'Ric'"
+        ).fetchone()[0]
+        == 0
+    )
+    assert (
+        db.execute(
+            "SELECT COUNT(*) FROM fellows_fts WHERE fellows_fts MATCH 'Bod'"
+        ).fetchone()[0]
+        == 0
+    )
+    cur = db.execute(
+        "SELECT name FROM fellows_fts WHERE fellows_fts MATCH 'Ric*'"
+    )
+    names = [r[0] for r in cur.fetchall()]
+    assert "Richard Bodo" in names
+
+
 def test_lookup_by_slug(db):
     """Lookup by slug aaron_bird returns Aaron Bird."""
     cur = db.execute("SELECT name FROM fellows WHERE slug = 'aaron_bird'")


### PR DESCRIPTION
## Summary

- When the phone's session expires, the worker can't fetch `/fellows.db` (403) and the app drops to `api+idb` fallback. The directory list renders from the IndexedDB cache, but `runSearch`'s `fetch('/api/search')` also 403s — and the existing code silently turned `!r.ok` into an empty result list, so users saw **"No fellows match that search."** for every query.
- Per `docs/email_gate.md` invariant 10, a stale session must not lock the user out of searching data they already downloaded. `runSearch` already had a `.catch` handler that routes network failures through `runLocalSearch` (substring filter over `loadFullFellows`); this change extends the same path to HTTP-error responses by throwing on `!r.ok`.
- Reproduced from a real-world report: Android phone in `api+idb` fallback (session aged out past the 7-day cookie TTL / in-memory session registry wipe), searching "Bodo" returned 0 results despite the directory list rendering all 515 fellows from cache. Diagnostic trace pinned `ensureFellowsDb: failed (code=fellows_db_fetch_http http=403)` and `directoryDataSource: api`.

## What changed

- `app/static/app.js` — one-line behavioral fix in `runSearch`: replace `if (!r.ok) return [];` with a thrown error so the existing `.catch → runLocalSearch` cascade runs.
- `tests/e2e/test_search_offline_fallback.py` (new) — two end-to-end cases ("Bodo", "Richard") that mock `/fellows.db`, `/api/fellows`, and `/api/search` to 401, seed the IDB cache with three known fellows, and assert the cached matches render. Both fail pre-fix with the exact symptom ("No fellows match that search."); both pass post-fix.
- `tests/test_database.py` + `tests/test_api.py` — additional whole-token / multi-token / partial-token FTS5 coverage. Closes the prior gap where only "Aaron" was asserted at either layer.

## Out of scope (called out separately)

- Misleading copy on About ("Directory data updates aren't available in this browser") and Settings ("Can't open backup and restore right now / OPFS didn't initialize") when the real cause is a 403, not a browser capability gap.
- A visible "using cached data" indicator. The build badge does flip to `server: offline · using cache` but it's small.
- A second mobile bug: bulk bar shows "select all N results" while the list shows "No fellows match that search." for the same query. Reproduced post-deploy, separate PR.

## Test plan

- [x] `just test-e2e search_offline_fallback` — 2/2 pass
- [x] `just test-e2e offline_only_mode` — 3/3 pass (no regression)
- [x] `just test-db` + `just test-api` — 22/22 pass
- [ ] **Manual on Android:** clear app cache (so session is gone), wait for cookie to age out or force-restart prod, then search "Bodo" — should now return Richard Bodo from the cached directory even with no live session.

🤖 Generated with [Claude Code](https://claude.com/claude-code)