### PR TITLE
chore(ui): never-SaaS framing — stop announcing server state in the chrome

### DIFF
--- a/app/static/app.js
+++ b/app/static/app.js
@@ -307,6 +307,24 @@
     if (clientEl) clientEl.textContent = 'app: ' + FELLOWS_UI_DIAG;
   }
 
+  // True when the dedicated worker spawned successfully and reports OPFS
+  // is fully functional (init.opfsCapable), but the page-level dataProvider
+  // ended up on the api+idb fallback — meaning the only thing wrong is the
+  // session-gated /fellows.db fetch returned 401/403, not the browser's
+  // local-storage capability. Distinguishing this from a real OPFS failure
+  // matters for user-facing copy: "sign in to refresh" is the honest fix;
+  // "your browser doesn't support OPFS" is a misattribution.
+  //
+  // Reads warmWorker (assigned later in the IIFE) via closure. Until the
+  // worker init resolves, returns false — which is safe: the surfaces that
+  // call this only fire after the boot path has settled.
+  function isWorkerOpfsCapableButInactive() {
+    if (!warmWorker || !warmWorker.init) return false;
+    if (!warmWorker.init.opfsCapable) return false;
+    if (!dataProvider) return false;
+    return dataProvider.kind !== 'worker';
+  }
+
   function setBuildBadgeServer(gitSha, builtAt) {
     var serverEl = document.getElementById('build-badge-server');
     var badgeEl = document.getElementById('build-badge');
@@ -323,26 +341,17 @@
     }
   }
 
-  function setBuildBadgeServerUnreachable() {
-    // Called from the auth-status fallback path when the server is 5xx or
-    // network-unreachable. Low-drama label: non-technical users should not
-    // read this as "something is broken" — the app continues to work from
-    // cached state.
-    var serverEl = document.getElementById('build-badge-server');
-    if (serverEl) serverEl.textContent = 'server: unreachable';
-  }
-
-  // True once the app has fallen back to cached local data because the
-  // server refused us (401 / expired session) or was otherwise unreachable
-  // during boot. Surface-only flag; the UI uses it to label the badge and
-  // show a gentle "using cached data" hint. The user stays in the app.
+  // Internal flag tracking that the boot path fell back to cached local
+  // data because the server refused us (401 / expired session) or was
+  // unreachable. Read by the boot trace and the "from cache" suffix on
+  // log lines. Deliberately NOT user-facing: this app is never-SaaS, so
+  // server connectivity is irrelevant outside the explicit "Check for
+  // updates" flow on the About page. The build badge stays informational
+  // (it shows the build label, full stop) — it does not double as a
+  // connectivity indicator.
   var offlineOnlyMode = false;
 
-  function setBuildBadgeOfflineOnly(reason) {
-    var serverEl = document.getElementById('build-badge-server');
-    if (serverEl) {
-      serverEl.textContent = 'server: offline · using cache';
-    }
+  function enterOfflineOnlyMode(reason) {
     offlineOnlyMode = true;
     bootDebugPush('entered offline-only mode: ' + (reason || 'unknown'));
   }
@@ -483,13 +492,19 @@
   //   'up-to-date'       — SHAs match
   //   'no-local-data'    — worker has no fellows.db (cold-start case)
   //   'unsupported'      — running on a provider that can't compare
-  //                        (api+idb fallback, no-OPFS browser)
+  //                        AND the browser genuinely lacks OPFS
+  //   'sign-in-required' — worker has OPFS but the page-level provider
+  //                        is api+idb because the session expired during
+  //                        boot. User can fix this by re-authenticating.
   //   'worker-stale'     — page is on a newer build than the worker
   //                        (transient SW upgrade race; worker doesn't
   //                        know the new RPC). Resolves on reload.
   //   'error'            — server unreachable or worker errored
   function checkForDirectoryDataUpdate() {
     if (!dataProvider || typeof dataProvider._compareFellowsDbSha !== 'function') {
+      if (isWorkerOpfsCapableButInactive()) {
+        return Promise.resolve({ status: 'sign-in-required' });
+      }
       return Promise.resolve({ status: 'unsupported' });
     }
     return fetch('/build-meta.json', { cache: 'no-store', credentials: 'same-origin' })
@@ -1056,6 +1071,27 @@
   // don't need to thread it through. Renders a specific "directory is
   // open in another window" panel — see plans/multi_tab_ownership_takeover.md
   // for the coordinated-takeover follow-up that supersedes this copy.
+  function renderSessionGatePanel(feature) {
+    // Render when the worker reports OPFS-capable but the page-level
+    // dataProvider fell back to api+idb — i.e. the local-data feature
+    // *is* available on this device, the session just expired during
+    // the directory-data fetch. Honest copy that doesn't blame the
+    // browser. Matches the "never-SaaS" framing: the server only
+    // matters when the user is doing an update or sign-in.
+    var label = feature || 'this feature';
+    var html = '<div class="local-data-unavailable-panel">';
+    html += '<h2>Sign in to refresh updates</h2>';
+    html += '<p>Your saved groups, notes, tags, and per-device settings ' +
+            'are intact on this device — local storage is working fine. ' +
+            'The session that authorizes update and backup checks has ' +
+            'expired, so ' + escapeHtml(label) + ' is paused until you ' +
+            'sign in again.</p>';
+    html += '<p><a class="local-data-unavailable-action" href="/?gate=1">' +
+            'Open the magic-link sign-in page</a></p>';
+    html += '</div>';
+    return html;
+  }
+
   function renderLocalDataUnavailablePanel(feature, opts) {
     opts = opts || {};
     if (opts.ownershipConflict == null) {
@@ -1063,6 +1099,13 @@
     }
     if (opts.ownershipConflict) {
       return renderOwnershipConflictPanel(feature);
+    }
+    // If OPFS is actually working, this panel's premise is wrong — the
+    // local-data feature *is* available; the page is just on the api+idb
+    // fallback because the directory-data fetch was session-gated. Send
+    // the user to the sign-in flow with copy that says so.
+    if (isWorkerOpfsCapableButInactive()) {
+      return renderSessionGatePanel(feature);
     }
     var b = detectBrowserSupport();
     var label = feature || 'this feature';
@@ -4823,7 +4866,6 @@
         // will just reload when the server is back.
         if (hasAuthenticatedOnce()) {
           authDebugPush('fallback: marker set → quiet email-gate (no auth-failure panel)');
-          setBuildBadgeServerUnreachable();
           initEmailGate(
             { authEnabled: true, authenticated: false, _offline: true },
             0,
@@ -6447,7 +6489,10 @@
       function paintDataRow(res) {
         if (!dataStatusEl) return;
         var statusText = '', actionHtml = '';
-        if (res.status === 'unsupported') {
+        if (res.status === 'sign-in-required') {
+          statusText = 'Sign in via the magic-link gate to enable update checks.';
+          actionHtml = '<a class="about-update-action-btn" href="/?gate=1">Sign in</a>';
+        } else if (res.status === 'unsupported') {
           statusText = 'Directory data updates aren\u2019t available in this browser.';
         } else if (res.status === 'no-local-data') {
           statusText = 'No local directory data \u2014 reload to download.';
@@ -9413,7 +9458,7 @@
     function tryListFromCache(originalErr) {
       return loadFullFellows().then(function (cached) {
         if (cached && cached.length) {
-          setBuildBadgeOfflineOnly('getList ' + (originalErr && originalErr.status));
+          enterOfflineOnlyMode('getList ' + (originalErr && originalErr.status));
           return cached;
         }
         throw originalErr;
@@ -9422,7 +9467,7 @@
     function tryFullFromCache(originalErr) {
       return loadFullFellows().then(function (cached) {
         if (cached && cached.length) {
-          setBuildBadgeOfflineOnly('getFull ' + (originalErr && originalErr.status));
+          enterOfflineOnlyMode('getFull ' + (originalErr && originalErr.status));
           return cached;
         }
         throw originalErr;

--- a/tests/e2e/test_never_saas_copy.py
+++ b/tests/e2e/test_never_saas_copy.py
@@ -1,0 +1,242 @@
+"""E2E: never-SaaS framing — stop announcing server connectivity outside
+the "Check for updates" flow, and stop misattributing a session-expired
+403 as a browser-capability gap.
+
+Context: the app is local-first. After install, the server is only
+consulted when the user explicitly clicks Check for updates. Yet the
+chrome currently shows a "server: offline · using cache" suffix in the
+build badge when /fellows.db 403s during boot, and Settings / About
+both render messages claiming OPFS didn't initialize — even when the
+diagnostic clearly shows OPFS *is* working (relationships.db opened
+fine, worker reports opfsCapable=true) and the only actual failure was
+the auth-gated /fellows.db fetch.
+
+These tests pin the corrected behavior:
+  1. Build badge never claims the server is offline / unreachable /
+     using cache. Connectivity is not a user concern outside the
+     explicit update-check flow.
+  2. About → Check for updates → Directory data row, when worker is
+     OPFS-capable but the active provider is api+idb (session expired),
+     offers re-authentication rather than blaming the browser.
+  3. Settings → Backup and restore, in the same condition, says the
+     feature is paused pending sign-in rather than "OPFS didn't
+     initialize on this load."
+"""
+import json
+
+import pytest
+from playwright.sync_api import expect
+
+from conftest import _STANDALONE_DISPLAY_INIT
+
+
+FELLOWS_DB = "**/fellows.db"
+API_FELLOWS = "**/api/fellows**"
+API_AUTH_STATUS = "**/api/auth/status"
+
+
+def _make_standalone_page(context):
+    page = context.new_page()
+    page.add_init_script(_STANDALONE_DISPLAY_INIT)
+    page.add_init_script(
+        "window.localStorage.setItem('fellows_authenticated_once', '1');"
+    )
+    return page
+
+
+def _seed_indexeddb_with_fellows(page, fellows):
+    """Prime fellows-local-db so getList/getFull have something to return."""
+    page.evaluate(
+        """
+        async (fellows) => {
+            return new Promise((resolve, reject) => {
+                const req = indexedDB.open('fellows-local-db', 1);
+                req.onupgradeneeded = () => {
+                    const db = req.result;
+                    if (!db.objectStoreNames.contains('meta')) {
+                        db.createObjectStore('meta', { keyPath: 'id' });
+                    }
+                };
+                req.onsuccess = () => {
+                    const db = req.result;
+                    const tx = db.transaction('meta', 'readwrite');
+                    tx.objectStore('meta').put({ id: 'allFellows', data: fellows });
+                    tx.oncomplete = () => { db.close(); resolve(true); };
+                    tx.onerror = () => reject(tx.error);
+                };
+                req.onerror = () => reject(req.error);
+            });
+        }
+        """,
+        fellows,
+    )
+
+
+SEED_FELLOWS = [
+    {
+        "record_id": "seed-1",
+        "slug": "seed_one",
+        "name": "Seed One",
+        "has_image": 0,
+        "has_contact_email": 1,
+        "contact_email": "one@example.com",
+    },
+]
+
+
+def _boot_into_api_idb_fallback(context, page, base_url):
+    """Drive the page into the session-expired api+idb fallback path.
+
+    Routes /fellows.db and /api/fellows to 401 BEFORE first navigation
+    (so the worker fails to fetch fellows.db and the page falls back).
+    Also overrides /api/auth/status so authEnabled=true + authenticated=
+    false — without that the dev server's no-auth passthrough takes a
+    different code path and we end up on the worker provider anyway.
+
+    Mirrors test_offline_only_mode.py's setup; see that file for the
+    rationale on each step.
+    """
+    context.route(
+        FELLOWS_DB,
+        lambda r: r.fulfill(status=401, body="session expired"),
+    )
+    context.route(
+        API_FELLOWS,
+        lambda r: r.fulfill(status=401, body="session expired"),
+    )
+    context.route(
+        API_AUTH_STATUS,
+        lambda r: r.fulfill(
+            status=200,
+            content_type="application/json",
+            body=json.dumps({
+                "authEnabled": True,
+                "authenticated": False,
+                "hasSessionCookie": False,
+                "installRecentlyAllowed": False,
+            }),
+        ),
+    )
+    page.goto(base_url + "/", wait_until="domcontentloaded")
+    page.wait_for_function("() => !!(window.indexedDB)", timeout=5000)
+    _seed_indexeddb_with_fellows(page, SEED_FELLOWS)
+    page.reload(wait_until="domcontentloaded")
+    page.locator("#loading").wait_for(state="hidden", timeout=10000)
+    page.locator("#directory").wait_for(state="visible", timeout=5000)
+    # Sanity-check we landed on api+idb with the warm worker reporting
+    # OPFS capable — that's the precise condition under which the
+    # misleading "OPFS didn't initialize" / "browser doesn't support"
+    # copy fires today.
+    state = page.evaluate(
+        """
+        () => ({
+            providerKind: (window.__dataProvider && window.__dataProvider.kind) || null,
+            // warmWorker is module-scope inside the IIFE so we can't read
+            // it directly; lean on the page-state debug panel input.
+            // Most reliable proxy: the diagnostics window properties
+            // pickDataProvider sets when it falls back after worker init
+            // succeeded.
+        })
+        """
+    )
+    assert state["providerKind"] == "api+idb", (
+        f"expected api+idb fallback, got {state['providerKind']!r}"
+    )
+
+
+class TestBuildBadgeNeverSaaS:
+    """Build badge is informational metadata, not a connectivity indicator."""
+
+    def test_badge_does_not_claim_server_offline_on_api_idb_fallback(
+        self, context, base_url_fixture
+    ):
+        page = _make_standalone_page(context)
+        try:
+            _boot_into_api_idb_fallback(context, page, base_url_fixture)
+            badge = page.locator("#build-badge")
+            # The fail signal: pre-fix, the build-badge-server line reads
+            # "server: offline · using cache" once tryListFromCache fires.
+            expect(badge).not_to_contain_text("offline", timeout=3000)
+            expect(badge).not_to_contain_text("unreachable")
+            expect(badge).not_to_contain_text("using cache")
+        finally:
+            context.unroute(FELLOWS_DB)
+            context.unroute(API_FELLOWS)
+            context.unroute(API_AUTH_STATUS)
+            page.close()
+
+
+class TestCheckForUpdatesCopy:
+    """Update-check result strings name the right cause."""
+
+    def test_data_row_offers_sign_in_when_worker_opfs_capable(
+        self, context, base_url_fixture
+    ):
+        page = _make_standalone_page(context)
+        try:
+            _boot_into_api_idb_fallback(context, page, base_url_fixture)
+            # Open About.
+            page.evaluate("location.hash = '#/about'")
+            page.locator("#about-check-updates").wait_for(state="visible", timeout=5000)
+            page.locator("#about-check-updates").click()
+            data_row = page.locator("#about-data-status")
+            expect(data_row).not_to_contain_text(
+                "isn", timeout=5000
+            )  # "isn't available in this browser" — the wrong attribution
+            # Post-fix copy should mention sign-in (case-insensitive).
+            row_text = data_row.text_content() or ""
+            assert "sign in" in row_text.lower() or "magic link" in row_text.lower(), (
+                f"data row should suggest re-authentication, got: {row_text!r}"
+            )
+        finally:
+            context.unroute(FELLOWS_DB)
+            context.unroute(API_FELLOWS)
+            context.unroute(API_AUTH_STATUS)
+            page.close()
+
+
+class TestSettingsBackupPanelCopy:
+    """Backup-and-restore panel doesn't blame OPFS when OPFS is fine.
+
+    On the api+idb path the api-provider's getSetting throws
+    `localDataUnavailable`, which currently replaces the ENTIRE Settings
+    detail pane with the runtime-failure panel (see
+    showUnsupportedAndDisable at app.js:8384). So we assert against
+    #detail's full text content rather than the export-section subtree.
+    """
+
+    def test_panel_does_not_claim_opfs_failed_when_worker_is_opfs_capable(
+        self, context, base_url_fixture
+    ):
+        page = _make_standalone_page(context)
+        try:
+            _boot_into_api_idb_fallback(context, page, base_url_fixture)
+            page.evaluate("location.hash = '#/settings'")
+            # Wait for either the panel headline or the normal settings
+            # title to appear — both routes land somewhere in #detail.
+            page.locator("#detail").wait_for(state="visible", timeout=5000)
+            page.wait_for_timeout(500)  # let the late-async getSetting reject settle
+            text = page.locator("#detail").text_content() or ""
+            # Pre-fix lede: "OPFS didn't initialize on this load."
+            assert "didn't initialize" not in text and "didn’t initialize" not in text, (
+                f"settings panel must not blame OPFS when it works; got: {text!r}"
+            )
+            # Post-fix should mention sign-in or the magic-link flow, OR
+            # the regular settings page renders (best outcome — backup
+            # works via the warm worker even in fallback). Either is
+            # better than the current OPFS-misattribution copy.
+            lower = text.lower()
+            ok = (
+                "sign in" in lower
+                or "magic link" in lower
+                or "your saved data" in lower  # regular settings export heading
+            )
+            assert ok, (
+                f"settings panel should suggest re-authentication or render "
+                f"normally; got: {text!r}"
+            )
+        finally:
+            context.unroute(FELLOWS_DB)
+            context.unroute(API_FELLOWS)
+            context.unroute(API_AUTH_STATUS)
+            page.close()

--- a/tests/e2e/test_offline_only_mode.py
+++ b/tests/e2e/test_offline_only_mode.py
@@ -129,9 +129,15 @@ class TestOfflineOnlyMode:
             directory.wait_for(state="visible", timeout=5000)
             expect(page.get_by_role("link", name="Ada Cached")).to_be_visible()
 
-            # Build badge signals offline-only mode.
-            badge_server = page.locator("#build-badge-server")
-            expect(badge_server).to_contain_text("offline", timeout=3000)
+            # We're on the api+idb fallback provider (the never-SaaS
+            # cleanup retired the "server: offline · using cache" badge
+            # suffix; dataProvider.kind is the structural signal now).
+            provider_kind = page.evaluate(
+                "() => (window.__dataProvider && window.__dataProvider.kind) || null"
+            )
+            assert provider_kind == "api+idb", (
+                f"expected api+idb fallback, got {provider_kind!r}"
+            )
 
             # Email-gate / install-landing / auth-error panels all stay hidden.
             expect(page.locator("#install-gate-private")).to_be_hidden()

--- a/tests/e2e/test_search_offline_fallback.py
+++ b/tests/e2e/test_search_offline_fallback.py
@@ -128,9 +128,9 @@ def _force_api_idb_fallback_with_cache(context, page, base_url):
     # If a future change makes the worker resilient to 401 on the bytes
     # fetch this assertion will start failing and we'll need a different
     # repro — better to fail loudly than to test the wrong code path.
-    expect(page.locator("#build-badge-server")).to_contain_text(
-        "offline", timeout=3000
-    )
+    # (The former "server: offline" badge text was retired in the
+    # never-SaaS copy cleanup; dataProvider.kind is the structural
+    # signal now.)
     provider_kind = page.evaluate(
         "() => (window.__dataProvider && window.__dataProvider.kind) || null"
     )


### PR DESCRIPTION
**Stacked on #172** (which is itself stacked on #171). GitHub will auto-retarget when those merge.

## Summary

The app is local-first. After install, the server is only consulted when the user explicitly clicks "Check for updates" on About. The build badge and several inline panels were leaking SaaS-paradigm framing at conditions where the local-data layer was actually working — the only thing wrong was that the session-gated `/fellows.db` fetch returned 401/403.

Three misleading surfaces fixed:

| Where | Before | After |
|---|---|---|
| Build badge (always visible) | `server: offline · using cache` | Stays informational. Always shows the server build label, never connectivity state. |
| About → Check for updates → Directory data row | `Directory data updates aren't available in this browser.` | `Sign in via the magic-link gate to enable update checks.` + Sign in button |
| Settings → Backup and restore (api+idb path) | `Can't open settings on this browser` + lecturing a Chrome 145 user that they need Chrome 102+ | `Sign in to refresh updates` + honest copy that says local storage is fine, the session just expired |

## What changed

- New `isWorkerOpfsCapableButInactive()` helper that distinguishes "OPFS is broken" from "session expired during /fellows.db fetch." The warm worker exposes `init.opfsCapable`; combined with `dataProvider.kind !== 'worker'` it tells us OPFS is fine but the page fell back.
- `renderLocalDataUnavailablePanel` routes through a new `renderSessionGatePanel` when the worker is OPFS-capable. Auto-fixes every callsite without threading flags through.
- `checkForDirectoryDataUpdate` returns a new `'sign-in-required'` status in the same condition. `paintDataRow` renders it with appropriate copy + a sign-in link.
- `setBuildBadgeServerUnreachable` removed entirely (no callers). `setBuildBadgeOfflineOnly` renamed to `enterOfflineOnlyMode` — same internal flag effect, just doesn't touch the badge text.

## Tests

- `tests/e2e/test_never_saas_copy.py` (new) — three cases:
  - Build badge never contains "offline" / "unreachable" / "using cache" when api+idb fallback boots
  - About data row offers sign-in copy when worker is OPFS-capable
  - Settings panel doesn't claim OPFS failed when OPFS works
- `tests/e2e/test_offline_only_mode.py` + `tests/e2e/test_search_offline_fallback.py` — both used the old "server: offline" badge text as a "we reached fallback" proxy. Updated to assert `dataProvider.kind === 'api+idb'` (the structural signal).

## Out of scope (worth a follow-up)

The Settings backup/restore controls are currently inaccessible in api+idb mode because the page-level `dataProvider` doesn't expose `exportRelationshipsBytes`. The warm worker has those methods and `relationships.db` is open — wiring backup through the warm worker (instead of the active provider) would make the feature actually work in fallback mode, not just have honest copy about why it doesn't. Separate PR.

## Test plan

- [x] `just test-e2e never_saas_copy` — 3/3 pass
- [x] `just test-e2e search_offline_fallback search_bulk_bar_stale offline_only_mode` — 9/9 pass
- [x] `just test-e2e directory_data_update_flow settings about_stats` — 16/16 pass (no copy regression in the happy paths)
- [x] `just test-fast` — 93/93 pass
- [ ] **Manual on Android (post-merge + ship):** boot with an expired session, confirm: build badge shows no offline framing, About → Check for updates → Directory data row offers sign-in, Settings backup panel offers sign-in (and doesn't lecture about OPFS).

🤖 Generated with [Claude Code](https://claude.com/claude-code)