### PR TITLE
feat(about): Profile photos completeness row + sign-in CTA

### DIFF
--- a/app/static/app.js
+++ b/app/static/app.js
@@ -6452,6 +6452,18 @@
     aboutHtml += '<div class="about-update-row-status" id="about-data-status" role="status" aria-live="polite">Click "Check for updates" to compare with the server.</div>';
     aboutHtml += '<div class="about-update-row-action" id="about-data-action"></div>';
     aboutHtml += '</div>';
+    // Profile photos completeness row. Distinct from data durability
+    // (the relationships.db status); this tells the user whether
+    // their install fetched all the assets it depends on. When the
+    // user landed in api+idb fallback the cache is typically empty
+    // (the prewarm was skipped to avoid 500 doomed fetches — see
+    // fix(prewarm) PR) and we offer a one-click path to fix it.
+    // Plan: plans/user_folder_storage.md § Refreshable assets, Option A.
+    aboutHtml += '<div class="about-update-row" id="about-images-row">';
+    aboutHtml += '<div class="about-update-row-label">Profile photos</div>';
+    aboutHtml += '<div class="about-update-row-status" id="about-images-status" role="status" aria-live="polite">Counting…</div>';
+    aboutHtml += '<div class="about-update-row-action" id="about-images-action"></div>';
+    aboutHtml += '</div>';
     // Signing-key row. The fingerprint here should match the value
     // printed in the magic-link email; mismatch means the bundle did
     // not come from the maintainer (or the email did not). See
@@ -6635,6 +6647,45 @@
           ' (fellows who uploaded a photo). Reload this page to update the count.';
       }).catch(function () {
         el.textContent = 'Profile photos cached locally: unknown.';
+      });
+    })();
+
+    // Render the completeness row in the update-check block. Same
+    // count as `stats-images-cached` below, but in the upper rows
+    // where the user looks for "is everything okay with this
+    // install?" — and with a sign-in CTA when the cache is partial
+    // because we're on the api+idb fallback (the case where the
+    // prewarm was skipped — see fix(prewarm) PR).
+    (function renderImagesCompletenessRow() {
+      var statusEl = document.getElementById('about-images-status');
+      var actionEl = document.getElementById('about-images-action');
+      if (!statusEl) return;
+      var withImageTotal = 0;
+      var source = Array.isArray(fullFellowsCache) ? fullFellowsCache : list;
+      source.forEach(function (f) {
+        if (f && (f.has_image === 1 || f.has_image === true)) withImageTotal++;
+      });
+      countCachedImages().then(function (result) {
+        if (!result) {
+          statusEl.textContent = 'Image cache unavailable in this browser.';
+          return;
+        }
+        var cached = result.count;
+        statusEl.textContent = cached + ' of ' + withImageTotal + ' cached';
+        // CTA fires when (a) we're on the api+idb fallback (no live
+        // session, prewarm couldn't fetch) AND (b) cache is partial.
+        // Re-authentication is the load-bearing fix: a subsequent
+        // boot will repopulate. Worker-mode users with a partial
+        // cache (rare — prewarm errored mid-flight, perhaps) are
+        // already authenticated; a sign-in CTA would log them out
+        // and isn't the right affordance.
+        if (offlineOnlyMode && cached < withImageTotal && actionEl) {
+          actionEl.innerHTML =
+            '<a class="about-update-action-btn" href="/?gate=1">' +
+            'Sign in to fetch the rest</a>';
+        }
+      }).catch(function () {
+        statusEl.textContent = 'Image cache state unknown.';
       });
     })();
 

--- a/tests/e2e/test_about_image_completeness_row.py
+++ b/tests/e2e/test_about_image_completeness_row.py
@@ -1,0 +1,167 @@
+"""E2E: About page surfaces an image-cache completeness row + sign-in
+CTA when the user landed in api+idb fallback.
+
+Companion to test_image_prewarm_skip_in_fallback.py. That PR stops
+hammering the server with doomed image fetches; this row tells the
+user *why* they have no profile photos and gives them a one-click
+path to fix it (sign in via the magic-link gate so a subsequent boot
+can populate the cache).
+
+Plan: Option A from plans/user_folder_storage.md § Refreshable assets.
+"""
+import json
+
+import pytest
+from playwright.sync_api import expect
+
+
+FELLOWS_DB = "**/fellows.db"
+API_FELLOWS = "**/api/fellows**"
+API_AUTH_STATUS = "**/api/auth/status"
+
+
+def _make_standalone_page(context):
+    from conftest import _STANDALONE_DISPLAY_INIT
+
+    page = context.new_page()
+    page.add_init_script(_STANDALONE_DISPLAY_INIT)
+    page.add_init_script(
+        "window.localStorage.setItem('fellows_authenticated_once', '1');"
+    )
+    return page
+
+
+def _seed_indexeddb_with_fellows(page, fellows):
+    page.evaluate(
+        """
+        async (fellows) => {
+            return new Promise((resolve, reject) => {
+                const req = indexedDB.open('fellows-local-db', 1);
+                req.onupgradeneeded = () => {
+                    const db = req.result;
+                    if (!db.objectStoreNames.contains('meta')) {
+                        db.createObjectStore('meta', { keyPath: 'id' });
+                    }
+                };
+                req.onsuccess = () => {
+                    const db = req.result;
+                    const tx = db.transaction('meta', 'readwrite');
+                    tx.objectStore('meta').put({ id: 'allFellows', data: fellows });
+                    tx.oncomplete = () => { db.close(); resolve(true); };
+                    tx.onerror = () => reject(tx.error);
+                };
+                req.onerror = () => reject(req.error);
+            });
+        }
+        """,
+        fellows,
+    )
+
+
+# Seeded fellows ALL have has_image=1 so the completeness denominator
+# is non-zero. Cache stays empty (the prewarm is skipped per the
+# prewarm-skip fix this PR is stacked on), so the numerator is 0.
+SEED_FELLOWS = [
+    {
+        "record_id": f"seed-{i}",
+        "slug": f"seed_{i}",
+        "name": f"Seed {i}",
+        "has_image": 1,
+        "has_contact_email": 1,
+        "contact_email": f"seed{i}@example.com",
+    }
+    for i in range(1, 6)
+]
+
+
+def _boot_into_api_idb_fallback(context, page, base_url):
+    context.route(
+        FELLOWS_DB,
+        lambda r: r.fulfill(status=401, body="session expired"),
+    )
+    context.route(
+        API_FELLOWS,
+        lambda r: r.fulfill(status=401, body="session expired"),
+    )
+    context.route(
+        API_AUTH_STATUS,
+        lambda r: r.fulfill(
+            status=200,
+            content_type="application/json",
+            body=json.dumps({
+                "authEnabled": True,
+                "authenticated": False,
+                "hasSessionCookie": False,
+                "installRecentlyAllowed": False,
+            }),
+        ),
+    )
+    page.goto(base_url + "/", wait_until="domcontentloaded")
+    page.wait_for_function("() => !!(window.indexedDB)", timeout=5000)
+    _seed_indexeddb_with_fellows(page, SEED_FELLOWS)
+    page.reload(wait_until="domcontentloaded")
+    page.locator("#loading").wait_for(state="hidden", timeout=10000)
+    page.locator("#directory").wait_for(state="visible", timeout=5000)
+    kind = page.evaluate(
+        "() => (window.__dataProvider && window.__dataProvider.kind) || null"
+    )
+    assert kind == "api+idb", f"expected api+idb fallback, got {kind!r}"
+
+
+class TestAboutImageCompletenessRow:
+    def test_about_row_shows_count_and_signin_cta_in_fallback(
+        self, context, base_url_fixture
+    ):
+        """In api+idb fallback with an incomplete image cache, About
+        renders a 'Profile photos' row with a 'Sign in' link to
+        /?gate=1. Pre-fix this row doesn't exist; the user has no
+        in-app explanation for missing photos."""
+        page = _make_standalone_page(context)
+        try:
+            _boot_into_api_idb_fallback(context, page, base_url_fixture)
+            page.evaluate("location.hash = '#/about'")
+            page.locator("#about-images-row").wait_for(
+                state="visible", timeout=5000
+            )
+            status = page.locator("#about-images-status")
+            # Counter should read "0 / 5 cached" (5 seeded fellows, all
+            # has_image=1, cache empty because prewarm was skipped).
+            expect(status).to_contain_text("0", timeout=3000)
+            expect(status).to_contain_text("5")
+            # CTA should be present and point at /?gate=1.
+            action = page.locator("#about-images-action a")
+            expect(action).to_be_visible()
+            href = action.get_attribute("href")
+            assert href and "gate=1" in href, (
+                f"sign-in link should target /?gate=1, got {href!r}"
+            )
+        finally:
+            context.unroute(FELLOWS_DB)
+            context.unroute(API_FELLOWS)
+            context.unroute(API_AUTH_STATUS)
+            page.close()
+
+    def test_about_row_omits_signin_cta_in_worker_mode(
+        self, standalone_page, base_url_fixture
+    ):
+        """Happy path: worker provider, no fallback. The row still
+        renders the count (informational), but no sign-in CTA — the
+        user is already authenticated; clicking gate=1 would log them
+        out and is the wrong affordance."""
+        page = standalone_page
+        page.goto(base_url_fixture + "/", wait_until="domcontentloaded")
+        page.locator("#loading").wait_for(state="hidden", timeout=10000)
+        page.locator("#directory").wait_for(state="visible", timeout=5000)
+        kind = page.evaluate(
+            "() => (window.__dataProvider && window.__dataProvider.kind) || null"
+        )
+        assert kind == "worker", f"happy path needs worker provider, got {kind!r}"
+        page.evaluate("location.hash = '#/about'")
+        page.locator("#about-images-row").wait_for(state="visible", timeout=5000)
+        action = page.locator("#about-images-action a")
+        # The action slot exists in DOM but should NOT contain a sign-in
+        # link in worker mode. .count() returns 0 when no link rendered.
+        assert action.count() == 0, (
+            "worker-mode About row must not offer a sign-in CTA; "
+            "the user is already signed in"
+        )

--- a/tests/e2e/test_never_saas_copy.py
+++ b/tests/e2e/test_never_saas_copy.py
@@ -180,13 +180,15 @@ class TestCheckForUpdatesCopy:
             page.locator("#about-check-updates").wait_for(state="visible", timeout=5000)
             page.locator("#about-check-updates").click()
             data_row = page.locator("#about-data-status")
-            expect(data_row).not_to_contain_text(
-                "isn", timeout=5000
-            )  # "isn't available in this browser" — the wrong attribution
-            # Post-fix copy should mention sign-in (case-insensitive).
+            # Wait for the FINAL post-click state, not just the absence
+            # of the wrong-attribution copy. The in-progress "Checking…"
+            # text passes `not_to_contain_text('isn')` but isn't the
+            # final state; polling on the absence creates a race that
+            # async work on the About page render can re-tickle.
+            expect(data_row).to_contain_text("Sign in", timeout=5000)
             row_text = data_row.text_content() or ""
-            assert "sign in" in row_text.lower() or "magic link" in row_text.lower(), (
-                f"data row should suggest re-authentication, got: {row_text!r}"
+            assert "isn’t available" not in row_text and "isn't available" not in row_text, (
+                f"data row must not blame the browser; got: {row_text!r}"
             )
         finally:
             context.unroute(FELLOWS_DB)


### PR DESCRIPTION
**Stacked on #176** (prewarm-skip). Auto-retargets to \`main\` as the stack merges.

Plan: Option A from [\`plans/user_folder_storage.md\` § Refreshable assets](https://github.com/richbodo/fellows_local_db/blob/feat/user-folder-storage/plans/user_folder_storage.md). Together with #176, this closes the "first-boot-in-fallback users get no images and don't know why" UX gap.

## What the user sees

New row in the About page's update-check block, alongside App / Directory data / Signing key:

| When | Status text | Action |
|---|---|---|
| Worker mode (authenticated) — cache full | `251 of 251 cached` | (none) |
| Worker mode — cache filling | `42 of 251 cached` | (none — the user is authenticated; prewarm will fill it) |
| **api+idb fallback — cache partial** | **\`0 of 251 cached\`** | **\`Sign in to fetch the rest\`** → \`/?gate=1\` |
| Cache API unavailable | \`Image cache unavailable in this browser.\` | (none) |

## Why the CTA conditions are what they are

The Sign-in link fires only when (a) we're on the api+idb fallback (no live session) AND (b) the cache is partial. In worker mode the user is already authenticated — a sign-in link would log them out and is the wrong affordance. The case the CTA addresses is exactly the user-reported one: a fresh install whose first boot landed in fallback because the magic-link session had already expired.

## What changed

- \`app/static/app.js\` — new \`#about-images-row\` rendered in the update-check block; new \`renderImagesCompletenessRow\` IIFE that computes (cached / withImageTotal) and conditionally renders the sign-in CTA.
- \`tests/e2e/test_about_image_completeness_row.py\` (new) — two cases (fallback shows row + CTA; worker mode shows row without CTA).
- \`tests/e2e/test_never_saas_copy.py\` — hardened \`test_data_row_offers_sign_in_when_worker_opfs_capable\` against a pre-existing race. The test polled on the *absence* of "isn't available" instead of the *presence* of the final "Sign in" copy; the intermediate "Checking…" text passed the absence check and flaked. Exposed by my new async \`countCachedImages()\` work on About render. Three consecutive runs confirm stable after fix.

## Test plan

- [x] \`just test-e2e about_image_completeness_row\` — 2/2 pass
- [x] \`just test-e2e never_saas_copy::TestCheckForUpdatesCopy\` — 3 consecutive runs, all green
- [x] \`just test-e2e about_image_completeness_row image_prewarm_skip_in_fallback about_stats directory_data_update_flow never_saas_copy warm_worker_backup_fallback warm_worker_groups_fallback\` — 23/23
- [ ] **Manual on Android post-merge:** boot with expired session, navigate to About, confirm the Profile photos row shows \`0 of 251 cached\` with a \`Sign in to fetch the rest\` button that lands on the email gate.

🤖 Generated with [Claude Code](https://claude.com/claude-code)