### PR TITLE
fix(search): hide bulk-select bar when a query produces 0 results

### DIFF
--- a/app/static/app.js
+++ b/app/static/app.js
@@ -9095,6 +9095,10 @@
           '<p class="placeholder">No fellows match that search with the current filter.</p>';
       }
       setSearchStatus('');
+      // Without this, the bar keeps the stale "select all N results" text
+      // from the previous non-empty render — user sees "No fellows match"
+      // in the body while the bar above still offers a 2-result selection.
+      updateBulkBar();
       return;
     }
     renderDirectoryList(filtered);

--- a/tests/e2e/test_search_bulk_bar_stale.py
+++ b/tests/e2e/test_search_bulk_bar_stale.py
@@ -1,0 +1,50 @@
+"""E2E: bulk-select bar must reset when the search produces 0 results.
+
+Reported symptom: on mobile, with the has-email filter on, search input
+"Rich" rendered the body as "No fellows match that search." while the
+bulk-select bar above it still said "select all 2 results" — the bar
+kept stale text from an earlier render that had matches.
+
+Root cause: renderSearchResults' empty-branch `return` skips the
+trailing updateBulkBar() call (app/static/app.js:9090-9098). The bar
+stays visible with whatever text it had after the previous non-empty
+search. The fix is to update the bulk bar on every render, including
+the empty branch (so it hides itself when displayedList is empty).
+"""
+import pytest
+from playwright.sync_api import expect
+
+
+class TestBulkBarStaleOnEmptySearch:
+    """renderSearchResults must call updateBulkBar in every code path."""
+
+    def test_bulk_bar_hides_after_query_changes_to_zero_results(
+        self, standalone_page, base_url_fixture
+    ):
+        page = standalone_page
+        page.goto(base_url_fixture + "/", wait_until="domcontentloaded")
+        page.locator("#loading").wait_for(state="hidden", timeout=10000)
+        page.locator("#directory").wait_for(state="visible", timeout=5000)
+
+        bulk_bar = page.locator("#bulk-select-bar")
+        bulk_text = page.locator("#bulk-select-text")
+        list_el = page.locator("#directory-list")
+
+        # First query: "Aaron" hits Aaron Bird + Aaron McDonald via FTS5.
+        # That populates displayedList with two fellows, so updateBulkBar
+        # makes the bar visible with "select all 2 results".
+        page.locator("#search-input").fill("Aaron")
+        page.wait_for_timeout(500)  # debounce 250 ms + chain settle
+        expect(list_el).to_contain_text("Aaron Bird")
+        expect(bulk_bar).to_be_visible()
+        expect(bulk_text).to_contain_text("2 results")
+
+        # Second query: nonsense token with no FTS5 hits. renderSearchResults
+        # enters the empty branch, sets displayedList = [], renders
+        # "No fellows match that search." — and must also hide the bulk bar.
+        page.locator("#search-input").fill("zzzzzzzz_no_match")
+        page.wait_for_timeout(500)
+        expect(list_el).to_contain_text("No fellows match that search")
+        # Pre-fix: bar still visible with stale "2 results" text.
+        # Post-fix: bar hidden because displayedList.length === 0.
+        expect(bulk_bar).to_be_hidden()


### PR DESCRIPTION
**Stacked on #171.** Once that merges, GitHub will auto-retarget this PR onto `main`. The diff below is only the new commit.

## Summary

- Reported symptom (mobile): with the has-email filter on, typing a query that previously had matches and then narrowing it past zero results left the bulk-select bar showing **"select all 2 results"** while the body below said **"No fellows match that search."** Two views of the same query, disagreeing about whether there are any results.
- Root cause: `renderSearchResults` (`app/static/app.js:9090-9099`) `return`s from the empty-result branch without calling `updateBulkBar()`. The bar's text and visibility are set by that helper, so they keep their stale state from the previous non-empty render.

## What changed

- `app/static/app.js` — call `updateBulkBar()` before the empty-branch `return`. The bar's existing guard (`!displayedList.length → add('hidden')`) then hides it.
- `tests/e2e/test_search_bulk_bar_stale.py` (new) — walks the two-stage search (Aaron → 2 hits, then a nonsense token → 0 hits). Asserts the bar is visible after stage one and hidden after stage two. Fails pre-fix with the bar still visible carrying stale text.

## Test plan

- [x] `just test-e2e search_bulk_bar_stale` — 1/1 pass
- [x] `just test-e2e search_offline_fallback offline_only_mode` — 5/5 pass (no regression in adjacent search paths)
- [ ] **Manual on Android (post-merge + ship):** search "Aaron" → see "select all 2 results" → keep typing to "Aaronxyz" → bar should disappear, body should read "No fellows match that search."

🤖 Generated with [Claude Code](https://claude.com/claude-code)