### PR TITLE
feat(folder-storage): P1 — user-folder durable storage (issue #165)

### DIFF
--- a/app/static/app.js
+++ b/app/static/app.js
@@ -37,7 +37,7 @@
   // app/static/vendor/sqlite-worker.js (`WORKER_RPC_VERSION`,
   // `RELATIONSHIPS_SCHEMA_VERSION`). See plans/local_first_worker_architecture.md
   // §"Why build label is not the gate".
-  var EXPECTED_WORKER_RPC_VERSION = 2;
+  var EXPECTED_WORKER_RPC_VERSION = 3;
   var EXPECTED_RELATIONSHIPS_SCHEMA_VERSION = 1;
 
   // Thrown by mutating dataProvider methods when the worker reports a
@@ -2545,6 +2545,41 @@
         (pss.finishedAt ? ' at=' + pss.finishedAt : '')
       );
     }
+    // Data folder (issue #165 Phase 1) — handle present? what subfolder?
+    // last save outcome? Pulled live from the worker so this reflects
+    // current truth even after the user disconnects mid-session.
+    lines.push('');
+    lines.push('Data folder:');
+    try {
+      var folderCtrl = window.__folderController;
+      if (!folderCtrl) {
+        lines.push('  (folder controller not initialized)');
+      } else {
+        var fState = await folderCtrl.getState();
+        lines.push('  browser supports showDirectoryPicker: ' + !!fState.supported);
+        lines.push('  worker reachable: ' + !!fState.workerAvailable);
+        lines.push('  handle persisted: ' + !!fState.hasHandle);
+        if (fState.hasHandle) {
+          lines.push('  parent folder name: ' + (fState.parentName || '(unset)'));
+          lines.push('  subfolder name: ' + (fState.subfolderName || '(unset)'));
+          lines.push('  permission: ' + (fState.permission || '(unknown)'));
+          lines.push('  last saved at: ' + (fState.lastSavedAt || '(never)'));
+          if (fState.fileLastModified) {
+            lines.push('  file mtime (folder): ' + new Date(fState.fileLastModified).toISOString());
+          }
+          if (fState.fileSize != null) {
+            lines.push('  file size (folder): ' + fState.fileSize + ' bytes');
+          }
+          if (fState.lastError && fState.lastError.reason) {
+            lines.push('  last error: ' + fState.lastError.reason +
+              ' at ' + (fState.lastError.at || '(unknown)'));
+          }
+        }
+        lines.push('  badge: ' + folderCtrl.badge(fState));
+      }
+    } catch (folderErr) {
+      lines.push('  (read failed: ' + String(folderErr && folderErr.message || folderErr) + ')');
+    }
     lines.push('');
     // Auth trace: which routing branches fired during this page load.
     // Mirrors the "Auth trace" surfaced in the bug-report dialog —
@@ -3684,6 +3719,29 @@
       },
       _findOrphanedGroupMembers: function () {
         return rpc.call('findOrphanedGroupMembers');
+      },
+      // ----- User-folder durable storage (issue #165 Phase 1).
+      // Reads are version-tolerant — page surfaces folder state even on
+      // a stale worker, since the badge has to make sense before the
+      // user reloads. Writes are gated alongside other mutations.
+      _getFolderState: function () { return rpc.call('getFolderState'); },
+      _setFolderHandle: function (args) {
+        return refuseIfVersionSkew('setFolderHandle') ||
+          rpc.call('setFolderHandle', args);
+      },
+      _clearFolderHandle: function () {
+        return refuseIfVersionSkew('clearFolderHandle') ||
+          rpc.call('clearFolderHandle');
+      },
+      _checkFolderPermission: function () { return rpc.call('checkFolderPermission'); },
+      _getFolderHandleForReconnect: function () { return rpc.call('getFolderHandleForReconnect'); },
+      _writeRelationshipsToFolder: function () {
+        return refuseIfVersionSkew('writeRelationshipsToFolder') ||
+          rpc.call('writeRelationshipsToFolder');
+      },
+      _readRelationshipsFromFolder: function () {
+        return refuseIfVersionSkew('readRelationshipsFromFolder') ||
+          rpc.call('readRelationshipsFromFolder');
       }
     };
   }
@@ -7991,6 +8049,164 @@
     });
   }
 
+  // ===== User-folder durable storage controller (issue #165 Phase 1) =======
+  // Page-side wrapper around the worker's folder RPCs + the small bit of
+  // user-gesture orchestration that has to live here (showDirectoryPicker
+  // and requestPermission both require transient user activation; the
+  // worker can't synthesize that). Pure controller — owns no DOM; the
+  // Settings page consumes it through render-time callbacks.
+
+  var FOLDER_CONTROLLER = (function () {
+    function browserSupportsFolderPicker() {
+      return typeof window.showDirectoryPicker === 'function';
+    }
+
+    function workerProvider() {
+      // The folder controller only operates against the worker provider.
+      // On api+idb fallback the warmWorker may still be alive (auth
+      // failure mid-boot); fall through to it so a Reconnect attempt in
+      // Settings doesn't pop a misleading "not available" message.
+      if (dataProvider && dataProvider.kind === 'worker') return dataProvider;
+      if (warmWorker && warmWorker.rpc) {
+        // Wrap a minimal subset around warmWorker.rpc so the API shape
+        // matches the worker provider.
+        return {
+          kind: 'worker-warm',
+          _getFolderState: function () { return warmWorker.rpc.call('getFolderState'); },
+          _setFolderHandle: function (a) { return warmWorker.rpc.call('setFolderHandle', a); },
+          _clearFolderHandle: function () { return warmWorker.rpc.call('clearFolderHandle'); },
+          _checkFolderPermission: function () { return warmWorker.rpc.call('checkFolderPermission'); },
+          _getFolderHandleForReconnect: function () { return warmWorker.rpc.call('getFolderHandleForReconnect'); },
+          _writeRelationshipsToFolder: function () { return warmWorker.rpc.call('writeRelationshipsToFolder'); },
+          _readRelationshipsFromFolder: function () { return warmWorker.rpc.call('readRelationshipsFromFolder'); }
+        };
+      }
+      return null;
+    }
+
+    function getState() {
+      var p = workerProvider();
+      if (!p) {
+        return Promise.resolve({
+          supported: browserSupportsFolderPicker(),
+          workerAvailable: false,
+          hasHandle: false,
+          parentName: null,
+          subfolderName: null,
+          permission: 'no-worker',
+          lastSavedAt: null,
+          lastError: null,
+          fileLastModified: null
+        });
+      }
+      return p._getFolderState().then(function (raw) {
+        raw.supported = browserSupportsFolderPicker();
+        raw.workerAvailable = true;
+        return raw;
+      });
+    }
+
+    // Compute the badge state from a state snapshot. Returns one of:
+    //   'unsupported'   — browser has no showDirectoryPicker.
+    //   'browser-only'  — supported but no folder chosen.
+    //   'saved'         — folder chosen and last write succeeded.
+    //   'pending'       — folder chosen but no write yet (open-existing path).
+    //   'inaccessible'  — folder chosen but queryPermission isn't 'granted'.
+    //   'write-failed'  — most recent write attempt errored.
+    function badge(state) {
+      if (!state.supported) return 'unsupported';
+      if (!state.hasHandle) return 'browser-only';
+      if (state.permission !== 'granted') return 'inaccessible';
+      if (state.lastError && state.lastError.at &&
+          (!state.lastSavedAt || state.lastError.at > state.lastSavedAt)) {
+        return 'write-failed';
+      }
+      if (!state.lastSavedAt) return 'pending';
+      return 'saved';
+    }
+
+    // Step 1: invoke the OS folder picker. Must be called from a user-
+    // gesture handler (showDirectoryPicker requires transient activation).
+    // Returns the FileSystemDirectoryHandle, or null on user-cancel /
+    // unsupported.
+    function pickParentFolder() {
+      if (!browserSupportsFolderPicker()) return Promise.resolve(null);
+      return window.showDirectoryPicker({ mode: 'readwrite', id: 'fellows-data-folder' })
+        .catch(function (e) {
+          // AbortError = user cancelled the picker. Treat as null, not a
+          // failure to surface to the user.
+          if (e && (e.name === 'AbortError' || /cancel/i.test(String(e.message || '')))) return null;
+          throw e;
+        });
+    }
+
+    // Step 2: hand the handle to the worker. Returns either
+    //   { ok: true, parentName, subfolderName }
+    // or
+    //   { ok: false, requiresChoice: true, existing, suggestion }
+    function setHandle(handle, mode) {
+      var p = workerProvider();
+      if (!p) return Promise.reject(new Error('worker provider unavailable'));
+      return p._setFolderHandle({ handle: handle, mode: mode || 'auto' });
+    }
+
+    function clearHandle() {
+      var p = workerProvider();
+      if (!p) return Promise.reject(new Error('worker provider unavailable'));
+      return p._clearFolderHandle();
+    }
+
+    function writeNow() {
+      var p = workerProvider();
+      if (!p) return Promise.reject(new Error('worker provider unavailable'));
+      return p._writeRelationshipsToFolder();
+    }
+
+    function readNow() {
+      var p = workerProvider();
+      if (!p) return Promise.reject(new Error('worker provider unavailable'));
+      return p._readRelationshipsFromFolder();
+    }
+
+    // Reconnect path: pull the in-memory handle from the worker, call
+    // requestPermission on it inside the page's user-gesture, then ask
+    // the worker to recheck. Returns the new state.
+    function reconnect() {
+      var p = workerProvider();
+      if (!p) return Promise.reject(new Error('worker provider unavailable'));
+      return p._getFolderHandleForReconnect().then(function (res) {
+        if (!res || !res.handle) {
+          throw new Error('no folder handle persisted');
+        }
+        var handle = res.handle;
+        if (typeof handle.requestPermission !== 'function') {
+          // Older shim — already granted (was returned by the picker).
+          return p._checkFolderPermission().then(function () { return getState(); });
+        }
+        return handle.requestPermission({ mode: 'readwrite' }).then(function (state) {
+          // Worker re-runs queryPermission to refresh its cached value.
+          return p._checkFolderPermission().then(function () {
+            return getState();
+          });
+        });
+      });
+    }
+
+    return {
+      browserSupportsFolderPicker: browserSupportsFolderPicker,
+      getState: getState,
+      badge: badge,
+      pickParentFolder: pickParentFolder,
+      setHandle: setHandle,
+      clearHandle: clearHandle,
+      writeNow: writeNow,
+      readNow: readNow,
+      reconnect: reconnect
+    };
+  })();
+  // Exposed for tests + diag panel.
+  window.__folderController = FOLDER_CONTROLLER;
+
   // ===== Settings page (PR 5) ==============================================
 
   function renderSettingsPage() {
@@ -8015,6 +8231,37 @@
           '<span id="settings-status" class="settings-status" aria-live="polite"></span>' +
         '</div>' +
       '</form>' +
+      '<div class="settings-section" id="settings-folder-section">' +
+        '<h3 class="settings-section-title">Data folder</h3>' +
+        '<p class="settings-hint">' +
+          'Pick a folder on your device for the app to keep <code>relationships.db</code> in. ' +
+          'The app creates a <code>Fellows/</code> subfolder inside the folder you choose, so your other files in that folder are untouched. ' +
+          'Your data still lives on your device — nothing is uploaded — but it becomes a real file you can browse to, copy, sync, or back up like any other file.' +
+        '</p>' +
+        '<div id="settings-folder-badge" class="settings-folder-badge" role="status" aria-live="polite">' +
+          '<span class="settings-folder-badge-dot"></span>' +
+          '<span class="settings-folder-badge-text">Checking…</span>' +
+        '</div>' +
+        '<div id="settings-folder-actions" class="settings-folder-actions">' +
+          '<button type="button" id="settings-folder-choose" class="settings-download" hidden>Choose data folder…</button>' +
+          '<button type="button" id="settings-folder-save-now" class="settings-download" hidden>Save now</button>' +
+          '<button type="button" id="settings-folder-refresh" class="settings-download" hidden>Refresh from folder</button>' +
+          '<button type="button" id="settings-folder-reconnect" class="settings-download" hidden>Reconnect folder…</button>' +
+          '<button type="button" id="settings-folder-disconnect" class="settings-download settings-folder-disconnect" hidden>Disconnect folder</button>' +
+        '</div>' +
+        '<p id="settings-folder-detail" class="settings-hint settings-folder-detail" hidden></p>' +
+      '</div>' +
+      '<dialog id="settings-folder-collision-dialog" class="settings-folder-dialog">' +
+        '<form method="dialog">' +
+          '<h4 id="settings-folder-collision-title">This folder already contains fellows data</h4>' +
+          '<p id="settings-folder-collision-body"></p>' +
+          '<menu class="settings-folder-dialog-actions">' +
+            '<button type="submit" value="create-new" class="settings-folder-dialog-primary" id="settings-folder-collision-create"></button>' +
+            '<button type="submit" value="open-existing" class="settings-folder-dialog-secondary">Open existing data</button>' +
+            '<button type="submit" value="cancel" class="settings-folder-dialog-cancel">Cancel</button>' +
+          '</menu>' +
+        '</form>' +
+      '</dialog>' +
       '<div class="settings-section" id="settings-export-section">' +
         '<h3 class="settings-section-title">Your saved data</h3>' +
         '<p class="settings-hint">' +
@@ -8422,6 +8669,330 @@
           });
       });
     }
+
+    wireFolderSection();
+  }
+
+  // Settings → Data folder section: badge, action buttons, collision
+  // dialog. State is owned by FOLDER_CONTROLLER; this function is pure
+  // glue between the controller and the DOM nodes injected by
+  // renderSettingsPage.
+  function wireFolderSection() {
+    var sectionEl = document.getElementById('settings-folder-section');
+    if (!sectionEl) return;
+    var badgeEl = document.getElementById('settings-folder-badge');
+    var detailEl2 = document.getElementById('settings-folder-detail');
+    var btnChoose = document.getElementById('settings-folder-choose');
+    var btnSave = document.getElementById('settings-folder-save-now');
+    var btnRefresh = document.getElementById('settings-folder-refresh');
+    var btnReconnect = document.getElementById('settings-folder-reconnect');
+    var btnDisconnect = document.getElementById('settings-folder-disconnect');
+    var dialog = document.getElementById('settings-folder-collision-dialog');
+    var dialogTitle = document.getElementById('settings-folder-collision-title');
+    var dialogBody = document.getElementById('settings-folder-collision-body');
+    var dialogCreateBtn = document.getElementById('settings-folder-collision-create');
+
+    if (!FOLDER_CONTROLLER) return;
+
+    var BADGE_COPY = {
+      'unsupported': {
+        text: 'Browser-only — this browser doesn\'t support saving to a folder',
+        cls: 'settings-folder-badge--warning'
+      },
+      'browser-only': {
+        text: 'Browser-only — your data is not yet saved to a folder',
+        cls: 'settings-folder-badge--warning'
+      },
+      'saved': {
+        text: 'Saved',
+        cls: 'settings-folder-badge--saved'
+      },
+      'pending': {
+        text: 'Folder selected — no save yet',
+        cls: 'settings-folder-badge--pending'
+      },
+      'inaccessible': {
+        text: 'Folder set but unreachable — reconnect to keep saving',
+        cls: 'settings-folder-badge--warning'
+      },
+      'write-failed': {
+        text: 'Last save failed — Retry to save again',
+        cls: 'settings-folder-badge--warning'
+      }
+    };
+
+    function renderState(state) {
+      if (!state) return;
+      var b = FOLDER_CONTROLLER.badge(state);
+      var copy = BADGE_COPY[b] || BADGE_COPY['browser-only'];
+      var dotEl = badgeEl && badgeEl.querySelector('.settings-folder-badge-dot');
+      var textEl = badgeEl && badgeEl.querySelector('.settings-folder-badge-text');
+      if (badgeEl) {
+        badgeEl.className = 'settings-folder-badge ' + copy.cls;
+        if (textEl) {
+          var label = copy.text;
+          if (b === 'saved' && state.parentName && state.subfolderName) {
+            label = 'Saved to ' + escapeHtml(state.parentName) + ' / ' + escapeHtml(state.subfolderName);
+            if (state.lastSavedAt) label += ' · ' + formatRelativeTime(state.lastSavedAt);
+            textEl.innerHTML = label;
+          } else {
+            textEl.textContent = label;
+          }
+        }
+        if (dotEl) dotEl.setAttribute('aria-hidden', 'true');
+      }
+      // The detail line is reserved for transient status/errors (the
+      // flashDetail messages). Don't stomp on it here — the badge above
+      // already shows folder path + timestamp, and an in-progress
+      // "Saving…" flash would be lost if we overwrote on every refresh.
+      // We only update detailEl2 here for a sticky error message; the
+      // happy path leaves whatever flashDetail last wrote in place.
+      if (detailEl2 && state.lastError && state.lastError.reason &&
+          (!state.lastSavedAt || (state.lastError.at && state.lastError.at > state.lastSavedAt))) {
+        detailEl2.textContent = 'Last error: ' + state.lastError.reason;
+        detailEl2.hidden = false;
+      }
+      // Wire which buttons are visible to the badge state.
+      var supported = !!state.supported && (state.workerAvailable !== false);
+      function showBtn(btn, on) { if (btn) btn.hidden = !on; }
+      showBtn(btnChoose,     supported && (b === 'browser-only'));
+      showBtn(btnSave,       supported && (b === 'pending' || b === 'saved' || b === 'write-failed'));
+      showBtn(btnRefresh,    supported && b === 'saved');
+      showBtn(btnReconnect,  supported && b === 'inaccessible');
+      showBtn(btnDisconnect, supported && state.hasHandle);
+    }
+
+    function refresh() {
+      return FOLDER_CONTROLLER.getState().then(renderState).catch(function (e) {
+        if (detailEl2) {
+          detailEl2.textContent = 'Could not read folder state: ' + (e && e.message || String(e));
+          detailEl2.hidden = false;
+        }
+      });
+    }
+
+    function flashDetail(msg) {
+      if (!detailEl2) return;
+      detailEl2.textContent = msg;
+      detailEl2.hidden = false;
+    }
+
+    function fmtCountsSummary(c) {
+      if (!c) return '';
+      return c.groups + ' group' + (c.groups === 1 ? '' : 's') +
+        ', ' + c.members + ' member' + (c.members === 1 ? '' : 's') +
+        ', ' + c.tags + ' tag' + (c.tags === 1 ? '' : 's');
+    }
+
+    function askCollision(parentName, existing, suggestion) {
+      // Native <dialog>.showModal — falls back to confirm() on browsers
+      // without dialog support (extremely rare in 2026; Chromium/Safari/
+      // Firefox all ship it).
+      if (!dialog || typeof dialog.showModal !== 'function') {
+        var msg = (existing && existing.counts)
+          ? 'This folder already has fellows data (' + fmtCountsSummary(existing.counts) + '). ' +
+            'Use existing data here? OK → Open existing · Cancel → save to a new folder (' + suggestion + ').'
+          : 'This folder already has fellows data. OK → Open existing · Cancel → save to a new folder (' + suggestion + ').';
+        return Promise.resolve(window.confirm(msg) ? 'open-existing' : 'create-new');
+      }
+      if (dialogTitle) {
+        dialogTitle.textContent = parentName
+          ? '"' + parentName + '" already contains fellows data'
+          : 'This folder already contains fellows data';
+      }
+      if (dialogBody) {
+        var summary = existing && existing.counts ? fmtCountsSummary(existing.counts) : '';
+        var lines = [];
+        if (existing && existing.subfolderName) {
+          lines.push('A "' + existing.subfolderName + '" folder is already there' +
+            (summary ? ' with ' + summary + '.' : '.'));
+        }
+        if (existing && existing.invalid) {
+          lines.push('(Existing relationships.db looks unreadable: ' +
+            (existing.invalidReason || 'unknown') + '.)');
+        }
+        lines.push(
+          'To avoid overwriting it, the app can save your current data into a new "' +
+          (suggestion || 'Fellows N') + '" folder. Or open the existing data and use it here.'
+        );
+        dialogBody.textContent = lines.join(' ');
+      }
+      if (dialogCreateBtn) {
+        dialogCreateBtn.textContent = 'Create "' + (suggestion || 'Fellows N') + '"';
+      }
+      return new Promise(function (resolve) {
+        dialog.addEventListener('close', function once() {
+          dialog.removeEventListener('close', once);
+          var v = dialog.returnValue;
+          if (v === 'open-existing' || v === 'create-new') resolve(v);
+          else resolve(null);
+        });
+        try { dialog.showModal(); }
+        catch (e) {
+          // Already open or browser quirk — treat as cancel.
+          resolve(null);
+        }
+      });
+    }
+
+    if (btnChoose) {
+      btnChoose.addEventListener('click', function () {
+        btnChoose.disabled = true;
+        flashDetail('Pick a folder…');
+        FOLDER_CONTROLLER.pickParentFolder()
+          .then(function (handle) {
+            if (!handle) {
+              flashDetail('No folder selected.');
+              return null;
+            }
+            return FOLDER_CONTROLLER.setHandle(handle, 'auto').then(function (res) {
+              if (res && res.requiresChoice) {
+                return askCollision(res.parentName, res.existing, res.suggestion).then(function (choice) {
+                  if (!choice) {
+                    flashDetail('Cancelled.');
+                    return null;
+                  }
+                  return FOLDER_CONTROLLER.setHandle(handle, choice).then(function (resolved) {
+                    return { picked: resolved, mode: choice };
+                  });
+                });
+              }
+              return { picked: res, mode: 'auto' };
+            });
+          })
+          .then(function (outcome) {
+            if (!outcome || !outcome.picked || !outcome.picked.ok) return;
+            // Newly-attached folder: do an immediate save so the badge
+            // flips to "Saved" right away on create-new, and (for the
+            // happy-path "auto" case where the subfolder was empty) the
+            // file exists. open-existing skips the write and instead
+            // reads the existing data into OPFS.
+            if (outcome.mode === 'open-existing') {
+              flashDetail('Loading existing data from folder…');
+              return FOLDER_CONTROLLER.readNow().then(function (result) {
+                flashDetail('Loaded ' + (result && result.counts ? fmtCountsSummary(result.counts) : '') +
+                  ' from the folder.');
+              });
+            }
+            flashDetail('Saving to folder…');
+            return FOLDER_CONTROLLER.writeNow().then(function () { flashDetail('Saved.'); });
+          })
+          .catch(function (e) {
+            flashDetail('Could not set folder: ' + (e && e.message || String(e)));
+          })
+          .then(function () {
+            btnChoose.disabled = false;
+            return refresh();
+          });
+      });
+    }
+
+    if (btnSave) {
+      btnSave.addEventListener('click', function () {
+        btnSave.disabled = true;
+        flashDetail('Saving to folder…');
+        FOLDER_CONTROLLER.writeNow()
+          .then(function (res) {
+            flashDetail('Saved (' + res.bytesWritten + ' bytes).');
+          })
+          .catch(function (e) {
+            flashDetail('Save failed: ' + (e && e.message || String(e)));
+          })
+          .then(function () {
+            btnSave.disabled = false;
+            return refresh();
+          });
+      });
+    }
+
+    if (btnRefresh) {
+      btnRefresh.addEventListener('click', function () {
+        var ok = window.confirm(
+          'Replace this browser\'s saved data with whatever\'s in the folder?\n\n' +
+          'Your current data is captured as an auto-backup first, so this is undoable.'
+        );
+        if (!ok) return;
+        btnRefresh.disabled = true;
+        flashDetail('Reading from folder…');
+        FOLDER_CONTROLLER.readNow()
+          .then(function (res) {
+            flashDetail('Loaded ' + fmtCountsSummary(res.counts) + ' from the folder.' +
+              (res.preRestoreSnapshot ? ' Previous data saved as auto-backup.' : ''));
+          })
+          .catch(function (e) {
+            flashDetail('Refresh failed: ' + (e && e.message || String(e)));
+          })
+          .then(function () {
+            btnRefresh.disabled = false;
+            return refresh();
+          });
+      });
+    }
+
+    if (btnReconnect) {
+      btnReconnect.addEventListener('click', function () {
+        btnReconnect.disabled = true;
+        flashDetail('Reconnecting…');
+        FOLDER_CONTROLLER.reconnect()
+          .then(function (state) {
+            renderState(state);
+            if (state && state.permission === 'granted') {
+              flashDetail('Reconnected.');
+            } else {
+              flashDetail('Reconnect declined — folder still unreachable.');
+            }
+          })
+          .catch(function (e) {
+            flashDetail('Reconnect failed: ' + (e && e.message || String(e)));
+          })
+          .then(function () {
+            btnReconnect.disabled = false;
+          });
+      });
+    }
+
+    if (btnDisconnect) {
+      btnDisconnect.addEventListener('click', function () {
+        var ok = window.confirm(
+          'Disconnect this folder?\n\n' +
+          'Your data stays in this browser (and the file in the folder is untouched). ' +
+          'You can re-pick the same folder later to reconnect.'
+        );
+        if (!ok) return;
+        btnDisconnect.disabled = true;
+        FOLDER_CONTROLLER.clearHandle()
+          .then(function () { flashDetail('Disconnected.'); })
+          .catch(function (e) {
+            flashDetail('Disconnect failed: ' + (e && e.message || String(e)));
+          })
+          .then(function () {
+            btnDisconnect.disabled = false;
+            return refresh();
+          });
+      });
+    }
+
+    refresh();
+  }
+
+  // Tiny relative-time formatter: "just now", "2 min ago", etc. Used by
+  // the folder badge so the timestamp doesn't dominate the UI.
+  function formatRelativeTime(iso) {
+    if (!iso) return '';
+    var t = new Date(iso).getTime();
+    if (isNaN(t)) return iso;
+    var ms = Date.now() - t;
+    if (ms < 0) return new Date(iso).toLocaleString();
+    var sec = Math.round(ms / 1000);
+    if (sec < 30) return 'just now';
+    if (sec < 60) return sec + 's ago';
+    var min = Math.round(sec / 60);
+    if (min < 60) return min + ' min ago';
+    var hr = Math.round(min / 60);
+    if (hr < 24) return hr + ' hr ago';
+    var day = Math.round(hr / 24);
+    if (day < 30) return day + ' day' + (day === 1 ? '' : 's') + ' ago';
+    return new Date(iso).toLocaleDateString();
   }
 
   /** Boot-time: if relationships.settings is empty for self_email but

--- a/app/static/styles.css
+++ b/app/static/styles.css
@@ -3247,6 +3247,125 @@ a.group-action-btn--primary {
   color: #fff;
 }
 
+/* Data folder section (issue #165 Phase 1) — durable storage badge +
+   actions. The badge is the load-bearing element; its color signals
+   whether the user's data is saved-to-disk, only-in-browser, or in a
+   warning state requiring attention. */
+.settings-folder-badge {
+  display: inline-flex;
+  align-items: center;
+  gap: 0.5rem;
+  padding: 0.4rem 0.75rem;
+  border-radius: 999px;
+  font-size: 0.9rem;
+  font-weight: 600;
+  margin-top: 0.5rem;
+  border: 1px solid transparent;
+  line-height: 1.2;
+}
+
+.settings-folder-badge-dot {
+  width: 0.6rem;
+  height: 0.6rem;
+  border-radius: 50%;
+  background: #94a3b8;
+  flex-shrink: 0;
+}
+
+.settings-folder-badge--saved {
+  background: #dcfce7;
+  color: #14532d;
+  border-color: #86efac;
+}
+.settings-folder-badge--saved .settings-folder-badge-dot { background: #16a34a; }
+
+.settings-folder-badge--pending {
+  background: #e0e7ff;
+  color: #312e81;
+  border-color: #c7d2fe;
+}
+.settings-folder-badge--pending .settings-folder-badge-dot { background: #6366f1; }
+
+.settings-folder-badge--warning {
+  background: #fef3c7;
+  color: #78350f;
+  border-color: #fcd34d;
+}
+.settings-folder-badge--warning .settings-folder-badge-dot { background: #d97706; }
+
+.settings-folder-actions {
+  display: flex;
+  flex-wrap: wrap;
+  gap: 0.5rem;
+  margin-top: 0.5rem;
+}
+
+.settings-folder-detail {
+  margin-top: 0.5rem;
+  font-style: italic;
+}
+
+.settings-folder-disconnect {
+  border-color: #fca5a5;
+  color: #991b1b;
+}
+.settings-folder-disconnect:hover:not(:disabled) { background: #fef2f2; }
+
+/* Collision dialog — confirm "Open existing" vs "Create Fellows 2".
+   <dialog> ships its own default styling on Chromium/Firefox/Safari;
+   we just tighten typography and reset the action-row layout. */
+.settings-folder-dialog {
+  border: 1px solid #cbd5e1;
+  border-radius: 8px;
+  padding: 1.25rem;
+  max-width: 28rem;
+  font: inherit;
+}
+.settings-folder-dialog::backdrop {
+  background: rgba(15, 23, 42, 0.45);
+}
+.settings-folder-dialog h4 {
+  margin: 0 0 0.6rem;
+  font-size: 1.05rem;
+  color: var(--text-strong, #0f172a);
+}
+.settings-folder-dialog p {
+  margin: 0 0 1rem;
+  font-size: 0.92rem;
+  color: #334155;
+  line-height: 1.45;
+}
+.settings-folder-dialog-actions {
+  margin: 0;
+  padding: 0;
+  display: flex;
+  flex-wrap: wrap;
+  gap: 0.5rem;
+  justify-content: flex-end;
+}
+.settings-folder-dialog-actions button {
+  font: inherit;
+  font-size: 0.9rem;
+  padding: 0.4rem 0.9rem;
+  border-radius: 3px;
+  border: 1px solid #94a3b8;
+  background: #fff;
+  color: var(--text-strong, #0f172a);
+  cursor: pointer;
+  font-weight: 600;
+}
+.settings-folder-dialog-actions button:hover { background: #f1f5f9; }
+.settings-folder-dialog-primary {
+  background: var(--accent) !important;
+  border-color: var(--accent) !important;
+  color: #fff !important;
+}
+.settings-folder-dialog-primary:hover { filter: brightness(0.95); }
+.settings-folder-dialog-cancel {
+  margin-right: auto;
+  color: #64748b !important;
+}
+
 .settings-backup-restore:disabled {
   opacity: 0.5;
   cursor: not-allowed;

--- a/app/static/vendor/sqlite-worker.js
+++ b/app/static/vendor/sqlite-worker.js
@@ -43,7 +43,14 @@ importScripts('./sqlite3.js');
 // arg and SHA-keyed refresh semantics. Page bumps its expected value in
 // lockstep; a stale page paired with this worker (or vice versa) refuses
 // mutations and waits for the SW's "New version available" reload banner.
-var WORKER_RPC_VERSION = 2;
+// v3 (issue #165 P1): user-folder durable storage RPCs added —
+// setFolderHandle / getFolderState / clearFolderHandle / checkFolderPermission /
+// getFolderHandleForReconnect / writeRelationshipsToFolder /
+// readRelationshipsFromFolder. Reads (getFolderState, checkFolderPermission)
+// are version-tolerant — the page is allowed to read folder state even
+// against a stale worker — but the mutating ops are version-gated alongside
+// the existing relationships.db writes.
+var WORKER_RPC_VERSION = 3;
 
 // Same value as relationships.db's PRAGMA user_version. Bumped only on
 // schema migrations. Mirrored from app/relationships.py:SCHEMA_VERSION.
@@ -599,6 +606,12 @@ handlers.init = async function () {
   // (per L4a). Init is network-free.
   var hasFellowsDb = _openFellowsDbIfPresent();
 
+  // Hydrate the user-folder handle from IDB so getFolderState reflects
+  // reality on the first page query. Permission lookup is deferred to
+  // the page-driven checkFolderPermission (queryPermission is cheap but
+  // there's no reason to block init on it).
+  await _hydrateFolderRecord();
+
   return {
     ok: true,
     workerRpcVersion: WORKER_RPC_VERSION,
@@ -608,6 +621,10 @@ handlers.init = async function () {
     hasRelationshipsDb: hasRelationshipsDb,
     relDbOpen: hasRelationshipsDb,
     hasFellowsDb: hasFellowsDb,
+    hasFolderHandle: !!folderRecord.parentHandle,
+    folderParentName: folderRecord.parentName,
+    folderSubfolderName: folderRecord.subfolderName,
+    folderLastSavedAt: folderRecord.lastSavedAt,
     poolFiles: (function () { try { return poolUtil.getFileNames(); } catch (e) { return []; } })(),
     trace: bootTrace.slice()
   };
@@ -1499,6 +1516,521 @@ handlers.getOpfsInventory = async function () {
   var poolFiles = [];
   try { poolFiles = poolUtil.getFileNames(); } catch (e2) {}
   return { root: rootEntries, poolFiles: poolFiles };
+};
+
+// ===== User-folder durable storage (issue #165 Phase 1) =====================
+// The worker is the owner of the user-picked FileSystemDirectoryHandle: it
+// persists the handle in its own IndexedDB and performs every read/write
+// against the folder. The page is the user-gesture gateway — it calls
+// showDirectoryPicker / requestPermission on its own (those APIs require
+// transient user activation) and either ships the handle in or borrows
+// the worker's copy back for a one-shot permission request.
+//
+// Subfolder layout: user picks a *parent* folder; we own a "Fellows/"
+// subfolder inside it. On collision (Fellows/ already has a
+// relationships.db) the page shows the open-existing vs create-Fellows-N
+// dialog; the page then re-invokes setFolderHandle with the explicit mode.
+// One file lives in the subfolder for Phase 1: relationships.db. (Backups
+// migrate in Phase 2.)
+//
+// "Saved" semantics: the badge flips to Saved only after a successful
+// createWritable → write → close round-trip — that's atomic per the
+// FileSystem Access spec (the browser writes through a temp file and
+// renames on close).
+
+var FOLDER_IDB_NAME = 'fellows-fs-handles';
+var FOLDER_IDB_STORE = 'handles';
+var FOLDER_IDB_KEY = 'relationships-folder';
+var FOLDER_SUBFOLDER_DEFAULT = 'Fellows';
+var FOLDER_RELATIONSHIPS_FILE = 'relationships.db';
+
+// In-memory mirror of what's persisted in IDB. Reloaded on init, mutated
+// alongside every IDB write. Shape: see _emptyFolderRecord().
+var folderRecord = _emptyFolderRecord();
+
+function _emptyFolderRecord() {
+  return {
+    parentHandle: null,    // FileSystemDirectoryHandle (the parent the user picked)
+    parentName: null,      // string — handle.name (for diag / UI)
+    subfolderName: null,   // string — e.g. "Fellows" or "Fellows 2"
+    lastSavedAt: null,     // ISO string of most recent successful write
+    lastError: null,       // { at, reason } of most recent failed read/write
+    lastPermission: null   // 'granted' | 'prompt' | 'denied' — most recent queryPermission result
+  };
+}
+
+// ----- IDB plumbing ---------------------------------------------------------
+
+function _folderIdbOpen() {
+  return new Promise(function (resolve, reject) {
+    if (!self.indexedDB) {
+      reject(new Error('indexedDB unavailable in worker'));
+      return;
+    }
+    var req = self.indexedDB.open(FOLDER_IDB_NAME, 1);
+    req.onupgradeneeded = function () {
+      var db = req.result;
+      if (!db.objectStoreNames.contains(FOLDER_IDB_STORE)) {
+        db.createObjectStore(FOLDER_IDB_STORE);
+      }
+    };
+    req.onsuccess = function () { resolve(req.result); };
+    req.onerror = function () { reject(req.error || new Error('IDB open failed')); };
+  });
+}
+
+function _folderIdbGet() {
+  return _folderIdbOpen().then(function (db) {
+    return new Promise(function (resolve, reject) {
+      var tx = db.transaction(FOLDER_IDB_STORE, 'readonly');
+      var store = tx.objectStore(FOLDER_IDB_STORE);
+      var req = store.get(FOLDER_IDB_KEY);
+      req.onsuccess = function () { resolve(req.result || null); };
+      req.onerror = function () { reject(req.error || new Error('IDB get failed')); };
+      tx.oncomplete = function () { try { db.close(); } catch (e) {} };
+    });
+  });
+}
+
+function _folderIdbPut(value) {
+  return _folderIdbOpen().then(function (db) {
+    return new Promise(function (resolve, reject) {
+      var tx = db.transaction(FOLDER_IDB_STORE, 'readwrite');
+      var store = tx.objectStore(FOLDER_IDB_STORE);
+      var req = store.put(value, FOLDER_IDB_KEY);
+      req.onsuccess = function () { resolve(true); };
+      req.onerror = function () { reject(req.error || new Error('IDB put failed')); };
+      tx.oncomplete = function () { try { db.close(); } catch (e) {} };
+    });
+  });
+}
+
+function _folderIdbDelete() {
+  return _folderIdbOpen().then(function (db) {
+    return new Promise(function (resolve, reject) {
+      var tx = db.transaction(FOLDER_IDB_STORE, 'readwrite');
+      var store = tx.objectStore(FOLDER_IDB_STORE);
+      var req = store.delete(FOLDER_IDB_KEY);
+      req.onsuccess = function () { resolve(true); };
+      req.onerror = function () { reject(req.error || new Error('IDB delete failed')); };
+      tx.oncomplete = function () { try { db.close(); } catch (e) {} };
+    });
+  });
+}
+
+// Re-persist `folderRecord` to IDB. Stores only the fields IDB cares
+// about; everything else is derived.
+function _folderRecordPersist() {
+  if (!folderRecord.parentHandle || !folderRecord.subfolderName) {
+    // Nothing to persist — defensive guard. Caller should _folderIdbDelete()
+    // explicitly when disconnecting.
+    return Promise.resolve(false);
+  }
+  return _folderIdbPut({
+    parentHandle: folderRecord.parentHandle,
+    parentName: folderRecord.parentName || null,
+    subfolderName: folderRecord.subfolderName,
+    lastSavedAt: folderRecord.lastSavedAt || null,
+    lastError: folderRecord.lastError || null
+  });
+}
+
+// Hydrate `folderRecord` from IDB on init. Non-fatal on any failure — the
+// app continues in OPFS-only mode and the page renders the
+// "Browser-only" badge.
+async function _hydrateFolderRecord() {
+  try {
+    var rec = await _folderIdbGet();
+    if (rec && rec.parentHandle && rec.subfolderName) {
+      folderRecord.parentHandle = rec.parentHandle;
+      folderRecord.parentName = rec.parentName || (rec.parentHandle && rec.parentHandle.name) || null;
+      folderRecord.subfolderName = rec.subfolderName;
+      folderRecord.lastSavedAt = rec.lastSavedAt || null;
+      folderRecord.lastError = rec.lastError || null;
+      trace('folder: hydrated handle parent=' + folderRecord.parentName +
+        ' subfolder=' + folderRecord.subfolderName +
+        ' lastSavedAt=' + (folderRecord.lastSavedAt || '(never)'));
+    } else {
+      trace('folder: no persisted handle (browser-only mode)');
+    }
+  } catch (e) {
+    trace('folder: IDB hydrate failed: ' + (e && e.message || e));
+  }
+}
+
+// ----- Subfolder helpers ----------------------------------------------------
+
+async function _findOrCreateSubfolder(parentHandle, mode) {
+  // mode: 'open-existing' → must use the existing default name; throws if
+  //   it doesn't exist or doesn't contain relationships.db.
+  // 'create-new' → pick the lowest-numbered unused name from "Fellows",
+  //   "Fellows 2", "Fellows 3", ...
+  // 'auto' (or null) → if "Fellows" exists with a relationships.db,
+  //   return { requiresChoice: true, ... }; otherwise behave like
+  //   'create-new' picking "Fellows".
+  var name = FOLDER_SUBFOLDER_DEFAULT;
+  if (mode === 'open-existing') {
+    var existing;
+    try {
+      existing = await parentHandle.getDirectoryHandle(name);
+    } catch (e) {
+      var nfErr = new Error('"' + name + '" subfolder not found in this folder');
+      nfErr.code = 'subfolder_missing';
+      throw nfErr;
+    }
+    return { handle: existing, subfolderName: name };
+  }
+  if (mode === 'create-new') {
+    var n = 1;
+    while (true) {
+      var candidate = (n === 1) ? FOLDER_SUBFOLDER_DEFAULT : (FOLDER_SUBFOLDER_DEFAULT + ' ' + n);
+      var exists = await _subfolderExists(parentHandle, candidate);
+      if (!exists) {
+        var created = await parentHandle.getDirectoryHandle(candidate, { create: true });
+        return { handle: created, subfolderName: candidate };
+      }
+      n++;
+      if (n > 999) {
+        throw new Error('could not find unused subfolder name after 999 tries');
+      }
+    }
+  }
+  // 'auto': probe "Fellows" — if it already exists with a relationships.db
+  // we need the page to confirm.
+  var probed = await _probeSubfolder(parentHandle, FOLDER_SUBFOLDER_DEFAULT);
+  if (probed.exists && probed.hasFile) {
+    var suggestion = await _suggestNextName(parentHandle);
+    return {
+      requiresChoice: true,
+      existing: {
+        subfolderName: FOLDER_SUBFOLDER_DEFAULT,
+        counts: probed.counts,
+        invalid: probed.invalid,
+        invalidReason: probed.invalidReason,
+        size: probed.size,
+        lastModified: probed.lastModified
+      },
+      suggestion: suggestion
+    };
+  }
+  // Empty default subfolder (or no subfolder at all) — happy path.
+  var fresh = await parentHandle.getDirectoryHandle(FOLDER_SUBFOLDER_DEFAULT, { create: true });
+  return { handle: fresh, subfolderName: FOLDER_SUBFOLDER_DEFAULT };
+}
+
+async function _subfolderExists(parentHandle, name) {
+  try {
+    await parentHandle.getDirectoryHandle(name);
+    return true;
+  } catch (e) { return false; }
+}
+
+async function _suggestNextName(parentHandle) {
+  var n = 2;
+  while (n < 999) {
+    var candidate = FOLDER_SUBFOLDER_DEFAULT + ' ' + n;
+    var exists = await _subfolderExists(parentHandle, candidate);
+    if (!exists) return candidate;
+    n++;
+  }
+  return FOLDER_SUBFOLDER_DEFAULT + ' ' + n;
+}
+
+// Read relationships.db out of a candidate subfolder and run inspectBytes
+// over it (without touching the live OPFS pool slot). Used both by the
+// collision probe and by readRelationshipsFromFolder.
+async function _probeSubfolder(parentHandle, subfolderName) {
+  var out = { exists: false, hasFile: false, counts: null, invalid: false, invalidReason: null, size: 0, lastModified: null };
+  var sub;
+  try {
+    sub = await parentHandle.getDirectoryHandle(subfolderName);
+  } catch (e) {
+    return out; // subfolder doesn't exist
+  }
+  out.exists = true;
+  var fh;
+  try {
+    fh = await sub.getFileHandle(FOLDER_RELATIONSHIPS_FILE);
+  } catch (e) {
+    return out; // subfolder exists but no relationships.db
+  }
+  out.hasFile = true;
+  try {
+    var f = await fh.getFile();
+    out.size = f.size;
+    out.lastModified = f.lastModified;
+    var bytes = new Uint8Array(await f.arrayBuffer());
+    var inspection = await inspectBytes(bytes);
+    if (inspection.valid) {
+      out.counts = inspection.counts;
+    } else {
+      out.invalid = true;
+      out.invalidReason = inspection.error || 'unreadable';
+    }
+  } catch (e) {
+    out.invalid = true;
+    out.invalidReason = (e && e.message) || String(e);
+  }
+  return out;
+}
+
+// ----- queryPermission wrapper ---------------------------------------------
+async function _folderQueryPermission() {
+  if (!folderRecord.parentHandle) return 'no-handle';
+  if (typeof folderRecord.parentHandle.queryPermission !== 'function') {
+    // Older browsers / non-FSA shims — treat as granted since the only way
+    // we got here is via showDirectoryPicker on a browser that supports it.
+    return 'granted';
+  }
+  try {
+    var state = await folderRecord.parentHandle.queryPermission({ mode: 'readwrite' });
+    folderRecord.lastPermission = state;
+    return state;
+  } catch (e) {
+    folderRecord.lastPermission = 'denied';
+    return 'denied';
+  }
+}
+
+// ----- State snapshot for the page -----------------------------------------
+
+async function _folderStateSnapshot() {
+  var state = {
+    hasHandle: !!folderRecord.parentHandle,
+    parentName: folderRecord.parentName,
+    subfolderName: folderRecord.subfolderName,
+    permission: 'no-handle',
+    lastSavedAt: folderRecord.lastSavedAt,
+    lastError: folderRecord.lastError,
+    fileLastModified: null,
+    fileSize: null
+  };
+  if (!folderRecord.parentHandle) return state;
+  state.permission = await _folderQueryPermission();
+  if (state.permission === 'granted') {
+    try {
+      var sub = await folderRecord.parentHandle.getDirectoryHandle(folderRecord.subfolderName);
+      var fh = await sub.getFileHandle(FOLDER_RELATIONSHIPS_FILE);
+      var f = await fh.getFile();
+      state.fileLastModified = f.lastModified;
+      state.fileSize = f.size;
+    } catch (e) {
+      // File missing or unreadable; not fatal — page surfaces empty state.
+    }
+  }
+  return state;
+}
+
+// ----- Folder RPCs ----------------------------------------------------------
+
+handlers.getFolderState = async function () {
+  return _folderStateSnapshot();
+};
+
+// Step one of the picker flow. Page passes the handle returned by
+// window.showDirectoryPicker. `mode` controls the collision policy:
+//   - undefined / 'auto' — happy path; if the default subfolder already
+//     contains a relationships.db, return { requiresChoice, existing,
+//     suggestion } so the page can show the open-existing vs Create
+//     Fellows N dialog without committing anything.
+//   - 'open-existing' — open the default subfolder. Throws if it doesn't
+//     exist or doesn't have relationships.db.
+//   - 'create-new' — create the next-numbered subfolder.
+handlers.setFolderHandle = async function (args) {
+  var parentHandle = args && args.handle;
+  if (!parentHandle) throw new Error('missing handle');
+  // queryPermission/requestPermission live on FileSystemHandle. The picker
+  // call should have returned 'granted', but verify so a stale call (e.g.
+  // the page restored a stub) fails cleanly.
+  var perm = 'granted';
+  if (typeof parentHandle.queryPermission === 'function') {
+    try { perm = await parentHandle.queryPermission({ mode: 'readwrite' }); }
+    catch (e) { perm = 'denied'; }
+  }
+  if (perm !== 'granted') {
+    var permErr = new Error('Picker returned a handle without readwrite permission (' + perm + ')');
+    permErr.code = 'permission_not_granted';
+    throw permErr;
+  }
+  var mode = (args && args.mode) || 'auto';
+  var result = await _findOrCreateSubfolder(parentHandle, mode);
+  if (result.requiresChoice) {
+    // Page will re-invoke with mode='open-existing' or 'create-new'.
+    // Don't persist anything yet.
+    return {
+      ok: false,
+      requiresChoice: true,
+      parentName: parentHandle.name || null,
+      existing: result.existing,
+      suggestion: result.suggestion
+    };
+  }
+  folderRecord.parentHandle = parentHandle;
+  folderRecord.parentName = parentHandle.name || null;
+  folderRecord.subfolderName = result.subfolderName;
+  // Don't clobber lastSavedAt — open-existing legitimately keeps it null
+  // until the user explicitly saves.
+  if (mode === 'create-new' || folderRecord.lastSavedAt === undefined) {
+    folderRecord.lastSavedAt = null;
+  }
+  folderRecord.lastError = null;
+  await _folderRecordPersist();
+  trace('folder: set parent=' + folderRecord.parentName + ' subfolder=' + folderRecord.subfolderName + ' mode=' + mode);
+  return {
+    ok: true,
+    parentName: folderRecord.parentName,
+    subfolderName: folderRecord.subfolderName
+  };
+};
+
+handlers.clearFolderHandle = async function () {
+  folderRecord = _emptyFolderRecord();
+  try { await _folderIdbDelete(); } catch (e) { trace('folder: IDB delete failed: ' + (e && e.message || e)); }
+  trace('folder: cleared');
+  return { ok: true };
+};
+
+handlers.checkFolderPermission = async function () {
+  var state = await _folderQueryPermission();
+  return { permission: state };
+};
+
+// Re-hands the in-memory handle to the page so the page can call
+// requestPermission inside a user-gesture handler. The handle is
+// structured-cloned across; the worker keeps its own copy. Returns null
+// when no handle is persisted.
+handlers.getFolderHandleForReconnect = async function () {
+  if (!folderRecord.parentHandle) return { handle: null };
+  return { handle: folderRecord.parentHandle };
+};
+
+handlers.writeRelationshipsToFolder = async function () {
+  if (!poolUtil) throw new Error('pool util unavailable');
+  if (!folderRecord.parentHandle || !folderRecord.subfolderName) {
+    var ne = new Error('no folder configured');
+    ne.code = 'no_folder';
+    throw ne;
+  }
+  var perm = await _folderQueryPermission();
+  if (perm !== 'granted') {
+    var pe = new Error('folder permission not granted (' + perm + ')');
+    pe.code = 'permission_required';
+    pe.permission = perm;
+    throw pe;
+  }
+  var poolFiles = [];
+  try { poolFiles = poolUtil.getFileNames(); } catch (e) {}
+  if (poolFiles.indexOf(RELATIONSHIPS_DB_SLOT) === -1) {
+    var nde = new Error('no relationships.db to save (worker hasn\'t opened it yet)');
+    nde.code = 'no_relationships_db';
+    throw nde;
+  }
+  var bytes = poolUtil.exportFile(RELATIONSHIPS_DB_SLOT);
+  if (!bytes || !bytes.byteLength) {
+    var ee = new Error('relationships.db export was empty');
+    ee.code = 'empty_export';
+    throw ee;
+  }
+  var sub;
+  try {
+    sub = await folderRecord.parentHandle.getDirectoryHandle(folderRecord.subfolderName, { create: true });
+  } catch (e) {
+    folderRecord.lastError = { at: new Date().toISOString(), reason: 'subfolder open: ' + ((e && e.message) || e) };
+    await _folderRecordPersist();
+    var se = new Error('Could not open subfolder ' + folderRecord.subfolderName + ': ' + ((e && e.message) || e));
+    se.code = 'subfolder_open_failed';
+    throw se;
+  }
+  // FileSystemWritableFileStream.close() commits atomically per spec —
+  // the browser writes to a temp file and renames on close. No need to
+  // do .tmp + rename ourselves.
+  var fh;
+  try {
+    fh = await sub.getFileHandle(FOLDER_RELATIONSHIPS_FILE, { create: true });
+    var writable = await fh.createWritable();
+    await writable.write(bytes);
+    await writable.close();
+  } catch (e) {
+    folderRecord.lastError = { at: new Date().toISOString(), reason: 'write: ' + ((e && e.message) || e) };
+    await _folderRecordPersist();
+    var we = new Error('Folder write failed: ' + ((e && e.message) || e));
+    we.code = 'write_failed';
+    throw we;
+  }
+  var now = new Date().toISOString();
+  folderRecord.lastSavedAt = now;
+  folderRecord.lastError = null;
+  await _folderRecordPersist();
+  trace('folder: wrote ' + bytes.byteLength + ' bytes to ' +
+    folderRecord.subfolderName + '/' + FOLDER_RELATIONSHIPS_FILE + ' at ' + now);
+  return { ok: true, bytesWritten: bytes.byteLength, lastSavedAt: now };
+};
+
+handlers.readRelationshipsFromFolder = async function () {
+  if (!poolUtil) throw new Error('pool util unavailable');
+  if (!folderRecord.parentHandle || !folderRecord.subfolderName) {
+    var ne = new Error('no folder configured');
+    ne.code = 'no_folder';
+    throw ne;
+  }
+  var perm = await _folderQueryPermission();
+  if (perm !== 'granted') {
+    var pe = new Error('folder permission not granted (' + perm + ')');
+    pe.code = 'permission_required';
+    pe.permission = perm;
+    throw pe;
+  }
+  var sub;
+  try {
+    sub = await folderRecord.parentHandle.getDirectoryHandle(folderRecord.subfolderName);
+  } catch (e) {
+    folderRecord.lastError = { at: new Date().toISOString(), reason: 'subfolder open: ' + ((e && e.message) || e) };
+    await _folderRecordPersist();
+    var se = new Error('Could not open subfolder ' + folderRecord.subfolderName + ': ' + ((e && e.message) || e));
+    se.code = 'subfolder_open_failed';
+    throw se;
+  }
+  var fh;
+  try {
+    fh = await sub.getFileHandle(FOLDER_RELATIONSHIPS_FILE);
+  } catch (e) {
+    var nfe = new Error('No relationships.db in ' + folderRecord.subfolderName + ' yet');
+    nfe.code = 'no_file_in_folder';
+    throw nfe;
+  }
+  var bytes;
+  var fileLastModified = null;
+  try {
+    var f = await fh.getFile();
+    fileLastModified = f.lastModified;
+    bytes = new Uint8Array(await f.arrayBuffer());
+  } catch (e) {
+    folderRecord.lastError = { at: new Date().toISOString(), reason: 'read: ' + ((e && e.message) || e) };
+    await _folderRecordPersist();
+    var re = new Error('Folder read failed: ' + ((e && e.message) || e));
+    re.code = 'read_failed';
+    throw re;
+  }
+  // Reuse importRelationshipsBytes — it inspects, snapshots the current
+  // OPFS state into the auto-backup ring (so reading-back-a-stale-folder
+  // is undoable), then atomically replaces the OPFS slot.
+  var result = await handlers.importRelationshipsBytes({ bytes: bytes });
+  // After a successful read, the OPFS working copy matches the folder
+  // file — "saved" semantics hold. Tag lastSavedAt with the file's
+  // mtime so the badge flips to Saved with the file's authoring time
+  // (more honest than `now` for an open-existing flow — the user
+  // didn't author this version *now*).
+  if (fileLastModified) {
+    folderRecord.lastSavedAt = new Date(fileLastModified).toISOString();
+  }
+  folderRecord.lastError = null;
+  await _folderRecordPersist();
+  return {
+    counts: result.counts,
+    preRestoreSnapshot: result.preRestoreSnapshot,
+    bytesRead: bytes.byteLength,
+    lastSavedAt: folderRecord.lastSavedAt
+  };
 };
 
 // ===== Dispatcher ===========================================================

--- a/docs/users_manual.md
+++ b/docs/users_manual.md
@@ -105,14 +105,82 @@ directory.
 
 ## Where your data is stored
 
-Your groups, notes, and settings live **inside your browser**. They
-stay there — never sent to any server, never visible to other apps
-or websites on your device.
+Your groups, notes, and settings live **on your device only** —
+never sent to any server, never visible to other apps or websites.
 
-There's no folder on your disk you can browse to or back up by hand;
-the data file lives in a private storage area your browser manages.
-What you *can* do is download and restore your data file
-(`relationships.db`) from inside the app. Here's how:
+There are two places they can sit, and you choose which:
+
+1. **In your browser** (default). The data file (`relationships.db`)
+   lives in a private storage area your browser manages. Survives
+   updates and **Clear App Cache**, but you can't see the file from
+   Finder/Explorer, and clearing site data or switching browsers
+   wipes it.
+2. **In a folder on your disk** (Settings → *Data folder*). A real
+   file at a path you pick — visible in Finder/Explorer, copyable,
+   syncable through Dropbox / iCloud Drive / Syncthing if you put it
+   there, durable across clearing site data or switching browsers.
+   Available in Chrome / Edge / Brave / Arc on desktop today.
+
+The browser is always your **working store** either way — that's
+where the app reads and writes during use. When you pick a data
+folder, the app keeps a copy of your data there too and updates it
+when you click *Save now*.
+
+### Setting up a data folder (Chrome / Edge / Brave on desktop)
+
+1. Go to **Settings → Data folder**.
+2. Click **Choose data folder…**.
+3. Your OS pops a folder picker. Pick any folder you like —
+   `Documents`, a Dropbox / iCloud / Syncthing folder, anywhere.
+4. The app creates a `Fellows/` subfolder inside it and saves
+   `relationships.db` there.
+
+The badge at the top of the section flips to **Saved** with the
+path and a timestamp, and your data is now a real file you can
+browse to.
+
+**If `Fellows/` already exists in the folder you picked**, the app
+asks before doing anything: open the existing data (the typical
+case — reinstalling, or pointing a second browser at a synced
+folder), or save your current data into a new `Fellows 2/`
+subfolder (the safe choice when you don't recognize what's there).
+Cancel leaves both untouched.
+
+After setup, every time you make changes you'll see the *Save now*
+button. (Phase 1 is manual save; automatic background sync ships
+in Phase 2.) **Refresh from folder** does the reverse: replace the
+browser's copy with whatever's currently in the folder — useful
+after editing in another browser or restoring a synced file.
+
+### Badge states
+
+The badge at the top of *Data folder* always tells you the current
+state of your data:
+
+- **Saved** (green) — your data is in the folder and the last save
+  succeeded.
+- **Folder selected — no save yet** (blue) — you've picked a folder
+  but haven't saved into it yet. Click *Save now*.
+- **Browser-only — your data is not yet saved to a folder** (yellow)
+  — default state on a fresh install. Working fine, but not yet
+  durable across browser-data clears.
+- **Folder set but unreachable — reconnect to keep saving** (yellow)
+  — the OS revoked permission to the folder (you moved it, denied
+  on session start, or the browser idle-revoked). Your data is fine
+  in the browser; click *Reconnect folder…* to grant access again.
+- **Last save failed — Retry to save again** (yellow) — the most
+  recent write threw an error (disk full, permissions changed
+  mid-write). The change is still safe in the browser; click
+  *Save now* to retry.
+- **Browser-only — this browser doesn't support saving to a folder**
+  (yellow) — Safari, Firefox, iOS, and Android Chrome don't ship the
+  File System Access API. Use *Download my user data* (below) for
+  manual backup instead.
+
+### Backup and restore (works in every browser)
+
+Even when you haven't picked a data folder, you can still grab a
+file copy by hand:
 
 - **Download a backup.** Settings → *⬇ Download my user data*. Your
   browser asks you where to save it (Chrome / Edge / Brave on desktop,
@@ -128,21 +196,29 @@ What you *can* do is download and restore your data file
 
 **What clearing does** (see *Clearing app data* below for the full
 breakdown): **Clear App Cache** keeps your data and auto-backups.
-**Reset Everything** wipes both — that's why it pops up a *Save a
-backup first?* dialog. Download a backup yourself first if you want
-a copy you control.
+**Reset Everything** wipes the in-browser data and auto-backups —
+that's why it pops up a *Save a backup first?* dialog. **Reset
+Everything does NOT delete the data folder file** — that file lives
+on your disk and is yours to keep or remove.
+
+**If you cleared site data and re-installed, but your data folder
+is still on disk**, choose the same folder again — the dialog will
+offer to *Open existing*, and your groups / notes / tags come back.
 
 **Phone gotchas.** On **Android**, *Clear Storage* for the browser
 in Android Settings wipes everything this app has saved, including
 the auto-backups. On **iOS**, *Settings → Safari → Clear History and
 Website Data* does the same. Both bypass the app's own confirm
-dialogs — download a backup yourself before doing either.
+dialogs — download a backup yourself before doing either. (Phones
+don't yet support the data-folder feature.)
 
-**Switching browsers or devices.** Your data doesn't follow the
-browser — the new browser starts empty. Download a backup in the
-source browser, move the file across (AirDrop, email-to-yourself,
-USB, cloud drive), then use *Restore from a file* in the new
-browser to carry your groups, notes, and settings over.
+**Switching browsers or devices.** If you set up a data folder
+inside a cloud-sync folder (Dropbox / iCloud Drive / Syncthing /
+OneDrive), point the new browser at the same folder and pick
+*Open existing* — your groups / notes / tags carry over.
+Otherwise, download a backup in the source browser, move the file
+across (AirDrop, email-to-yourself, USB, cloud drive), then use
+*Restore from a file* in the new browser.
 
 ---
 

--- a/plans/user_folder_storage.md
+++ b/plans/user_folder_storage.md
@@ -34,6 +34,24 @@ G7. **Migration without data loss.** Existing users with OPFS-only data are walk
 - **Folder-first as the only mode.** Even on Chromium, "Browser-only" remains a valid (unsafe-flagged) state for users who decline to pick a folder. We surface the warning; we don't force the choice.
 - **Replacing OPFS as the working store.** sqlite-wasm performs best against OPFS-resident `FileSystemSyncAccessHandle`s. The working DB stays in OPFS; the user's folder is the durable mirror. See § Architecture.
 
+## Refreshable assets (images, fellows.db, etc.)
+
+The plan above is about `relationships.db` — *user-authored* data we cannot regenerate from any other source. A separate class of assets is *refreshable*: bytes the server can hand back any time, that lose nothing if locally destroyed. Today that's `fellows.db` (regenerated from the Knack source on every build) and the ~250 profile images served from `/images/<slug>`.
+
+The plan keeps `fellows.db` in OPFS by design — the per-build SHA in `/build-meta.json` already handles "is my local copy stale?" — but it does not yet address **images**. The gap matters: images are session-gated on prod, so a user who installs while their session is expired (or whose first boot lands in api+idb fallback for any other reason) gets *zero* profile photos and no mechanism to fill them in until they re-authenticate. We have a real user-report of this in the wild.
+
+Three options, listed in increasing scope:
+
+**Option A — Skip prewarm on unauthenticated boot + completeness counter.** The current image prewarm fires ~500 doomed requests every cold boot in api+idb fallback. Gate it on `authStatus.authenticated`. Add an About-page row: `Images: 230 / 251 cached — Sign in to fetch the rest` (linking to `/?gate=1`). Smallest possible fix; doesn't make images durable across browser-data wipes. Shippable independently of any folder work.
+
+**Option B — Bundle images in the static bundle.** ~250 × ~30 KB ≈ 7-10 MB added to `deploy/dist/`. Images become as durable as `app.js` and signed by the same manifest. Trade-off: every directory-data update re-downloads all images even if only one changed. Could be mitigated by per-image hashes in `build-meta.json`, but that's its own work.
+
+**Option C — Sync images into the user's folder once folder-mode is active (Phase 1+).** Folder-mode users get full durability — images survive Clear Site Data, browser switches, even hardware moves through a synced folder. OPFS-only users (mobile, Safari, Firefox) still need Option A as the floor since folder-mode never lands for them.
+
+**Recommendation:** Option A now (it's a current production bug). Option C with Phase 2 (along with auto-sync). Option B held in reserve in case the bundle-weight conversation tips that way later.
+
+Out of scope either way: a sync strategy for `fellows.db` itself. That's an existing concern handled by Check for updates → Update directory data and is unchanged by this plan.
+
 ## Browser compatibility matrix
 
 | Browser / mode | `showDirectoryPicker` | Persistent handle re-grant | Behavior in this plan |
@@ -98,6 +116,14 @@ Bright line: **the user-folder feature is opt-in and additive.** Today's OPFS-on
 A new mutation always lands in OPFS first, then syncs out. So a stale-permission session is still safe: the data is preserved in OPFS even if the folder write keeps failing.
 
 ## UI / UX
+
+### Status surfaces: durability vs completeness
+
+The status badge below tracks **where your data is saved** — Browser-only / Pending / Saved / Folder inaccessible. That is "data durability."
+
+A separate concern, surfaced elsewhere, is **install completeness** — has the app downloaded every refreshable asset it depends on, so subsequent server-less use is fully functional? On a normal authenticated install, prewarm fills the image cache and the answer is yes. On an install whose first boot landed in api+idb fallback (expired session, anti-enum 403, etc.), the answer is no — *and the durability badge has no way to express that.* The user's data is durable; the install itself is partial.
+
+Don't conflate the two in the same badge. Surface completeness on the About page (where the user already goes to ask "is everything okay with this install?") as a separate row, with a link to sign-in when items are missing. The signal evolves as Phase 1 / 2 land — once images sync into the user's folder, the same "X of N images present" check applies, just against a different storage substrate.
 
 ### Status badge (the load-bearing UI element)
 
@@ -272,6 +298,20 @@ Settings UI calls it: data folder? backup folder? sync folder? save folder? Wort
   - Safari desktop: confirms unsupported-browser badge appears without spamming errors.
   - Firefox: same.
   - iOS Safari PWA: same.
+
+### Mobile verification
+
+The plan calls mobile "unsupported in v1" for folder-mode itself — neither iOS nor Android Chrome will see the folder picker until / unless we revisit. But **the OPFS-only fallback path IS the mobile experience** and that path absolutely needs verification: the image-prewarm-on-fallback bug bit a real mobile user before we noticed it, and "we tested on desktop Chrome" did not catch it. We're shipping a PWA primarily consumed on phones; not having a mobile test loop is the gap that lets bugs like that ship to the user before we notice.
+
+Options for adding a mobile test loop, listed in increasing fidelity / cost:
+
+- **Playwright mobile emulation** (we use it today in `tests/e2e/mobile/`). UA + viewport spoofing. Catches CSS / layout regressions; does *not* replicate WebKit-on-iOS (Playwright Chromium is still Chromium under the hood) or Android Chrome's storage-eviction behavior. Better than nothing; insufficient on its own.
+- **BrowserStack / Sauce Labs / similar.** Real iOS Safari and Android Chrome, scriptable from CI. Costs money; replicates engine + storage quirks. Worth it for security and privacy-sensitive features once we have the appetite.
+- **Manual ship checklist on a personal phone.** Per-deploy smoke (≈ a quarter-hour). Catches the worst bugs; can't be automated. Belongs in `docs/users_manual.md` or a sibling so any maintainer can run it.
+
+**Recommendation for #165:** before Phase 1 ships, formalize the manual mobile checklist as the floor; revisit cloud-device testing in Phase 4 alongside other polish. Even on desktop-only features, run the manual mobile pass once to confirm the OPFS-only fallback didn't degrade.
+
+This is also a good time to remember the AC-12 commitment in `docs/Architecture.md` (capability detection inside the worker): mobile is where AC-12 gets stressed the most, since iOS WebKit constraints differ from desktop Safari's in ways that don't always surface in Playwright.
 
 ## Risks
 

--- a/plans/user_folder_storage.md
+++ b/plans/user_folder_storage.md
@@ -154,6 +154,24 @@ If the user explicitly clicks "Disconnect folder," we delete the IDB entry and r
 
 ## Phases
 
+### Phase 0 — Worker-direct export / import (pre-cursor, shippable now)
+
+**Independent of all the user-folder work below.** Decouples the page-side `dataProvider` from the worker's relationship-DB byte operations, which Phase 2's auto-sync needs anyway and which fixes a current production bug for free.
+
+The page-level `dataProvider` today exposes `exportRelationshipsBytes` / `importRelationshipsBytes` only when its `kind === 'worker'`. When the page falls back to `api+idb` (most commonly because the session-gated `/fellows.db` fetch returned 401/403 during boot), the warm worker is still alive with `relationships.db` open, but the Settings backup and restore controls can't reach it — so users on an expired session can't back up their data before reinstalling or switching browsers.
+
+Phase 2's debounced sync ("worker enqueues a sync after every committed mutation") is written from the worker's perspective and similarly cannot depend on the active page-level provider. The plumbing is the same: a worker-direct path to the bytes, addressable regardless of which provider the page picked at boot. Landing it here shortens Phase 2.
+
+- New page-side helpers that reach `warmWorker.rpc` directly:
+  - `warmWorkerExportRelationshipsBytes()`
+  - `warmWorkerImportRelationshipsBytes(bytes)`
+  - `warmWorkerListRelationshipsBackups()` (for the auto-backup list in Settings)
+- Settings page wires the download / restore buttons through the warm-worker helpers when `dataProvider.kind !== 'worker'` AND `isWorkerOpfsCapableButInactive()` (the helper added in the never-SaaS copy cleanup, PR #173).
+- When the warm worker is genuinely absent (no OPFS, no worker init), keep today's "this feature isn't available" panel — that's the honest case.
+- E2E: extend `tests/e2e/test_never_saas_copy.py` (or sibling) to seed the api+idb-fallback scenario, click Download, assert a real `relationships.db` blob comes back; click Restore on a known-good blob, assert the worker accepted it.
+
+Out of scope for P0: anything about user-picked folders, the status badge state machine, IDB handle persistence, the migration wizard. Those all stay below.
+
 ### Phase 1 — Folder picker + status UI + manual save/restore
 
 **Shippable on its own.** No automatic sync; the user explicitly hits "Save to folder" or "Refresh from folder" buttons in Settings. Validates the API surface, the handle-storage model, and the status UI before adding cadence logic.
@@ -186,6 +204,14 @@ Out of scope for P1: auto-sync, migration wizard, fellow.db.
 - "Open data folder" deep link if any platform exposes it without re-picking.
 - Diagnostic panel additions (folder path, last sync time, sync-failure count, current permission state).
 - Maybe-eventual: `FileSystemObserver` watch on the folder so external edits surface as conflicts.
+
+## Plan-polish items (not blocking, worth resolving before code lands)
+
+Two gaps surfaced during a plan review. Neither blocks ship; both are worth a sentence each in the relevant phase before that phase starts.
+
+**G1 — Post-commit hook on relationships.db RPCs (Phase 2 dependency).** Phase 2's spec says "Worker enqueues a sync after every committed mutation to `relationships.db`." The worker's current RPC shape doesn't have a notion of "this RPC just committed a mutation" — most handlers read and write synchronously inside one function with no after-hook. P2 needs a small "post-commit" concept: each RPC that mutates `relationships.db` (createGroup, updateGroup, deleteGroup, setSetting, importRelationshipsBytes, …) flags the worker to schedule a debounced sync after the response is sent. Cleanest implementation is probably a small `markRelationshipsDirty()` helper called at the end of each mutating RPC, with the debounce timer living at module scope. Worth wiring in P2 the day P2 code starts.
+
+**G2 — `fellows.db.meta.json` sidecar location and migration.** Today the SHA-keyed sidecar that drives the About → Check for updates flow lives in OPFS at `fellows.db.meta.json` (sibling of the SAH pool). The plan moves `relationships.db` to the user's folder but is silent on the sidecar. Decision needed: stays in OPFS (sidecar tracks the OPFS-resident `fellows.db`, which never moves under this plan), or moves to the folder alongside `relationships.db` (so a user copying their folder to a new machine sees the same update-state). Reco: **stays in OPFS** — it tracks `fellows.db` freshness on this device, which is per-device by definition. A new device starts with an empty sidecar and re-fetches naturally. Worth one sentence in § Architecture once decided, and a note in the migration wizard (Phase 3) confirming the wizard does NOT copy the sidecar.
 
 ## Open questions for @richbodo
 

--- a/plans/user_folder_storage.md
+++ b/plans/user_folder_storage.md
@@ -172,6 +172,16 @@ Phase 2's debounced sync ("worker enqueues a sync after every committed mutation
 
 Out of scope for P0: anything about user-picked folders, the status badge state machine, IDB handle persistence, the migration wizard. Those all stay below.
 
+### Phase 0b — Worker-direct groups RPCs (small follow-on)
+
+Same shape as Phase 0, extended to the five groups RPCs (`listGroups`, `getGroup`, `createGroup`, `updateGroup`, `deleteGroup`) so the entire `relationships.db` read/write surface — settings, backups, AND groups — stays reachable when the page falls back to api+idb. Without this, a user with an expired session could back up their data (P0) but couldn't browse the groups they were trying to back up.
+
+- Prereq: hoist `attachMemberNamesFromCache` and `withResolvedMembers` out of `createWorkerDataProvider`'s scope to module scope. Both read only the module-level `fellowsBySlug` cache; the hoist is mechanical.
+- Extend `viaWarmWorker` (added in P0) to accept an optional post-process function so `getGroup` / `createGroup` / `updateGroup` can chain `withResolvedMembers`.
+- Five new methods on `createApiPlusIdbDataProvider`, same dispatcher pattern as P0.
+
+Out of scope for P0b: version-skew gating on mutating group ops in the api+idb path. The worker provider gates create/update/delete with `refuseIfVersionSkew`; the api+idb fallback doesn't, on the rationale that the fallback path is already exceptional and worker-vs-page version skew is a separate SW-upgrade-race concern surfaced by the existing reload banner. Worth revisiting if real-user telemetry shows skew-related failures.
+
 ### Phase 1 — Folder picker + status UI + manual save/restore
 
 **Shippable on its own.** No automatic sync; the user explicitly hits "Save to folder" or "Refresh from folder" buttons in Settings. Validates the API surface, the handle-storage model, and the status UI before adding cadence logic.

--- a/plans/user_folder_storage.md
+++ b/plans/user_folder_storage.md
@@ -1,0 +1,252 @@
+# User-Folder Durable Storage
+
+A plan to move the durable home of the user's private relationships data out of browser-managed OPFS and into a user-chosen folder on their filesystem, following the VS Code for Web pattern: **browser as runtime, filesystem as durable home.**
+
+## Context
+
+Today, `relationships.db` lives in OPFS (Origin Private File System), owned by `vendor/sqlite-worker.js` per the local-first plan. OPFS is fast (sqlite-wasm gets `FileSystemSyncAccessHandle`), private to the app's origin, and survives Clear App Cache. But it has three load-bearing user-experience problems:
+
+1. **Invisible.** Users can't see, browse, back up, or move their `relationships.db` from outside the app. The "Where your data is stored" copy in `users_manual.md` essentially apologizes for this.
+2. **Browser-coupled.** Clearing site data, switching browsers, switching devices, or having Android `Clear Storage` invoked on the browser all silently destroy data. The auto-backup ring is also in OPFS, so it dies with the same wipe.
+3. **No external observability.** Backup is a manual download-then-store-the-file flow the user has to remember. Auto-backups don't escape OPFS.
+
+VS Code for Web shows the inverse model: open a folder, work in the browser, every save is a real write to the user's filesystem. Files behave like files. Other apps can read them, sync services (iCloud Drive, Dropbox, Syncthing) can replicate them, the user can `cp` them. The browser is just the runtime.
+
+This plan brings that model to `relationships.db`.
+
+## Goals
+
+G1. **A real file at a real path.** After first-run setup, `relationships.db` exists at a user-chosen filesystem path. The user can browse to it in Finder / Explorer / `ls`. Auto-backups land in the same folder.
+G2. **Durable across browser-data wipes.** Clearing site data, switching browsers (on the same machine), and switching browser profiles do not destroy the user's data — the folder survives.
+G3. **Persistent permission across sessions.** A `FileSystemDirectoryHandle` saved in IndexedDB is re-acquired on every launch without re-prompting the user, when the underlying OS permission is still granted.
+G4. **Honest "saved" semantics.** The UI displays "Saved to `<path>` at `<time>`" only after a successful write to the user's folder. Until then, status is explicit: "Pending save," "Browser-only (unsafe)," or "Folder inaccessible — re-select."
+G5. **No silent data loss on permission lapse.** If the OS revokes folder access (user moved the folder, denied permission on session restart, etc.), the app continues to operate against the OPFS working copy, surfaces a prominent reconnect prompt, and refuses to declare anything "saved" until the folder is reachable again.
+G6. **Graceful degradation on unsupported browsers.** On Safari, Firefox, and mobile (no `showDirectoryPicker`), the app continues to work in today's OPFS-only mode with an explicit "Browser-only (unsafe)" badge and a documented manual-backup workflow.
+G7. **Migration without data loss.** Existing users with OPFS-only data are walked through folder setup on their first launch of the new version; their current OPFS contents are exported into the chosen folder before anything changes.
+
+## Non-goals
+
+- **`fellows.db` moves too.** Out of scope. `fellows.db` is a refreshable snapshot of a remote source — losing it means re-downloading, not losing user-created data. Stays in OPFS.
+- **Multiple folders.** One folder per origin. Power users with multiple "directories of relationships" can wait until there's evidence demand exists.
+- **Conflict resolution for folders synced across devices** (Dropbox, iCloud Drive, etc.). The folder is a single-writer durable store. Two browsers pointed at the same Dropbox-synced folder will produce dueling writes; we'll warn but not resolve.
+- **Live folder watching.** `FileSystemObserver` is landing in Chrome but we don't depend on it. Pure write-out; no read-on-external-change.
+- **Cross-device handle portability.** A directory handle is scoped to one browser on one machine. Moving to another machine requires re-picking a folder (typically a synced folder pointing at the same backing storage).
+- **Folder-first as the only mode.** Even on Chromium, "Browser-only" remains a valid (unsafe-flagged) state for users who decline to pick a folder. We surface the warning; we don't force the choice.
+- **Replacing OPFS as the working store.** sqlite-wasm performs best against OPFS-resident `FileSystemSyncAccessHandle`s. The working DB stays in OPFS; the user's folder is the durable mirror. See § Architecture.
+
+## Browser compatibility matrix
+
+| Browser / mode | `showDirectoryPicker` | Persistent handle re-grant | Behavior in this plan |
+|---|---|---|---|
+| **Chrome / Edge / Brave (desktop, including PWA window)** | ✅ | ✅ via IndexedDB | Full feature. First-launch wizard. |
+| **Arc** | ✅ (Chromium) | ✅ | Same as Chrome. |
+| **Safari (desktop)** | ❌ (as of 2026 — `showOpenFilePicker` / `showSaveFilePicker` only; no directory) | n/a | Today's OPFS path, with persistent "Browser-only (unsafe)" badge + manual download/restore workflow. |
+| **Firefox** | ❌ (no File System Access API) | n/a | Same as Safari. |
+| **iOS Safari (incl. PWA)** | ❌ | n/a | Same as Safari desktop. |
+| **Android Chrome (incl. PWA)** | ⚠️ Partial; directory picker exists but reliability and UX are mixed; OS app-data wipe via *Clear Storage* still beats the model. | ⚠️ Partial | **v1 treats mobile as unsupported.** Reuses the desktop-Safari fallback. Revisit when File System Access on Android matures. |
+
+Bright line: **the user-folder feature is opt-in and additive.** Today's OPFS-only flow continues to work on every supported browser. We never block boot on the API being available.
+
+## Architecture: hybrid storage (OPFS working, folder durable)
+
+```
+┌─────────────────────────────────────────────────────────────────┐
+│  worker (sqlite-worker.js)                                       │
+│                                                                  │
+│  ┌───────────────────┐         ┌──────────────────────────────┐ │
+│  │ OPFS working DB    │ ──────► │ Sync-out (debounced):        │ │
+│  │ (today's location) │  every  │   read .db bytes from OPFS,  │ │
+│  │ relationships.db   │ commit  │   write to user's folder     │ │
+│  └───────────────────┘         │   via FileSystemFileHandle    │ │
+│           ▲                    └──────────────────────────────┘ │
+│           │                                                      │
+│           └─── boot: copy folder's .db into OPFS, then attach    │
+└─────────────────────────────────────────────────────────────────┘
+```
+
+### Why hybrid, not pure-folder
+
+- sqlite-wasm's fast VFS (`OpfsSAHPoolVfs`) needs `FileSystemSyncAccessHandle`. Sync access handles are **OPFS-only.** Files in user-picked folders only expose async `FileSystemFileHandle` / `FileSystemWritableFileStream`.
+- A pure-folder model would either need a custom async-only VFS (every read/write becomes a Promise — measurable hit even for small DBs; complex code) or have sqlite-wasm work entirely in-memory and rewrite the whole file on every commit (correctness risk on crash; thrashes the OS file cache).
+- Hybrid keeps today's working-store performance unchanged. The only new code path is "after a committed mutation, copy the .db bytes out to the user's folder." That's cheap (the DB is tens of KB), debounceable, and idempotent.
+
+### Sync-out cadence
+
+- **Trigger:** every committed write RPC the worker handles for `relationships.db` enqueues a sync.
+- **Debounce:** 500 ms after the last commit, or 5 s max wait, whichever fires first. Tunable.
+- **Atomicity:** write to `relationships.db.tmp`, then `move` to `relationships.db`. The user never sees a half-written file. The renaming pattern matches what `Atomics`-flavored save flows use elsewhere.
+- **Failure:** logged + surfaced as "Sync failed at `<time>`: `<reason>` — Retry?" in the status badge. **The committed change in OPFS is not rolled back** — the working DB and the durable mirror diverge until the next successful sync. This is the only state where they ever diverge, and it's visible.
+
+### Auto-backup ring
+
+- Existing auto-backup logic moves to the user's folder. Filenames continue to follow the `relationships.db.bak.<ISO timestamp>` pattern.
+- Rotation continues server-side-equivalent — keep the newest N (currently 3) backups; on each new backup, prune older ones in the folder.
+- If the user inspects the folder, the rotation is visible: `relationships.db`, `relationships.db.bak.2026-05-14T10-32Z`, etc.
+
+### Boot sequence
+
+1. Worker spawns.
+2. Worker opens OPFS pool, attaches `fellows.db` RO (unchanged from today).
+3. Worker reads the saved folder handle from IndexedDB.
+4. **If handle missing** → "Browser-only (unsafe)" state. OPFS working DB is the source of truth. Bootstrap schema if absent. Continue.
+5. **If handle present** → call `queryPermission({mode: 'readwrite'})`:
+   - `'granted'` → read `relationships.db` from the folder, copy into OPFS, attach. **"Saved" state.**
+   - `'prompt'` → don't auto-prompt. Continue against OPFS working DB but surface a "Reconnect data folder" CTA in the status badge that, on click, calls `requestPermission`.
+   - `'denied'` → same as `'prompt'` plus an explicit "Permission was denied; you'll need to pick the folder again."
+6. **If handle present but folder empty / file missing** → "Folder selected but empty: was your data moved?" with options to "Restore from this folder's backups" / "Restore from the auto-backups inside OPFS" / "Choose a different folder" / "Start fresh in this folder."
+
+A new mutation always lands in OPFS first, then syncs out. So a stale-permission session is still safe: the data is preserved in OPFS even if the folder write keeps failing.
+
+## UI / UX
+
+### Status badge (the load-bearing UI element)
+
+Lives in Settings → top of the *Your saved data* section, and also as a small pill in the app's persistent header (mobile redesign mockup-compatible).
+
+| State | Badge text | Color | Affordances |
+|---|---|---|---|
+| Saved | `Saved to /Users/rich/Documents/Fellows • 2 min ago` | green | "Show in Finder", "Change folder…" |
+| Pending save | `Saving to folder…` | neutral | (none — transient, ~500ms) |
+| Browser-only (no folder ever chosen) | `Browser-only — your data is not yet saved to disk` | yellow / warning | **"Choose a data folder…"** CTA |
+| Folder selected but inaccessible | `Folder set but unreachable — reconnect to keep saving` | yellow / warning | **"Reconnect folder…"** CTA |
+| Sync failed (last attempt errored) | `Last save failed (<reason>) • Retry` | yellow / warning | **"Retry now"** + "Change folder…" |
+| Unsupported browser | `Browser-only — this browser doesn't support saving to a folder` | yellow / warning | Link to docs explaining the manual backup flow |
+
+Critical rule: **"Saved" is shown only after a write to the user's folder has been acknowledged by the OS.** OPFS writes alone are never "Saved" — they're "Pending" or "Browser-only," depending on whether a folder has ever been chosen.
+
+### First-launch wizard (Phase 3)
+
+When an existing user (OPFS data exists, no folder handle set) opens the new version:
+
+1. Banner above the directory: *"Your data is currently only in this browser. Choose a folder to save it to disk."* Dismissible (continues "Browser-only"), one click to engage.
+2. On click, native folder picker. User picks (or creates) a folder.
+3. App writes the current OPFS contents (relationships.db + the existing auto-backup ring) to the folder atomically.
+4. Status flips to "Saved to `<path>`."
+5. Subsequent launches from this browser auto-reconnect via the saved handle.
+
+### Settings page additions
+
+In the existing *Your saved data* section, above the existing download / restore buttons:
+
+- **Data folder:** `<path>` or `Not set` — with **Choose folder…** / **Change folder…** / **Disconnect folder** buttons.
+- **Last saved:** `<ISO time>` or `Never`.
+- **Open folder:** invokes whatever the platform's "show in file manager" call is (limited support; degrade gracefully).
+
+The existing "Download my user data" stays — it's still useful for grabbing a snapshot to email someone, restore on another machine, etc. The new "Saved to folder" state doesn't replace it.
+
+## Permission model & handle persistence
+
+### Storing the handle
+
+`FileSystemDirectoryHandle` is structured-clonable, so it can be put directly into IndexedDB. We store it in a new IDB database `fellows-fs-handles`, key `relationships-folder`. Single entry; no need to manage multiple.
+
+This survives Clear App Cache (per the existing behavior; IDB is not site-data in the OPFS-strict sense — but **it IS cleared by "Clear site data" / full reset**). Worth being precise in docs.
+
+### Permission lifecycle
+
+On each session start, we call `queryPermission({mode: 'readwrite'})`. The three return values map to:
+
+- `'granted'` — proceed silently. No user-visible prompt.
+- `'prompt'` — the OS needs user gesture to re-grant. **We do not auto-`requestPermission` on boot** (no user gesture available, would fail or pop a confusing dialog mid-load). Instead surface a "Reconnect data folder" button; clicking it is the gesture.
+- `'denied'` — same UX path. We say "Folder was selected previously but permission has been denied — reconnect to continue."
+
+If the user explicitly clicks "Disconnect folder," we delete the IDB entry and revert to "Browser-only (unsafe)."
+
+## Phases
+
+### Phase 1 — Folder picker + status UI + manual save/restore
+
+**Shippable on its own.** No automatic sync; the user explicitly hits "Save to folder" or "Refresh from folder" buttons in Settings. Validates the API surface, the handle-storage model, and the status UI before adding cadence logic.
+
+- New `vendor/sqlite-worker.js` RPCs: `getFolderHandle()`, `setFolderHandle(handle)`, `writeRelationshipsToFolder()`, `readRelationshipsFromFolder()`, `checkFolderPermission()`.
+- Settings page UI for choose / change / disconnect folder.
+- Status badge with the six states from § UI / UX (only the manual subset is wired — Saved / Pending / Browser-only / Folder inaccessible).
+- Unit test for the IndexedDB handle persistence.
+- E2E test (Chromium-only) using Playwright's `BrowserContext.grantPermissions(['fileSystem'])` and the underlying CDP to seed a directory handle.
+
+Out of scope for P1: auto-sync, migration wizard, fellow.db.
+
+### Phase 2 — Automatic debounced sync
+
+- Worker enqueues a sync after every committed mutation to `relationships.db`.
+- Debounce: 500 ms quiet period, 5 s max wait.
+- Atomic write via `.tmp` + rename.
+- Sync-failed state surfaces in status badge with "Retry now."
+- Auto-backup rotation moves to the user's folder (Phase 1 leaves auto-backups in OPFS).
+
+### Phase 3 — First-launch migration wizard
+
+- Banner for OPFS-only users on first launch after P3 ships.
+- One-click "Choose folder & save now" flow.
+- Bulk export of current OPFS contents into the chosen folder (relationships.db + auto-backup ring).
+
+### Phase 4 — Polish & accessibility (post-MVP)
+
+- "Show in Finder" via `showDirectoryPicker` round-trip when supported.
+- "Open data folder" deep link if any platform exposes it without re-picking.
+- Diagnostic panel additions (folder path, last sync time, sync-failure count, current permission state).
+- Maybe-eventual: `FileSystemObserver` watch on the folder so external edits surface as conflicts.
+
+## Open questions for @richbodo
+
+Each one needs your call before phase 1 code lands.
+
+**Q1: Folder layout — single file or directory?**
+
+Option A: drop `relationships.db` straight into the folder the user picks (alongside whatever's already there). Pros: matches "it's just a file" intuition. Cons: auto-backups (`relationships.db.bak.*`) and any future metadata clutter the user's folder.
+
+Option B: require an empty folder, treat the folder as ours, manage all contents (`relationships.db`, backups, maybe a `.fellows-manifest.json`). Pros: clean ownership boundary. Cons: more friction on first setup; pickier about pre-existing folders.
+
+Option C: drop a subfolder. User picks a parent folder; we make `EHF Fellows Data/` inside it and own that. Compromise; mirrors how VS Code creates `.vscode/`.
+
+**Recommendation:** C — clearest user mental model, no destructive collisions, naming visible in Finder.
+
+**Q2: What happens when the picked folder already contains a `relationships.db`?**
+
+Scenarios: user re-installs and points at their old folder (✓ we want to load that), user picks a colleague's folder by accident (✗ we should not silently merge), user picks the SAME folder another browser is also using (✗ split-brain).
+
+**Recommendation:** if the chosen folder contains `relationships.db`, show a confirm dialog: *"This folder already has fellows data — `<groups summary>`. Use it?* / Keep my browser's data and back this folder's data up first / Cancel". Don't silently merge.
+
+**Q3: Mobile in the matrix — pretend unsupported, or partial Android support?**
+
+Android Chrome 121+ does support `showDirectoryPicker`, but with worse permission persistence and *Clear Storage* still nuking handles. v1 plan calls it unsupported; the alternative is "partial — works but bigger 'unsafe in Android Settings' warnings."
+
+**Recommendation:** v1 unsupported. Treat mobile as today's OPFS-only flow. Revisit when Android File System Access feels solid.
+
+**Q4: Diagnostic surface — how much state to expose?**
+
+The full permission lifecycle (handle present, last permission query result, last sync attempt + outcome, current path) is useful for support cases. Could land in the existing `?diag` panel.
+
+**Recommendation:** yes, add a "Data folder" subsection to the `?diag` panel. Low cost; high payoff when someone files a "I lost my data" issue.
+
+**Q5: Naming.**
+
+Settings UI calls it: data folder? backup folder? sync folder? save folder? Worth picking one and using it everywhere.
+
+**Recommendation:** "**Data folder**" — implies durability and ownership; doesn't mislead users into thinking it's a backup of something else.
+
+## Testing approach
+
+- **Unit:** IndexedDB handle round-trip; sync-out write logic against a stubbed `FileSystemDirectoryHandle`.
+- **Playwright E2E (Chromium):** seed a folder handle via CDP, exercise full save / load / disconnect / reconnect flows. Verify status-badge state machine.
+- **Manual smoke:**
+  - Chrome desktop PWA: full happy path.
+  - Chrome desktop PWA + revoke permission via Site Settings → permission-prompt path.
+  - Chrome desktop PWA + user-moves-folder-out-from-under-us → "folder inaccessible" state.
+  - Safari desktop: confirms unsupported-browser badge appears without spamming errors.
+  - Firefox: same.
+  - iOS Safari PWA: same.
+
+## Risks
+
+- **OPFS and folder drift permanently if sync keeps failing.** Mitigation: status badge surfaces the divergence loudly; auto-retry on next mutation; "Save now" button always available.
+- **User picks a folder inside a synced location (Dropbox/iCloud) and runs the app in two browsers.** Mitigation: Q2's "already has data here?" dialog catches the first case; multi-writer is documented as unsupported in `users_manual.md`.
+- **`Clear site data` still wipes the IDB-stored handle**, forcing re-pick. Mitigation: the FOLDER survives, so the user just re-picks and the data is unchanged. Document this in `users_manual.md` as the recovery path.
+- **Browser auto-revokes file system permissions on idle eviction.** Chrome does this for tabs that have been backgrounded for a long time. Mitigation: the `'prompt'` state and reconnect CTA already cover this. Tested.
+
+## Links
+
+- File System Access API spec: <https://wicg.github.io/file-system-access/>
+- VS Code for Web architecture talk (the reference design): <https://code.visualstudio.com/blogs/2021/10/20/vscode-dev>
+- sqlite-wasm OPFS VFS docs: <https://sqlite.org/wasm/doc/trunk/persistence.md>
+- Related plan: [`local_first_worker_architecture.md`](./local_first_worker_architecture.md)

--- a/tests/e2e/test_user_folder_storage.py
+++ b/tests/e2e/test_user_folder_storage.py
@@ -1,0 +1,275 @@
+"""E2E for issue #165 Phase 1 — user-folder durable storage.
+
+Pins:
+- The Data folder section renders on the Settings page.
+- Choose data folder picks a folder, the badge flips to Saved, and a
+  real relationships.db lands in the Fellows/ subfolder.
+- Save Now updates the file timestamp.
+- Disconnect folder reverts the badge to Browser-only and clears the
+  IDB handle (subsequent boots see no handle).
+- Re-picking the same parent triggers the collision dialog, and
+  Create-Fellows-2 lands in a sibling subfolder.
+
+The picker is stubbed to return a real FileSystemDirectoryHandle backed
+by an OPFS subfolder. The worker's write/read path runs unchanged
+against a real handle — same File System Access async API as the
+production user-picker flow. The only thing this doesn't exercise is
+the OS permission round-trip itself (OPFS handles auto-grant); that's
+covered by the unit-level checkFolderPermission tests separately.
+
+Chromium-only by virtue of `showDirectoryPicker` — Firefox / WebKit
+take the unsupported-browser badge path, which is its own test.
+"""
+from __future__ import annotations
+
+import pytest
+from playwright.sync_api import expect
+
+
+# Install a fake `window.showDirectoryPicker` that returns a real OPFS
+# subfolder handle. The "user folder" stays at OPFS root under a
+# stable name so we can re-pick the same folder in collision tests.
+_STUB_DIRECTORY_PICKER = """
+(function () {
+  var STUB_NAME = '__e2e_user_folder__';
+  window.showDirectoryPicker = async function () {
+    var root = await navigator.storage.getDirectory();
+    return await root.getDirectoryHandle(STUB_NAME, { create: true });
+  };
+  // Test affordance: nuke the stub folder so each test starts from a
+  // clean slate. Called from the test via page.evaluate.
+  window.__resetE2EUserFolder = async function () {
+    var root = await navigator.storage.getDirectory();
+    try { await root.removeEntry(STUB_NAME, { recursive: true }); } catch (e) {}
+  };
+  // Test affordance: read back a probe of what landed in the stub
+  // folder. Returns { hasFellows: bool, hasFellows2: bool,
+  // relSize: int|null }.
+  window.__probeE2EUserFolder = async function () {
+    var root = await navigator.storage.getDirectory();
+    var out = { hasFellows: false, hasFellows2: false, relSize: null };
+    var stub;
+    try { stub = await root.getDirectoryHandle(STUB_NAME); }
+    catch (e) { return out; }
+    try {
+      var f = await stub.getDirectoryHandle('Fellows');
+      out.hasFellows = true;
+      try {
+        var fh = await f.getFileHandle('relationships.db');
+        var file = await fh.getFile();
+        out.relSize = file.size;
+      } catch (e) {}
+    } catch (e) {}
+    try {
+      await stub.getDirectoryHandle('Fellows 2');
+      out.hasFellows2 = true;
+    } catch (e) {}
+    return out;
+  };
+  // Test affordance: clear the worker's IDB-persisted handle so the
+  // next page load boots fresh. Same DB the worker uses internally.
+  window.__clearE2EFolderIdb = function () {
+    return new Promise(function (resolve) {
+      var req = indexedDB.deleteDatabase('fellows-fs-handles');
+      req.onsuccess = req.onerror = req.onblocked = function () { resolve(true); };
+    });
+  };
+})();
+"""
+
+
+@pytest.fixture
+def folder_page(standalone_page, base_url_fixture):
+    """Like worker_data but with the picker stub installed at init.
+    Yields the page; tests drive __dataProvider directly when they need
+    setup beyond the UI.
+    """
+    page = standalone_page
+    page.add_init_script(_STUB_DIRECTORY_PICKER)
+    page.goto(base_url_fixture + "/", wait_until="domcontentloaded")
+    # Wait for the worker provider to land.
+    page.wait_for_function(
+        "() => window.__dataProvider && typeof window.__dataProvider.listGroups === 'function'",
+        timeout=10000,
+    )
+    # Skip if we somehow ended up on the api+idb fallback — File System
+    # Access tests need the worker path.
+    kind = page.evaluate("() => window.__dataProvider.kind")
+    if kind != "worker":
+        pytest.skip(f"folder tests need the worker provider; got {kind!r}")
+    # Clean start: clear the IDB-stored handle and wipe any stub folder
+    # leftover from a previous run.
+    page.evaluate("() => window.__clearE2EFolderIdb()")
+    page.evaluate("() => window.__resetE2EUserFolder()")
+    # Wipe relationships state so each test has a known baseline.
+    page.evaluate("""
+      async () => {
+        var dp = window.__dataProvider;
+        var groups = await dp.listGroups();
+        for (var i = 0; i < groups.length; i++) {
+          try { await dp.deleteGroup(groups[i].id); } catch (e) {}
+        }
+        var bag = await dp.getSettings();
+        for (var k in bag) { try { await dp.setSetting(k, ''); } catch (e) {} }
+      }
+    """)
+    try:
+        yield page
+    finally:
+        try:
+            page.evaluate("() => window.__resetE2EUserFolder()")
+        except Exception:
+            pass
+
+
+def _open_settings(page, base_url):
+    page.goto(f"{base_url}/#/settings", wait_until="domcontentloaded")
+    page.locator(".settings-title").wait_for(state="visible", timeout=5000)
+    page.locator("#settings-folder-section").wait_for(state="visible", timeout=5000)
+
+
+class TestUserFolderStorage:
+    def test_data_folder_section_renders_with_browser_only_badge(
+        self, folder_page, base_url_fixture
+    ):
+        _open_settings(folder_page, base_url_fixture)
+        # On a fresh state, badge says "Browser-only" and only the
+        # Choose button is visible.
+        badge_text = folder_page.locator("#settings-folder-badge .settings-folder-badge-text")
+        expect(badge_text).to_contain_text("Browser-only")
+        expect(folder_page.locator("#settings-folder-choose")).to_be_visible()
+        expect(folder_page.locator("#settings-folder-save-now")).to_be_hidden()
+        expect(folder_page.locator("#settings-folder-disconnect")).to_be_hidden()
+
+    def test_choose_folder_writes_file_and_flips_badge_to_saved(
+        self, folder_page, base_url_fixture
+    ):
+        _open_settings(folder_page, base_url_fixture)
+        # Seed a group so the relationships.db isn't empty.
+        full = folder_page.evaluate("() => window.__dataProvider.getFull()")
+        rid = full[0]["record_id"]
+        folder_page.evaluate(
+            "(rid) => window.__dataProvider.createGroup({name: 'Folder seed', note: '', fellow_record_ids: [rid]})",
+            rid,
+        )
+        folder_page.locator("#settings-folder-choose").click()
+        # Badge flips to Saved after the auto-save.
+        badge_text = folder_page.locator("#settings-folder-badge .settings-folder-badge-text")
+        expect(badge_text).to_contain_text("Saved to", timeout=10000)
+        # Real file landed in the stub folder.
+        probe = folder_page.evaluate("() => window.__probeE2EUserFolder()")
+        assert probe["hasFellows"] is True, "Fellows/ subfolder should exist"
+        assert probe["relSize"] is not None and probe["relSize"] > 0, (
+            f"relationships.db should have bytes; probe={probe!r}"
+        )
+        # Save Now and Disconnect appear; Choose no longer.
+        expect(folder_page.locator("#settings-folder-save-now")).to_be_visible()
+        expect(folder_page.locator("#settings-folder-disconnect")).to_be_visible()
+        expect(folder_page.locator("#settings-folder-choose")).to_be_hidden()
+
+    def test_save_now_updates_file_after_mutation(
+        self, folder_page, base_url_fixture
+    ):
+        _open_settings(folder_page, base_url_fixture)
+        folder_page.locator("#settings-folder-choose").click()
+        badge_text = folder_page.locator("#settings-folder-badge .settings-folder-badge-text")
+        expect(badge_text).to_contain_text("Saved to", timeout=10000)
+        size_before = folder_page.evaluate(
+            "() => window.__probeE2EUserFolder().then(p => p.relSize)"
+        )
+        # Add a group + members to grow the DB.
+        full = folder_page.evaluate("() => window.__dataProvider.getFull()")
+        rids = [f["record_id"] for f in full[:5]]
+        folder_page.evaluate(
+            "(rids) => window.__dataProvider.createGroup({name: 'Grow', note: 'x', fellow_record_ids: rids})",
+            rids,
+        )
+        # Click Save now and assert the file changed.
+        folder_page.locator("#settings-folder-save-now").click()
+        # The Save now click fires writeRelationshipsToFolder; wait for
+        # the detail to flash "Saved (N bytes)."
+        detail = folder_page.locator("#settings-folder-detail")
+        expect(detail).to_contain_text("Saved (", timeout=10000)
+        size_after = folder_page.evaluate(
+            "() => window.__probeE2EUserFolder().then(p => p.relSize)"
+        )
+        assert size_after >= size_before, (
+            f"file should not shrink after adding a group; before={size_before} after={size_after}"
+        )
+
+    def test_disconnect_clears_handle(self, folder_page, base_url_fixture):
+        _open_settings(folder_page, base_url_fixture)
+        folder_page.locator("#settings-folder-choose").click()
+        badge_text = folder_page.locator("#settings-folder-badge .settings-folder-badge-text")
+        expect(badge_text).to_contain_text("Saved to", timeout=10000)
+        # Auto-accept the confirm dialog from window.confirm.
+        folder_page.once("dialog", lambda d: d.accept())
+        folder_page.locator("#settings-folder-disconnect").click()
+        expect(badge_text).to_contain_text("Browser-only", timeout=5000)
+        # Worker reports no handle now.
+        state = folder_page.evaluate("() => window.__folderController.getState()")
+        assert state["hasHandle"] is False
+
+    def test_collision_dialog_offers_open_existing_or_create_new(
+        self, folder_page, base_url_fixture
+    ):
+        _open_settings(folder_page, base_url_fixture)
+        # First pick → creates Fellows/.
+        folder_page.locator("#settings-folder-choose").click()
+        badge_text = folder_page.locator("#settings-folder-badge .settings-folder-badge-text")
+        expect(badge_text).to_contain_text("Saved to", timeout=10000)
+        # Disconnect (handle gone from IDB; Fellows/ stays in the folder).
+        folder_page.once("dialog", lambda d: d.accept())
+        folder_page.locator("#settings-folder-disconnect").click()
+        expect(badge_text).to_contain_text("Browser-only", timeout=5000)
+        # Re-pick the same parent. The worker probes, finds Fellows/
+        # already with a relationships.db, returns requiresChoice → the
+        # collision dialog opens.
+        folder_page.locator("#settings-folder-choose").click()
+        dialog = folder_page.locator("#settings-folder-collision-dialog")
+        expect(dialog).to_be_visible(timeout=5000)
+        # Click "Create Fellows 2".
+        folder_page.locator("#settings-folder-collision-create").click()
+        expect(badge_text).to_contain_text("Saved to", timeout=10000)
+        probe = folder_page.evaluate("() => window.__probeE2EUserFolder()")
+        assert probe["hasFellows"] is True, "original Fellows/ should be untouched"
+        assert probe["hasFellows2"] is True, "Fellows 2/ should have been created"
+
+    def test_open_existing_loads_data_back(self, folder_page, base_url_fixture):
+        _open_settings(folder_page, base_url_fixture)
+        # Round 1: seed a group, pick folder, save.
+        full = folder_page.evaluate("() => window.__dataProvider.getFull()")
+        rid = full[0]["record_id"]
+        folder_page.evaluate(
+            "(rid) => window.__dataProvider.createGroup({name: 'Round 1 group', note: '', fellow_record_ids: [rid]})",
+            rid,
+        )
+        folder_page.locator("#settings-folder-choose").click()
+        badge_text = folder_page.locator("#settings-folder-badge .settings-folder-badge-text")
+        expect(badge_text).to_contain_text("Saved to", timeout=10000)
+        # Disconnect + nuke groups in OPFS so a Refresh / Open-existing
+        # actually has work to do.
+        folder_page.once("dialog", lambda d: d.accept())
+        folder_page.locator("#settings-folder-disconnect").click()
+        expect(badge_text).to_contain_text("Browser-only", timeout=5000)
+        folder_page.evaluate("""
+          async () => {
+            var dp = window.__dataProvider;
+            var groups = await dp.listGroups();
+            for (var i = 0; i < groups.length; i++) {
+              await dp.deleteGroup(groups[i].id);
+            }
+          }
+        """)
+        assert folder_page.evaluate("() => window.__dataProvider.listGroups()") == []
+        # Re-pick → collision dialog → Open existing → groups come back.
+        folder_page.locator("#settings-folder-choose").click()
+        dialog = folder_page.locator("#settings-folder-collision-dialog")
+        expect(dialog).to_be_visible(timeout=5000)
+        folder_page.locator(".settings-folder-dialog-secondary").click()
+        expect(badge_text).to_contain_text("Saved to", timeout=10000)
+        groups = folder_page.evaluate("() => window.__dataProvider.listGroups()")
+        names = [g["name"] for g in groups]
+        assert "Round 1 group" in names, (
+            f"open-existing should have loaded the saved group back; got {names!r}"
+        )


### PR DESCRIPTION
Closes #165 (Phase 1).

## Summary

- Adds a *Data folder* mode in Settings: pick a parent folder, the app creates a `Fellows/` subfolder, and `relationships.db` lives there as a real file the user can browse, copy, sync, or back up.
- OPFS stays as the working store (sqlite-wasm needs `FileSystemSyncAccessHandle`). The user's folder is the durable mirror, written through atomic `FileSystemWritableFileStream.close()`.
- Status-badge state machine (Saved / Pending / Browser-only / Folder inaccessible / Last save failed / Unsupported) — "Saved" only after an OS-acknowledged write.
- Collision dialog: if the picked parent already contains `Fellows/relationships.db`, the user is prompted to *Open existing* or *Create "Fellows 2"* (auto-incrementing). Defaults to safe-by-default — no silent merging.
- Worker is sole owner of the `FileSystemDirectoryHandle`; persists it in a per-worker IndexedDB store (`fellows-fs-handles`) and hands it back to the page only on the reconnect gesture.
- Manual save/load only in P1. Auto-sync is P2 per the plan.

## Five open questions, resolved

| Q | Resolution |
|---|---|
| Q1 — folder layout | Subfolder named `Fellows`, auto-created inside the user-picked parent. |
| Q2 — folder already has data | Confirm dialog with member-count summary; primary action is *Create "Fellows N"* (safe), secondary *Open existing*, tertiary *Cancel*. |
| Q3 — mobile | Unsupported in v1 (no `showDirectoryPicker` on iOS / Android). Renders the "this browser doesn't support saving to a folder" badge. |
| Q4 — diagnostics | Added a *Data folder* subsection to the `?diag` panel. |
| Q5 — naming | "Data folder" everywhere in UI + docs. |

## Out of scope (deferred per plan)

- Automatic debounced sync (P2).
- First-launch migration wizard (P3).
- Auto-backup ring moving into the folder (P2).
- `fellows.db` moving into the folder (non-goal).
- Reconnect path's full permission-revoke UX — implemented in code but not exercised by E2E since OPFS handles auto-grant; covered by manual smoke instead.

## Test plan

- [x] `pytest tests/test_database.py tests/test_api.py` — 31 passed
- [x] `pytest tests/e2e/test_user_folder_storage.py` — 6 new tests pass (stubs `showDirectoryPicker` with a real OPFS subfolder handle so the worker exercises the actual File System Access async API)
- [x] `pytest tests/e2e/test_settings.py tests/e2e/test_diagnostics_panel.py tests/e2e/test_clear_app_cache.py` — pass, no regressions
- [x] Full e2e — 4 pre-existing failures on `main` (download-event timeouts in `test_groups_export` + `test_reset_everything`), unrelated to this change
- [ ] **Manual QA for the maintainer** (Chrome desktop PWA):
  - [ ] *Choose data folder…* → pick `~/Documents` → confirm `Fellows/relationships.db` lands there
  - [ ] Add a group → *Save now* → file `mtime` updates
  - [ ] *Disconnect folder* → badge flips to *Browser-only* (file in folder is **untouched**)
  - [ ] *Choose data folder…* same parent → collision dialog appears → *Open existing* → groups come back
  - [ ] Same flow → collision dialog → *Create "Fellows 2"* → `Fellows 2/` sibling appears, `Fellows/` untouched
  - [ ] Revoke folder permission in `chrome://settings/content/fileSystemWrite` → reload → badge flips to *Folder set but unreachable* → *Reconnect folder…* re-grants
  - [ ] Safari / Firefox: badge shows *this browser doesn't support saving to a folder*, no console errors
- [ ] **Watchouts**:
  - Folder-handle IDB (`fellows-fs-handles`) survives *Clear App Cache* but is wiped by *Clear site data* — re-pick the same folder and *Open existing* restores
  - Two browsers pointed at the same synced folder = dueling writes (documented as unsupported in users_manual.md)

🤖 Generated with [Claude Code](https://claude.com/claude-code)