### PR TITLE
feat(data-provider): warm-worker fallback for groups RPCs (Phase 0b)

### DIFF
--- a/app/static/app.js
+++ b/app/static/app.js
@@ -3581,6 +3581,32 @@
     };
   }
 
+  // Member-name resolution helpers. Worker RPCs that return a group
+  // (getGroup / createGroup / updateGroup) hand back members as bare
+  // record_id strings; the page-side cache `fellowsBySlug` carries the
+  // names and these helpers attach them + sort. Hoisted to module scope
+  // (out of createWorkerDataProvider) so the api+idb fallback provider's
+  // warm-worker variants can use the same post-process step. Both
+  // helpers only read `fellowsBySlug` — no provider-instance state.
+  function attachMemberNamesFromCache(members) {
+    if (!Array.isArray(members)) return [];
+    var out = members.map(function (m) {
+      var rid = m && m.record_id;
+      var fellow = fellowsBySlug.get(rid);
+      return { record_id: rid, name: fellow ? fellow.name : rid };
+    });
+    out.sort(function (a, b) {
+      var an = (a.name || '').toLowerCase(), bn = (b.name || '').toLowerCase();
+      return an < bn ? -1 : (an > bn ? 1 : 0);
+    });
+    return out;
+  }
+  function withResolvedMembers(group) {
+    if (!group) return null;
+    group.members = attachMemberNamesFromCache(group.members || []);
+    return group;
+  }
+
   // Wrap the worker RPC in a data-provider whose method shapes match the
   // legacy main-thread provider's callsite contract (so consumers in the
   // rest of app.js don't need to learn a new shape). `init` already ran
@@ -3599,24 +3625,6 @@
         ' but worker reports rpc=' + init.workerRpcVersion +
         ' schema=' + init.schemaVersion + ' — ' + opLabel + ' refused, reload to update';
       return Promise.reject(VersionMismatchError(msg));
-    }
-    function attachMemberNamesFromCache(members) {
-      if (!Array.isArray(members)) return [];
-      var out = members.map(function (m) {
-        var rid = m && m.record_id;
-        var fellow = fellowsBySlug.get(rid);
-        return { record_id: rid, name: fellow ? fellow.name : rid };
-      });
-      out.sort(function (a, b) {
-        var an = (a.name || '').toLowerCase(), bn = (b.name || '').toLowerCase();
-        return an < bn ? -1 : (an > bn ? 1 : 0);
-      });
-      return out;
-    }
-    function withResolvedMembers(group) {
-      if (!group) return null;
-      group.members = attachMemberNamesFromCache(group.members || []);
-      return group;
     }
     return {
       kind: 'worker',
@@ -3749,13 +3757,16 @@
     // and groups RPCs stay on the api provider — those are out of
     // scope for Phase 0 (groups are a follow-up; directory data
     // genuinely needs the session-gated fellows.db bytes).
-    function viaWarmWorker(rpcName, argsMap) {
+    function viaWarmWorker(rpcName, argsMap, postProcess) {
       return function () {
+        var args = argsMap ? argsMap.apply(null, arguments) : undefined;
+        var promise;
         if (isWorkerOpfsCapableButInactive() && warmWorker && warmWorker.rpc) {
-          var args = argsMap ? argsMap.apply(null, arguments) : undefined;
-          return warmWorker.rpc.call(rpcName, args);
+          promise = warmWorker.rpc.call(rpcName, args);
+        } else {
+          promise = apiProvider[rpcName].apply(apiProvider, arguments);
         }
-        return apiProvider[rpcName].apply(apiProvider, arguments);
+        return postProcess ? promise.then(postProcess) : promise;
       };
     }
     return {
@@ -3766,15 +3777,29 @@
       getOne: apiProvider.getOne.bind(apiProvider),
       search: apiProvider.search.bind(apiProvider),
       getStats: apiProvider.getStats.bind(apiProvider),
-      // Groups stay on the api provider until a follow-up PR extends
-      // the warm-worker fallback to listGroups / getGroup / etc.
-      // (those need a member-name-resolution helper hoisted out of
-      // createWorkerDataProvider's scope before they can route here).
-      listGroups: apiProvider.listGroups.bind(apiProvider),
-      getGroup: apiProvider.getGroup.bind(apiProvider),
-      createGroup: apiProvider.createGroup.bind(apiProvider),
-      updateGroup: apiProvider.updateGroup.bind(apiProvider),
-      deleteGroup: apiProvider.deleteGroup.bind(apiProvider),
+      // Groups route through the warm worker too (Phase 0b — the
+      // member-name-resolution helper is hoisted out of
+      // createWorkerDataProvider so we can apply it here on the same
+      // bare-record_id response shape the worker returns).
+      listGroups: viaWarmWorker('listGroups'),
+      getGroup: viaWarmWorker(
+        'getGroup',
+        function (id) { return { id: id }; },
+        withResolvedMembers
+      ),
+      createGroup: viaWarmWorker(
+        'createGroup',
+        function (data) { return data; },
+        withResolvedMembers
+      ),
+      updateGroup: viaWarmWorker(
+        'updateGroup',
+        function (id, patch) { return { id: id, patch: patch }; },
+        withResolvedMembers
+      ),
+      deleteGroup: viaWarmWorker('deleteGroup', function (id) {
+        return { id: id };
+      }),
       // Settings + backup / restore route through the warm worker when
       // it's alive with OPFS — Phase 0 scope.
       getSetting: viaWarmWorker('getSetting', function (key) {

--- a/tests/e2e/test_warm_worker_groups_fallback.py
+++ b/tests/e2e/test_warm_worker_groups_fallback.py
@@ -1,0 +1,223 @@
+"""E2E: Groups read/write works via the warm worker even when the
+page-level dataProvider is on the api+idb fallback.
+
+Phase 0b of plans/user_folder_storage.md, follow-up to Phase 0
+(test_warm_worker_backup_fallback.py). Same scenario, different data
+surface: relationships.db has both groups AND settings tables, and
+both need to be reachable when the page falls back to api+idb because
+the session-gated /fellows.db fetch returned 401.
+
+Pre-fix, the Groups index in api+idb fallback rendered the
+"Sign in to refresh" panel (post-PR #173) instead of the user's saved
+groups. Post-fix, listGroups / getGroup / createGroup / updateGroup /
+deleteGroup all route through warmWorker.rpc so the groups feature
+keeps working with an expired session.
+"""
+import json
+
+import pytest
+from playwright.sync_api import expect
+
+from conftest import _STANDALONE_DISPLAY_INIT
+
+
+FELLOWS_DB = "**/fellows.db"
+API_FELLOWS = "**/api/fellows**"
+API_AUTH_STATUS = "**/api/auth/status"
+
+
+SEED_FELLOWS = [
+    {
+        "record_id": "seed-1",
+        "slug": "seed_one",
+        "name": "Seed One",
+        "has_image": 0,
+        "has_contact_email": 1,
+        "contact_email": "one@example.com",
+    },
+    {
+        "record_id": "seed-2",
+        "slug": "seed_two",
+        "name": "Seed Two",
+        "has_image": 0,
+        "has_contact_email": 1,
+        "contact_email": "two@example.com",
+    },
+]
+
+
+def _make_standalone_page(context):
+    page = context.new_page()
+    page.add_init_script(_STANDALONE_DISPLAY_INIT)
+    page.add_init_script(
+        "window.localStorage.setItem('fellows_authenticated_once', '1');"
+    )
+    return page
+
+
+def _seed_indexeddb_with_fellows(page, fellows):
+    page.evaluate(
+        """
+        async (fellows) => {
+            return new Promise((resolve, reject) => {
+                const req = indexedDB.open('fellows-local-db', 1);
+                req.onupgradeneeded = () => {
+                    const db = req.result;
+                    if (!db.objectStoreNames.contains('meta')) {
+                        db.createObjectStore('meta', { keyPath: 'id' });
+                    }
+                };
+                req.onsuccess = () => {
+                    const db = req.result;
+                    const tx = db.transaction('meta', 'readwrite');
+                    tx.objectStore('meta').put({ id: 'allFellows', data: fellows });
+                    tx.oncomplete = () => { db.close(); resolve(true); };
+                    tx.onerror = () => reject(tx.error);
+                };
+                req.onerror = () => reject(req.error);
+            });
+        }
+        """,
+        fellows,
+    )
+
+
+def _boot_into_api_idb_fallback(context, page, base_url):
+    """Same setup as test_warm_worker_backup_fallback._boot_into_api_idb_fallback.
+    Kept inline rather than imported to keep the test file standalone."""
+    context.route(
+        FELLOWS_DB,
+        lambda r: r.fulfill(status=401, body="session expired"),
+    )
+    context.route(
+        API_FELLOWS,
+        lambda r: r.fulfill(status=401, body="session expired"),
+    )
+    context.route(
+        API_AUTH_STATUS,
+        lambda r: r.fulfill(
+            status=200,
+            content_type="application/json",
+            body=json.dumps({
+                "authEnabled": True,
+                "authenticated": False,
+                "hasSessionCookie": False,
+                "installRecentlyAllowed": False,
+            }),
+        ),
+    )
+    page.goto(base_url + "/", wait_until="domcontentloaded")
+    page.wait_for_function("() => !!(window.indexedDB)", timeout=5000)
+    _seed_indexeddb_with_fellows(page, SEED_FELLOWS)
+    page.reload(wait_until="domcontentloaded")
+    page.locator("#loading").wait_for(state="hidden", timeout=10000)
+    page.locator("#directory").wait_for(state="visible", timeout=5000)
+    kind = page.evaluate(
+        "() => (window.__dataProvider && window.__dataProvider.kind) || null"
+    )
+    assert kind == "api+idb", f"expected api+idb fallback, got {kind!r}"
+
+
+class TestWarmWorkerGroupsFallback:
+    """Groups RPCs work via the warm worker when the page is on api+idb."""
+
+    def test_list_groups_returns_array_not_localdataunavailable(
+        self, context, base_url_fixture
+    ):
+        """listGroups must return an array (possibly empty) — not reject
+        with localDataUnavailable as it does pre-fix via the api provider."""
+        page = _make_standalone_page(context)
+        try:
+            _boot_into_api_idb_fallback(context, page, base_url_fixture)
+            result = page.evaluate(
+                """
+                async () => {
+                    try {
+                        const groups = await window.__dataProvider.listGroups();
+                        return { ok: true, length: Array.isArray(groups) ? groups.length : null };
+                    } catch (err) {
+                        return { ok: false, message: String(err && err.message || err),
+                                 localDataUnavailable: !!(err && err.localDataUnavailable) };
+                    }
+                }
+                """
+            )
+            assert result.get("ok"), (
+                f"listGroups should succeed via warm worker, got {result!r}"
+            )
+            assert result.get("length") is not None, (
+                f"listGroups should return an array, got {result!r}"
+            )
+        finally:
+            context.unroute(FELLOWS_DB)
+            context.unroute(API_FELLOWS)
+            context.unroute(API_AUTH_STATUS)
+            page.close()
+
+    def test_create_then_get_then_delete_round_trip(
+        self, context, base_url_fixture
+    ):
+        """createGroup → getGroup → deleteGroup must all work via the
+        warm worker. getGroup's response must include `members` as an
+        array of {record_id, name} — that's withResolvedMembers'
+        contract, which previously lived inside createWorkerDataProvider
+        but is now reachable from createApiPlusIdbDataProvider too."""
+        page = _make_standalone_page(context)
+        try:
+            _boot_into_api_idb_fallback(context, page, base_url_fixture)
+            outcome = page.evaluate(
+                """
+                async () => {
+                    const dp = window.__dataProvider;
+                    // Create with one member (using a real seeded record_id
+                    // so member-name resolution can find a name).
+                    const created = await dp.createGroup({
+                        name: 'Phase 0b smoke',
+                        note: 'wired via warm worker',
+                        fellow_record_ids: ['seed-1']
+                    });
+                    if (!created || !created.id) {
+                        return { ok: false, stage: 'create', detail: created };
+                    }
+                    const fetched = await dp.getGroup(created.id);
+                    if (!fetched || !Array.isArray(fetched.members)) {
+                        return { ok: false, stage: 'get', detail: fetched };
+                    }
+                    // members should be objects with record_id + name keys,
+                    // not bare record_id strings. Pre-helper-hoist they'd
+                    // come back as bare strings since withResolvedMembers
+                    // wouldn't run.
+                    const member = fetched.members[0];
+                    const hasShape =
+                        member && typeof member === 'object' &&
+                        'record_id' in member && 'name' in member;
+                    await dp.deleteGroup(created.id);
+                    const after = await dp.listGroups();
+                    return {
+                        ok: true,
+                        memberHasShape: hasShape,
+                        memberName: member && member.name,
+                        listEmptyAfterDelete: Array.isArray(after) && after.length === 0
+                    };
+                }
+                """
+            )
+            assert outcome.get("ok"), (
+                f"round-trip should succeed, got {outcome!r}"
+            )
+            assert outcome.get("memberHasShape"), (
+                f"members should be {{record_id, name}} objects via "
+                f"withResolvedMembers, got {outcome!r}"
+            )
+            assert outcome.get("memberName") == "Seed One", (
+                f"members should resolve their names from the fellow cache; "
+                f"got {outcome.get('memberName')!r}"
+            )
+            assert outcome.get("listEmptyAfterDelete"), (
+                f"deleteGroup should leave list empty, got {outcome!r}"
+            )
+        finally:
+            context.unroute(FELLOWS_DB)
+            context.unroute(API_FELLOWS)
+            context.unroute(API_AUTH_STATUS)
+            page.close()


### PR DESCRIPTION
**Phase 0b of [#165](https://github.com/richbodo/fellows_local_db/issues/165).** Stacked on #174. Auto-retargets to \`main\` as the stack merges.

Plan note for Phase 0b will be added to \`plans/user_folder_storage.md\` in a follow-up commit on \`feat/user-folder-storage\`.

## Why

PR #174 (Phase 0) wired settings + backup / restore through the warm worker so users in api+idb fallback could read settings and download a backup. This closes the remaining gap: their saved **groups** were still unreachable, because the api+idb provider's \`listGroups\` / \`getGroup\` / \`createGroup\` / \`updateGroup\` / \`deleteGroup\` all rejected with \`localDataUnavailable\` (prod's \`/api/groups\` route was retired in Phase 1 of the local-first cutover).

After this PR, **the entire relationships.db read/write surface keeps working when the page is on api+idb**:

| Surface | Phase 0 | Phase 0b |
|---|---|---|
| Settings (read / write self_email, etc.) | ✅ | ✅ |
| Download my user data | ✅ | ✅ |
| Restore from a file | ✅ | ✅ |
| Recent auto-backups list | ✅ | ✅ |
| Groups index (\`#/groups\`) | ❌ | ✅ |
| Group detail (\`#/groups/<id>\`) | ❌ | ✅ |
| Edit a group | ❌ | ✅ |
| Create a new group | ❌ | ✅ |
| Delete a group | ❌ | ✅ |

So a user whose session expired can still browse, edit, create, and delete their saved groups — all backed by the OPFS-resident \`relationships.db\` the warm worker has open.

## What changed

### Prereq refactor: hoist `withResolvedMembers` + `attachMemberNamesFromCache`

Both helpers previously lived inside \`createWorkerDataProvider\`'s scope. They only read the module-level \`fellowsBySlug\` cache — no provider-instance state — so the hoist to module scope is mechanical. The worker provider continues to use the same helpers (just imported from outer scope instead of redeclared inline).

### `viaWarmWorker` gains an optional post-process

The three group RPCs that need member-name resolution (\`getGroup\`, \`createGroup\`, \`updateGroup\`) chain \`withResolvedMembers\` after the warm-worker RPC resolves. \`listGroups\` and \`deleteGroup\` don't.

### Five new methods on the api+idb provider

All five group methods now route through \`viaWarmWorker\` (same dispatcher Phase 0 added). When \`isWorkerOpfsCapableButInactive()\` + \`warmWorker.rpc\` is alive, RPCs go to the worker; otherwise the existing api-provider rejection path runs.

## What's deliberately not in this PR

- **Version-skew gating** on mutating group ops in the api+idb path. The worker provider gates create/update/delete with \`refuseIfVersionSkew\`; the api+idb fallback doesn't. Rationale: the fallback path is already exceptional (active when /fellows.db 401'd), and worker-vs-page version skew is a separate SW-upgrade-race condition surfaced by the existing reload banner. Worth revisiting if telemetry shows it matters.
- **Phase 1 of #165** (user-folder storage proper). Unchanged.

## Test plan

- [x] \`just test-e2e warm_worker_groups_fallback\` — 2/2 pass (listGroups returns array, create→get→delete round-trip with member-name resolution)
- [x] \`just test-e2e worker_rpc warm_worker_backup_fallback warm_worker_groups_fallback never_saas_copy search_offline_fallback search_bulk_bar_stale offline_only_mode settings groups_index groups_detail groups_edit\` — 56/56 (no regression in worker provider, api+idb fallback, or any groups surface)
- [ ] **Manual on Android post-merge:** boot with an expired session, confirm Groups index lists your saved groups, you can open one, add/remove members, save, and the changes persist on reload.

🤖 Generated with [Claude Code](https://claude.com/claude-code)