### PR TITLE
feat(mcpb): port comms.py to TypeScript + .mcpb build pipeline

### DIFF
--- a/build/build_mcpb.py
+++ b/build/build_mcpb.py
@@ -1,0 +1,176 @@
+#!/usr/bin/env python3
+"""Build .mcpb (Anthropic Desktop Extension) bundles from mcpb/node/.
+
+For each manifest in ``mcpb/node/manifests/<name>.json`` (currently only
+``comms``; ``shared`` and ``private`` land in their own PRs), assembles a
+staging directory of the shape that Claude Desktop's MCPB format expects:
+
+    staging/
+      manifest.json    # the per-bundle manifest, copied verbatim
+      server/          # compiled JS + production node_modules
+        index.js
+        node_modules/
+
+...then runs ``npx @anthropic-ai/mcpb pack staging/ out.mcpb`` to produce
+the final bundle. Output goes to ``deploy/dist/mcpb/<name>.mcpb``.
+
+Run from the repo root:
+
+    python build/build_mcpb.py           # builds every available bundle
+    python build/build_mcpb.py comms     # one named bundle
+
+Or via the recipe wrapper:
+
+    just build-mcpb
+    just build-mcpb comms
+
+Prerequisites: Node 20+ and npm. The ``@anthropic-ai/mcpb`` CLI is
+invoked via ``npx`` so no global install is required.
+
+Why a Python build driver in a Node project: it keeps the build entry
+points uniform with the rest of the repo's tooling (``build_pwa.py``,
+``restore_from_knack_scrapefile.py``), and Python's subprocess + pathlib
+ergonomics fit the orchestration cleanly. The TypeScript inside
+``mcpb/node/`` is compiled by ``tsc``; this script just orchestrates.
+"""
+
+from __future__ import annotations
+
+import argparse
+import json
+import shutil
+import subprocess
+import sys
+from pathlib import Path
+
+REPO_ROOT = Path(__file__).resolve().parent.parent
+MCPB_NODE_DIR = REPO_ROOT / "mcpb" / "node"
+MANIFESTS_DIR = MCPB_NODE_DIR / "manifests"
+DIST_TS_DIR = MCPB_NODE_DIR / "dist"
+PACKAGE_JSON = MCPB_NODE_DIR / "package.json"
+OUTPUT_DIR = REPO_ROOT / "deploy" / "dist" / "mcpb"
+
+
+def _run(cmd: list[str], cwd: Path) -> None:
+    """Run a subprocess and surface stdout/stderr inline. Raises on failure."""
+    print(f"  $ {' '.join(cmd)}", file=sys.stderr)
+    result = subprocess.run(cmd, cwd=cwd)
+    if result.returncode != 0:
+        raise SystemExit(f"command failed (exit {result.returncode}): {' '.join(cmd)}")
+
+
+def _ensure_node_modules() -> None:
+    """Install Node dependencies in mcpb/node/ if missing."""
+    if (MCPB_NODE_DIR / "node_modules").is_dir():
+        return
+    print("Installing mcpb/node/ dependencies...", file=sys.stderr)
+    _run(["npm", "install"], cwd=MCPB_NODE_DIR)
+
+
+def _compile_typescript() -> None:
+    """Compile TS sources to JS into mcpb/node/dist/."""
+    print("Compiling TypeScript...", file=sys.stderr)
+    _run(["npx", "tsc"], cwd=MCPB_NODE_DIR)
+
+
+def _load_manifest(name: str) -> dict:
+    path = MANIFESTS_DIR / f"{name}.json"
+    if not path.is_file():
+        raise SystemExit(f"no manifest for '{name}' at {path}")
+    return json.loads(path.read_text(encoding="utf-8"))
+
+
+def _stage_bundle(name: str, manifest: dict, staging: Path) -> None:
+    """Assemble the bundle layout under ``staging`` per the MCPB Node format."""
+    if staging.exists():
+        shutil.rmtree(staging)
+    staging.mkdir(parents=True)
+
+    # Per-bundle manifest at the root of the staging dir.
+    (staging / "manifest.json").write_text(
+        json.dumps(manifest, indent=2) + "\n", encoding="utf-8"
+    )
+
+    # Server entry: compiled JS + production node_modules. Each bundle
+    # only ships the one server's compiled output (not the whole dist/).
+    server_dir = staging / "server"
+    server_dir.mkdir()
+    src_dir = DIST_TS_DIR / name
+    if not src_dir.is_dir():
+        raise SystemExit(
+            f"compiled output for '{name}' not found at {src_dir} — did tsc run?"
+        )
+    # Copy compiled JS as server/index.js + any sibling files (sourcemaps etc).
+    for item in src_dir.iterdir():
+        shutil.copy2(item, server_dir / item.name)
+
+    # Bundle production node_modules INSIDE server/ so the manifest's
+    # entry_point and ${__dirname}/server/index.js Just Work after install.
+    # Use --production to skip devDeps; --no-package-lock to avoid touching
+    # the source tree's lockfile from inside a staging dir.
+    print("  Installing production node_modules into staging/server/...", file=sys.stderr)
+    # Copy package.json into server/ so npm install knows what to fetch.
+    pkg = json.loads(PACKAGE_JSON.read_text(encoding="utf-8"))
+    # Strip devDependencies + scripts that aren't relevant in the bundle.
+    pkg.pop("devDependencies", None)
+    pkg.pop("scripts", None)
+    (server_dir / "package.json").write_text(
+        json.dumps(pkg, indent=2) + "\n", encoding="utf-8"
+    )
+    _run(
+        ["npm", "install", "--omit=dev", "--no-package-lock", "--ignore-scripts"],
+        cwd=server_dir,
+    )
+
+
+def _pack(staging: Path, output_path: Path) -> None:
+    """Run mcpb pack against the staging dir."""
+    output_path.parent.mkdir(parents=True, exist_ok=True)
+    if output_path.exists():
+        output_path.unlink()
+    _run(["npx", "--yes", "@anthropic-ai/mcpb", "pack", str(staging), str(output_path)],
+         cwd=REPO_ROOT)
+
+
+def build_bundle(name: str) -> Path:
+    """Build one named bundle. Returns the output .mcpb path."""
+    print(f"\n=== Building {name}.mcpb ===", file=sys.stderr)
+    manifest = _load_manifest(name)
+    staging = MCPB_NODE_DIR / ".staging" / name
+    _stage_bundle(name, manifest, staging)
+    output_path = OUTPUT_DIR / f"{name}.mcpb"
+    _pack(staging, output_path)
+    size_kb = output_path.stat().st_size // 1024
+    print(f"  -> {output_path} ({size_kb} KB)", file=sys.stderr)
+    return output_path
+
+
+def available_bundles() -> list[str]:
+    """All manifests currently in mcpb/node/manifests/."""
+    return sorted(p.stem for p in MANIFESTS_DIR.glob("*.json"))
+
+
+def main(argv: list[str] | None = None) -> int:
+    parser = argparse.ArgumentParser(description="Build .mcpb bundles.")
+    parser.add_argument(
+        "names",
+        nargs="*",
+        help="Bundle names to build (default: all available).",
+    )
+    args = parser.parse_args(argv)
+
+    _ensure_node_modules()
+    _compile_typescript()
+
+    targets = args.names or available_bundles()
+    if not targets:
+        print("No manifests found in mcpb/node/manifests/.", file=sys.stderr)
+        return 1
+    for name in targets:
+        build_bundle(name)
+    print(f"\nBuilt {len(targets)} bundle(s) into {OUTPUT_DIR}", file=sys.stderr)
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/justfile
+++ b/justfile
@@ -315,6 +315,27 @@ test-comms:
 test-mcp: test-shared-data-ops test-private-data-ops test-comms
 
 
+# ---- MCPB bundles (Claude Desktop install path) --------------------------
+# See plans/easy_mcp_install.md and mcpb/node/README.md.
+
+# Build all available .mcpb Desktop Extension bundles into
+# deploy/dist/mcpb/. Runs npm install in mcpb/node/ on first call,
+# compiles TS via tsc, then runs `npx @anthropic-ai/mcpb pack` per
+# bundle. Pass a name to build just one (e.g. `just build-mcpb comms`).
+[group('mcpb')]
+build-mcpb *NAMES:
+    python3 build/build_mcpb.py {{NAMES}}
+
+# Run the dual-codebase parity test: same inputs through the Python
+# servers in mcp_servers/ and the Node servers in mcpb/node/, assert
+# structurally-equal output against the PNA spec contracts. Required
+# to pass before any change to either implementation merges.
+# See plans/easy_mcp_install.md § 6.
+[group('mcpb')]
+test-mcpb-parity:
+    {{mcp_pytest}} tests/test_mcpb_parity.py -v
+
+
 # ---- build / deploy ------------------------------------------------------
 
 # Assemble deploy/dist/ (runs build/build_pwa.py).

--- a/mcpb/node/.gitignore
+++ b/mcpb/node/.gitignore
@@ -1,0 +1,4 @@
+node_modules/
+dist/
+*.mcpb
+.staging/

--- a/mcpb/node/README.md
+++ b/mcpb/node/README.md
@@ -1,0 +1,80 @@
+# mcpb/node — TypeScript MCP servers, packaged as Desktop Extensions
+
+This directory holds the **TypeScript** implementations of the Fellows
+MCP servers, packaged as Anthropic Desktop Extensions (`.mcpb` files)
+for one-click install in Claude Desktop. Claude Desktop bundles a
+Node.js runtime, so a Node-based `.mcpb` installs with zero user
+prerequisites — no Python, no Terminal, no JSON editing.
+
+See [`plans/easy_mcp_install.md`](../../plans/easy_mcp_install.md) for
+the plan this directory implements.
+
+## Why two implementations?
+
+`mcp_servers/` (Python) and `mcpb/node/` (TypeScript) implement the
+**same MCP surface** for **different audiences**:
+
+| | `mcp_servers/` (Python) | `mcpb/node/` (TS, in `.mcpb`) |
+|---|---|---|
+| Audience | Rich's own workflows, Cursor + uv power users, AI clients that want programmatic access, audit/test | End-user fellows installing into Claude Desktop |
+| Install path | `pip install` + manual `claude_desktop_config.json` edits | Double-click a `.mcpb` file |
+| Prerequisites | Python 3.10+, the `mcp` SDK | None (Claude Desktop bundles Node) |
+| Dependency on system Python | Yes | No |
+
+Both target the same PNA-spec contracts
+(`mcp-shared-data-ops.schema.json`, `mcp-private-data-ops.schema.json`,
+`mcp-comms.schema.json`). Behavioral parity is asserted by
+`tests/test_mcpb_parity.py` — see
+[`plans/easy_mcp_install.md` § 6](../../plans/easy_mcp_install.md)
+for the dual-codebase governance.
+
+## Why three bundles?
+
+One `.mcpb` per MCP server: Shared, Private, Comms. Claude Desktop's
+Extensions UI toggles whole bundles, so per-server enable/disable
+requires per-server bundles. This preserves AC-MCP-A's exception
+clause (a user can wire only Shared to a cloud client) at the
+install layer. See
+[`docs/acdecisionslog.md` § 2026-05-21](../../docs/acdecisionslog.md).
+
+## Layout
+
+```
+mcpb/node/
+├── src/
+│   ├── comms/index.ts          # Stage-only mailto: composer (port of mcp_servers/comms.py)
+│   ├── shared_data_ops/        # (planned) port of mcp_servers/shared_data_ops.py
+│   ├── private_data_ops/       # (planned) port of mcp_servers/private_data_ops.py
+│   └── _shared/                # (planned) shared helpers for SQLite, response shaping
+├── manifests/
+│   └── comms.json              # Anthropic MCPB manifest for the comms bundle
+├── package.json
+├── tsconfig.json
+└── .gitignore
+```
+
+Build artifacts go to `deploy/dist/mcpb/<name>.mcpb`. See
+`build/build_mcpb.py` and `just build-mcpb`.
+
+## Building locally
+
+From the repo root:
+
+```bash
+just build-mcpb       # builds all currently-implemented bundles
+```
+
+That installs node_modules in `mcpb/node/`, compiles TS to JS, and
+runs `npx @anthropic-ai/mcpb pack` against each manifest.
+
+## Testing
+
+Behavioral parity with the Python servers is the merge gate:
+
+```bash
+just test-mcpb-parity # runs tests/test_mcpb_parity.py
+```
+
+The parity test seeds expand as more servers are ported. Don't merge
+a change to either `mcp_servers/<name>.py` or `mcpb/node/src/<name>/`
+without the parity test green.

--- a/mcpb/node/manifests/comms.json
+++ b/mcpb/node/manifests/comms.json
@@ -1,0 +1,44 @@
+{
+  "manifest_version": "0.3",
+  "name": "fellows-comms",
+  "display_name": "Fellows: Email Staging",
+  "version": "0.1.0",
+  "description": "Lets Claude prepare draft emails to your fellows groups and hand them back to you for review. Claude never sends mail itself — drafts open in your mail app with To, Subject, and Body pre-filled, and you click Send.",
+  "long_description": "Part of the Fellows Directory integration with Claude Desktop. The Communications extension stages outreach as a mailto: URL that your mail client opens with the composition pre-populated. This server never launches a transport itself, never logs who you emailed, and writes nothing to disk. Architectural posture: AC-MCP-B — the MCP server proposes, the workspace disposes.",
+  "author": {
+    "name": "Rich Bodo",
+    "email": "richbodo@gmail.com"
+  },
+  "homepage": "https://github.com/richbodo/fellows_local_db",
+  "repository": {
+    "type": "git",
+    "url": "https://github.com/richbodo/fellows_local_db.git"
+  },
+  "license": "MIT",
+  "keywords": ["fellows", "ehf", "email", "mailto", "outreach"],
+  "server": {
+    "type": "node",
+    "entry_point": "server/index.js",
+    "mcp_config": {
+      "command": "node",
+      "args": ["${__dirname}/server/index.js"],
+      "env": {}
+    }
+  },
+  "tools": [
+    {
+      "name": "stage_email",
+      "description": "Stage an email composition as a mailto: URL for the user to review and send."
+    },
+    {
+      "name": "get_staged",
+      "description": "Look up a previously staged composition by id."
+    }
+  ],
+  "compatibility": {
+    "platforms": ["darwin"],
+    "runtimes": {
+      "node": ">=20.0.0"
+    }
+  }
+}

--- a/mcpb/node/package-lock.json
+++ b/mcpb/node/package-lock.json
@@ -1,0 +1,1194 @@
+{
+  "name": "fellows-mcpb-node",
+  "version": "0.1.0",
+  "lockfileVersion": 3,
+  "requires": true,
+  "packages": {
+    "": {
+      "name": "fellows-mcpb-node",
+      "version": "0.1.0",
+      "dependencies": {
+        "@modelcontextprotocol/sdk": "^1.29.0",
+        "zod": "^4.4.3"
+      },
+      "devDependencies": {
+        "@types/node": "^22.0.0",
+        "typescript": "^5.6.0"
+      },
+      "engines": {
+        "node": ">=20"
+      }
+    },
+    "node_modules/@hono/node-server": {
+      "version": "1.19.14",
+      "resolved": "https://registry.npmjs.org/@hono/node-server/-/node-server-1.19.14.tgz",
+      "integrity": "sha512-GwtvgtXxnWsucXvbQXkRgqksiH2Qed37H9xHZocE5sA3N8O8O8/8FA3uclQXxXVzc9XBZuEOMK7+r02FmSpHtw==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=18.14.1"
+      },
+      "peerDependencies": {
+        "hono": "^4"
+      }
+    },
+    "node_modules/@modelcontextprotocol/sdk": {
+      "version": "1.29.0",
+      "resolved": "https://registry.npmjs.org/@modelcontextprotocol/sdk/-/sdk-1.29.0.tgz",
+      "integrity": "sha512-zo37mZA9hJWpULgkRpowewez1y6ML5GsXJPY8FI0tBBCd77HEvza4jDqRKOXgHNn867PVGCyTdzqpz0izu5ZjQ==",
+      "license": "MIT",
+      "dependencies": {
+        "@hono/node-server": "^1.19.9",
+        "ajv": "^8.17.1",
+        "ajv-formats": "^3.0.1",
+        "content-type": "^1.0.5",
+        "cors": "^2.8.5",
+        "cross-spawn": "^7.0.5",
+        "eventsource": "^3.0.2",
+        "eventsource-parser": "^3.0.0",
+        "express": "^5.2.1",
+        "express-rate-limit": "^8.2.1",
+        "hono": "^4.11.4",
+        "jose": "^6.1.3",
+        "json-schema-typed": "^8.0.2",
+        "pkce-challenge": "^5.0.0",
+        "raw-body": "^3.0.0",
+        "zod": "^3.25 || ^4.0",
+        "zod-to-json-schema": "^3.25.1"
+      },
+      "engines": {
+        "node": ">=18"
+      },
+      "peerDependencies": {
+        "@cfworker/json-schema": "^4.1.1",
+        "zod": "^3.25 || ^4.0"
+      },
+      "peerDependenciesMeta": {
+        "@cfworker/json-schema": {
+          "optional": true
+        },
+        "zod": {
+          "optional": false
+        }
+      }
+    },
+    "node_modules/@types/node": {
+      "version": "22.19.19",
+      "resolved": "https://registry.npmjs.org/@types/node/-/node-22.19.19.tgz",
+      "integrity": "sha512-dyh/xO2Fh5bYrfWaaqGrRQQGkNdmYw6AmaAUvYeUMNTWQtvb796ikLdmTchRmOlOiIJ1TDXfWgVx1QkUlQ6Hew==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "undici-types": "~6.21.0"
+      }
+    },
+    "node_modules/accepts": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/accepts/-/accepts-2.0.0.tgz",
+      "integrity": "sha512-5cvg6CtKwfgdmVqY1WIiXKc3Q1bkRqGLi+2W/6ao+6Y7gu/RCwRuAhGEzh5B4KlszSuTLgZYuqFqo5bImjNKng==",
+      "license": "MIT",
+      "dependencies": {
+        "mime-types": "^3.0.0",
+        "negotiator": "^1.0.0"
+      },
+      "engines": {
+        "node": ">= 0.6"
+      }
+    },
+    "node_modules/ajv": {
+      "version": "8.20.0",
+      "resolved": "https://registry.npmjs.org/ajv/-/ajv-8.20.0.tgz",
+      "integrity": "sha512-Thbli+OlOj+iMPYFBVBfJ3OmCAnaSyNn4M1vz9T6Gka5Jt9ba/HIR56joy65tY6kx/FCF5VXNB819Y7/GUrBGA==",
+      "license": "MIT",
+      "dependencies": {
+        "fast-deep-equal": "^3.1.3",
+        "fast-uri": "^3.0.1",
+        "json-schema-traverse": "^1.0.0",
+        "require-from-string": "^2.0.2"
+      },
+      "funding": {
+        "type": "github",
+        "url": "https://github.com/sponsors/epoberezkin"
+      }
+    },
+    "node_modules/ajv-formats": {
+      "version": "3.0.1",
+      "resolved": "https://registry.npmjs.org/ajv-formats/-/ajv-formats-3.0.1.tgz",
+      "integrity": "sha512-8iUql50EUR+uUcdRQ3HDqa6EVyo3docL8g5WJ3FNcWmu62IbkGUue/pEyLBW8VGKKucTPgqeks4fIU1DA4yowQ==",
+      "license": "MIT",
+      "dependencies": {
+        "ajv": "^8.0.0"
+      },
+      "peerDependencies": {
+        "ajv": "^8.0.0"
+      },
+      "peerDependenciesMeta": {
+        "ajv": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/body-parser": {
+      "version": "2.2.2",
+      "resolved": "https://registry.npmjs.org/body-parser/-/body-parser-2.2.2.tgz",
+      "integrity": "sha512-oP5VkATKlNwcgvxi0vM0p/D3n2C3EReYVX+DNYs5TjZFn/oQt2j+4sVJtSMr18pdRr8wjTcBl6LoV+FUwzPmNA==",
+      "license": "MIT",
+      "dependencies": {
+        "bytes": "^3.1.2",
+        "content-type": "^1.0.5",
+        "debug": "^4.4.3",
+        "http-errors": "^2.0.0",
+        "iconv-lite": "^0.7.0",
+        "on-finished": "^2.4.1",
+        "qs": "^6.14.1",
+        "raw-body": "^3.0.1",
+        "type-is": "^2.0.1"
+      },
+      "engines": {
+        "node": ">=18"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/express"
+      }
+    },
+    "node_modules/bytes": {
+      "version": "3.1.2",
+      "resolved": "https://registry.npmjs.org/bytes/-/bytes-3.1.2.tgz",
+      "integrity": "sha512-/Nf7TyzTx6S3yRJObOAV7956r8cr2+Oj8AC5dt8wSP3BQAoeX58NoHyCU8P8zGkNXStjTSi6fzO6F0pBdcYbEg==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.8"
+      }
+    },
+    "node_modules/call-bind-apply-helpers": {
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/call-bind-apply-helpers/-/call-bind-apply-helpers-1.0.2.tgz",
+      "integrity": "sha512-Sp1ablJ0ivDkSzjcaJdxEunN5/XvksFJ2sMBFfq6x0ryhQV/2b/KwFe21cMpmHtPOSij8K99/wSfoEuTObmuMQ==",
+      "license": "MIT",
+      "dependencies": {
+        "es-errors": "^1.3.0",
+        "function-bind": "^1.1.2"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      }
+    },
+    "node_modules/call-bound": {
+      "version": "1.0.4",
+      "resolved": "https://registry.npmjs.org/call-bound/-/call-bound-1.0.4.tgz",
+      "integrity": "sha512-+ys997U96po4Kx/ABpBCqhA9EuxJaQWDQg7295H4hBphv3IZg0boBKuwYpt4YXp6MZ5AmZQnU/tyMTlRpaSejg==",
+      "license": "MIT",
+      "dependencies": {
+        "call-bind-apply-helpers": "^1.0.2",
+        "get-intrinsic": "^1.3.0"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/content-disposition": {
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/content-disposition/-/content-disposition-1.1.0.tgz",
+      "integrity": "sha512-5jRCH9Z/+DRP7rkvY83B+yGIGX96OYdJmzngqnw2SBSxqCFPd0w2km3s5iawpGX8krnwSGmF0FW5Nhr0Hfai3g==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=18"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/express"
+      }
+    },
+    "node_modules/content-type": {
+      "version": "1.0.5",
+      "resolved": "https://registry.npmjs.org/content-type/-/content-type-1.0.5.tgz",
+      "integrity": "sha512-nTjqfcBFEipKdXCv4YDQWCfmcLZKm81ldF0pAopTvyrFGVbcR6P/VAAd5G7N+0tTr8QqiU0tFadD6FK4NtJwOA==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.6"
+      }
+    },
+    "node_modules/cookie": {
+      "version": "0.7.2",
+      "resolved": "https://registry.npmjs.org/cookie/-/cookie-0.7.2.tgz",
+      "integrity": "sha512-yki5XnKuf750l50uGTllt6kKILY4nQ1eNIQatoXEByZ5dWgnKqbnqmTrBE5B4N7lrMJKQ2ytWMiTO2o0v6Ew/w==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.6"
+      }
+    },
+    "node_modules/cookie-signature": {
+      "version": "1.2.2",
+      "resolved": "https://registry.npmjs.org/cookie-signature/-/cookie-signature-1.2.2.tgz",
+      "integrity": "sha512-D76uU73ulSXrD1UXF4KE2TMxVVwhsnCgfAyTg9k8P6KGZjlXKrOLe4dJQKI3Bxi5wjesZoFXJWElNWBjPZMbhg==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=6.6.0"
+      }
+    },
+    "node_modules/cors": {
+      "version": "2.8.6",
+      "resolved": "https://registry.npmjs.org/cors/-/cors-2.8.6.tgz",
+      "integrity": "sha512-tJtZBBHA6vjIAaF6EnIaq6laBBP9aq/Y3ouVJjEfoHbRBcHBAHYcMh/w8LDrk2PvIMMq8gmopa5D4V8RmbrxGw==",
+      "license": "MIT",
+      "dependencies": {
+        "object-assign": "^4",
+        "vary": "^1"
+      },
+      "engines": {
+        "node": ">= 0.10"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/express"
+      }
+    },
+    "node_modules/cross-spawn": {
+      "version": "7.0.6",
+      "resolved": "https://registry.npmjs.org/cross-spawn/-/cross-spawn-7.0.6.tgz",
+      "integrity": "sha512-uV2QOWP2nWzsy2aMp8aRibhi9dlzF5Hgh5SHaB9OiTGEyDTiJJyx0uy51QXdyWbtAHNua4XJzUKca3OzKUd3vA==",
+      "license": "MIT",
+      "dependencies": {
+        "path-key": "^3.1.0",
+        "shebang-command": "^2.0.0",
+        "which": "^2.0.1"
+      },
+      "engines": {
+        "node": ">= 8"
+      }
+    },
+    "node_modules/debug": {
+      "version": "4.4.3",
+      "resolved": "https://registry.npmjs.org/debug/-/debug-4.4.3.tgz",
+      "integrity": "sha512-RGwwWnwQvkVfavKVt22FGLw+xYSdzARwm0ru6DhTVA3umU5hZc28V3kO4stgYryrTlLpuvgI9GiijltAjNbcqA==",
+      "license": "MIT",
+      "dependencies": {
+        "ms": "^2.1.3"
+      },
+      "engines": {
+        "node": ">=6.0"
+      },
+      "peerDependenciesMeta": {
+        "supports-color": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/depd": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/depd/-/depd-2.0.0.tgz",
+      "integrity": "sha512-g7nH6P6dyDioJogAAGprGpCtVImJhpPk/roCzdb3fIh61/s/nPsfR6onyMwkCAR/OlC3yBC0lESvUoQEAssIrw==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.8"
+      }
+    },
+    "node_modules/dunder-proto": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/dunder-proto/-/dunder-proto-1.0.1.tgz",
+      "integrity": "sha512-KIN/nDJBQRcXw0MLVhZE9iQHmG68qAVIBg9CqmUYjmQIhgij9U5MFvrqkUL5FbtyyzZuOeOt0zdeRe4UY7ct+A==",
+      "license": "MIT",
+      "dependencies": {
+        "call-bind-apply-helpers": "^1.0.1",
+        "es-errors": "^1.3.0",
+        "gopd": "^1.2.0"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      }
+    },
+    "node_modules/ee-first": {
+      "version": "1.1.1",
+      "resolved": "https://registry.npmjs.org/ee-first/-/ee-first-1.1.1.tgz",
+      "integrity": "sha512-WMwm9LhRUo+WUaRN+vRuETqG89IgZphVSNkdFgeb6sS/E4OrDIN7t48CAewSHXc6C8lefD8KKfr5vY61brQlow==",
+      "license": "MIT"
+    },
+    "node_modules/encodeurl": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/encodeurl/-/encodeurl-2.0.0.tgz",
+      "integrity": "sha512-Q0n9HRi4m6JuGIV1eFlmvJB7ZEVxu93IrMyiMsGC0lrMJMWzRgx6WGquyfQgZVb31vhGgXnfmPNNXmxnOkRBrg==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.8"
+      }
+    },
+    "node_modules/es-define-property": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/es-define-property/-/es-define-property-1.0.1.tgz",
+      "integrity": "sha512-e3nRfgfUZ4rNGL232gUgX06QNyyez04KdjFrF+LTRoOXmrOgFKDg4BCdsjW8EnT69eqdYGmRpJwiPVYNrCaW3g==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.4"
+      }
+    },
+    "node_modules/es-errors": {
+      "version": "1.3.0",
+      "resolved": "https://registry.npmjs.org/es-errors/-/es-errors-1.3.0.tgz",
+      "integrity": "sha512-Zf5H2Kxt2xjTvbJvP2ZWLEICxA6j+hAmMzIlypy4xcBg1vKVnx89Wy0GbS+kf5cwCVFFzdCFh2XSCFNULS6csw==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.4"
+      }
+    },
+    "node_modules/es-object-atoms": {
+      "version": "1.1.1",
+      "resolved": "https://registry.npmjs.org/es-object-atoms/-/es-object-atoms-1.1.1.tgz",
+      "integrity": "sha512-FGgH2h8zKNim9ljj7dankFPcICIK9Cp5bm+c2gQSYePhpaG5+esrLODihIorn+Pe6FGJzWhXQotPv73jTaldXA==",
+      "license": "MIT",
+      "dependencies": {
+        "es-errors": "^1.3.0"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      }
+    },
+    "node_modules/escape-html": {
+      "version": "1.0.3",
+      "resolved": "https://registry.npmjs.org/escape-html/-/escape-html-1.0.3.tgz",
+      "integrity": "sha512-NiSupZ4OeuGwr68lGIeym/ksIZMJodUGOSCZ/FSnTxcrekbvqrgdUxlJOMpijaKZVjAJrWrGs/6Jy8OMuyj9ow==",
+      "license": "MIT"
+    },
+    "node_modules/etag": {
+      "version": "1.8.1",
+      "resolved": "https://registry.npmjs.org/etag/-/etag-1.8.1.tgz",
+      "integrity": "sha512-aIL5Fx7mawVa300al2BnEE4iNvo1qETxLrPI/o05L7z6go7fCw1J6EQmbK4FmJ2AS7kgVF/KEZWufBfdClMcPg==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.6"
+      }
+    },
+    "node_modules/eventsource": {
+      "version": "3.0.7",
+      "resolved": "https://registry.npmjs.org/eventsource/-/eventsource-3.0.7.tgz",
+      "integrity": "sha512-CRT1WTyuQoD771GW56XEZFQ/ZoSfWid1alKGDYMmkt2yl8UXrVR4pspqWNEcqKvVIzg6PAltWjxcSSPrboA4iA==",
+      "license": "MIT",
+      "dependencies": {
+        "eventsource-parser": "^3.0.1"
+      },
+      "engines": {
+        "node": ">=18.0.0"
+      }
+    },
+    "node_modules/eventsource-parser": {
+      "version": "3.0.8",
+      "resolved": "https://registry.npmjs.org/eventsource-parser/-/eventsource-parser-3.0.8.tgz",
+      "integrity": "sha512-70QWGkr4snxr0OXLRWsFLeRBIRPuQOvt4s8QYjmUlmlkyTZkRqS7EDVRZtzU3TiyDbXSzaOeF0XUKy8PchzukQ==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=18.0.0"
+      }
+    },
+    "node_modules/express": {
+      "version": "5.2.1",
+      "resolved": "https://registry.npmjs.org/express/-/express-5.2.1.tgz",
+      "integrity": "sha512-hIS4idWWai69NezIdRt2xFVofaF4j+6INOpJlVOLDO8zXGpUVEVzIYk12UUi2JzjEzWL3IOAxcTubgz9Po0yXw==",
+      "license": "MIT",
+      "dependencies": {
+        "accepts": "^2.0.0",
+        "body-parser": "^2.2.1",
+        "content-disposition": "^1.0.0",
+        "content-type": "^1.0.5",
+        "cookie": "^0.7.1",
+        "cookie-signature": "^1.2.1",
+        "debug": "^4.4.0",
+        "depd": "^2.0.0",
+        "encodeurl": "^2.0.0",
+        "escape-html": "^1.0.3",
+        "etag": "^1.8.1",
+        "finalhandler": "^2.1.0",
+        "fresh": "^2.0.0",
+        "http-errors": "^2.0.0",
+        "merge-descriptors": "^2.0.0",
+        "mime-types": "^3.0.0",
+        "on-finished": "^2.4.1",
+        "once": "^1.4.0",
+        "parseurl": "^1.3.3",
+        "proxy-addr": "^2.0.7",
+        "qs": "^6.14.0",
+        "range-parser": "^1.2.1",
+        "router": "^2.2.0",
+        "send": "^1.1.0",
+        "serve-static": "^2.2.0",
+        "statuses": "^2.0.1",
+        "type-is": "^2.0.1",
+        "vary": "^1.1.2"
+      },
+      "engines": {
+        "node": ">= 18"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/express"
+      }
+    },
+    "node_modules/express-rate-limit": {
+      "version": "8.5.2",
+      "resolved": "https://registry.npmjs.org/express-rate-limit/-/express-rate-limit-8.5.2.tgz",
+      "integrity": "sha512-5Kb34ipNX694DH48vN9irak1Qx30nb0PLYHXfJgw4YEjiC3ZEmZJhwOp+VfiCYwFzvFTdB9QkArYS5kXa2cx2A==",
+      "license": "MIT",
+      "dependencies": {
+        "ip-address": "^10.2.0"
+      },
+      "engines": {
+        "node": ">= 16"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/express-rate-limit"
+      },
+      "peerDependencies": {
+        "express": ">= 4.11"
+      }
+    },
+    "node_modules/fast-deep-equal": {
+      "version": "3.1.3",
+      "resolved": "https://registry.npmjs.org/fast-deep-equal/-/fast-deep-equal-3.1.3.tgz",
+      "integrity": "sha512-f3qQ9oQy9j2AhBe/H9VC91wLmKBCCU/gDOnKNAYG5hswO7BLKj09Hc5HYNz9cGI++xlpDCIgDaitVs03ATR84Q==",
+      "license": "MIT"
+    },
+    "node_modules/fast-uri": {
+      "version": "3.1.2",
+      "resolved": "https://registry.npmjs.org/fast-uri/-/fast-uri-3.1.2.tgz",
+      "integrity": "sha512-rVjf7ArG3LTk+FS6Yw81V1DLuZl1bRbNrev6Tmd/9RaroeeRRJhAt7jg/6YFxbvAQXUCavSoZhPPj6oOx+5KjQ==",
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/fastify"
+        },
+        {
+          "type": "opencollective",
+          "url": "https://opencollective.com/fastify"
+        }
+      ],
+      "license": "BSD-3-Clause"
+    },
+    "node_modules/finalhandler": {
+      "version": "2.1.1",
+      "resolved": "https://registry.npmjs.org/finalhandler/-/finalhandler-2.1.1.tgz",
+      "integrity": "sha512-S8KoZgRZN+a5rNwqTxlZZePjT/4cnm0ROV70LedRHZ0p8u9fRID0hJUZQpkKLzro8LfmC8sx23bY6tVNxv8pQA==",
+      "license": "MIT",
+      "dependencies": {
+        "debug": "^4.4.0",
+        "encodeurl": "^2.0.0",
+        "escape-html": "^1.0.3",
+        "on-finished": "^2.4.1",
+        "parseurl": "^1.3.3",
+        "statuses": "^2.0.1"
+      },
+      "engines": {
+        "node": ">= 18.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/express"
+      }
+    },
+    "node_modules/forwarded": {
+      "version": "0.2.0",
+      "resolved": "https://registry.npmjs.org/forwarded/-/forwarded-0.2.0.tgz",
+      "integrity": "sha512-buRG0fpBtRHSTCOASe6hD258tEubFoRLb4ZNA6NxMVHNw2gOcwHo9wyablzMzOA5z9xA9L1KNjk/Nt6MT9aYow==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.6"
+      }
+    },
+    "node_modules/fresh": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/fresh/-/fresh-2.0.0.tgz",
+      "integrity": "sha512-Rx/WycZ60HOaqLKAi6cHRKKI7zxWbJ31MhntmtwMoaTeF7XFH9hhBp8vITaMidfljRQ6eYWCKkaTK+ykVJHP2A==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.8"
+      }
+    },
+    "node_modules/function-bind": {
+      "version": "1.1.2",
+      "resolved": "https://registry.npmjs.org/function-bind/-/function-bind-1.1.2.tgz",
+      "integrity": "sha512-7XHNxH7qX9xG5mIwxkhumTox/MIRNcOgDrxWsMt2pAr23WHp6MrRlN7FBSFpCpr+oVO0F744iUgR82nJMfG2SA==",
+      "license": "MIT",
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/get-intrinsic": {
+      "version": "1.3.0",
+      "resolved": "https://registry.npmjs.org/get-intrinsic/-/get-intrinsic-1.3.0.tgz",
+      "integrity": "sha512-9fSjSaos/fRIVIp+xSJlE6lfwhES7LNtKaCBIamHsjr2na1BiABJPo0mOjjz8GJDURarmCPGqaiVg5mfjb98CQ==",
+      "license": "MIT",
+      "dependencies": {
+        "call-bind-apply-helpers": "^1.0.2",
+        "es-define-property": "^1.0.1",
+        "es-errors": "^1.3.0",
+        "es-object-atoms": "^1.1.1",
+        "function-bind": "^1.1.2",
+        "get-proto": "^1.0.1",
+        "gopd": "^1.2.0",
+        "has-symbols": "^1.1.0",
+        "hasown": "^2.0.2",
+        "math-intrinsics": "^1.1.0"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/get-proto": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/get-proto/-/get-proto-1.0.1.tgz",
+      "integrity": "sha512-sTSfBjoXBp89JvIKIefqw7U2CCebsc74kiY6awiGogKtoSGbgjYE/G/+l9sF3MWFPNc9IcoOC4ODfKHfxFmp0g==",
+      "license": "MIT",
+      "dependencies": {
+        "dunder-proto": "^1.0.1",
+        "es-object-atoms": "^1.0.0"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      }
+    },
+    "node_modules/gopd": {
+      "version": "1.2.0",
+      "resolved": "https://registry.npmjs.org/gopd/-/gopd-1.2.0.tgz",
+      "integrity": "sha512-ZUKRh6/kUFoAiTAtTYPZJ3hw9wNxx+BIBOijnlG9PnrJsCcSjs1wyyD6vJpaYtgnzDrKYRSqf3OO6Rfa93xsRg==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.4"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/has-symbols": {
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/has-symbols/-/has-symbols-1.1.0.tgz",
+      "integrity": "sha512-1cDNdwJ2Jaohmb3sg4OmKaMBwuC48sYni5HUw2DvsC8LjGTLK9h+eb1X6RyuOHe4hT0ULCW68iomhjUoKUqlPQ==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.4"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/hasown": {
+      "version": "2.0.3",
+      "resolved": "https://registry.npmjs.org/hasown/-/hasown-2.0.3.tgz",
+      "integrity": "sha512-ej4AhfhfL2Q2zpMmLo7U1Uv9+PyhIZpgQLGT1F9miIGmiCJIoCgSmczFdrc97mWT4kVY72KA+WnnhJ5pghSvSg==",
+      "license": "MIT",
+      "dependencies": {
+        "function-bind": "^1.1.2"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      }
+    },
+    "node_modules/hono": {
+      "version": "4.12.21",
+      "resolved": "https://registry.npmjs.org/hono/-/hono-4.12.21.tgz",
+      "integrity": "sha512-uV63apnb0kyPtAUwoWgaGh9HyIFcv8lgmzPZSiTBQAFOFGIzka5EZ1dZocmGnn0XdX0+XTqJ6Tqv7selMuGLRQ==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=16.9.0"
+      }
+    },
+    "node_modules/http-errors": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/http-errors/-/http-errors-2.0.1.tgz",
+      "integrity": "sha512-4FbRdAX+bSdmo4AUFuS0WNiPz8NgFt+r8ThgNWmlrjQjt1Q7ZR9+zTlce2859x4KSXrwIsaeTqDoKQmtP8pLmQ==",
+      "license": "MIT",
+      "dependencies": {
+        "depd": "~2.0.0",
+        "inherits": "~2.0.4",
+        "setprototypeof": "~1.2.0",
+        "statuses": "~2.0.2",
+        "toidentifier": "~1.0.1"
+      },
+      "engines": {
+        "node": ">= 0.8"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/express"
+      }
+    },
+    "node_modules/iconv-lite": {
+      "version": "0.7.2",
+      "resolved": "https://registry.npmjs.org/iconv-lite/-/iconv-lite-0.7.2.tgz",
+      "integrity": "sha512-im9DjEDQ55s9fL4EYzOAv0yMqmMBSZp6G0VvFyTMPKWxiSBHUj9NW/qqLmXUwXrrM7AvqSlTCfvqRb0cM8yYqw==",
+      "license": "MIT",
+      "dependencies": {
+        "safer-buffer": ">= 2.1.2 < 3.0.0"
+      },
+      "engines": {
+        "node": ">=0.10.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/express"
+      }
+    },
+    "node_modules/inherits": {
+      "version": "2.0.4",
+      "resolved": "https://registry.npmjs.org/inherits/-/inherits-2.0.4.tgz",
+      "integrity": "sha512-k/vGaX4/Yla3WzyMCvTQOXYeIHvqOKtnqBduzTHpzpQZzAskKMhZ2K+EnBiSM9zGSoIFeMpXKxa4dYeZIQqewQ==",
+      "license": "ISC"
+    },
+    "node_modules/ip-address": {
+      "version": "10.2.0",
+      "resolved": "https://registry.npmjs.org/ip-address/-/ip-address-10.2.0.tgz",
+      "integrity": "sha512-/+S6j4E9AHvW9SWMSEY9Xfy66O5PWvVEJ08O0y5JGyEKQpojb0K0GKpz/v5HJ/G0vi3D2sjGK78119oXZeE0qA==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 12"
+      }
+    },
+    "node_modules/ipaddr.js": {
+      "version": "1.9.1",
+      "resolved": "https://registry.npmjs.org/ipaddr.js/-/ipaddr.js-1.9.1.tgz",
+      "integrity": "sha512-0KI/607xoxSToH7GjN1FfSbLoU0+btTicjsQSWQlh/hZykN8KpmMf7uYwPW3R+akZ6R/w18ZlXSHBYXiYUPO3g==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.10"
+      }
+    },
+    "node_modules/is-promise": {
+      "version": "4.0.0",
+      "resolved": "https://registry.npmjs.org/is-promise/-/is-promise-4.0.0.tgz",
+      "integrity": "sha512-hvpoI6korhJMnej285dSg6nu1+e6uxs7zG3BYAm5byqDsgJNWwxzM6z6iZiAgQR4TJ30JmBTOwqZUw3WlyH3AQ==",
+      "license": "MIT"
+    },
+    "node_modules/isexe": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/isexe/-/isexe-2.0.0.tgz",
+      "integrity": "sha512-RHxMLp9lnKHGHRng9QFhRCMbYAcVpn69smSGcq3f36xjgVVWThj4qqLbTLlq7Ssj8B+fIQ1EuCEGI2lKsyQeIw==",
+      "license": "ISC"
+    },
+    "node_modules/jose": {
+      "version": "6.2.3",
+      "resolved": "https://registry.npmjs.org/jose/-/jose-6.2.3.tgz",
+      "integrity": "sha512-YYVDInQKFJfR/xa3ojUTl8c2KoTwiL1R5Wg9YCydwH0x0B9grbzlg5HC7mMjCtUJjbQ/YnGEZIhI5tCgfTb4Hw==",
+      "license": "MIT",
+      "funding": {
+        "url": "https://github.com/sponsors/panva"
+      }
+    },
+    "node_modules/json-schema-traverse": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/json-schema-traverse/-/json-schema-traverse-1.0.0.tgz",
+      "integrity": "sha512-NM8/P9n3XjXhIZn1lLhkFaACTOURQXjWhV4BA/RnOv8xvgqtqpAX9IO4mRQxSx1Rlo4tqzeqb0sOlruaOy3dug==",
+      "license": "MIT"
+    },
+    "node_modules/json-schema-typed": {
+      "version": "8.0.2",
+      "resolved": "https://registry.npmjs.org/json-schema-typed/-/json-schema-typed-8.0.2.tgz",
+      "integrity": "sha512-fQhoXdcvc3V28x7C7BMs4P5+kNlgUURe2jmUT1T//oBRMDrqy1QPelJimwZGo7Hg9VPV3EQV5Bnq4hbFy2vetA==",
+      "license": "BSD-2-Clause"
+    },
+    "node_modules/math-intrinsics": {
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/math-intrinsics/-/math-intrinsics-1.1.0.tgz",
+      "integrity": "sha512-/IXtbwEk5HTPyEwyKX6hGkYXxM9nbj64B+ilVJnC/R6B0pH5G4V3b0pVbL7DBj4tkhBAppbQUlf6F6Xl9LHu1g==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.4"
+      }
+    },
+    "node_modules/media-typer": {
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/media-typer/-/media-typer-1.1.0.tgz",
+      "integrity": "sha512-aisnrDP4GNe06UcKFnV5bfMNPBUw4jsLGaWwWfnH3v02GnBuXX2MCVn5RbrWo0j3pczUilYblq7fQ7Nw2t5XKw==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.8"
+      }
+    },
+    "node_modules/merge-descriptors": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/merge-descriptors/-/merge-descriptors-2.0.0.tgz",
+      "integrity": "sha512-Snk314V5ayFLhp3fkUREub6WtjBfPdCPY1Ln8/8munuLuiYhsABgBVWsozAG+MWMbVEvcdcpbi9R7ww22l9Q3g==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=18"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/mime-db": {
+      "version": "1.54.0",
+      "resolved": "https://registry.npmjs.org/mime-db/-/mime-db-1.54.0.tgz",
+      "integrity": "sha512-aU5EJuIN2WDemCcAp2vFBfp/m4EAhWJnUNSSw0ixs7/kXbd6Pg64EmwJkNdFhB8aWt1sH2CTXrLxo/iAGV3oPQ==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.6"
+      }
+    },
+    "node_modules/mime-types": {
+      "version": "3.0.2",
+      "resolved": "https://registry.npmjs.org/mime-types/-/mime-types-3.0.2.tgz",
+      "integrity": "sha512-Lbgzdk0h4juoQ9fCKXW4by0UJqj+nOOrI9MJ1sSj4nI8aI2eo1qmvQEie4VD1glsS250n15LsWsYtCugiStS5A==",
+      "license": "MIT",
+      "dependencies": {
+        "mime-db": "^1.54.0"
+      },
+      "engines": {
+        "node": ">=18"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/express"
+      }
+    },
+    "node_modules/ms": {
+      "version": "2.1.3",
+      "resolved": "https://registry.npmjs.org/ms/-/ms-2.1.3.tgz",
+      "integrity": "sha512-6FlzubTLZG3J2a/NVCAleEhjzq5oxgHyaCU9yYXvcLsvoVaHJq/s5xXI6/XXP6tz7R9xAOtHnSO/tXtF3WRTlA==",
+      "license": "MIT"
+    },
+    "node_modules/negotiator": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/negotiator/-/negotiator-1.0.0.tgz",
+      "integrity": "sha512-8Ofs/AUQh8MaEcrlq5xOX0CQ9ypTF5dl78mjlMNfOK08fzpgTHQRQPBxcPlEtIw0yRpws+Zo/3r+5WRby7u3Gg==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.6"
+      }
+    },
+    "node_modules/object-assign": {
+      "version": "4.1.1",
+      "resolved": "https://registry.npmjs.org/object-assign/-/object-assign-4.1.1.tgz",
+      "integrity": "sha512-rJgTQnkUnH1sFw8yT6VSU3zD3sWmu6sZhIseY8VX+GRu3P6F7Fu+JNDoXfklElbLJSnc3FUQHVe4cU5hj+BcUg==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=0.10.0"
+      }
+    },
+    "node_modules/object-inspect": {
+      "version": "1.13.4",
+      "resolved": "https://registry.npmjs.org/object-inspect/-/object-inspect-1.13.4.tgz",
+      "integrity": "sha512-W67iLl4J2EXEGTbfeHCffrjDfitvLANg0UlX3wFUUSTx92KXRFegMHUVgSqE+wvhAbi4WqjGg9czysTV2Epbew==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.4"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/on-finished": {
+      "version": "2.4.1",
+      "resolved": "https://registry.npmjs.org/on-finished/-/on-finished-2.4.1.tgz",
+      "integrity": "sha512-oVlzkg3ENAhCk2zdv7IJwd/QUD4z2RxRwpkcGY8psCVcCYZNq4wYnVWALHM+brtuJjePWiYF/ClmuDr8Ch5+kg==",
+      "license": "MIT",
+      "dependencies": {
+        "ee-first": "1.1.1"
+      },
+      "engines": {
+        "node": ">= 0.8"
+      }
+    },
+    "node_modules/once": {
+      "version": "1.4.0",
+      "resolved": "https://registry.npmjs.org/once/-/once-1.4.0.tgz",
+      "integrity": "sha512-lNaJgI+2Q5URQBkccEKHTQOPaXdUxnZZElQTZY0MFUAuaEqe1E+Nyvgdz/aIyNi6Z9MzO5dv1H8n58/GELp3+w==",
+      "license": "ISC",
+      "dependencies": {
+        "wrappy": "1"
+      }
+    },
+    "node_modules/parseurl": {
+      "version": "1.3.3",
+      "resolved": "https://registry.npmjs.org/parseurl/-/parseurl-1.3.3.tgz",
+      "integrity": "sha512-CiyeOxFT/JZyN5m0z9PfXw4SCBJ6Sygz1Dpl0wqjlhDEGGBP1GnsUVEL0p63hoG1fcj3fHynXi9NYO4nWOL+qQ==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.8"
+      }
+    },
+    "node_modules/path-key": {
+      "version": "3.1.1",
+      "resolved": "https://registry.npmjs.org/path-key/-/path-key-3.1.1.tgz",
+      "integrity": "sha512-ojmeN0qd+y0jszEtoY48r0Peq5dwMEkIlCOu6Q5f41lfkswXuKtYrhgoTpLnyIcHm24Uhqx+5Tqm2InSwLhE6Q==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/path-to-regexp": {
+      "version": "8.4.2",
+      "resolved": "https://registry.npmjs.org/path-to-regexp/-/path-to-regexp-8.4.2.tgz",
+      "integrity": "sha512-qRcuIdP69NPm4qbACK+aDogI5CBDMi1jKe0ry5rSQJz8JVLsC7jV8XpiJjGRLLol3N+R5ihGYcrPLTno6pAdBA==",
+      "license": "MIT",
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/express"
+      }
+    },
+    "node_modules/pkce-challenge": {
+      "version": "5.0.1",
+      "resolved": "https://registry.npmjs.org/pkce-challenge/-/pkce-challenge-5.0.1.tgz",
+      "integrity": "sha512-wQ0b/W4Fr01qtpHlqSqspcj3EhBvimsdh0KlHhH8HRZnMsEa0ea2fTULOXOS9ccQr3om+GcGRk4e+isrZWV8qQ==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=16.20.0"
+      }
+    },
+    "node_modules/proxy-addr": {
+      "version": "2.0.7",
+      "resolved": "https://registry.npmjs.org/proxy-addr/-/proxy-addr-2.0.7.tgz",
+      "integrity": "sha512-llQsMLSUDUPT44jdrU/O37qlnifitDP+ZwrmmZcoSKyLKvtZxpyV0n2/bD/N4tBAAZ/gJEdZU7KMraoK1+XYAg==",
+      "license": "MIT",
+      "dependencies": {
+        "forwarded": "0.2.0",
+        "ipaddr.js": "1.9.1"
+      },
+      "engines": {
+        "node": ">= 0.10"
+      }
+    },
+    "node_modules/qs": {
+      "version": "6.15.2",
+      "resolved": "https://registry.npmjs.org/qs/-/qs-6.15.2.tgz",
+      "integrity": "sha512-Rzq0KEyX/w/tEybncDgdkZrJgVUsUMk3xjh3t5bv3S1HTAtg+uOYt72+ZfwiQwKdysThkTBdL/rTi6HDmX9Ddw==",
+      "license": "BSD-3-Clause",
+      "dependencies": {
+        "side-channel": "^1.1.0"
+      },
+      "engines": {
+        "node": ">=0.6"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/range-parser": {
+      "version": "1.2.1",
+      "resolved": "https://registry.npmjs.org/range-parser/-/range-parser-1.2.1.tgz",
+      "integrity": "sha512-Hrgsx+orqoygnmhFbKaHE6c296J+HTAQXoxEF6gNupROmmGJRoyzfG3ccAveqCBrwr/2yxQ5BVd/GTl5agOwSg==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.6"
+      }
+    },
+    "node_modules/raw-body": {
+      "version": "3.0.2",
+      "resolved": "https://registry.npmjs.org/raw-body/-/raw-body-3.0.2.tgz",
+      "integrity": "sha512-K5zQjDllxWkf7Z5xJdV0/B0WTNqx6vxG70zJE4N0kBs4LovmEYWJzQGxC9bS9RAKu3bgM40lrd5zoLJ12MQ5BA==",
+      "license": "MIT",
+      "dependencies": {
+        "bytes": "~3.1.2",
+        "http-errors": "~2.0.1",
+        "iconv-lite": "~0.7.0",
+        "unpipe": "~1.0.0"
+      },
+      "engines": {
+        "node": ">= 0.10"
+      }
+    },
+    "node_modules/require-from-string": {
+      "version": "2.0.2",
+      "resolved": "https://registry.npmjs.org/require-from-string/-/require-from-string-2.0.2.tgz",
+      "integrity": "sha512-Xf0nWe6RseziFMu+Ap9biiUbmplq6S9/p+7w7YXP/JBHhrUDDUhwa+vANyubuqfZWTveU//DYVGsDG7RKL/vEw==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=0.10.0"
+      }
+    },
+    "node_modules/router": {
+      "version": "2.2.0",
+      "resolved": "https://registry.npmjs.org/router/-/router-2.2.0.tgz",
+      "integrity": "sha512-nLTrUKm2UyiL7rlhapu/Zl45FwNgkZGaCpZbIHajDYgwlJCOzLSk+cIPAnsEqV955GjILJnKbdQC1nVPz+gAYQ==",
+      "license": "MIT",
+      "dependencies": {
+        "debug": "^4.4.0",
+        "depd": "^2.0.0",
+        "is-promise": "^4.0.0",
+        "parseurl": "^1.3.3",
+        "path-to-regexp": "^8.0.0"
+      },
+      "engines": {
+        "node": ">= 18"
+      }
+    },
+    "node_modules/safer-buffer": {
+      "version": "2.1.2",
+      "resolved": "https://registry.npmjs.org/safer-buffer/-/safer-buffer-2.1.2.tgz",
+      "integrity": "sha512-YZo3K82SD7Riyi0E1EQPojLz7kpepnSQI9IyPbHHg1XXXevb5dJI7tpyN2ADxGcQbHG7vcyRHk0cbwqcQriUtg==",
+      "license": "MIT"
+    },
+    "node_modules/send": {
+      "version": "1.2.1",
+      "resolved": "https://registry.npmjs.org/send/-/send-1.2.1.tgz",
+      "integrity": "sha512-1gnZf7DFcoIcajTjTwjwuDjzuz4PPcY2StKPlsGAQ1+YH20IRVrBaXSWmdjowTJ6u8Rc01PoYOGHXfP1mYcZNQ==",
+      "license": "MIT",
+      "dependencies": {
+        "debug": "^4.4.3",
+        "encodeurl": "^2.0.0",
+        "escape-html": "^1.0.3",
+        "etag": "^1.8.1",
+        "fresh": "^2.0.0",
+        "http-errors": "^2.0.1",
+        "mime-types": "^3.0.2",
+        "ms": "^2.1.3",
+        "on-finished": "^2.4.1",
+        "range-parser": "^1.2.1",
+        "statuses": "^2.0.2"
+      },
+      "engines": {
+        "node": ">= 18"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/express"
+      }
+    },
+    "node_modules/serve-static": {
+      "version": "2.2.1",
+      "resolved": "https://registry.npmjs.org/serve-static/-/serve-static-2.2.1.tgz",
+      "integrity": "sha512-xRXBn0pPqQTVQiC8wyQrKs2MOlX24zQ0POGaj0kultvoOCstBQM5yvOhAVSUwOMjQtTvsPWoNCHfPGwaaQJhTw==",
+      "license": "MIT",
+      "dependencies": {
+        "encodeurl": "^2.0.0",
+        "escape-html": "^1.0.3",
+        "parseurl": "^1.3.3",
+        "send": "^1.2.0"
+      },
+      "engines": {
+        "node": ">= 18"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/express"
+      }
+    },
+    "node_modules/setprototypeof": {
+      "version": "1.2.0",
+      "resolved": "https://registry.npmjs.org/setprototypeof/-/setprototypeof-1.2.0.tgz",
+      "integrity": "sha512-E5LDX7Wrp85Kil5bhZv46j8jOeboKq5JMmYM3gVGdGH8xFpPWXUMsNrlODCrkoxMEeNi/XZIwuRvY4XNwYMJpw==",
+      "license": "ISC"
+    },
+    "node_modules/shebang-command": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/shebang-command/-/shebang-command-2.0.0.tgz",
+      "integrity": "sha512-kHxr2zZpYtdmrN1qDjrrX/Z1rR1kG8Dx+gkpK1G4eXmvXswmcE1hTWBWYUzlraYw1/yZp6YuDY77YtvbN0dmDA==",
+      "license": "MIT",
+      "dependencies": {
+        "shebang-regex": "^3.0.0"
+      },
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/shebang-regex": {
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/shebang-regex/-/shebang-regex-3.0.0.tgz",
+      "integrity": "sha512-7++dFhtcx3353uBaq8DDR4NuxBetBzC7ZQOhmTQInHEd6bSrXdiEyzCvG07Z44UYdLShWUyXt5M/yhz8ekcb1A==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/side-channel": {
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/side-channel/-/side-channel-1.1.0.tgz",
+      "integrity": "sha512-ZX99e6tRweoUXqR+VBrslhda51Nh5MTQwou5tnUDgbtyM0dBgmhEDtWGP/xbKn6hqfPRHujUNwz5fy/wbbhnpw==",
+      "license": "MIT",
+      "dependencies": {
+        "es-errors": "^1.3.0",
+        "object-inspect": "^1.13.3",
+        "side-channel-list": "^1.0.0",
+        "side-channel-map": "^1.0.1",
+        "side-channel-weakmap": "^1.0.2"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/side-channel-list": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/side-channel-list/-/side-channel-list-1.0.1.tgz",
+      "integrity": "sha512-mjn/0bi/oUURjc5Xl7IaWi/OJJJumuoJFQJfDDyO46+hBWsfaVM65TBHq2eoZBhzl9EchxOijpkbRC8SVBQU0w==",
+      "license": "MIT",
+      "dependencies": {
+        "es-errors": "^1.3.0",
+        "object-inspect": "^1.13.4"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/side-channel-map": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/side-channel-map/-/side-channel-map-1.0.1.tgz",
+      "integrity": "sha512-VCjCNfgMsby3tTdo02nbjtM/ewra6jPHmpThenkTYh8pG9ucZ/1P8So4u4FGBek/BjpOVsDCMoLA/iuBKIFXRA==",
+      "license": "MIT",
+      "dependencies": {
+        "call-bound": "^1.0.2",
+        "es-errors": "^1.3.0",
+        "get-intrinsic": "^1.2.5",
+        "object-inspect": "^1.13.3"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/side-channel-weakmap": {
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/side-channel-weakmap/-/side-channel-weakmap-1.0.2.tgz",
+      "integrity": "sha512-WPS/HvHQTYnHisLo9McqBHOJk2FkHO/tlpvldyrnem4aeQp4hai3gythswg6p01oSoTl58rcpiFAjF2br2Ak2A==",
+      "license": "MIT",
+      "dependencies": {
+        "call-bound": "^1.0.2",
+        "es-errors": "^1.3.0",
+        "get-intrinsic": "^1.2.5",
+        "object-inspect": "^1.13.3",
+        "side-channel-map": "^1.0.1"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/statuses": {
+      "version": "2.0.2",
+      "resolved": "https://registry.npmjs.org/statuses/-/statuses-2.0.2.tgz",
+      "integrity": "sha512-DvEy55V3DB7uknRo+4iOGT5fP1slR8wQohVdknigZPMpMstaKJQWhwiYBACJE3Ul2pTnATihhBYnRhZQHGBiRw==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.8"
+      }
+    },
+    "node_modules/toidentifier": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/toidentifier/-/toidentifier-1.0.1.tgz",
+      "integrity": "sha512-o5sSPKEkg/DIQNmH43V0/uerLrpzVedkUh8tGNvaeXpfpuwjKenlSox/2O/BTlZUtEe+JG7s5YhEz608PlAHRA==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=0.6"
+      }
+    },
+    "node_modules/type-is": {
+      "version": "2.1.0",
+      "resolved": "https://registry.npmjs.org/type-is/-/type-is-2.1.0.tgz",
+      "integrity": "sha512-faYHw0anBbc/kWF3zFTEnxSFOAGUX9GFbOBthvDdLsIlEoWOFOtS0zgCiQYwIskL9iGXZL3kAXD8OoZ4GmMATA==",
+      "license": "MIT",
+      "dependencies": {
+        "content-type": "^2.0.0",
+        "media-typer": "^1.1.0",
+        "mime-types": "^3.0.0"
+      },
+      "engines": {
+        "node": ">= 18"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/express"
+      }
+    },
+    "node_modules/type-is/node_modules/content-type": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/content-type/-/content-type-2.0.0.tgz",
+      "integrity": "sha512-j/O/d7GcZCyNl7/hwZAb606rzqkyvaDctLmckbxLzHvFBzTJHuGEdodATcP3yIRoDrLHkIATJuvzbFlp/ki2cQ==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=18"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/express"
+      }
+    },
+    "node_modules/typescript": {
+      "version": "5.9.3",
+      "resolved": "https://registry.npmjs.org/typescript/-/typescript-5.9.3.tgz",
+      "integrity": "sha512-jl1vZzPDinLr9eUt3J/t7V6FgNEw9QjvBPdysz9KfQDD41fQrC2Y4vKQdiaUpFT4bXlb1RHhLpp8wtm6M5TgSw==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "bin": {
+        "tsc": "bin/tsc",
+        "tsserver": "bin/tsserver"
+      },
+      "engines": {
+        "node": ">=14.17"
+      }
+    },
+    "node_modules/undici-types": {
+      "version": "6.21.0",
+      "resolved": "https://registry.npmjs.org/undici-types/-/undici-types-6.21.0.tgz",
+      "integrity": "sha512-iwDZqg0QAGrg9Rav5H4n0M64c3mkR59cJ6wQp+7C4nI0gsmExaedaYLNO44eT4AtBBwjbTiGPMlt2Md0T9H9JQ==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/unpipe": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/unpipe/-/unpipe-1.0.0.tgz",
+      "integrity": "sha512-pjy2bYhSsufwWlKwPc+l3cN7+wuJlK6uz0YdJEOlQDbl6jo/YlPi4mb8agUkVC8BF7V8NuzeyPNqRksA3hztKQ==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.8"
+      }
+    },
+    "node_modules/vary": {
+      "version": "1.1.2",
+      "resolved": "https://registry.npmjs.org/vary/-/vary-1.1.2.tgz",
+      "integrity": "sha512-BNGbWLfd0eUPabhkXUVm0j8uuvREyTh5ovRa/dyow/BqAbZJyC+5fU+IzQOzmAKzYqYRAISoRhdQr3eIZ/PXqg==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.8"
+      }
+    },
+    "node_modules/which": {
+      "version": "2.0.2",
+      "resolved": "https://registry.npmjs.org/which/-/which-2.0.2.tgz",
+      "integrity": "sha512-BLI3Tl1TW3Pvl70l3yq3Y64i+awpwXqsGBYWkkqMtnbXgrMD+yj7rhW0kuEDxzJaYXGjEW5ogapKNMEKNMjibA==",
+      "license": "ISC",
+      "dependencies": {
+        "isexe": "^2.0.0"
+      },
+      "bin": {
+        "node-which": "bin/node-which"
+      },
+      "engines": {
+        "node": ">= 8"
+      }
+    },
+    "node_modules/wrappy": {
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/wrappy/-/wrappy-1.0.2.tgz",
+      "integrity": "sha512-l4Sp/DRseor9wL6EvV2+TuQn63dMkPjZ/sp9XkghTEbV9KlPS1xUsZ3u7/IQO4wxtcFB4bgpQPRcR3QCvezPcQ==",
+      "license": "ISC"
+    },
+    "node_modules/zod": {
+      "version": "4.4.3",
+      "resolved": "https://registry.npmjs.org/zod/-/zod-4.4.3.tgz",
+      "integrity": "sha512-ytENFjIJFl2UwYglde2jchW2Hwm4GJFLDiSXWdTrJQBIN9Fcyp7n4DhxJEiWNAJMV1/BqWfW/kkg71UDcHJyTQ==",
+      "license": "MIT",
+      "funding": {
+        "url": "https://github.com/sponsors/colinhacks"
+      }
+    },
+    "node_modules/zod-to-json-schema": {
+      "version": "3.25.2",
+      "resolved": "https://registry.npmjs.org/zod-to-json-schema/-/zod-to-json-schema-3.25.2.tgz",
+      "integrity": "sha512-O/PgfnpT1xKSDeQYSCfRI5Gy3hPf91mKVDuYLUHZJMiDFptvP41MSnWofm8dnCm0256ZNfZIM7DSzuSMAFnjHA==",
+      "license": "ISC",
+      "peerDependencies": {
+        "zod": "^3.25.28 || ^4"
+      }
+    }
+  }
+}

--- a/mcpb/node/package.json
+++ b/mcpb/node/package.json
@@ -1,0 +1,22 @@
+{
+  "name": "fellows-mcpb-node",
+  "version": "0.1.0",
+  "private": true,
+  "description": "TypeScript MCP server implementations for the Fellows Directory app, packaged as .mcpb Desktop Extensions for Claude Desktop. The Python source in ../../mcp_servers/ stays as the standalone-client surface; this directory is the end-user Claude Desktop install path.",
+  "type": "module",
+  "engines": {
+    "node": ">=20"
+  },
+  "scripts": {
+    "build": "tsc",
+    "clean": "rm -rf dist"
+  },
+  "dependencies": {
+    "@modelcontextprotocol/sdk": "^1.29.0",
+    "zod": "^4.4.3"
+  },
+  "devDependencies": {
+    "@types/node": "^22.0.0",
+    "typescript": "^5.6.0"
+  }
+}

--- a/mcpb/node/src/comms/index.ts
+++ b/mcpb/node/src/comms/index.ts
@@ -1,0 +1,231 @@
+#!/usr/bin/env node
+/**
+ * Communications MCP server (Node port of ../../mcp_servers/comms.py).
+ *
+ * Exposes two tools to AI clients via stdio:
+ *
+ *  - stage_email   Build a mailto: URL + payload preview. Returns
+ *                  staging_id, URL, and warnings (URL-length, missing
+ *                  recipients, addresses-visible nudge).
+ *  - get_staged    Echo a previously staged composition by id (in-memory).
+ *
+ * Architectural posture (AC-MCP-B — PNA Spec § Universal architectural
+ * commitments): the MCP server proposes, the workspace disposes. This
+ * server never launches a transport itself. It returns a mailto: URL
+ * that the user's mail client opens with the composition pre-populated;
+ * the user reviews and clicks Send.
+ *
+ * State posture: staged compositions live in-memory only. Process exit
+ * clears them. Nothing on disk — no logs of who you emailed, no draft
+ * persistence. That belongs to the workspace (PR-2 record_comms_history
+ * in the PNA spec — opt-in, off by default).
+ *
+ * Behavioral parity with mcp_servers/comms.py is asserted by
+ * tests/test_mcpb_parity.py per the dual-codebase governance in
+ * plans/easy_mcp_install.md § 6.
+ */
+import { McpServer } from "@modelcontextprotocol/sdk/server/mcp.js";
+import { StdioServerTransport } from "@modelcontextprotocol/sdk/server/stdio.js";
+import { z } from "zod";
+import { randomBytes } from "node:crypto";
+
+const MAILTO_URL_WARN_BYTES = 2000;
+const STAGED_MAX = 100;
+
+interface StagedRecord {
+  mailto_url: string;
+  preview: {
+    recipients: { to: string[]; cc: string[]; bcc: string[]; total: number };
+    subject: string;
+    body: string;
+    url_byte_length: number;
+  };
+  warnings: string[];
+}
+
+const STAGED: Map<string, StagedRecord> = new Map();
+
+function newStagingId(): string {
+  return randomBytes(12).toString("base64url").slice(0, 16);
+}
+
+function cleanEmail(addr: string | null | undefined): string {
+  return (addr ?? "").trim();
+}
+
+function dedupeEmails(addrs: ReadonlyArray<string> | null | undefined): string[] {
+  const seen = new Set<string>();
+  const out: string[] = [];
+  for (const a of addrs ?? []) {
+    const c = cleanEmail(a);
+    if (!c) continue;
+    const key = c.toLowerCase();
+    if (seen.has(key)) continue;
+    seen.add(key);
+    out.push(c);
+  }
+  return out;
+}
+
+const UTF8 = new TextEncoder();
+
+function pyQuote(s: string, safe: string): string {
+  const safeSet = new Set<number>();
+  for (const ch of safe) safeSet.add(ch.charCodeAt(0));
+  let out = "";
+  for (const ch of s) {
+    const code = ch.codePointAt(0)!;
+    const isUnreserved =
+      (code >= 0x30 && code <= 0x39) ||
+      (code >= 0x41 && code <= 0x5a) ||
+      (code >= 0x61 && code <= 0x7a) ||
+      code === 0x5f || code === 0x2e || code === 0x2d || code === 0x7e;
+    if (isUnreserved || (code < 0x80 && safeSet.has(code))) {
+      out += ch;
+    } else {
+      for (const b of UTF8.encode(ch)) {
+        out += "%" + b.toString(16).toUpperCase().padStart(2, "0");
+      }
+    }
+  }
+  return out;
+}
+
+function buildMailto(
+  to: string[],
+  cc: string[],
+  bcc: string[],
+  subject: string,
+  body: string,
+): string {
+  const path = to.map((addr) => pyQuote(addr, "@")).join(",");
+  const params: Array<[string, string]> = [];
+  if (cc.length) params.push(["cc", cc.join(",")]);
+  if (bcc.length) params.push(["bcc", bcc.join(",")]);
+  if (subject) params.push(["subject", subject]);
+  if (body) params.push(["body", body]);
+  if (params.length === 0) return `mailto:${path}`;
+  const qs = params.map(([k, v]) => `${k}=${pyQuote(v, "@,")}`).join("&");
+  return `mailto:${path}?${qs}`;
+}
+
+function store(record: StagedRecord): string {
+  const sid = newStagingId();
+  if (STAGED.size >= STAGED_MAX) {
+    const oldest = STAGED.keys().next().value;
+    if (oldest !== undefined) STAGED.delete(oldest);
+  }
+  STAGED.set(sid, record);
+  return sid;
+}
+
+const server = new McpServer({ name: "comms", version: "0.1.0" });
+
+server.registerTool(
+  "stage_email",
+  {
+    description:
+      "Stage an email composition for the user to review and send. Builds a mailto: URL that the user's mail client opens with everything pre-populated. The MCP server never sends — opening the URL is what the user does to hand the composition off to the mail client. For groups, prefer bcc over to so individual addresses aren't visible in everyone's To: header. Recipients are deduplicated case-insensitively; empty addresses are silently dropped.",
+    inputSchema: {
+      subject: z
+        .string()
+        .describe("The email subject. Required (empty string allowed)."),
+      body: z
+        .string()
+        .describe("The email body. Required (empty string allowed)."),
+      to: z
+        .array(z.string())
+        .nullish()
+        .describe(
+          "Visible primary recipients. Optional; pass an empty list or omit for BCC-only group sends.",
+        ),
+      cc: z.array(z.string()).nullish().describe("Carbon-copied recipients."),
+      bcc: z
+        .array(z.string())
+        .nullish()
+        .describe("Blind-carbon-copied recipients."),
+    },
+  },
+  async ({ subject, body, to, cc, bcc }) => {
+    const toClean = dedupeEmails(to);
+    const ccClean = dedupeEmails(cc);
+    const bccClean = dedupeEmails(bcc);
+    const safeSubject = subject ?? "";
+    const safeBody = body ?? "";
+
+    const mailtoUrl = buildMailto(
+      toClean,
+      ccClean,
+      bccClean,
+      safeSubject,
+      safeBody,
+    );
+    const urlBytes = Buffer.byteLength(mailtoUrl, "utf-8");
+    const total = toClean.length + ccClean.length + bccClean.length;
+
+    const warnings: string[] = [];
+    if (total === 0) {
+      warnings.push(
+        "No recipients — the mail client will open but won't have anyone to send to.",
+      );
+    }
+    if (urlBytes > MAILTO_URL_WARN_BYTES) {
+      warnings.push(
+        `mailto: URL is ${urlBytes} bytes; some mail clients (Outlook, Gmail-via-mailto) start truncating around ${MAILTO_URL_WARN_BYTES} bytes. Consider splitting the recipient list, or paste the body into the mail composer after it opens.`,
+      );
+    }
+    if (toClean.length && total > 1 && bccClean.length === 0) {
+      warnings.push(
+        "Multiple recipients in `to`. Consider moving them to `bcc` so addresses aren't visible to everyone on the thread.",
+      );
+    }
+
+    const preview = {
+      recipients: {
+        to: toClean,
+        cc: ccClean,
+        bcc: bccClean,
+        total,
+      },
+      subject: safeSubject,
+      body: safeBody,
+      url_byte_length: urlBytes,
+    };
+    const record: StagedRecord = {
+      mailto_url: mailtoUrl,
+      preview,
+      warnings,
+    };
+    const sid = store(record);
+    const payload = { staging_id: sid, ...record };
+
+    return {
+      content: [{ type: "text", text: JSON.stringify(payload) }],
+    };
+  },
+);
+
+server.registerTool(
+  "get_staged",
+  {
+    description:
+      "Look up a previously staged composition by id. Useful when the user asks 'what did you draft a minute ago?'. Returns null when the id isn't known (process restart, eviction, or never staged). Staged records live in memory only; nothing persists across restarts.",
+    inputSchema: {
+      staging_id: z.string().describe("The id returned by stage_email."),
+    },
+  },
+  async ({ staging_id }) => {
+    const sid = (staging_id ?? "").trim();
+    let result: unknown = null;
+    if (sid) {
+      const rec = STAGED.get(sid);
+      if (rec) result = { staging_id: sid, ...rec };
+    }
+    return {
+      content: [{ type: "text", text: JSON.stringify(result) }],
+    };
+  },
+);
+
+const transport = new StdioServerTransport();
+await server.connect(transport);

--- a/mcpb/node/tsconfig.json
+++ b/mcpb/node/tsconfig.json
@@ -1,0 +1,18 @@
+{
+  "compilerOptions": {
+    "target": "ES2022",
+    "module": "NodeNext",
+    "moduleResolution": "NodeNext",
+    "outDir": "./dist",
+    "rootDir": "./src",
+    "strict": true,
+    "esModuleInterop": true,
+    "skipLibCheck": true,
+    "forceConsistentCasingInFileNames": true,
+    "resolveJsonModule": true,
+    "declaration": false,
+    "sourceMap": false
+  },
+  "include": ["src/**/*"],
+  "exclude": ["node_modules", "dist"]
+}

--- a/tests/test_mcpb_parity.py
+++ b/tests/test_mcpb_parity.py
@@ -1,0 +1,231 @@
+"""Dual-codebase parity tests for MCP servers.
+
+Per ``plans/easy_mcp_install.md`` § 6 (dual-codebase governance): the
+Python servers in ``mcp_servers/`` and the TypeScript servers compiled
+under ``mcpb/node/dist/`` implement the **same** MCP surface for
+**different** audiences (Python source for power users / AI audit; Node
+bundles for end-user Claude Desktop install). The risk that makes that
+arrangement dangerous is silent behavioral drift — a bug fix lands in
+one implementation but not the other, or a privacy boundary tightens
+in one but not the other.
+
+This test is the structural backstop. For each tool defined in the PNA
+spec contracts, we send a fixed input through both implementations'
+stdio JSON-RPC surface and assert structurally-equal output (modulo
+intentionally-variable fields like ``staging_id`` in
+``comms.stage_email``).
+
+When tests fail, the right reaction is to either reconcile the
+divergence or — if the divergence is intentional — explicitly document
+which implementation is the new source of truth and update the other.
+Do not disable a test to ship faster. (If the test ever catches a
+privacy-boundary drift, that's exactly what it's for.)
+
+Tests are seeded incrementally as servers are ported. v1 covers
+``comms.stage_email`` and ``comms.get_staged``; ``shared_data_ops`` and
+``private_data_ops`` cases land in their respective port PRs.
+
+Run via:
+
+    just test-mcpb-parity
+
+Skip cleanly when the Node bundle isn't built yet (e.g. on a fresh
+checkout that hasn't run ``just build-mcpb``).
+"""
+
+from __future__ import annotations
+
+import json
+import subprocess
+import sys
+from pathlib import Path
+
+import pytest
+
+REPO_ROOT = Path(__file__).resolve().parent.parent
+PY_VENV_PYTHON = REPO_ROOT / "mcp_servers" / ".venv" / "bin" / "python"
+NODE_COMMS_JS = REPO_ROOT / "mcpb" / "node" / "dist" / "comms" / "index.js"
+PY_COMMS = REPO_ROOT / "mcp_servers" / "comms.py"
+
+
+def _have_python_server() -> bool:
+    return PY_VENV_PYTHON.is_file() and PY_COMMS.is_file()
+
+
+def _have_node_server() -> bool:
+    return NODE_COMMS_JS.is_file()
+
+
+needs_both = pytest.mark.skipif(
+    not (_have_python_server() and _have_node_server()),
+    reason=(
+        "Parity test needs both implementations available. "
+        "Run `just mcp-install-deps` and `just build-mcpb comms` first."
+    ),
+)
+
+
+def _call_tool(cmd: list[str], tool_name: str, arguments: dict) -> dict:
+    """Spawn an MCP server, send the init handshake, call one tool, return the
+    parsed JSON payload from the tool's text content. Raises on protocol
+    error or non-zero exit.
+    """
+    frames = [
+        {
+            "jsonrpc": "2.0",
+            "id": 1,
+            "method": "initialize",
+            "params": {
+                "protocolVersion": "2024-11-05",
+                "capabilities": {},
+                "clientInfo": {"name": "parity-test", "version": "0.0"},
+            },
+        },
+        {"jsonrpc": "2.0", "method": "notifications/initialized"},
+        {
+            "jsonrpc": "2.0",
+            "id": 2,
+            "method": "tools/call",
+            "params": {"name": tool_name, "arguments": arguments},
+        },
+    ]
+    stdin = "\n".join(json.dumps(f) for f in frames) + "\n"
+    proc = subprocess.run(
+        cmd,
+        input=stdin,
+        capture_output=True,
+        text=True,
+        timeout=30,
+    )
+    if proc.returncode != 0:
+        raise AssertionError(
+            f"{cmd[0]} exited {proc.returncode}\nstderr:\n{proc.stderr}"
+        )
+    # Parse each response line; pick the one with id=2 (the tool call).
+    response = None
+    for line in proc.stdout.splitlines():
+        line = line.strip()
+        if not line:
+            continue
+        try:
+            obj = json.loads(line)
+        except json.JSONDecodeError:
+            continue
+        if obj.get("id") == 2:
+            response = obj
+            break
+    if response is None:
+        raise AssertionError(
+            f"no tools/call response from {cmd[0]}\nstdout:\n{proc.stdout}"
+        )
+    result = response.get("result")
+    if not result:
+        raise AssertionError(
+            f"tools/call returned no result: {response}"
+        )
+    content = result.get("content", [])
+    if not content or content[0].get("type") != "text":
+        raise AssertionError(f"unexpected content shape: {content}")
+    # Tool returns a JSON-encoded payload as text. Parse it so the parity
+    # comparison doesn't trip on indent/whitespace differences between
+    # Python's json.dumps(indent=2) (via fastmcp) and Node's compact
+    # JSON.stringify.
+    return json.loads(content[0]["text"])
+
+
+def _call_both(tool_name: str, arguments: dict) -> tuple[dict, dict]:
+    py = _call_tool(
+        [str(PY_VENV_PYTHON), str(PY_COMMS)],
+        tool_name,
+        arguments,
+    )
+    node = _call_tool(
+        ["node", str(NODE_COMMS_JS)],
+        tool_name,
+        arguments,
+    )
+    return py, node
+
+
+def _scrub_volatile(payload: dict) -> dict:
+    """Replace fields that are intentionally not stable across runs (random
+    ids) with a sentinel so the structural comparison still asserts that
+    both implementations PRODUCED such a field, just not its specific value.
+    """
+    out = dict(payload)
+    if "staging_id" in out:
+        assert isinstance(out["staging_id"], str) and out["staging_id"], (
+            f"staging_id should be a non-empty string, got {out['staging_id']!r}"
+        )
+        # Both implementations produce 16-char URL-safe-base64 ids per
+        # mcp_servers/comms.py:_new_staging_id and the Node port. Asserting
+        # length here catches accidental divergence on id width.
+        assert len(out["staging_id"]) == 16, (
+            f"staging_id should be 16 chars, got {len(out['staging_id'])}: {out['staging_id']!r}"
+        )
+        out["staging_id"] = "<scrubbed>"
+    return out
+
+
+@needs_both
+class TestCommsStageEmail:
+    """``stage_email`` is the load-bearing tool — any drift here either
+    breaks the flagship demo or, worse, lets the addresses-visible warning
+    fire in one implementation and not the other, which would be a real
+    privacy-UX regression.
+    """
+
+    def test_bcc_group_send_dedupes_case_insensitively(self):
+        args = {
+            "subject": "Hi there!",
+            "body": "Hello\nworld — & stuff",
+            "to": ["someone@example.com"],
+            "bcc": ["a@example.com", "B@example.com", "a@example.com"],
+        }
+        py, node = _call_both("stage_email", args)
+        assert _scrub_volatile(py) == _scrub_volatile(node)
+
+    def test_empty_recipients_warning(self):
+        args = {"subject": "Empty test", "body": "no one"}
+        py, node = _call_both("stage_email", args)
+        assert _scrub_volatile(py) == _scrub_volatile(node)
+        # And confirm the warning IS present (both sides).
+        assert any("No recipients" in w for w in py["warnings"])
+        assert any("No recipients" in w for w in node["warnings"])
+
+    def test_addresses_visible_nudge_fires_for_multi_to(self):
+        args = {
+            "subject": "Group",
+            "body": "Hi",
+            "to": ["a@example.com", "b@example.com"],
+        }
+        py, node = _call_both("stage_email", args)
+        assert _scrub_volatile(py) == _scrub_volatile(node)
+        assert any("`bcc`" in w for w in py["warnings"])
+        assert any("`bcc`" in w for w in node["warnings"])
+
+    def test_long_url_warning_fires(self):
+        # A body big enough to push the mailto: URL past 2000 bytes.
+        big_body = "x" * 2500
+        args = {"subject": "Big", "body": big_body, "to": ["a@example.com"]}
+        py, node = _call_both("stage_email", args)
+        assert _scrub_volatile(py) == _scrub_volatile(node)
+        assert any("2000 bytes" in w for w in py["warnings"])
+        assert any("2000 bytes" in w for w in node["warnings"])
+
+    def test_mailto_url_is_byte_identical(self):
+        """The mailto: URL itself is the load-bearing output — it's what the
+        user's mail client opens. Byte-identical URL = byte-identical mail
+        composition across implementations.
+        """
+        args = {
+            "subject": "Hi there!",
+            "body": "Hello\nworld — & stuff",
+            "to": ["someone@example.com"],
+            "bcc": ["a@example.com", "B@example.com"],
+        }
+        py, node = _call_both("stage_email", args)
+        assert py["mailto_url"] == node["mailto_url"], (
+            f"mailto encoding diverged.\n  py:   {py['mailto_url']}\n  node: {node['mailto_url']}"
+        )
+        assert py["preview"]["url_byte_length"] == node["preview"]["url_byte_length"]


### PR DESCRIPTION
## Summary

First implementation PR of [`plans/easy_mcp_install.md`](https://github.com/richbodo/fellows_local_db/blob/main/plans/easy_mcp_install.md) — the Stage 1 sequence in § 12, step 2. Ports the smallest of the three MCP servers (`comms.py`, no DB, smallest surface) to TypeScript and exercises the full `.mcpb` build pipeline end-to-end so the SQLite-heavy ports in subsequent PRs land on a known-working foundation.

### What ships

- **`mcpb/node/`** — TypeScript implementation tree (package.json, tsconfig, README, `src/comms/index.ts`, `manifests/comms.json`). Sibling to `mcp_servers/` per the dual-codebase governance in plan § 6.
- **`build/build_mcpb.py`** + **`just build-mcpb`** — runs `npm install` + `tsc` + stages the bundle + invokes `npx @anthropic-ai/mcpb pack`. Uniform with the existing `build/` script style.
- **`tests/test_mcpb_parity.py`** + **`just test-mcpb-parity`** — the dual-codebase parity test required by plan § 6. Five seeded cases for `comms`; passes on this branch (verified locally — output below).

### Output of `just build-mcpb comms`

```
=== Building comms.mcpb ===
Validating manifest...
Manifest schema validation passes!
📦  fellows-comms@0.1.0
  package size: 3.2MB
  unpacked size: 10.3MB
  -> /Users/.../deploy/dist/mcpb/comms.mcpb (3298 KB)
```

3.2 MB is mostly `@modelcontextprotocol/sdk` + zod. Can slim to <500 KB later with esbuild bundling; not v1.

### Output of `just test-mcpb-parity`

```
tests/test_mcpb_parity.py::TestCommsStageEmail::test_bcc_group_send_dedupes_case_insensitively PASSED
tests/test_mcpb_parity.py::TestCommsStageEmail::test_empty_recipients_warning              PASSED
tests/test_mcpb_parity.py::TestCommsStageEmail::test_addresses_visible_nudge_fires_for_multi_to PASSED
tests/test_mcpb_parity.py::TestCommsStageEmail::test_long_url_warning_fires                PASSED
tests/test_mcpb_parity.py::TestCommsStageEmail::test_mailto_url_is_byte_identical          PASSED
============================== 5 passed in 2.42s ===============================
```

Byte-identical `mailto:` URLs across Python and Node — the `pyQuote` shim in `index.ts` matches Python's `urllib.parse.quote(safe=...)` semantics so the user's mail composition is the same regardless of which implementation runs.

## What does NOT ship in this PR

Per the suggested PR sequence in plan § 12, kept narrow so review is tractable:

- `shared_data_ops` port — its own PR (`feat/mcpb-shared-data-ops`).
- `private_data_ops` port — its own PR (`feat/mcpb-private-data-ops`).
- `deploy/server.py` `/mcpb/<name>.mcpb` routes — its own PR (`feat/mcpb-prod-routes`).
- PWA Settings UI + preamble dialog — its own PR (`feat/mcpb-settings-ui`).
- `docs/use_with_claude_desktop.md` rewrite — its own PR (`docs/mcpb-walkthrough-rewrite`).

## Caveats / things worth knowing during review

- **Tool-name collision with existing Python `comms`.** Your `claude_desktop_config.json` currently has the Python `comms` server registered. Installing `comms.mcpb` will register a second server exposing the same `stage_email` / `get_staged` tool names. Behavior depends on Claude Desktop's collision resolution — worth testing both with and without the Python `comms` disabled before merging.
- **CI gating not wired yet.** The parity test runs cleanly but isn't tied into a merge-gate workflow. That belongs in a follow-up CI PR — flagged in plan § 6 as governance, not implementation.
- **Bundle bloat.** 3.2 MB. esbuild would cut it dramatically; deferred. Stage-1 acceptance criteria don't pin a size.
- **`@anthropic-ai/mcpb` invoked via `npx`** not a global install — keeps the `build_mcpb.py` script self-contained at the cost of a small npx-resolve delay on first build.
- **Branched off `main` before #184 merges**, so this PR's references in any new docs use post-rename `ac_decisions_log.md` paths only where I added new files. No actual references to the AC log in this PR's surface (the README in `mcpb/node/` links it as `../../docs/acdecisionslog.md` which will resolve after #184 — easy fix if needed).

## Test plan (manual; I can't drive Claude Desktop from Claude Code)

- [ ] Pull this branch locally, run `just build-mcpb comms` and confirm the bundle builds.
- [ ] Run `just test-mcpb-parity` and confirm 5 PASSED.
- [ ] Double-click `deploy/dist/mcpb/comms.mcpb` in Finder. Claude Desktop should pop an install dialog showing 'Fellows: Email Staging' with the two tools listed. Click Install.
- [ ] (Optional) Disable the Python `comms` server in `claude_desktop_config.json` to avoid the tool-name collision during testing.
- [ ] Quit Claude Desktop (⌘Q) and reopen.
- [ ] In a new chat: *"Use the comms tool to stage an email to alice@example.com and bob@example.com with subject 'Test from .mcpb' and body 'Hello world'. Don't send — just stage it."*
- [ ] Verify Claude returns a `staging_id`, a `mailto_url`, a `preview`, and an empty (or warning-bearing) `warnings` list.
- [ ] (Optional) Compare the returned mailto URL to what `mcp_servers/comms.py` produces for the same input — should be byte-identical.

## Next PR

`feat/mcpb-shared-data-ops` — port `shared_data_ops.py` to TS, bundle `fellows.db` inside the resulting `.mcpb`, extend parity test with `search_fellows` / `get_fellow` / `list_fellows` / `get_directory_stats` cases.

🤖 Generated with [Claude Code](https://claude.com/claude-code)