### PR TITLE
feat(data-provider): warm-worker fallback for settings + backup/restore

### DIFF
--- a/app/static/app.js
+++ b/app/static/app.js
@@ -3738,6 +3738,26 @@
   // that backs `email_gate.md` invariant 10 on no-OPFS browsers.
   function createApiPlusIdbDataProvider() {
     var apiProvider = createApiDataProvider();
+    // Phase 0 of plans/user_folder_storage.md: when the worker spawned
+    // successfully and has relationships.db open, the local-data
+    // settings + backup ops are reachable directly via warmWorker.rpc
+    // even though the page-level provider fell back to api+idb because
+    // /fellows.db 401'd. Wire those through the warm worker so a user
+    // with an expired session can still read/write their settings and
+    // download a backup of their data before reinstalling or switching
+    // browsers. Directory reads (getList/getFull/getOne/search/getStats)
+    // and groups RPCs stay on the api provider — those are out of
+    // scope for Phase 0 (groups are a follow-up; directory data
+    // genuinely needs the session-gated fellows.db bytes).
+    function viaWarmWorker(rpcName, argsMap) {
+      return function () {
+        if (isWorkerOpfsCapableButInactive() && warmWorker && warmWorker.rpc) {
+          var args = argsMap ? argsMap.apply(null, arguments) : undefined;
+          return warmWorker.rpc.call(rpcName, args);
+        }
+        return apiProvider[rpcName].apply(apiProvider, arguments);
+      };
+    }
     return {
       kind: 'api+idb',
       // Directory: API only (IDB write/read mirroring is wired into bootDirectoryAsApp).
@@ -3746,22 +3766,36 @@
       getOne: apiProvider.getOne.bind(apiProvider),
       search: apiProvider.search.bind(apiProvider),
       getStats: apiProvider.getStats.bind(apiProvider),
-      // Everything relationships-shaped rejects with localDataUnavailable
-      // so the unsupported-browser panel renders.
+      // Groups stay on the api provider until a follow-up PR extends
+      // the warm-worker fallback to listGroups / getGroup / etc.
+      // (those need a member-name-resolution helper hoisted out of
+      // createWorkerDataProvider's scope before they can route here).
       listGroups: apiProvider.listGroups.bind(apiProvider),
       getGroup: apiProvider.getGroup.bind(apiProvider),
       createGroup: apiProvider.createGroup.bind(apiProvider),
       updateGroup: apiProvider.updateGroup.bind(apiProvider),
       deleteGroup: apiProvider.deleteGroup.bind(apiProvider),
-      getSetting: apiProvider.getSetting.bind(apiProvider),
-      getSettings: apiProvider.getSettings.bind(apiProvider),
-      setSetting: apiProvider.setSetting.bind(apiProvider),
-      exportRelationshipsBytes: apiProvider.exportRelationshipsBytes.bind(apiProvider),
-      inspectRelationshipsBytes: apiProvider.inspectRelationshipsBytes.bind(apiProvider),
-      countRelationships: apiProvider.countRelationships.bind(apiProvider),
-      importRelationshipsBytes: apiProvider.importRelationshipsBytes.bind(apiProvider),
-      listRelationshipsBackups: apiProvider.listRelationshipsBackups.bind(apiProvider),
-      restoreRelationshipsBackup: apiProvider.restoreRelationshipsBackup.bind(apiProvider)
+      // Settings + backup / restore route through the warm worker when
+      // it's alive with OPFS — Phase 0 scope.
+      getSetting: viaWarmWorker('getSetting', function (key) {
+        return { key: key };
+      }),
+      getSettings: viaWarmWorker('getSettings'),
+      setSetting: viaWarmWorker('setSetting', function (key, value) {
+        return { key: key, value: value };
+      }),
+      exportRelationshipsBytes: viaWarmWorker('exportRelationshipsBytes'),
+      inspectRelationshipsBytes: viaWarmWorker('inspectRelationshipsBytes', function (bytes) {
+        return { bytes: bytes };
+      }),
+      countRelationships: viaWarmWorker('countRelationships'),
+      importRelationshipsBytes: viaWarmWorker('importRelationshipsBytes', function (bytes) {
+        return { bytes: bytes };
+      }),
+      listRelationshipsBackups: viaWarmWorker('listRelationshipsBackups'),
+      restoreRelationshipsBackup: viaWarmWorker('restoreRelationshipsBackup', function (name) {
+        return { name: name };
+      })
     };
   }
 
@@ -8116,10 +8150,18 @@
     // The late `localDataUnavailable` click-handler paths below remain
     // for paranoia / late provider downgrades.
     // 'worker' = the dedicated sqlite-worker.js owns OPFS; backup/restore
-    // both go through worker RPC. 'api+idb' = worker init failed (no OPFS-
-    // capable browser); the unavailable-panel covers groups/settings.
+    // both go through worker RPC. 'api+idb' WITH an OPFS-capable warm
+    // worker = the page fell back because /fellows.db 401'd at boot, but
+    // the worker is still alive with relationships.db open — backup and
+    // restore are reachable via the warm-worker fallback the api+idb
+    // provider installs (Phase 0 of plans/user_folder_storage.md).
+    // The remaining "no warm worker / OPFS truly broken" case still
+    // surfaces the unavailable-panel.
     var localPersistenceAvailable = !!(
-      dataProvider && dataProvider.kind === 'worker'
+      dataProvider && (
+        dataProvider.kind === 'worker' ||
+        isWorkerOpfsCapableButInactive()
+      )
     );
     if (!localPersistenceAvailable) {
       var preExport = document.getElementById('settings-export-section');

--- a/tests/e2e/test_warm_worker_backup_fallback.py
+++ b/tests/e2e/test_warm_worker_backup_fallback.py
@@ -1,0 +1,216 @@
+"""E2E: backup / restore work via the warm worker even when the page-level
+dataProvider is on the api+idb fallback.
+
+Phase 0 of plans/user_folder_storage.md. When the worker spawned
+successfully and has relationships.db open (worker.init.opfsCapable
+true; relationships.db handle alive), the user's saved data IS
+accessible — it's just that the page-level dataProvider fell back to
+api+idb because the directory-data fetch was session-gated. Before
+this fix the Settings backup buttons disappeared entirely (the api
+provider's exportRelationshipsBytes etc. all rejected with
+localDataUnavailable, which triggered the never-SaaS sign-in panel,
+which has no backup button).
+
+After this fix, the same buttons stay on the page and route through
+warmWorker.rpc directly, so a user with an expired session can still
+download a backup of their groups, notes, tags, and settings before
+they reinstall, switch browsers, or re-authenticate.
+
+Companion to:
+  - test_never_saas_copy.py (copy is honest in the same scenario)
+  - test_search_offline_fallback.py (search still works in the same scenario)
+"""
+import base64
+import json
+
+import pytest
+from playwright.sync_api import expect
+
+from conftest import _STANDALONE_DISPLAY_INIT
+
+
+FELLOWS_DB = "**/fellows.db"
+API_FELLOWS = "**/api/fellows**"
+API_AUTH_STATUS = "**/api/auth/status"
+
+
+SEED_FELLOWS = [
+    {
+        "record_id": "seed-1",
+        "slug": "seed_one",
+        "name": "Seed One",
+        "has_image": 0,
+        "has_contact_email": 1,
+        "contact_email": "one@example.com",
+    },
+]
+
+
+def _make_standalone_page(context):
+    page = context.new_page()
+    page.add_init_script(_STANDALONE_DISPLAY_INIT)
+    page.add_init_script(
+        "window.localStorage.setItem('fellows_authenticated_once', '1');"
+    )
+    return page
+
+
+def _seed_indexeddb_with_fellows(page, fellows):
+    """Prime fellows-local-db so the directory renders from cache once
+    /api/fellows 401s during boot."""
+    page.evaluate(
+        """
+        async (fellows) => {
+            return new Promise((resolve, reject) => {
+                const req = indexedDB.open('fellows-local-db', 1);
+                req.onupgradeneeded = () => {
+                    const db = req.result;
+                    if (!db.objectStoreNames.contains('meta')) {
+                        db.createObjectStore('meta', { keyPath: 'id' });
+                    }
+                };
+                req.onsuccess = () => {
+                    const db = req.result;
+                    const tx = db.transaction('meta', 'readwrite');
+                    tx.objectStore('meta').put({ id: 'allFellows', data: fellows });
+                    tx.oncomplete = () => { db.close(); resolve(true); };
+                    tx.onerror = () => reject(tx.error);
+                };
+                req.onerror = () => reject(req.error);
+            });
+        }
+        """,
+        fellows,
+    )
+
+
+def _boot_into_api_idb_fallback(context, page, base_url):
+    """Drive a fresh boot into the api+idb fallback. The worker spawns,
+    opens OPFS (relationships.db gets created fresh), but the
+    auth-gated /fellows.db fetch 401s — same path the user's phone
+    hit. Returns once the page is in steady state at the directory
+    with provider kind == 'api+idb'."""
+    context.route(
+        FELLOWS_DB,
+        lambda r: r.fulfill(status=401, body="session expired"),
+    )
+    context.route(
+        API_FELLOWS,
+        lambda r: r.fulfill(status=401, body="session expired"),
+    )
+    context.route(
+        API_AUTH_STATUS,
+        lambda r: r.fulfill(
+            status=200,
+            content_type="application/json",
+            body=json.dumps({
+                "authEnabled": True,
+                "authenticated": False,
+                "hasSessionCookie": False,
+                "installRecentlyAllowed": False,
+            }),
+        ),
+    )
+    page.goto(base_url + "/", wait_until="domcontentloaded")
+    page.wait_for_function("() => !!(window.indexedDB)", timeout=5000)
+    _seed_indexeddb_with_fellows(page, SEED_FELLOWS)
+    page.reload(wait_until="domcontentloaded")
+    page.locator("#loading").wait_for(state="hidden", timeout=10000)
+    page.locator("#directory").wait_for(state="visible", timeout=5000)
+    kind = page.evaluate(
+        "() => (window.__dataProvider && window.__dataProvider.kind) || null"
+    )
+    assert kind == "api+idb", f"expected api+idb fallback, got {kind!r}"
+
+
+class TestWarmWorkerBackupFallback:
+    """Backup, restore, and the underlying relationships.db reads work
+    via the warm worker when the page-level provider is api+idb but
+    the worker reports OPFS-capable + relationships.db open."""
+
+    def test_download_userdata_button_is_reachable_in_api_idb_fallback(
+        self, context, base_url_fixture
+    ):
+        """The export section stays in the DOM and the Download button is
+        visible. Pre-fix the Settings page replaces it with the
+        never-SaaS sign-in panel that has no backup affordance."""
+        page = _make_standalone_page(context)
+        try:
+            _boot_into_api_idb_fallback(context, page, base_url_fixture)
+            page.evaluate("location.hash = '#/settings'")
+            page.wait_for_timeout(500)
+            expect(page.locator("#settings-download-userdata")).to_be_visible(
+                timeout=5000
+            )
+        finally:
+            context.unroute(FELLOWS_DB)
+            context.unroute(API_FELLOWS)
+            context.unroute(API_AUTH_STATUS)
+            page.close()
+
+    def test_export_relationships_returns_valid_sqlite_bytes(
+        self, context, base_url_fixture
+    ):
+        """Calling exportRelationshipsBytes via the active dataProvider
+        in api+idb mode must return a real SQLite blob (first 16 bytes =
+        'SQLite format 3\\0'). Pre-fix it rejected with
+        localDataUnavailable; post-fix it routes through warmWorker.rpc.
+
+        The exported DB is a freshly-bootstrapped relationships.db (no
+        user data yet — this test is about the plumbing). The schema
+        rows from `bootstrapRelationshipsSchema` are enough to make the
+        DB non-empty and confirm we're reading a real file, not getting
+        an empty buffer back."""
+        page = _make_standalone_page(context)
+        try:
+            _boot_into_api_idb_fallback(context, page, base_url_fixture)
+            header_b64 = page.evaluate(
+                """
+                async () => {
+                    const bytes = await window.__dataProvider.exportRelationshipsBytes();
+                    if (!bytes || !bytes.byteLength) return null;
+                    const u8 = new Uint8Array(bytes.buffer || bytes, 0, 16);
+                    return btoa(String.fromCharCode.apply(null, u8));
+                }
+                """
+            )
+            assert header_b64, "exportRelationshipsBytes returned no bytes"
+            header = base64.b64decode(header_b64)
+            assert header.startswith(b"SQLite format 3"), (
+                f"expected SQLite header in exported bytes, got {header!r}"
+            )
+        finally:
+            context.unroute(FELLOWS_DB)
+            context.unroute(API_FELLOWS)
+            context.unroute(API_AUTH_STATUS)
+            page.close()
+
+    def test_setting_round_trip_in_api_idb_fallback(
+        self, context, base_url_fixture
+    ):
+        """setSetting and getSetting must both work via the warm worker
+        fallback. Without this, the Settings page can't save the user's
+        email override, and the page-render path (which calls getSetting
+        for self_email) blows the whole page away with the
+        showUnsupportedAndDisable panel."""
+        page = _make_standalone_page(context)
+        try:
+            _boot_into_api_idb_fallback(context, page, base_url_fixture)
+            value = page.evaluate(
+                """
+                async () => {
+                    await window.__dataProvider.setSetting(
+                        'backup_fallback_marker', 'rich_was_here'
+                    );
+                    return window.__dataProvider.getSetting('backup_fallback_marker');
+                }
+                """
+            )
+            assert value == "rich_was_here", (
+                f"expected setting to round-trip via warm worker, got {value!r}"
+            )
+        finally:
+            context.unroute(FELLOWS_DB)
+            context.unroute(API_FELLOWS)
+            context.unroute(API_AUTH_STATUS)
+            page.close()


### PR DESCRIPTION
**Phase 0 of [#165](https://github.com/richbodo/fellows_local_db/issues/165).** Stacked on #173 (never-SaaS copy cleanup). GitHub will auto-retarget to \`main\` as the stack merges.

Plan note for this work [landed on the user-folder-storage branch](https://github.com/richbodo/fellows_local_db/pull/166).

## Why this is independent of #165's bigger surgery

#165 moves the durable home of \`relationships.db\` out of OPFS and into a user-chosen folder on disk. That's weeks of work spanning a status-badge state machine, IDB handle persistence, permission lifecycle, migration wizard, and graceful degradation on Safari / Firefox / mobile.

This PR is just the worker-direct-export RPC contract that #165 P2 ("debounced sync after every commit") will need anyway. Decoupled from all the folder-picker UX, shippable now, and it fixes a current production bug for free.

## What was broken

When the page-level \`dataProvider\` falls back to \`api+idb\` — most commonly because \`/fellows.db\` returned 401 at boot (expired session, server restart, anything that wipes the in-memory session registry) — the warm worker is still alive with \`relationships.db\` open. But the api+idb provider's settings + backup/restore methods all reject with \`localDataUnavailable\`, which:

1. Triggers the never-SaaS sign-in panel (PR #173 made the copy honest, but the panel still has no backup button).
2. Leaves users with no way to back up their data before reinstalling, switching browsers, or re-authenticating.

That's not a never-SaaS posture; that's stranding the user with their data inaccessible.

## What changed

\`createApiPlusIdbDataProvider\` now installs warm-worker-routing variants for nine relationships.db methods:

- \`getSetting\`, \`getSettings\`, \`setSetting\` — so the Settings page can read self_email + the user can save changes
- \`exportRelationshipsBytes\`, \`inspectRelationshipsBytes\`, \`countRelationships\` — so Download works and the row-count preview works
- \`importRelationshipsBytes\`, \`listRelationshipsBackups\`, \`restoreRelationshipsBackup\` — so Restore works and the recent-backups list populates

Each is wrapped in a small dispatcher: if \`isWorkerOpfsCapableButInactive()\` (the helper from PR #173) AND \`warmWorker.rpc\` is alive, route the call through the worker; otherwise fall back to the existing api-provider behavior (which rejects with localDataUnavailable on true OPFS failure).

The Settings page's \`localPersistenceAvailable\` gate is widened the same way, so the Backup and Restore sections render normally instead of being replaced with the sign-in panel.

## What's deliberately not in this PR

- **Groups RPCs** (\`listGroups\`, \`getGroup\`, \`createGroup\`, \`updateGroup\`, \`deleteGroup\`). Same pattern applies, but the worker provider's variants apply a \`withResolvedMembers\` helper that's scoped inside \`createWorkerDataProvider\` and uses the per-instance fellow cache. Hoisting that to module scope is a small refactor that deserves its own PR. Track as Phase 0b.
- **#165 P1 proper** (folder picker, status badge, IDB handle persistence, etc.). All untouched.

## Test plan

- [x] \`just test-e2e warm_worker_backup_fallback\` — 3/3 pass (Download button visible, export returns valid SQLite header, setting round-trip)
- [x] \`just test-e2e never_saas_copy search_offline_fallback search_bulk_bar_stale offline_only_mode settings directory_data_update_flow worker_rpc\` — 35/35 (no regression in adjacent areas)
- [ ] **Manual on Android post-merge:** boot with an expired session, confirm Settings shows the Backup section + Download produces a real \`relationships-*.db\` file. Try a Restore from that file in worker mode to confirm round-trip.

🤖 Generated with [Claude Code](https://claude.com/claude-code)