### PR TITLE
feat(mcpb): port shared_data_ops.py to TypeScript, bundle fellows.db

### DIFF
--- a/build/build_mcpb.py
+++ b/build/build_mcpb.py
@@ -49,6 +49,13 @@ MANIFESTS_DIR = MCPB_NODE_DIR / "manifests"
 DIST_TS_DIR = MCPB_NODE_DIR / "dist"
 PACKAGE_JSON = MCPB_NODE_DIR / "package.json"
 OUTPUT_DIR = REPO_ROOT / "deploy" / "dist" / "mcpb"
+FELLOWS_DB = REPO_ROOT / "app" / "fellows.db"
+
+# Bundles that need fellows.db bundled inside server/data/ at build time.
+# Per plans/easy_mcp_install.md § 5: fellows.db is the read-only shared
+# snapshot — safe to bundle. relationships.db is per-user OPFS and
+# **never** bundled.
+BUNDLES_NEEDING_FELLOWS_DB = {"shared_data_ops"}
 
 
 def _run(cmd: list[str], cwd: Path) -> None:
@@ -103,6 +110,29 @@ def _stage_bundle(name: str, manifest: dict, staging: Path) -> None:
     # Copy compiled JS as server/index.js + any sibling files (sourcemaps etc).
     for item in src_dir.iterdir():
         shutil.copy2(item, server_dir / item.name)
+
+    # Some servers import from a sibling `_shared/` module (e.g.
+    # shared_data_ops imports fellows_queries.js). Carry those compiled
+    # helpers across so the import resolves inside the staged bundle.
+    shared_src = DIST_TS_DIR / "_shared"
+    if shared_src.is_dir():
+        shutil.copytree(shared_src, server_dir / "_shared")
+
+    # Bundles that read fellows.db get a copy of the live build at
+    # server/data/fellows.db. The server resolves the path relative to
+    # __dirname so it Just Works after install. Per plan § 5: fellows.db
+    # is the read-only shared snapshot — bundling it is safe. relationships.db
+    # is per-user OPFS and is never bundled.
+    if name in BUNDLES_NEEDING_FELLOWS_DB:
+        if not FELLOWS_DB.is_file():
+            raise SystemExit(
+                f"fellows.db not found at {FELLOWS_DB} — run `just db-rebuild` first."
+            )
+        data_dir = server_dir / "data"
+        data_dir.mkdir()
+        shutil.copy2(FELLOWS_DB, data_dir / "fellows.db")
+        sz_mb = FELLOWS_DB.stat().st_size / (1024 * 1024)
+        print(f"  Bundled fellows.db ({sz_mb:.1f} MB) into staging/server/data/", file=sys.stderr)
 
     # Bundle production node_modules INSIDE server/ so the manifest's
     # entry_point and ${__dirname}/server/index.js Just Work after install.

--- a/build/build_mcpb.py
+++ b/build/build_mcpb.py
@@ -112,27 +112,35 @@ def _stage_bundle(name: str, manifest: dict, staging: Path) -> None:
         shutil.copy2(item, server_dir / item.name)
 
     # Some servers import from a sibling `_shared/` module (e.g.
-    # shared_data_ops imports fellows_queries.js). Carry those compiled
-    # helpers across so the import resolves inside the staged bundle.
+    # shared_data_ops imports ../_shared/fellows_queries.js). The compiled
+    # output in `dist/` has shared_data_ops/ and _shared/ as siblings, so
+    # the import resolves there in dev. In the bundle, server/index.js
+    # comes from dist/shared_data_ops/, so `../_shared/` must live ONE
+    # LEVEL UP from server/ — i.e. at the bundle root, sibling to server/.
+    # Don't place it inside server/, that's what broke #187 — the import
+    # path would refer to a non-existent dir and ESM would throw
+    # ERR_MODULE_NOT_FOUND during module load, before our own code runs.
     shared_src = DIST_TS_DIR / "_shared"
     if shared_src.is_dir():
-        shutil.copytree(shared_src, server_dir / "_shared")
+        shutil.copytree(shared_src, staging / "_shared")
 
     # Bundles that read fellows.db get a copy of the live build at
-    # server/data/fellows.db. The server resolves the path relative to
-    # __dirname so it Just Works after install. Per plan § 5: fellows.db
-    # is the read-only shared snapshot — bundling it is safe. relationships.db
-    # is per-user OPFS and is never bundled.
+    # bundle-root/data/fellows.db (sibling to server/). The server's
+    # default path resolution does `resolve(__dirname, "..", "data",
+    # "fellows.db")` — so `data/` must live ONE LEVEL UP from server/,
+    # not inside it. Same trap as `_shared/` above; mirrored fix.
+    # Per plan § 5: fellows.db is the read-only shared snapshot — safe
+    # to bundle. relationships.db is per-user OPFS and never bundled.
     if name in BUNDLES_NEEDING_FELLOWS_DB:
         if not FELLOWS_DB.is_file():
             raise SystemExit(
                 f"fellows.db not found at {FELLOWS_DB} — run `just db-rebuild` first."
             )
-        data_dir = server_dir / "data"
+        data_dir = staging / "data"
         data_dir.mkdir()
         shutil.copy2(FELLOWS_DB, data_dir / "fellows.db")
         sz_mb = FELLOWS_DB.stat().st_size / (1024 * 1024)
-        print(f"  Bundled fellows.db ({sz_mb:.1f} MB) into staging/server/data/", file=sys.stderr)
+        print(f"  Bundled fellows.db ({sz_mb:.1f} MB) into staging/data/", file=sys.stderr)
 
     # Bundle production node_modules INSIDE server/ so the manifest's
     # entry_point and ${__dirname}/server/index.js Just Work after install.

--- a/docs/ac_decisions_log.md
+++ b/docs/ac_decisions_log.md
@@ -18,6 +18,91 @@ link to the newer entry. Newest first.
 
 ---
 
+## 2026-05-21 — `.mcpb` bundles do not ship native Node dependencies
+
+**Why this is worth recording.** A future contributor adding the
+`private-data-ops` port (or any new server in `mcpb/node/`) will be
+tempted to reach for `better-sqlite3` (or `sharp`, or any other
+N-API/native module). The existing Python `mcp_servers/` uses the
+stdlib `sqlite3` module — there's no parallel "obvious" choice for
+Node, and the better-sqlite3 ergonomics are excellent. The constraint
+that forbids it isn't visible from the source side; it shows up only
+when the bundle is installed in Claude Desktop and fails to load.
+
+**Context.** Found during smoke test of #187. The first
+`shared-data-ops.mcpb` build used `better-sqlite3`. It built cleanly,
+passed all parity tests on the host, and the `.mcpb` validated. But
+on install in Claude Desktop, the server process crashed 64ms after
+the `initialize` message arrived — before the SDK could even respond.
+Claude Desktop logged *"Server transport closed unexpectedly"*.
+
+Direct reproduction (against the installed bundle):
+
+```
+$ node -e 'new (require("better-sqlite3"))("./fellows.db")'
+Error: Could not locate the bindings file. Tried:
+ → .../better-sqlite3/build/Release/better_sqlite3.node
+ → ... [13 more paths]
+```
+
+The native `.node` binary wasn't in the bundle. Two compounding
+reasons:
+
+1. **`build/build_mcpb.py` ran `npm install --ignore-scripts`** so
+   better-sqlite3's `install` hook (which downloads/compiles the
+   native binding via `prebuild-install`) never ran.
+2. **Even with that flag removed, the prebuilt would have been wrong:**
+   the host machine runs Node 25 (modules ABI v141); Claude Desktop's
+   Electron 41.6.1 bundles Node 24.15.0 (modules ABI v137).
+   `prebuild-install` matches against the host's ABI, so a host-built
+   bundle would have shipped a v141 binary that Claude Desktop's v137
+   runtime couldn't load.
+
+**Alternatives considered.**
+
+1. **Remove `--ignore-scripts` and accept the ABI mismatch.**
+   Doesn't actually work — the host-built binary would crash in
+   Claude Desktop with a different error.
+
+2. **Cross-build the binary against Claude Desktop's Node ABI.**
+   Requires pinning a specific Node version in CI, running
+   `prebuild-install --target=24.15.0`. Fragile to Electron's Node
+   version changes (every Electron release updates the bundled Node
+   version eventually). High maintenance cost.
+
+3. **Use Node's built-in `node:sqlite` module.** Stable since
+   Node 24.0. Zero native dependencies — it's compiled into Node
+   itself, so it's *guaranteed* to work whatever Node version
+   Claude Desktop bundles. **Chosen.**
+
+**Decision.** `.mcpb` bundles do not ship native Node dependencies.
+For SQLite specifically, `node:sqlite` is the path. For anything
+else that would normally call for a native module (image processing,
+crypto-with-fast-paths, etc.), the bundle either uses Node's
+built-ins, falls back to a pure-JS implementation, or doesn't ship
+that capability.
+
+**Consequences.**
+
+- Pro: zero ABI surface area between the bundle and Claude Desktop's
+  Node runtime. Survives any Electron version change.
+- Pro: smaller bundles — `shared_data_ops.mcpb` dropped from 6.7 MB
+  to 3.8 MB after the better-sqlite3 removal.
+- Pro: build pipeline can keep `--ignore-scripts` as a defense-in-depth
+  measure against postinstall script supply-chain attacks.
+- Con: gives up some performance-sensitive native libraries. Not
+  relevant for our current surface; revisit if a future tool needs
+  one (and address as a per-tool exception rather than a blanket
+  policy change).
+
+**Links.**
+
+- Fix commit on `feat/mcpb-shared-data-ops`: `2807bba`
+- [`plans/easy_mcp_install.md`](../plans/easy_mcp_install.md) — the parent plan
+- [`mcpb/node/src/_shared/fellows_queries.ts`](../mcpb/node/src/_shared/fellows_queries.ts) — the actual `node:sqlite` import comment
+
+---
+
 ## 2026-05-21 — MCP servers ship as three separate `.mcpb` files, not one consolidated bundle
 
 **Why this is worth recording.** A future contributor looking at

--- a/mcpb/node/README.md
+++ b/mcpb/node/README.md
@@ -35,7 +35,7 @@ Extensions UI toggles whole bundles, so per-server enable/disable
 requires per-server bundles. This preserves AC-MCP-A's exception
 clause (a user can wire only Shared to a cloud client) at the
 install layer. See
-[`docs/acdecisionslog.md` § 2026-05-21](../../docs/acdecisionslog.md).
+[`docs/ac_decisions_log.md` § 2026-05-21](../../docs/ac_decisions_log.md).
 
 ## Layout
 

--- a/mcpb/node/manifests/shared_data_ops.json
+++ b/mcpb/node/manifests/shared_data_ops.json
@@ -1,0 +1,52 @@
+{
+  "manifest_version": "0.3",
+  "name": "fellows-shared-data-ops",
+  "display_name": "Fellows: Directory (Shared)",
+  "version": "0.1.0",
+  "description": "Lets Claude read the EHF fellows directory: search, look up individual fellows, list by filters, and pull aggregate statistics. Read-only — never modifies the directory data.",
+  "long_description": "Part of the Fellows Directory integration with Claude Desktop. Bundles a snapshot of fellows.db inside the extension so it works offline. Read-only access only — the SQLite connection is opened with the readonly flag so even a buggy tool cannot mutate the directory snapshot. Architectural posture: spec axis pick `mcp-exposure:shared+private+comms`, the Shared half of that boundary. The fellows directory is the public-shared layer (per docs/Architecture.md § Two-DB architecture); when Claude reads it, that data goes to Anthropic's cloud — see the privacy disclosure in the PWA's setup screen.",
+  "author": {
+    "name": "Rich Bodo",
+    "email": "richbodo@gmail.com"
+  },
+  "homepage": "https://github.com/richbodo/fellows_local_db",
+  "repository": {
+    "type": "git",
+    "url": "https://github.com/richbodo/fellows_local_db.git"
+  },
+  "license": "MIT",
+  "keywords": ["fellows", "ehf", "directory", "search", "sqlite"],
+  "server": {
+    "type": "node",
+    "entry_point": "server/index.js",
+    "mcp_config": {
+      "command": "node",
+      "args": ["${__dirname}/server/index.js"],
+      "env": {}
+    }
+  },
+  "tools": [
+    {
+      "name": "search_fellows",
+      "description": "Full-text search across name, bio, cohort, fellow type, search tags, and key links."
+    },
+    {
+      "name": "get_fellow",
+      "description": "Fetch one fellow's full record by slug or record_id."
+    },
+    {
+      "name": "list_fellows",
+      "description": "List fellows by structured filters (fellow_type, cohort, region, primary_citizenship, has_contact_email)."
+    },
+    {
+      "name": "get_directory_stats",
+      "description": "Aggregate statistics: totals, breakdowns by fellow type / cohort / region, field-completeness counts."
+    }
+  ],
+  "compatibility": {
+    "platforms": ["darwin"],
+    "runtimes": {
+      "node": ">=20.0.0"
+    }
+  }
+}

--- a/mcpb/node/package-lock.json
+++ b/mcpb/node/package-lock.json
@@ -9,12 +9,10 @@
       "version": "0.1.0",
       "dependencies": {
         "@modelcontextprotocol/sdk": "^1.29.0",
-        "better-sqlite3": "^12.10.0",
         "zod": "^4.4.3"
       },
       "devDependencies": {
-        "@types/better-sqlite3": "^7.6.0",
-        "@types/node": "^22.0.0",
+        "@types/node": "^24.0.0",
         "typescript": "^5.6.0"
       },
       "engines": {
@@ -73,24 +71,14 @@
         }
       }
     },
-    "node_modules/@types/better-sqlite3": {
-      "version": "7.6.13",
-      "resolved": "https://registry.npmjs.org/@types/better-sqlite3/-/better-sqlite3-7.6.13.tgz",
-      "integrity": "sha512-NMv9ASNARoKksWtsq/SHakpYAYnhBrQgGD8zkLYk/jaK8jUGn08CfEdTRgYhMypUQAfzSP8W6gNLe0q19/t4VA==",
-      "dev": true,
-      "license": "MIT",
-      "dependencies": {
-        "@types/node": "*"
-      }
-    },
     "node_modules/@types/node": {
-      "version": "22.19.19",
-      "resolved": "https://registry.npmjs.org/@types/node/-/node-22.19.19.tgz",
-      "integrity": "sha512-dyh/xO2Fh5bYrfWaaqGrRQQGkNdmYw6AmaAUvYeUMNTWQtvb796ikLdmTchRmOlOiIJ1TDXfWgVx1QkUlQ6Hew==",
+      "version": "24.12.4",
+      "resolved": "https://registry.npmjs.org/@types/node/-/node-24.12.4.tgz",
+      "integrity": "sha512-GUUEShf+PBCGW2KaXwcIt3Yk+e3pkKwWKb9GSyM9WQVE+ep2jzmHdGsHzu4wgcZy5fN9FBdVzjpBQsYlpfpgLA==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
-        "undici-types": "~6.21.0"
+        "undici-types": "~7.16.0"
       }
     },
     "node_modules/accepts": {
@@ -139,60 +127,6 @@
         }
       }
     },
-    "node_modules/base64-js": {
-      "version": "1.5.1",
-      "resolved": "https://registry.npmjs.org/base64-js/-/base64-js-1.5.1.tgz",
-      "integrity": "sha512-AKpaYlHn8t4SVbOHCy+b5+KKgvR4vrsD8vbvrbiQJps7fKDTkjkDry6ji0rUJjC0kzbNePLwzxq8iypo41qeWA==",
-      "funding": [
-        {
-          "type": "github",
-          "url": "https://github.com/sponsors/feross"
-        },
-        {
-          "type": "patreon",
-          "url": "https://www.patreon.com/feross"
-        },
-        {
-          "type": "consulting",
-          "url": "https://feross.org/support"
-        }
-      ],
-      "license": "MIT"
-    },
-    "node_modules/better-sqlite3": {
-      "version": "12.10.0",
-      "resolved": "https://registry.npmjs.org/better-sqlite3/-/better-sqlite3-12.10.0.tgz",
-      "integrity": "sha512-CyzaZRQKyHkB2ZInfTTl2nvT33EbDpjkLEbE8/Zck3Ll6O0qqvuGdrJ45HgtH+HykRg88ITY3AdreBGN70aBSQ==",
-      "hasInstallScript": true,
-      "license": "MIT",
-      "dependencies": {
-        "bindings": "^1.5.0",
-        "prebuild-install": "^7.1.1"
-      },
-      "engines": {
-        "node": "20.x || 22.x || 23.x || 24.x || 25.x || 26.x"
-      }
-    },
-    "node_modules/bindings": {
-      "version": "1.5.0",
-      "resolved": "https://registry.npmjs.org/bindings/-/bindings-1.5.0.tgz",
-      "integrity": "sha512-p2q/t/mhvuOj/UeLlV6566GD/guowlr0hHxClI0W9m7MWYkL1F0hLo+0Aexs9HSPCtR1SXQ0TD3MMKrXZajbiQ==",
-      "license": "MIT",
-      "dependencies": {
-        "file-uri-to-path": "1.0.0"
-      }
-    },
-    "node_modules/bl": {
-      "version": "4.1.0",
-      "resolved": "https://registry.npmjs.org/bl/-/bl-4.1.0.tgz",
-      "integrity": "sha512-1W07cM9gS6DcLperZfFSj+bWLtaPGSOHWhPiGzXmvVJbRLdG82sH/Kn8EtW1VqWVA54AKf2h5k5BbnIbwF3h6w==",
-      "license": "MIT",
-      "dependencies": {
-        "buffer": "^5.5.0",
-        "inherits": "^2.0.4",
-        "readable-stream": "^3.4.0"
-      }
-    },
     "node_modules/body-parser": {
       "version": "2.2.2",
       "resolved": "https://registry.npmjs.org/body-parser/-/body-parser-2.2.2.tgz",
@@ -215,30 +149,6 @@
       "funding": {
         "type": "opencollective",
         "url": "https://opencollective.com/express"
-      }
-    },
-    "node_modules/buffer": {
-      "version": "5.7.1",
-      "resolved": "https://registry.npmjs.org/buffer/-/buffer-5.7.1.tgz",
-      "integrity": "sha512-EHcyIPBQ4BSGlvjB16k5KgAJ27CIsHY/2JBmCRReo48y9rQ3MaUzWX3KVlBa4U7MyX02HdVj0K7C3WaB3ju7FQ==",
-      "funding": [
-        {
-          "type": "github",
-          "url": "https://github.com/sponsors/feross"
-        },
-        {
-          "type": "patreon",
-          "url": "https://www.patreon.com/feross"
-        },
-        {
-          "type": "consulting",
-          "url": "https://feross.org/support"
-        }
-      ],
-      "license": "MIT",
-      "dependencies": {
-        "base64-js": "^1.3.1",
-        "ieee754": "^1.1.13"
       }
     },
     "node_modules/bytes": {
@@ -278,12 +188,6 @@
       "funding": {
         "url": "https://github.com/sponsors/ljharb"
       }
-    },
-    "node_modules/chownr": {
-      "version": "1.1.4",
-      "resolved": "https://registry.npmjs.org/chownr/-/chownr-1.1.4.tgz",
-      "integrity": "sha512-jJ0bqzaylmJtVnNgzTeSOs8DPavpbYgEr/b0YL8/2GO3xJEhInFmhKMUnEJQjZumK7KXGFhUy89PrsJWlakBVg==",
-      "license": "ISC"
     },
     "node_modules/content-disposition": {
       "version": "1.1.0",
@@ -373,30 +277,6 @@
         }
       }
     },
-    "node_modules/decompress-response": {
-      "version": "6.0.0",
-      "resolved": "https://registry.npmjs.org/decompress-response/-/decompress-response-6.0.0.tgz",
-      "integrity": "sha512-aW35yZM6Bb/4oJlZncMH2LCoZtJXTRxES17vE3hoRiowU2kWHaJKFkSBDnDR+cm9J+9QhXmREyIfv0pji9ejCQ==",
-      "license": "MIT",
-      "dependencies": {
-        "mimic-response": "^3.1.0"
-      },
-      "engines": {
-        "node": ">=10"
-      },
-      "funding": {
-        "url": "https://github.com/sponsors/sindresorhus"
-      }
-    },
-    "node_modules/deep-extend": {
-      "version": "0.6.0",
-      "resolved": "https://registry.npmjs.org/deep-extend/-/deep-extend-0.6.0.tgz",
-      "integrity": "sha512-LOHxIOaPYdHlJRtCQfDIVZtfw/ufM8+rVj649RIHzcm/vGwQRXFt6OPqIFWsm2XEMrNIEtWR64sY1LEKD2vAOA==",
-      "license": "MIT",
-      "engines": {
-        "node": ">=4.0.0"
-      }
-    },
     "node_modules/depd": {
       "version": "2.0.0",
       "resolved": "https://registry.npmjs.org/depd/-/depd-2.0.0.tgz",
@@ -404,15 +284,6 @@
       "license": "MIT",
       "engines": {
         "node": ">= 0.8"
-      }
-    },
-    "node_modules/detect-libc": {
-      "version": "2.1.2",
-      "resolved": "https://registry.npmjs.org/detect-libc/-/detect-libc-2.1.2.tgz",
-      "integrity": "sha512-Btj2BOOO83o3WyH59e8MgXsxEQVcarkUOpEYrubB0urwnN10yQ364rsiByU11nZlqWYZm05i/of7io4mzihBtQ==",
-      "license": "Apache-2.0",
-      "engines": {
-        "node": ">=8"
       }
     },
     "node_modules/dunder-proto": {
@@ -442,15 +313,6 @@
       "license": "MIT",
       "engines": {
         "node": ">= 0.8"
-      }
-    },
-    "node_modules/end-of-stream": {
-      "version": "1.4.5",
-      "resolved": "https://registry.npmjs.org/end-of-stream/-/end-of-stream-1.4.5.tgz",
-      "integrity": "sha512-ooEGc6HP26xXq/N+GCGOT0JKCLDGrq2bQUZrQ7gyrJiZANJ/8YDTxTpQBXGMn+WbIQXNVpyWymm7KYVICQnyOg==",
-      "license": "MIT",
-      "dependencies": {
-        "once": "^1.4.0"
       }
     },
     "node_modules/es-define-property": {
@@ -517,15 +379,6 @@
       "license": "MIT",
       "engines": {
         "node": ">=18.0.0"
-      }
-    },
-    "node_modules/expand-template": {
-      "version": "2.0.3",
-      "resolved": "https://registry.npmjs.org/expand-template/-/expand-template-2.0.3.tgz",
-      "integrity": "sha512-XYfuKMvj4O35f/pOXLObndIRvyQ+/+6AhODh+OKWj9S9498pHHn/IMszH+gt0fBCRWMNfk1ZSp5x3AifmnI2vg==",
-      "license": "(MIT OR WTFPL)",
-      "engines": {
-        "node": ">=6"
       }
     },
     "node_modules/express": {
@@ -611,12 +464,6 @@
       ],
       "license": "BSD-3-Clause"
     },
-    "node_modules/file-uri-to-path": {
-      "version": "1.0.0",
-      "resolved": "https://registry.npmjs.org/file-uri-to-path/-/file-uri-to-path-1.0.0.tgz",
-      "integrity": "sha512-0Zt+s3L7Vf1biwWZ29aARiVYLx7iMGnEUl9x33fbB/j3jR81u/O2LbqK+Bm1CDSNDKVtJ/YjwY7TUd5SkeLQLw==",
-      "license": "MIT"
-    },
     "node_modules/finalhandler": {
       "version": "2.1.1",
       "resolved": "https://registry.npmjs.org/finalhandler/-/finalhandler-2.1.1.tgz",
@@ -655,12 +502,6 @@
       "engines": {
         "node": ">= 0.8"
       }
-    },
-    "node_modules/fs-constants": {
-      "version": "1.0.0",
-      "resolved": "https://registry.npmjs.org/fs-constants/-/fs-constants-1.0.0.tgz",
-      "integrity": "sha512-y6OAwoSIf7FyjMIv94u+b5rdheZEjzR63GTyZJm5qh4Bi+2YgwLCcI/fPFZkL5PSixOt6ZNKm+w+Hfp/Bciwow==",
-      "license": "MIT"
     },
     "node_modules/function-bind": {
       "version": "1.1.2",
@@ -707,12 +548,6 @@
       "engines": {
         "node": ">= 0.4"
       }
-    },
-    "node_modules/github-from-package": {
-      "version": "0.0.0",
-      "resolved": "https://registry.npmjs.org/github-from-package/-/github-from-package-0.0.0.tgz",
-      "integrity": "sha512-SyHy3T1v2NUXn29OsWdxmK6RwHD+vkj3v8en8AOBZ1wBQ/hCAQ5bAQTD02kW4W9tUp/3Qh6J8r9EvntiyCmOOw==",
-      "license": "MIT"
     },
     "node_modules/gopd": {
       "version": "1.2.0",
@@ -795,36 +630,10 @@
         "url": "https://opencollective.com/express"
       }
     },
-    "node_modules/ieee754": {
-      "version": "1.2.1",
-      "resolved": "https://registry.npmjs.org/ieee754/-/ieee754-1.2.1.tgz",
-      "integrity": "sha512-dcyqhDvX1C46lXZcVqCpK+FtMRQVdIMN6/Df5js2zouUsqG7I6sFxitIC+7KYK29KdXOLHdu9zL4sFnoVQnqaA==",
-      "funding": [
-        {
-          "type": "github",
-          "url": "https://github.com/sponsors/feross"
-        },
-        {
-          "type": "patreon",
-          "url": "https://www.patreon.com/feross"
-        },
-        {
-          "type": "consulting",
-          "url": "https://feross.org/support"
-        }
-      ],
-      "license": "BSD-3-Clause"
-    },
     "node_modules/inherits": {
       "version": "2.0.4",
       "resolved": "https://registry.npmjs.org/inherits/-/inherits-2.0.4.tgz",
       "integrity": "sha512-k/vGaX4/Yla3WzyMCvTQOXYeIHvqOKtnqBduzTHpzpQZzAskKMhZ2K+EnBiSM9zGSoIFeMpXKxa4dYeZIQqewQ==",
-      "license": "ISC"
-    },
-    "node_modules/ini": {
-      "version": "1.3.8",
-      "resolved": "https://registry.npmjs.org/ini/-/ini-1.3.8.tgz",
-      "integrity": "sha512-JV/yugV2uzW5iMRSiZAyDtQd+nxtUnjeLt0acNdw98kKLrvuRVyB80tsREOE7yvGVgalhZ6RNXCmEHkUKBKxew==",
       "license": "ISC"
     },
     "node_modules/ip-address": {
@@ -933,43 +742,10 @@
         "url": "https://opencollective.com/express"
       }
     },
-    "node_modules/mimic-response": {
-      "version": "3.1.0",
-      "resolved": "https://registry.npmjs.org/mimic-response/-/mimic-response-3.1.0.tgz",
-      "integrity": "sha512-z0yWI+4FDrrweS8Zmt4Ej5HdJmky15+L2e6Wgn3+iK5fWzb6T3fhNFq2+MeTRb064c6Wr4N/wv0DzQTjNzHNGQ==",
-      "license": "MIT",
-      "engines": {
-        "node": ">=10"
-      },
-      "funding": {
-        "url": "https://github.com/sponsors/sindresorhus"
-      }
-    },
-    "node_modules/minimist": {
-      "version": "1.2.8",
-      "resolved": "https://registry.npmjs.org/minimist/-/minimist-1.2.8.tgz",
-      "integrity": "sha512-2yyAR8qBkN3YuheJanUpWC5U3bb5osDywNB8RzDVlDwDHbocAJveqqj1u8+SVD7jkWT4yvsHCpWqqWqAxb0zCA==",
-      "license": "MIT",
-      "funding": {
-        "url": "https://github.com/sponsors/ljharb"
-      }
-    },
-    "node_modules/mkdirp-classic": {
-      "version": "0.5.3",
-      "resolved": "https://registry.npmjs.org/mkdirp-classic/-/mkdirp-classic-0.5.3.tgz",
-      "integrity": "sha512-gKLcREMhtuZRwRAfqP3RFW+TK4JqApVBtOIftVgjuABpAtpxhPGaDcfvbhNvD0B8iD1oUr/txX35NjcaY6Ns/A==",
-      "license": "MIT"
-    },
     "node_modules/ms": {
       "version": "2.1.3",
       "resolved": "https://registry.npmjs.org/ms/-/ms-2.1.3.tgz",
       "integrity": "sha512-6FlzubTLZG3J2a/NVCAleEhjzq5oxgHyaCU9yYXvcLsvoVaHJq/s5xXI6/XXP6tz7R9xAOtHnSO/tXtF3WRTlA==",
-      "license": "MIT"
-    },
-    "node_modules/napi-build-utils": {
-      "version": "2.0.0",
-      "resolved": "https://registry.npmjs.org/napi-build-utils/-/napi-build-utils-2.0.0.tgz",
-      "integrity": "sha512-GEbrYkbfF7MoNaoh2iGG84Mnf/WZfB0GdGEsM8wz7Expx/LlWf5U8t9nvJKXSp3qr5IsEbK04cBGhol/KwOsWA==",
       "license": "MIT"
     },
     "node_modules/negotiator": {
@@ -979,18 +755,6 @@
       "license": "MIT",
       "engines": {
         "node": ">= 0.6"
-      }
-    },
-    "node_modules/node-abi": {
-      "version": "3.92.0",
-      "resolved": "https://registry.npmjs.org/node-abi/-/node-abi-3.92.0.tgz",
-      "integrity": "sha512-KdHvFWZjEKDf0cakgFjebl371GPsISX2oZHcuyKqM7DtogIsHrqKeLTo8wBHxaXRAQlY2PsPlZmfo+9ZCxEREQ==",
-      "license": "MIT",
-      "dependencies": {
-        "semver": "^7.3.5"
-      },
-      "engines": {
-        "node": ">=10"
       }
     },
     "node_modules/object-assign": {
@@ -1072,33 +836,6 @@
         "node": ">=16.20.0"
       }
     },
-    "node_modules/prebuild-install": {
-      "version": "7.1.3",
-      "resolved": "https://registry.npmjs.org/prebuild-install/-/prebuild-install-7.1.3.tgz",
-      "integrity": "sha512-8Mf2cbV7x1cXPUILADGI3wuhfqWvtiLA1iclTDbFRZkgRQS0NqsPZphna9V+HyTEadheuPmjaJMsbzKQFOzLug==",
-      "deprecated": "No longer maintained. Please contact the author of the relevant native addon; alternatives are available.",
-      "license": "MIT",
-      "dependencies": {
-        "detect-libc": "^2.0.0",
-        "expand-template": "^2.0.3",
-        "github-from-package": "0.0.0",
-        "minimist": "^1.2.3",
-        "mkdirp-classic": "^0.5.3",
-        "napi-build-utils": "^2.0.0",
-        "node-abi": "^3.3.0",
-        "pump": "^3.0.0",
-        "rc": "^1.2.7",
-        "simple-get": "^4.0.0",
-        "tar-fs": "^2.0.0",
-        "tunnel-agent": "^0.6.0"
-      },
-      "bin": {
-        "prebuild-install": "bin.js"
-      },
-      "engines": {
-        "node": ">=10"
-      }
-    },
     "node_modules/proxy-addr": {
       "version": "2.0.7",
       "resolved": "https://registry.npmjs.org/proxy-addr/-/proxy-addr-2.0.7.tgz",
@@ -1110,16 +847,6 @@
       },
       "engines": {
         "node": ">= 0.10"
-      }
-    },
-    "node_modules/pump": {
-      "version": "3.0.4",
-      "resolved": "https://registry.npmjs.org/pump/-/pump-3.0.4.tgz",
-      "integrity": "sha512-VS7sjc6KR7e1ukRFhQSY5LM2uBWAUPiOPa/A3mkKmiMwSmRFUITt0xuj+/lesgnCv+dPIEYlkzrcyXgquIHMcA==",
-      "license": "MIT",
-      "dependencies": {
-        "end-of-stream": "^1.1.0",
-        "once": "^1.3.1"
       }
     },
     "node_modules/qs": {
@@ -1161,35 +888,6 @@
         "node": ">= 0.10"
       }
     },
-    "node_modules/rc": {
-      "version": "1.2.8",
-      "resolved": "https://registry.npmjs.org/rc/-/rc-1.2.8.tgz",
-      "integrity": "sha512-y3bGgqKj3QBdxLbLkomlohkvsA8gdAiUQlSBJnBhfn+BPxg4bc62d8TcBW15wavDfgexCgccckhcZvywyQYPOw==",
-      "license": "(BSD-2-Clause OR MIT OR Apache-2.0)",
-      "dependencies": {
-        "deep-extend": "^0.6.0",
-        "ini": "~1.3.0",
-        "minimist": "^1.2.0",
-        "strip-json-comments": "~2.0.1"
-      },
-      "bin": {
-        "rc": "cli.js"
-      }
-    },
-    "node_modules/readable-stream": {
-      "version": "3.6.2",
-      "resolved": "https://registry.npmjs.org/readable-stream/-/readable-stream-3.6.2.tgz",
-      "integrity": "sha512-9u/sniCrY3D5WdsERHzHE4G2YCXqoG5FTHUiCC4SIbr6XcLZBY05ya9EKjYek9O5xOAwjGq+1JdGBAS7Q9ScoA==",
-      "license": "MIT",
-      "dependencies": {
-        "inherits": "^2.0.3",
-        "string_decoder": "^1.1.1",
-        "util-deprecate": "^1.0.1"
-      },
-      "engines": {
-        "node": ">= 6"
-      }
-    },
     "node_modules/require-from-string": {
       "version": "2.0.2",
       "resolved": "https://registry.npmjs.org/require-from-string/-/require-from-string-2.0.2.tgz",
@@ -1215,43 +913,11 @@
         "node": ">= 18"
       }
     },
-    "node_modules/safe-buffer": {
-      "version": "5.2.1",
-      "resolved": "https://registry.npmjs.org/safe-buffer/-/safe-buffer-5.2.1.tgz",
-      "integrity": "sha512-rp3So07KcdmmKbGvgaNxQSJr7bGVSVk5S9Eq1F+ppbRo70+YeaDxkw5Dd8NPN+GD6bjnYm2VuPuCXmpuYvmCXQ==",
-      "funding": [
-        {
-          "type": "github",
-          "url": "https://github.com/sponsors/feross"
-        },
-        {
-          "type": "patreon",
-          "url": "https://www.patreon.com/feross"
-        },
-        {
-          "type": "consulting",
-          "url": "https://feross.org/support"
-        }
-      ],
-      "license": "MIT"
-    },
     "node_modules/safer-buffer": {
       "version": "2.1.2",
       "resolved": "https://registry.npmjs.org/safer-buffer/-/safer-buffer-2.1.2.tgz",
       "integrity": "sha512-YZo3K82SD7Riyi0E1EQPojLz7kpepnSQI9IyPbHHg1XXXevb5dJI7tpyN2ADxGcQbHG7vcyRHk0cbwqcQriUtg==",
       "license": "MIT"
-    },
-    "node_modules/semver": {
-      "version": "7.8.0",
-      "resolved": "https://registry.npmjs.org/semver/-/semver-7.8.0.tgz",
-      "integrity": "sha512-AcM7dV/5ul4EekoQ29Agm5vri8JNqRyj39o0qpX6vDF2GZrtutZl5RwgD1XnZjiTAfncsJhMI48QQH3sN87YNA==",
-      "license": "ISC",
-      "bin": {
-        "semver": "bin/semver.js"
-      },
-      "engines": {
-        "node": ">=10"
-      }
     },
     "node_modules/send": {
       "version": "1.2.1",
@@ -1397,51 +1063,6 @@
         "url": "https://github.com/sponsors/ljharb"
       }
     },
-    "node_modules/simple-concat": {
-      "version": "1.0.1",
-      "resolved": "https://registry.npmjs.org/simple-concat/-/simple-concat-1.0.1.tgz",
-      "integrity": "sha512-cSFtAPtRhljv69IK0hTVZQ+OfE9nePi/rtJmw5UjHeVyVroEqJXP1sFztKUy1qU+xvz3u/sfYJLa947b7nAN2Q==",
-      "funding": [
-        {
-          "type": "github",
-          "url": "https://github.com/sponsors/feross"
-        },
-        {
-          "type": "patreon",
-          "url": "https://www.patreon.com/feross"
-        },
-        {
-          "type": "consulting",
-          "url": "https://feross.org/support"
-        }
-      ],
-      "license": "MIT"
-    },
-    "node_modules/simple-get": {
-      "version": "4.0.1",
-      "resolved": "https://registry.npmjs.org/simple-get/-/simple-get-4.0.1.tgz",
-      "integrity": "sha512-brv7p5WgH0jmQJr1ZDDfKDOSeWWg+OVypG99A/5vYGPqJ6pxiaHLy8nxtFjBA7oMa01ebA9gfh1uMCFqOuXxvA==",
-      "funding": [
-        {
-          "type": "github",
-          "url": "https://github.com/sponsors/feross"
-        },
-        {
-          "type": "patreon",
-          "url": "https://www.patreon.com/feross"
-        },
-        {
-          "type": "consulting",
-          "url": "https://feross.org/support"
-        }
-      ],
-      "license": "MIT",
-      "dependencies": {
-        "decompress-response": "^6.0.0",
-        "once": "^1.3.1",
-        "simple-concat": "^1.0.0"
-      }
-    },
     "node_modules/statuses": {
       "version": "2.0.2",
       "resolved": "https://registry.npmjs.org/statuses/-/statuses-2.0.2.tgz",
@@ -1451,52 +1072,6 @@
         "node": ">= 0.8"
       }
     },
-    "node_modules/string_decoder": {
-      "version": "1.3.0",
-      "resolved": "https://registry.npmjs.org/string_decoder/-/string_decoder-1.3.0.tgz",
-      "integrity": "sha512-hkRX8U1WjJFd8LsDJ2yQ/wWWxaopEsABU1XfkM8A+j0+85JAGppt16cr1Whg6KIbb4okU6Mql6BOj+uup/wKeA==",
-      "license": "MIT",
-      "dependencies": {
-        "safe-buffer": "~5.2.0"
-      }
-    },
-    "node_modules/strip-json-comments": {
-      "version": "2.0.1",
-      "resolved": "https://registry.npmjs.org/strip-json-comments/-/strip-json-comments-2.0.1.tgz",
-      "integrity": "sha512-4gB8na07fecVVkOI6Rs4e7T6NOTki5EmL7TUduTs6bu3EdnSycntVJ4re8kgZA+wx9IueI2Y11bfbgwtzuE0KQ==",
-      "license": "MIT",
-      "engines": {
-        "node": ">=0.10.0"
-      }
-    },
-    "node_modules/tar-fs": {
-      "version": "2.1.4",
-      "resolved": "https://registry.npmjs.org/tar-fs/-/tar-fs-2.1.4.tgz",
-      "integrity": "sha512-mDAjwmZdh7LTT6pNleZ05Yt65HC3E+NiQzl672vQG38jIrehtJk/J3mNwIg+vShQPcLF/LV7CMnDW6vjj6sfYQ==",
-      "license": "MIT",
-      "dependencies": {
-        "chownr": "^1.1.1",
-        "mkdirp-classic": "^0.5.2",
-        "pump": "^3.0.0",
-        "tar-stream": "^2.1.4"
-      }
-    },
-    "node_modules/tar-stream": {
-      "version": "2.2.0",
-      "resolved": "https://registry.npmjs.org/tar-stream/-/tar-stream-2.2.0.tgz",
-      "integrity": "sha512-ujeqbceABgwMZxEJnk2HDY2DlnUZ+9oEcb1KzTVfYHio0UE6dG71n60d8D2I4qNvleWrrXpmjpt7vZeF1LnMZQ==",
-      "license": "MIT",
-      "dependencies": {
-        "bl": "^4.0.3",
-        "end-of-stream": "^1.4.1",
-        "fs-constants": "^1.0.0",
-        "inherits": "^2.0.3",
-        "readable-stream": "^3.1.1"
-      },
-      "engines": {
-        "node": ">=6"
-      }
-    },
     "node_modules/toidentifier": {
       "version": "1.0.1",
       "resolved": "https://registry.npmjs.org/toidentifier/-/toidentifier-1.0.1.tgz",
@@ -1504,18 +1079,6 @@
       "license": "MIT",
       "engines": {
         "node": ">=0.6"
-      }
-    },
-    "node_modules/tunnel-agent": {
-      "version": "0.6.0",
-      "resolved": "https://registry.npmjs.org/tunnel-agent/-/tunnel-agent-0.6.0.tgz",
-      "integrity": "sha512-McnNiV1l8RYeY8tBgEpuodCC1mLUdbSN+CYBL7kJsJNInOP8UjDDEwdk6Mw60vdLLrr5NHKZhMAOSrR2NZuQ+w==",
-      "license": "Apache-2.0",
-      "dependencies": {
-        "safe-buffer": "^5.0.1"
-      },
-      "engines": {
-        "node": "*"
       }
     },
     "node_modules/type-is": {
@@ -1564,9 +1127,9 @@
       }
     },
     "node_modules/undici-types": {
-      "version": "6.21.0",
-      "resolved": "https://registry.npmjs.org/undici-types/-/undici-types-6.21.0.tgz",
-      "integrity": "sha512-iwDZqg0QAGrg9Rav5H4n0M64c3mkR59cJ6wQp+7C4nI0gsmExaedaYLNO44eT4AtBBwjbTiGPMlt2Md0T9H9JQ==",
+      "version": "7.16.0",
+      "resolved": "https://registry.npmjs.org/undici-types/-/undici-types-7.16.0.tgz",
+      "integrity": "sha512-Zz+aZWSj8LE6zoxD+xrjh4VfkIG8Ya6LvYkZqtUQGJPZjYl53ypCaUwWqo7eI0x66KBGeRo+mlBEkMSeSZ38Nw==",
       "dev": true,
       "license": "MIT"
     },
@@ -1578,12 +1141,6 @@
       "engines": {
         "node": ">= 0.8"
       }
-    },
-    "node_modules/util-deprecate": {
-      "version": "1.0.2",
-      "resolved": "https://registry.npmjs.org/util-deprecate/-/util-deprecate-1.0.2.tgz",
-      "integrity": "sha512-EPD5q1uXyFxJpCrLnCc1nHnq3gOa6DZBocAIiI2TaSCA7VCJ1UJDMagCzIkXNsUYfD1daK//LTEQ8xiIbrHtcw==",
-      "license": "MIT"
     },
     "node_modules/vary": {
       "version": "1.1.2",

--- a/mcpb/node/package-lock.json
+++ b/mcpb/node/package-lock.json
@@ -9,9 +9,11 @@
       "version": "0.1.0",
       "dependencies": {
         "@modelcontextprotocol/sdk": "^1.29.0",
+        "better-sqlite3": "^12.10.0",
         "zod": "^4.4.3"
       },
       "devDependencies": {
+        "@types/better-sqlite3": "^7.6.0",
         "@types/node": "^22.0.0",
         "typescript": "^5.6.0"
       },
@@ -71,6 +73,16 @@
         }
       }
     },
+    "node_modules/@types/better-sqlite3": {
+      "version": "7.6.13",
+      "resolved": "https://registry.npmjs.org/@types/better-sqlite3/-/better-sqlite3-7.6.13.tgz",
+      "integrity": "sha512-NMv9ASNARoKksWtsq/SHakpYAYnhBrQgGD8zkLYk/jaK8jUGn08CfEdTRgYhMypUQAfzSP8W6gNLe0q19/t4VA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@types/node": "*"
+      }
+    },
     "node_modules/@types/node": {
       "version": "22.19.19",
       "resolved": "https://registry.npmjs.org/@types/node/-/node-22.19.19.tgz",
@@ -127,6 +139,60 @@
         }
       }
     },
+    "node_modules/base64-js": {
+      "version": "1.5.1",
+      "resolved": "https://registry.npmjs.org/base64-js/-/base64-js-1.5.1.tgz",
+      "integrity": "sha512-AKpaYlHn8t4SVbOHCy+b5+KKgvR4vrsD8vbvrbiQJps7fKDTkjkDry6ji0rUJjC0kzbNePLwzxq8iypo41qeWA==",
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/feross"
+        },
+        {
+          "type": "patreon",
+          "url": "https://www.patreon.com/feross"
+        },
+        {
+          "type": "consulting",
+          "url": "https://feross.org/support"
+        }
+      ],
+      "license": "MIT"
+    },
+    "node_modules/better-sqlite3": {
+      "version": "12.10.0",
+      "resolved": "https://registry.npmjs.org/better-sqlite3/-/better-sqlite3-12.10.0.tgz",
+      "integrity": "sha512-CyzaZRQKyHkB2ZInfTTl2nvT33EbDpjkLEbE8/Zck3Ll6O0qqvuGdrJ45HgtH+HykRg88ITY3AdreBGN70aBSQ==",
+      "hasInstallScript": true,
+      "license": "MIT",
+      "dependencies": {
+        "bindings": "^1.5.0",
+        "prebuild-install": "^7.1.1"
+      },
+      "engines": {
+        "node": "20.x || 22.x || 23.x || 24.x || 25.x || 26.x"
+      }
+    },
+    "node_modules/bindings": {
+      "version": "1.5.0",
+      "resolved": "https://registry.npmjs.org/bindings/-/bindings-1.5.0.tgz",
+      "integrity": "sha512-p2q/t/mhvuOj/UeLlV6566GD/guowlr0hHxClI0W9m7MWYkL1F0hLo+0Aexs9HSPCtR1SXQ0TD3MMKrXZajbiQ==",
+      "license": "MIT",
+      "dependencies": {
+        "file-uri-to-path": "1.0.0"
+      }
+    },
+    "node_modules/bl": {
+      "version": "4.1.0",
+      "resolved": "https://registry.npmjs.org/bl/-/bl-4.1.0.tgz",
+      "integrity": "sha512-1W07cM9gS6DcLperZfFSj+bWLtaPGSOHWhPiGzXmvVJbRLdG82sH/Kn8EtW1VqWVA54AKf2h5k5BbnIbwF3h6w==",
+      "license": "MIT",
+      "dependencies": {
+        "buffer": "^5.5.0",
+        "inherits": "^2.0.4",
+        "readable-stream": "^3.4.0"
+      }
+    },
     "node_modules/body-parser": {
       "version": "2.2.2",
       "resolved": "https://registry.npmjs.org/body-parser/-/body-parser-2.2.2.tgz",
@@ -149,6 +215,30 @@
       "funding": {
         "type": "opencollective",
         "url": "https://opencollective.com/express"
+      }
+    },
+    "node_modules/buffer": {
+      "version": "5.7.1",
+      "resolved": "https://registry.npmjs.org/buffer/-/buffer-5.7.1.tgz",
+      "integrity": "sha512-EHcyIPBQ4BSGlvjB16k5KgAJ27CIsHY/2JBmCRReo48y9rQ3MaUzWX3KVlBa4U7MyX02HdVj0K7C3WaB3ju7FQ==",
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/feross"
+        },
+        {
+          "type": "patreon",
+          "url": "https://www.patreon.com/feross"
+        },
+        {
+          "type": "consulting",
+          "url": "https://feross.org/support"
+        }
+      ],
+      "license": "MIT",
+      "dependencies": {
+        "base64-js": "^1.3.1",
+        "ieee754": "^1.1.13"
       }
     },
     "node_modules/bytes": {
@@ -188,6 +278,12 @@
       "funding": {
         "url": "https://github.com/sponsors/ljharb"
       }
+    },
+    "node_modules/chownr": {
+      "version": "1.1.4",
+      "resolved": "https://registry.npmjs.org/chownr/-/chownr-1.1.4.tgz",
+      "integrity": "sha512-jJ0bqzaylmJtVnNgzTeSOs8DPavpbYgEr/b0YL8/2GO3xJEhInFmhKMUnEJQjZumK7KXGFhUy89PrsJWlakBVg==",
+      "license": "ISC"
     },
     "node_modules/content-disposition": {
       "version": "1.1.0",
@@ -277,6 +373,30 @@
         }
       }
     },
+    "node_modules/decompress-response": {
+      "version": "6.0.0",
+      "resolved": "https://registry.npmjs.org/decompress-response/-/decompress-response-6.0.0.tgz",
+      "integrity": "sha512-aW35yZM6Bb/4oJlZncMH2LCoZtJXTRxES17vE3hoRiowU2kWHaJKFkSBDnDR+cm9J+9QhXmREyIfv0pji9ejCQ==",
+      "license": "MIT",
+      "dependencies": {
+        "mimic-response": "^3.1.0"
+      },
+      "engines": {
+        "node": ">=10"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/deep-extend": {
+      "version": "0.6.0",
+      "resolved": "https://registry.npmjs.org/deep-extend/-/deep-extend-0.6.0.tgz",
+      "integrity": "sha512-LOHxIOaPYdHlJRtCQfDIVZtfw/ufM8+rVj649RIHzcm/vGwQRXFt6OPqIFWsm2XEMrNIEtWR64sY1LEKD2vAOA==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=4.0.0"
+      }
+    },
     "node_modules/depd": {
       "version": "2.0.0",
       "resolved": "https://registry.npmjs.org/depd/-/depd-2.0.0.tgz",
@@ -284,6 +404,15 @@
       "license": "MIT",
       "engines": {
         "node": ">= 0.8"
+      }
+    },
+    "node_modules/detect-libc": {
+      "version": "2.1.2",
+      "resolved": "https://registry.npmjs.org/detect-libc/-/detect-libc-2.1.2.tgz",
+      "integrity": "sha512-Btj2BOOO83o3WyH59e8MgXsxEQVcarkUOpEYrubB0urwnN10yQ364rsiByU11nZlqWYZm05i/of7io4mzihBtQ==",
+      "license": "Apache-2.0",
+      "engines": {
+        "node": ">=8"
       }
     },
     "node_modules/dunder-proto": {
@@ -313,6 +442,15 @@
       "license": "MIT",
       "engines": {
         "node": ">= 0.8"
+      }
+    },
+    "node_modules/end-of-stream": {
+      "version": "1.4.5",
+      "resolved": "https://registry.npmjs.org/end-of-stream/-/end-of-stream-1.4.5.tgz",
+      "integrity": "sha512-ooEGc6HP26xXq/N+GCGOT0JKCLDGrq2bQUZrQ7gyrJiZANJ/8YDTxTpQBXGMn+WbIQXNVpyWymm7KYVICQnyOg==",
+      "license": "MIT",
+      "dependencies": {
+        "once": "^1.4.0"
       }
     },
     "node_modules/es-define-property": {
@@ -379,6 +517,15 @@
       "license": "MIT",
       "engines": {
         "node": ">=18.0.0"
+      }
+    },
+    "node_modules/expand-template": {
+      "version": "2.0.3",
+      "resolved": "https://registry.npmjs.org/expand-template/-/expand-template-2.0.3.tgz",
+      "integrity": "sha512-XYfuKMvj4O35f/pOXLObndIRvyQ+/+6AhODh+OKWj9S9498pHHn/IMszH+gt0fBCRWMNfk1ZSp5x3AifmnI2vg==",
+      "license": "(MIT OR WTFPL)",
+      "engines": {
+        "node": ">=6"
       }
     },
     "node_modules/express": {
@@ -464,6 +611,12 @@
       ],
       "license": "BSD-3-Clause"
     },
+    "node_modules/file-uri-to-path": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/file-uri-to-path/-/file-uri-to-path-1.0.0.tgz",
+      "integrity": "sha512-0Zt+s3L7Vf1biwWZ29aARiVYLx7iMGnEUl9x33fbB/j3jR81u/O2LbqK+Bm1CDSNDKVtJ/YjwY7TUd5SkeLQLw==",
+      "license": "MIT"
+    },
     "node_modules/finalhandler": {
       "version": "2.1.1",
       "resolved": "https://registry.npmjs.org/finalhandler/-/finalhandler-2.1.1.tgz",
@@ -502,6 +655,12 @@
       "engines": {
         "node": ">= 0.8"
       }
+    },
+    "node_modules/fs-constants": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/fs-constants/-/fs-constants-1.0.0.tgz",
+      "integrity": "sha512-y6OAwoSIf7FyjMIv94u+b5rdheZEjzR63GTyZJm5qh4Bi+2YgwLCcI/fPFZkL5PSixOt6ZNKm+w+Hfp/Bciwow==",
+      "license": "MIT"
     },
     "node_modules/function-bind": {
       "version": "1.1.2",
@@ -548,6 +707,12 @@
       "engines": {
         "node": ">= 0.4"
       }
+    },
+    "node_modules/github-from-package": {
+      "version": "0.0.0",
+      "resolved": "https://registry.npmjs.org/github-from-package/-/github-from-package-0.0.0.tgz",
+      "integrity": "sha512-SyHy3T1v2NUXn29OsWdxmK6RwHD+vkj3v8en8AOBZ1wBQ/hCAQ5bAQTD02kW4W9tUp/3Qh6J8r9EvntiyCmOOw==",
+      "license": "MIT"
     },
     "node_modules/gopd": {
       "version": "1.2.0",
@@ -630,10 +795,36 @@
         "url": "https://opencollective.com/express"
       }
     },
+    "node_modules/ieee754": {
+      "version": "1.2.1",
+      "resolved": "https://registry.npmjs.org/ieee754/-/ieee754-1.2.1.tgz",
+      "integrity": "sha512-dcyqhDvX1C46lXZcVqCpK+FtMRQVdIMN6/Df5js2zouUsqG7I6sFxitIC+7KYK29KdXOLHdu9zL4sFnoVQnqaA==",
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/feross"
+        },
+        {
+          "type": "patreon",
+          "url": "https://www.patreon.com/feross"
+        },
+        {
+          "type": "consulting",
+          "url": "https://feross.org/support"
+        }
+      ],
+      "license": "BSD-3-Clause"
+    },
     "node_modules/inherits": {
       "version": "2.0.4",
       "resolved": "https://registry.npmjs.org/inherits/-/inherits-2.0.4.tgz",
       "integrity": "sha512-k/vGaX4/Yla3WzyMCvTQOXYeIHvqOKtnqBduzTHpzpQZzAskKMhZ2K+EnBiSM9zGSoIFeMpXKxa4dYeZIQqewQ==",
+      "license": "ISC"
+    },
+    "node_modules/ini": {
+      "version": "1.3.8",
+      "resolved": "https://registry.npmjs.org/ini/-/ini-1.3.8.tgz",
+      "integrity": "sha512-JV/yugV2uzW5iMRSiZAyDtQd+nxtUnjeLt0acNdw98kKLrvuRVyB80tsREOE7yvGVgalhZ6RNXCmEHkUKBKxew==",
       "license": "ISC"
     },
     "node_modules/ip-address": {
@@ -742,10 +933,43 @@
         "url": "https://opencollective.com/express"
       }
     },
+    "node_modules/mimic-response": {
+      "version": "3.1.0",
+      "resolved": "https://registry.npmjs.org/mimic-response/-/mimic-response-3.1.0.tgz",
+      "integrity": "sha512-z0yWI+4FDrrweS8Zmt4Ej5HdJmky15+L2e6Wgn3+iK5fWzb6T3fhNFq2+MeTRb064c6Wr4N/wv0DzQTjNzHNGQ==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=10"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/minimist": {
+      "version": "1.2.8",
+      "resolved": "https://registry.npmjs.org/minimist/-/minimist-1.2.8.tgz",
+      "integrity": "sha512-2yyAR8qBkN3YuheJanUpWC5U3bb5osDywNB8RzDVlDwDHbocAJveqqj1u8+SVD7jkWT4yvsHCpWqqWqAxb0zCA==",
+      "license": "MIT",
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/mkdirp-classic": {
+      "version": "0.5.3",
+      "resolved": "https://registry.npmjs.org/mkdirp-classic/-/mkdirp-classic-0.5.3.tgz",
+      "integrity": "sha512-gKLcREMhtuZRwRAfqP3RFW+TK4JqApVBtOIftVgjuABpAtpxhPGaDcfvbhNvD0B8iD1oUr/txX35NjcaY6Ns/A==",
+      "license": "MIT"
+    },
     "node_modules/ms": {
       "version": "2.1.3",
       "resolved": "https://registry.npmjs.org/ms/-/ms-2.1.3.tgz",
       "integrity": "sha512-6FlzubTLZG3J2a/NVCAleEhjzq5oxgHyaCU9yYXvcLsvoVaHJq/s5xXI6/XXP6tz7R9xAOtHnSO/tXtF3WRTlA==",
+      "license": "MIT"
+    },
+    "node_modules/napi-build-utils": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/napi-build-utils/-/napi-build-utils-2.0.0.tgz",
+      "integrity": "sha512-GEbrYkbfF7MoNaoh2iGG84Mnf/WZfB0GdGEsM8wz7Expx/LlWf5U8t9nvJKXSp3qr5IsEbK04cBGhol/KwOsWA==",
       "license": "MIT"
     },
     "node_modules/negotiator": {
@@ -755,6 +979,18 @@
       "license": "MIT",
       "engines": {
         "node": ">= 0.6"
+      }
+    },
+    "node_modules/node-abi": {
+      "version": "3.92.0",
+      "resolved": "https://registry.npmjs.org/node-abi/-/node-abi-3.92.0.tgz",
+      "integrity": "sha512-KdHvFWZjEKDf0cakgFjebl371GPsISX2oZHcuyKqM7DtogIsHrqKeLTo8wBHxaXRAQlY2PsPlZmfo+9ZCxEREQ==",
+      "license": "MIT",
+      "dependencies": {
+        "semver": "^7.3.5"
+      },
+      "engines": {
+        "node": ">=10"
       }
     },
     "node_modules/object-assign": {
@@ -836,6 +1072,33 @@
         "node": ">=16.20.0"
       }
     },
+    "node_modules/prebuild-install": {
+      "version": "7.1.3",
+      "resolved": "https://registry.npmjs.org/prebuild-install/-/prebuild-install-7.1.3.tgz",
+      "integrity": "sha512-8Mf2cbV7x1cXPUILADGI3wuhfqWvtiLA1iclTDbFRZkgRQS0NqsPZphna9V+HyTEadheuPmjaJMsbzKQFOzLug==",
+      "deprecated": "No longer maintained. Please contact the author of the relevant native addon; alternatives are available.",
+      "license": "MIT",
+      "dependencies": {
+        "detect-libc": "^2.0.0",
+        "expand-template": "^2.0.3",
+        "github-from-package": "0.0.0",
+        "minimist": "^1.2.3",
+        "mkdirp-classic": "^0.5.3",
+        "napi-build-utils": "^2.0.0",
+        "node-abi": "^3.3.0",
+        "pump": "^3.0.0",
+        "rc": "^1.2.7",
+        "simple-get": "^4.0.0",
+        "tar-fs": "^2.0.0",
+        "tunnel-agent": "^0.6.0"
+      },
+      "bin": {
+        "prebuild-install": "bin.js"
+      },
+      "engines": {
+        "node": ">=10"
+      }
+    },
     "node_modules/proxy-addr": {
       "version": "2.0.7",
       "resolved": "https://registry.npmjs.org/proxy-addr/-/proxy-addr-2.0.7.tgz",
@@ -847,6 +1110,16 @@
       },
       "engines": {
         "node": ">= 0.10"
+      }
+    },
+    "node_modules/pump": {
+      "version": "3.0.4",
+      "resolved": "https://registry.npmjs.org/pump/-/pump-3.0.4.tgz",
+      "integrity": "sha512-VS7sjc6KR7e1ukRFhQSY5LM2uBWAUPiOPa/A3mkKmiMwSmRFUITt0xuj+/lesgnCv+dPIEYlkzrcyXgquIHMcA==",
+      "license": "MIT",
+      "dependencies": {
+        "end-of-stream": "^1.1.0",
+        "once": "^1.3.1"
       }
     },
     "node_modules/qs": {
@@ -888,6 +1161,35 @@
         "node": ">= 0.10"
       }
     },
+    "node_modules/rc": {
+      "version": "1.2.8",
+      "resolved": "https://registry.npmjs.org/rc/-/rc-1.2.8.tgz",
+      "integrity": "sha512-y3bGgqKj3QBdxLbLkomlohkvsA8gdAiUQlSBJnBhfn+BPxg4bc62d8TcBW15wavDfgexCgccckhcZvywyQYPOw==",
+      "license": "(BSD-2-Clause OR MIT OR Apache-2.0)",
+      "dependencies": {
+        "deep-extend": "^0.6.0",
+        "ini": "~1.3.0",
+        "minimist": "^1.2.0",
+        "strip-json-comments": "~2.0.1"
+      },
+      "bin": {
+        "rc": "cli.js"
+      }
+    },
+    "node_modules/readable-stream": {
+      "version": "3.6.2",
+      "resolved": "https://registry.npmjs.org/readable-stream/-/readable-stream-3.6.2.tgz",
+      "integrity": "sha512-9u/sniCrY3D5WdsERHzHE4G2YCXqoG5FTHUiCC4SIbr6XcLZBY05ya9EKjYek9O5xOAwjGq+1JdGBAS7Q9ScoA==",
+      "license": "MIT",
+      "dependencies": {
+        "inherits": "^2.0.3",
+        "string_decoder": "^1.1.1",
+        "util-deprecate": "^1.0.1"
+      },
+      "engines": {
+        "node": ">= 6"
+      }
+    },
     "node_modules/require-from-string": {
       "version": "2.0.2",
       "resolved": "https://registry.npmjs.org/require-from-string/-/require-from-string-2.0.2.tgz",
@@ -913,11 +1215,43 @@
         "node": ">= 18"
       }
     },
+    "node_modules/safe-buffer": {
+      "version": "5.2.1",
+      "resolved": "https://registry.npmjs.org/safe-buffer/-/safe-buffer-5.2.1.tgz",
+      "integrity": "sha512-rp3So07KcdmmKbGvgaNxQSJr7bGVSVk5S9Eq1F+ppbRo70+YeaDxkw5Dd8NPN+GD6bjnYm2VuPuCXmpuYvmCXQ==",
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/feross"
+        },
+        {
+          "type": "patreon",
+          "url": "https://www.patreon.com/feross"
+        },
+        {
+          "type": "consulting",
+          "url": "https://feross.org/support"
+        }
+      ],
+      "license": "MIT"
+    },
     "node_modules/safer-buffer": {
       "version": "2.1.2",
       "resolved": "https://registry.npmjs.org/safer-buffer/-/safer-buffer-2.1.2.tgz",
       "integrity": "sha512-YZo3K82SD7Riyi0E1EQPojLz7kpepnSQI9IyPbHHg1XXXevb5dJI7tpyN2ADxGcQbHG7vcyRHk0cbwqcQriUtg==",
       "license": "MIT"
+    },
+    "node_modules/semver": {
+      "version": "7.8.0",
+      "resolved": "https://registry.npmjs.org/semver/-/semver-7.8.0.tgz",
+      "integrity": "sha512-AcM7dV/5ul4EekoQ29Agm5vri8JNqRyj39o0qpX6vDF2GZrtutZl5RwgD1XnZjiTAfncsJhMI48QQH3sN87YNA==",
+      "license": "ISC",
+      "bin": {
+        "semver": "bin/semver.js"
+      },
+      "engines": {
+        "node": ">=10"
+      }
     },
     "node_modules/send": {
       "version": "1.2.1",
@@ -1063,6 +1397,51 @@
         "url": "https://github.com/sponsors/ljharb"
       }
     },
+    "node_modules/simple-concat": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/simple-concat/-/simple-concat-1.0.1.tgz",
+      "integrity": "sha512-cSFtAPtRhljv69IK0hTVZQ+OfE9nePi/rtJmw5UjHeVyVroEqJXP1sFztKUy1qU+xvz3u/sfYJLa947b7nAN2Q==",
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/feross"
+        },
+        {
+          "type": "patreon",
+          "url": "https://www.patreon.com/feross"
+        },
+        {
+          "type": "consulting",
+          "url": "https://feross.org/support"
+        }
+      ],
+      "license": "MIT"
+    },
+    "node_modules/simple-get": {
+      "version": "4.0.1",
+      "resolved": "https://registry.npmjs.org/simple-get/-/simple-get-4.0.1.tgz",
+      "integrity": "sha512-brv7p5WgH0jmQJr1ZDDfKDOSeWWg+OVypG99A/5vYGPqJ6pxiaHLy8nxtFjBA7oMa01ebA9gfh1uMCFqOuXxvA==",
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/feross"
+        },
+        {
+          "type": "patreon",
+          "url": "https://www.patreon.com/feross"
+        },
+        {
+          "type": "consulting",
+          "url": "https://feross.org/support"
+        }
+      ],
+      "license": "MIT",
+      "dependencies": {
+        "decompress-response": "^6.0.0",
+        "once": "^1.3.1",
+        "simple-concat": "^1.0.0"
+      }
+    },
     "node_modules/statuses": {
       "version": "2.0.2",
       "resolved": "https://registry.npmjs.org/statuses/-/statuses-2.0.2.tgz",
@@ -1072,6 +1451,52 @@
         "node": ">= 0.8"
       }
     },
+    "node_modules/string_decoder": {
+      "version": "1.3.0",
+      "resolved": "https://registry.npmjs.org/string_decoder/-/string_decoder-1.3.0.tgz",
+      "integrity": "sha512-hkRX8U1WjJFd8LsDJ2yQ/wWWxaopEsABU1XfkM8A+j0+85JAGppt16cr1Whg6KIbb4okU6Mql6BOj+uup/wKeA==",
+      "license": "MIT",
+      "dependencies": {
+        "safe-buffer": "~5.2.0"
+      }
+    },
+    "node_modules/strip-json-comments": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/strip-json-comments/-/strip-json-comments-2.0.1.tgz",
+      "integrity": "sha512-4gB8na07fecVVkOI6Rs4e7T6NOTki5EmL7TUduTs6bu3EdnSycntVJ4re8kgZA+wx9IueI2Y11bfbgwtzuE0KQ==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=0.10.0"
+      }
+    },
+    "node_modules/tar-fs": {
+      "version": "2.1.4",
+      "resolved": "https://registry.npmjs.org/tar-fs/-/tar-fs-2.1.4.tgz",
+      "integrity": "sha512-mDAjwmZdh7LTT6pNleZ05Yt65HC3E+NiQzl672vQG38jIrehtJk/J3mNwIg+vShQPcLF/LV7CMnDW6vjj6sfYQ==",
+      "license": "MIT",
+      "dependencies": {
+        "chownr": "^1.1.1",
+        "mkdirp-classic": "^0.5.2",
+        "pump": "^3.0.0",
+        "tar-stream": "^2.1.4"
+      }
+    },
+    "node_modules/tar-stream": {
+      "version": "2.2.0",
+      "resolved": "https://registry.npmjs.org/tar-stream/-/tar-stream-2.2.0.tgz",
+      "integrity": "sha512-ujeqbceABgwMZxEJnk2HDY2DlnUZ+9oEcb1KzTVfYHio0UE6dG71n60d8D2I4qNvleWrrXpmjpt7vZeF1LnMZQ==",
+      "license": "MIT",
+      "dependencies": {
+        "bl": "^4.0.3",
+        "end-of-stream": "^1.4.1",
+        "fs-constants": "^1.0.0",
+        "inherits": "^2.0.3",
+        "readable-stream": "^3.1.1"
+      },
+      "engines": {
+        "node": ">=6"
+      }
+    },
     "node_modules/toidentifier": {
       "version": "1.0.1",
       "resolved": "https://registry.npmjs.org/toidentifier/-/toidentifier-1.0.1.tgz",
@@ -1079,6 +1504,18 @@
       "license": "MIT",
       "engines": {
         "node": ">=0.6"
+      }
+    },
+    "node_modules/tunnel-agent": {
+      "version": "0.6.0",
+      "resolved": "https://registry.npmjs.org/tunnel-agent/-/tunnel-agent-0.6.0.tgz",
+      "integrity": "sha512-McnNiV1l8RYeY8tBgEpuodCC1mLUdbSN+CYBL7kJsJNInOP8UjDDEwdk6Mw60vdLLrr5NHKZhMAOSrR2NZuQ+w==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "safe-buffer": "^5.0.1"
+      },
+      "engines": {
+        "node": "*"
       }
     },
     "node_modules/type-is": {
@@ -1141,6 +1578,12 @@
       "engines": {
         "node": ">= 0.8"
       }
+    },
+    "node_modules/util-deprecate": {
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/util-deprecate/-/util-deprecate-1.0.2.tgz",
+      "integrity": "sha512-EPD5q1uXyFxJpCrLnCc1nHnq3gOa6DZBocAIiI2TaSCA7VCJ1UJDMagCzIkXNsUYfD1daK//LTEQ8xiIbrHtcw==",
+      "license": "MIT"
     },
     "node_modules/vary": {
       "version": "1.1.2",

--- a/mcpb/node/package.json
+++ b/mcpb/node/package.json
@@ -13,9 +13,11 @@
   },
   "dependencies": {
     "@modelcontextprotocol/sdk": "^1.29.0",
+    "better-sqlite3": "^12.10.0",
     "zod": "^4.4.3"
   },
   "devDependencies": {
+    "@types/better-sqlite3": "^7.6.0",
     "@types/node": "^22.0.0",
     "typescript": "^5.6.0"
   }

--- a/mcpb/node/package.json
+++ b/mcpb/node/package.json
@@ -13,12 +13,10 @@
   },
   "dependencies": {
     "@modelcontextprotocol/sdk": "^1.29.0",
-    "better-sqlite3": "^12.10.0",
     "zod": "^4.4.3"
   },
   "devDependencies": {
-    "@types/better-sqlite3": "^7.6.0",
-    "@types/node": "^22.0.0",
+    "@types/node": "^24.0.0",
     "typescript": "^5.6.0"
   }
 }

--- a/mcpb/node/src/_shared/fellows_queries.ts
+++ b/mcpb/node/src/_shared/fellows_queries.ts
@@ -1,0 +1,214 @@
+/**
+ * Pure-logic query helpers over fellows.db — Node port of
+ * ../../../../app/fellows_queries.py.
+ *
+ * Shared between mcpb/node/src/shared_data_ops/ (and any future Node
+ * server that reads the directory snapshot) so all of them surface
+ * identical record shapes to AI clients. No transport, no framework —
+ * just SQL helpers and the rowToFellow shape that merges ``extra_json``
+ * overflow keys into the record.
+ *
+ * Conforms to mcp-shared-data-ops.schema.json from the PNA spec.
+ * Behavioral parity with the Python helper is asserted by
+ * tests/test_mcpb_parity.py per plans/easy_mcp_install.md § 6.
+ */
+import type Database from "better-sqlite3";
+
+export const FELLOW_COLUMNS = [
+  "record_id",
+  "slug",
+  "name",
+  "bio_tagline",
+  "fellow_type",
+  "cohort",
+  "contact_email",
+  "key_links",
+  "key_links_urls",
+  "image_url",
+  "currently_based_in",
+  "search_tags",
+  "fellow_status",
+  "gender_pronouns",
+  "ethnicity",
+  "primary_citizenship",
+  "global_regions_currently_based_in",
+  "has_image",
+] as const;
+
+export type FellowsRow = Record<string, unknown>;
+
+/**
+ * Convert a DB row to the API fellow object: parse key_links_urls JSON
+ * and merge extra_json overflow keys. Mirrors row_to_fellow in
+ * app/fellows_queries.py byte-for-byte (including the silent fallback
+ * on malformed JSON).
+ */
+export function rowToFellow(row: FellowsRow): Record<string, unknown> {
+  const out: Record<string, unknown> = {};
+  for (const key of FELLOW_COLUMNS) {
+    const val = row[key] ?? null;
+    if (key === "key_links_urls" && val !== null && typeof val === "string") {
+      try {
+        out[key] = JSON.parse(val);
+      } catch {
+        out[key] = val;
+      }
+    } else {
+      out[key] = val;
+    }
+  }
+  const extra = row["extra_json"];
+  if (extra && typeof extra === "string") {
+    try {
+      const parsed = JSON.parse(extra);
+      if (parsed && typeof parsed === "object" && !Array.isArray(parsed)) {
+        Object.assign(out, parsed);
+      }
+    } catch {
+      // Silent fallback matches Python.
+    }
+  }
+  return out;
+}
+
+export function getFellowBySlugOrId(
+  db: Database.Database,
+  slugOrId: string,
+): Record<string, unknown> | null {
+  const row = db
+    .prepare("SELECT * FROM fellows WHERE slug = ? OR record_id = ? LIMIT 1")
+    .get(slugOrId, slugOrId) as FellowsRow | undefined;
+  return row ? rowToFellow(row) : null;
+}
+
+export function searchFellows(
+  db: Database.Database,
+  q: string,
+): Array<Record<string, unknown>> {
+  const trimmed = (q ?? "").trim();
+  if (!trimmed) return [];
+  // Python caps query length at 200 chars before passing to FTS5 — match.
+  const capped = trimmed.length > 200 ? trimmed.slice(0, 200) : trimmed;
+  const rows = db
+    .prepare(
+      `
+      SELECT f.* FROM fellows f
+      WHERE f.rowid IN (
+        SELECT rowid FROM fellows_fts WHERE fellows_fts MATCH ?
+      )
+      ORDER BY f.name ASC
+      `,
+    )
+    .all(capped) as FellowsRow[];
+  return rows.map(rowToFellow);
+}
+
+/**
+ * Get aggregate directory stats. Mirrors get_stats in
+ * app/fellows_queries.py.
+ */
+export function getStats(db: Database.Database): Record<string, unknown> {
+  const total = (
+    db.prepare("SELECT COUNT(*) as c FROM fellows").get() as { c: number }
+  ).c;
+
+  const groupCounts = (sql: string): Array<{ label: string; count: number }> =>
+    (db.prepare(sql).all() as Array<{ label: string; count: number }>).map(
+      (r) => ({ label: r.label, count: r.count }),
+    );
+
+  // Region splitting: comma-separated values stored as one field per row;
+  // expand and tally. Order is most-common-first (Python uses
+  // Counter.most_common which preserves insertion order for ties).
+  const regionCounter = new Map<string, number>();
+  const regionRows = db
+    .prepare(
+      `SELECT global_regions_currently_based_in FROM fellows
+       WHERE global_regions_currently_based_in IS NOT NULL
+       AND global_regions_currently_based_in != ''`,
+    )
+    .all() as Array<{ global_regions_currently_based_in: string }>;
+  for (const r of regionRows) {
+    for (const part of r.global_regions_currently_based_in.split(",")) {
+      const region = part.trim();
+      if (region) {
+        regionCounter.set(region, (regionCounter.get(region) ?? 0) + 1);
+      }
+    }
+  }
+  // Sort descending by count; ties preserve first-seen order (matches
+  // Python Counter.most_common stability).
+  const byRegion = Array.from(regionCounter.entries())
+    .map(([label, count]) => ({ label, count }))
+    .sort((a, b) => b.count - a.count);
+
+  const fieldCounts: Array<{ label: string; count: number }> = [];
+  const colLabels: Record<string, string> = {
+    name: "Name",
+    bio_tagline: "Bio / Tagline",
+    fellow_type: "Fellow Type",
+    cohort: "Cohort",
+    contact_email: "Contact Email",
+    key_links: "Key Links",
+    image_url: "Image URL",
+    currently_based_in: "Currently Based In",
+    search_tags: "Search Tags",
+    fellow_status: "Fellow Status",
+    gender_pronouns: "Gender / Pronouns",
+    ethnicity: "Ethnicity",
+    primary_citizenship: "Primary Citizenship",
+    global_regions_currently_based_in: "Global Regions Based In",
+  };
+  for (const [col, label] of Object.entries(colLabels)) {
+    const count = (
+      db
+        .prepare(
+          `SELECT COUNT(*) as c FROM fellows WHERE ${col} IS NOT NULL AND ${col} != ''`,
+        )
+        .get() as { c: number }
+    ).c;
+    fieldCounts.push({ label, count });
+  }
+  const extraLabels: Record<string, string> = {
+    all_citizenships: "All Citizenships",
+    ventures: "Ventures",
+    industries: "Industries",
+    career_highlights: "Career Highlights",
+    key_networks: "Key Networks",
+    how_im_looking_to_support_the_nz_ecosystem: "How Supporting NZ Ecosystem",
+    what_is_your_main_mode_of_working: "Main Mode of Working",
+    do_you_consider_yourself_an_investor_in_one_or_more_of_these_categories:
+      "Investor Categories",
+    mobile_number: "Mobile Number",
+    five_things_to_know: "Five Things to Know",
+    skills_to_give: "Skills to Give",
+    skills_to_receive: "Skills to Receive",
+  };
+  const extraStmt = db.prepare(
+    `SELECT COUNT(*) as c FROM fellows WHERE extra_json IS NOT NULL
+     AND json_extract(extra_json, ?) IS NOT NULL
+     AND json_extract(extra_json, ?) != ''`,
+  );
+  for (const [key, label] of Object.entries(extraLabels)) {
+    const path = `$.${key}`;
+    const count = (extraStmt.get(path, path) as { c: number }).c;
+    fieldCounts.push({ label, count });
+  }
+  fieldCounts.sort((a, b) => b.count - a.count);
+
+  return {
+    total,
+    by_fellow_type: groupCounts(
+      `SELECT fellow_type as label, COUNT(*) as count FROM fellows
+       WHERE fellow_type IS NOT NULL
+       GROUP BY fellow_type ORDER BY COUNT(*) DESC`,
+    ),
+    by_cohort: groupCounts(
+      `SELECT cohort as label, COUNT(*) as count FROM fellows
+       WHERE cohort IS NOT NULL
+       GROUP BY cohort ORDER BY COUNT(*) DESC`,
+    ),
+    by_region: byRegion,
+    field_completeness: fieldCounts,
+  };
+}

--- a/mcpb/node/src/_shared/fellows_queries.ts
+++ b/mcpb/node/src/_shared/fellows_queries.ts
@@ -11,8 +11,14 @@
  * Conforms to mcp-shared-data-ops.schema.json from the PNA spec.
  * Behavioral parity with the Python helper is asserted by
  * tests/test_mcpb_parity.py per plans/easy_mcp_install.md § 6.
+ *
+ * Uses Node's built-in `node:sqlite` (stable since Node 24) rather than
+ * better-sqlite3 — the latter ships a native .node binding that has to
+ * match the host's Node ABI exactly, and Claude Desktop bundles a
+ * different Node version than the build machine. Built-in sqlite has
+ * zero native deps, no ABI to mismatch, and a nearly identical API.
  */
-import type Database from "better-sqlite3";
+import type { DatabaseSync } from "node:sqlite";
 
 export const FELLOW_COLUMNS = [
   "record_id",
@@ -72,7 +78,7 @@ export function rowToFellow(row: FellowsRow): Record<string, unknown> {
 }
 
 export function getFellowBySlugOrId(
-  db: Database.Database,
+  db: DatabaseSync,
   slugOrId: string,
 ): Record<string, unknown> | null {
   const row = db
@@ -82,7 +88,7 @@ export function getFellowBySlugOrId(
 }
 
 export function searchFellows(
-  db: Database.Database,
+  db: DatabaseSync,
   q: string,
 ): Array<Record<string, unknown>> {
   const trimmed = (q ?? "").trim();
@@ -107,7 +113,7 @@ export function searchFellows(
  * Get aggregate directory stats. Mirrors get_stats in
  * app/fellows_queries.py.
  */
-export function getStats(db: Database.Database): Record<string, unknown> {
+export function getStats(db: DatabaseSync): Record<string, unknown> {
   const total = (
     db.prepare("SELECT COUNT(*) as c FROM fellows").get() as { c: number }
   ).c;

--- a/mcpb/node/src/comms/index.ts
+++ b/mcpb/node/src/comms/index.ts
@@ -29,6 +29,10 @@ import { StdioServerTransport } from "@modelcontextprotocol/sdk/server/stdio.js"
 import { z } from "zod";
 import { randomBytes } from "node:crypto";
 
+// Unconditional startup line — appears in Claude Desktop's per-server
+// log so any future startup failure has a trace.
+process.stderr.write(`comms: boot node=${process.version}\n`);
+
 const MAILTO_URL_WARN_BYTES = 2000;
 const STAGED_MAX = 100;
 

--- a/mcpb/node/src/shared_data_ops/index.ts
+++ b/mcpb/node/src/shared_data_ops/index.ts
@@ -16,9 +16,14 @@
  * See plans/easy_mcp_install.md § 5 (OPFS handoff) and
  * docs/Architecture.md § Two-DB architecture for why these are split.
  *
- * Read-only-ness is enforced at the SQLite layer (readonly: true on the
- * better-sqlite3 connection, same posture as Python's mode=ro URI flag).
+ * Read-only-ness is enforced at the SQLite layer (readOnly: true on the
+ * node:sqlite connection, same posture as Python's mode=ro URI flag).
  * Even a buggy tool can't mutate the directory snapshot.
+ *
+ * Uses Node's built-in `node:sqlite` (stable since Node 24) so the bundle
+ * has zero native dependencies — Claude Desktop ships Electron with
+ * Node 24, and a native better-sqlite3 binding would not survive any
+ * Node version skew between the build machine and Claude Desktop.
  *
  * DB path resolution mirrors the Python server: CLI --db, then env
  * FELLOWS_DB_PATH, then ${__dirname}/../data/fellows.db (the path inside
@@ -33,7 +38,7 @@ import { z } from "zod";
 import { existsSync, statSync } from "node:fs";
 import { dirname, resolve } from "node:path";
 import { fileURLToPath } from "node:url";
-import Database from "better-sqlite3";
+import { DatabaseSync } from "node:sqlite";
 
 import {
   getFellowBySlugOrId,
@@ -79,7 +84,7 @@ if (!existsSync(DB_PATH) || !statSync(DB_PATH).isFile()) {
   process.exit(1);
 }
 
-const db = new Database(DB_PATH, { readonly: true, fileMustExist: true });
+const db = new DatabaseSync(DB_PATH, { readOnly: true });
 // Sanity check before handing control to the stdio loop — fail fast with
 // a useful stderr message rather than a cryptic JSON-RPC error on the
 // first tool call.

--- a/mcpb/node/src/shared_data_ops/index.ts
+++ b/mcpb/node/src/shared_data_ops/index.ts
@@ -1,0 +1,310 @@
+#!/usr/bin/env node
+/**
+ * Shared Data Ops MCP server — Node port of
+ * ../../../mcp_servers/shared_data_ops.py.
+ *
+ * Read-only MCP access to the Shared DB (fellows.db). Exposes four tools
+ * to AI clients via stdio:
+ *
+ *  - search_fellows       FTS5 full-text search.
+ *  - get_fellow           Single record by slug or record_id, full shape.
+ *  - list_fellows         Structured-filter list with pagination.
+ *  - get_directory_stats  Aggregates for "what's in this directory" questions.
+ *
+ * Storage scope: the Shared DB only (fellows.db). The Private DB
+ * (relationships.db) is the future Private Data Ops bundle's surface.
+ * See plans/easy_mcp_install.md § 5 (OPFS handoff) and
+ * docs/Architecture.md § Two-DB architecture for why these are split.
+ *
+ * Read-only-ness is enforced at the SQLite layer (readonly: true on the
+ * better-sqlite3 connection, same posture as Python's mode=ro URI flag).
+ * Even a buggy tool can't mutate the directory snapshot.
+ *
+ * DB path resolution mirrors the Python server: CLI --db, then env
+ * FELLOWS_DB_PATH, then ${__dirname}/../data/fellows.db (the path inside
+ * an installed .mcpb where fellows.db is bundled at build time).
+ *
+ * Behavioral parity with mcp_servers/shared_data_ops.py is asserted by
+ * tests/test_mcpb_parity.py per plans/easy_mcp_install.md § 6.
+ */
+import { McpServer } from "@modelcontextprotocol/sdk/server/mcp.js";
+import { StdioServerTransport } from "@modelcontextprotocol/sdk/server/stdio.js";
+import { z } from "zod";
+import { existsSync, statSync } from "node:fs";
+import { dirname, resolve } from "node:path";
+import { fileURLToPath } from "node:url";
+import Database from "better-sqlite3";
+
+import {
+  getFellowBySlugOrId,
+  getStats,
+  rowToFellow,
+  searchFellows,
+  type FellowsRow,
+} from "../_shared/fellows_queries.js";
+
+const SEARCH_LIMIT_DEFAULT = 25;
+const SEARCH_LIMIT_MAX = 100;
+const LIST_LIMIT_DEFAULT = 50;
+const LIST_LIMIT_MAX = 100;
+
+function parseCliDb(argv: ReadonlyArray<string>): string | null {
+  // Match argparse: --db PATH  or  --db=PATH
+  for (let i = 0; i < argv.length; i++) {
+    const a = argv[i];
+    if (a === "--db" && i + 1 < argv.length) return argv[i + 1] ?? null;
+    if (a.startsWith("--db=")) return a.slice("--db=".length);
+  }
+  return null;
+}
+
+function resolveDbPath(argv: ReadonlyArray<string>): string {
+  const cli = parseCliDb(argv);
+  if (cli) return resolve(cli);
+  const env = process.env.FELLOWS_DB_PATH;
+  if (env) return resolve(env);
+  // Default: ${__dirname}/../data/fellows.db. This is where build_mcpb.py
+  // places fellows.db inside the staged bundle. For local dev / standalone
+  // runs (without a built .mcpb), point at the repo's app/fellows.db
+  // via --db or FELLOWS_DB_PATH instead.
+  const here = dirname(fileURLToPath(import.meta.url));
+  return resolve(here, "..", "data", "fellows.db");
+}
+
+const DB_PATH = resolveDbPath(process.argv.slice(2));
+if (!existsSync(DB_PATH) || !statSync(DB_PATH).isFile()) {
+  process.stderr.write(
+    `shared-data-ops: fellows.db not found at ${DB_PATH}\n`,
+  );
+  process.exit(1);
+}
+
+const db = new Database(DB_PATH, { readonly: true, fileMustExist: true });
+// Sanity check before handing control to the stdio loop — fail fast with
+// a useful stderr message rather than a cryptic JSON-RPC error on the
+// first tool call.
+try {
+  db.prepare("SELECT 1 FROM fellows LIMIT 1").get();
+} catch (err) {
+  process.stderr.write(
+    `shared-data-ops: cannot read ${DB_PATH}: ${(err as Error).message}\n`,
+  );
+  process.exit(1);
+}
+
+function toSummary(fellow: Record<string, unknown>): Record<string, unknown> {
+  return {
+    record_id: fellow.record_id ?? null,
+    slug: fellow.slug ?? null,
+    name: fellow.name ?? null,
+    fellow_type: fellow.fellow_type ?? null,
+    cohort: fellow.cohort ?? null,
+    currently_based_in: fellow.currently_based_in ?? null,
+    bio_tagline: fellow.bio_tagline ?? null,
+    has_contact_email: Boolean(fellow.contact_email),
+  };
+}
+
+function clampInt(value: number, min: number, max: number): number {
+  return Math.max(min, Math.min(Math.floor(value), max));
+}
+
+const server = new McpServer({ name: "shared-data-ops", version: "0.1.0" });
+
+server.registerTool(
+  "search_fellows",
+  {
+    description:
+      "Full-text search across name, bio, cohort, fellow type, search tags, and key links. Uses SQLite FTS5; pass natural keywords (FTS5 also accepts operators like 'climate OR healthcare' and prefix matches like 'auck*').",
+    inputSchema: {
+      query: z.string().describe("Search keywords. Must be non-empty."),
+      limit: z
+        .number()
+        .int()
+        .nullish()
+        .describe("Max results to return. Default 25, capped at 100."),
+    },
+  },
+  async ({ query, limit }) => {
+    const q = (query ?? "").trim();
+    if (!q) {
+      return {
+        content: [
+          {
+            type: "text",
+            text: JSON.stringify({ query: "", total: 0, results: [] }),
+          },
+        ],
+      };
+    }
+    const lim = clampInt(limit ?? SEARCH_LIMIT_DEFAULT, 1, SEARCH_LIMIT_MAX);
+    const rows = searchFellows(db, q);
+    const total = rows.length;
+    const results = rows.slice(0, lim).map(toSummary);
+    return {
+      content: [
+        {
+          type: "text",
+          text: JSON.stringify({ query: q, total, results }),
+        },
+      ],
+    };
+  },
+);
+
+server.registerTool(
+  "get_fellow",
+  {
+    description:
+      "Fetch one fellow's full record by slug or record_id. Returns the full shape — all DB columns plus extra_json fields merged (ventures, career_highlights, mobile_number, skills_to_give, etc.). Returns null if no such record exists.",
+    inputSchema: {
+      id: z
+        .string()
+        .describe("A fellow's slug (e.g. 'jane-doe') or record_id."),
+    },
+  },
+  async ({ id }) => {
+    const key = (id ?? "").trim();
+    let result: unknown = null;
+    if (key) result = getFellowBySlugOrId(db, key);
+    return {
+      content: [{ type: "text", text: JSON.stringify(result) }],
+    };
+  },
+);
+
+server.registerTool(
+  "list_fellows",
+  {
+    description:
+      "List fellows by structured filters (use search_fellows for full-text). Filters AND together. The region filter matches against global_regions_currently_based_in (comma-separated), so a fellow in 'Asia Pacific, Americas' matches either value.",
+    inputSchema: {
+      fellow_type: z
+        .string()
+        .nullish()
+        .describe("Exact match on fellow_type."),
+      cohort: z.string().nullish().describe("Exact match on cohort."),
+      region: z
+        .string()
+        .nullish()
+        .describe(
+          "Substring-match against global_regions_currently_based_in.",
+        ),
+      primary_citizenship: z
+        .string()
+        .nullish()
+        .describe("Exact match on primary_citizenship."),
+      has_contact_email: z
+        .boolean()
+        .nullish()
+        .describe(
+          "True for fellows with a contact email; false for those without; null for no filter.",
+        ),
+      limit: z
+        .number()
+        .int()
+        .nullish()
+        .describe("Max results to return. Default 50, capped at 100."),
+      offset: z
+        .number()
+        .int()
+        .nullish()
+        .describe(
+          "Number of results to skip before returning (for pagination).",
+        ),
+    },
+  },
+  async ({
+    fellow_type,
+    cohort,
+    region,
+    primary_citizenship,
+    has_contact_email,
+    limit,
+    offset,
+  }) => {
+    const lim = clampInt(limit ?? LIST_LIMIT_DEFAULT, 1, LIST_LIMIT_MAX);
+    const off = Math.max(0, Math.floor(offset ?? 0));
+    const where: string[] = [];
+    const params: Array<string | number> = [];
+    if (fellow_type) {
+      where.push("fellow_type = ?");
+      params.push(fellow_type);
+    }
+    if (cohort) {
+      where.push("cohort = ?");
+      params.push(cohort);
+    }
+    if (region) {
+      where.push("global_regions_currently_based_in LIKE ?");
+      params.push(`%${region}%`);
+    }
+    if (primary_citizenship) {
+      where.push("primary_citizenship = ?");
+      params.push(primary_citizenship);
+    }
+    if (has_contact_email === true) {
+      where.push("contact_email IS NOT NULL AND contact_email != ''");
+    } else if (has_contact_email === false) {
+      where.push("(contact_email IS NULL OR contact_email = '')");
+    }
+    const whereSql = where.length ? " WHERE " + where.join(" AND ") : "";
+
+    const total = (
+      db
+        .prepare(`SELECT COUNT(*) as c FROM fellows${whereSql}`)
+        .get(...params) as { c: number }
+    ).c;
+    const rows = db
+      .prepare(
+        `SELECT * FROM fellows${whereSql} ORDER BY name ASC LIMIT ? OFFSET ?`,
+      )
+      .all(...params, lim, off) as FellowsRow[];
+    const results = rows.map(rowToFellow).map(toSummary);
+
+    const filtersAppliedRaw: Record<string, unknown> = {
+      fellow_type: fellow_type ?? null,
+      cohort: cohort ?? null,
+      region: region ?? null,
+      primary_citizenship: primary_citizenship ?? null,
+      has_contact_email: has_contact_email ?? null,
+    };
+    const filtersApplied: Record<string, unknown> = {};
+    for (const [k, v] of Object.entries(filtersAppliedRaw)) {
+      if (v !== null && v !== undefined) filtersApplied[k] = v;
+    }
+
+    return {
+      content: [
+        {
+          type: "text",
+          text: JSON.stringify({
+            total,
+            offset: off,
+            limit: lim,
+            filters_applied: filtersApplied,
+            results,
+          }),
+        },
+      ],
+    };
+  },
+);
+
+server.registerTool(
+  "get_directory_stats",
+  {
+    description:
+      "Aggregate statistics for 'what's in this directory' questions. Same shape as the dev HTTP server's GET /api/stats response: total count, breakdowns by fellow type / cohort / region, plus field-completeness counts (how many fellows have a non-empty value for each column or extra_json key).",
+    inputSchema: {},
+  },
+  async () => {
+    const stats = getStats(db);
+    return {
+      content: [{ type: "text", text: JSON.stringify(stats) }],
+    };
+  },
+);
+
+const transport = new StdioServerTransport();
+await server.connect(transport);

--- a/mcpb/node/src/shared_data_ops/index.ts
+++ b/mcpb/node/src/shared_data_ops/index.ts
@@ -76,7 +76,16 @@ function resolveDbPath(argv: ReadonlyArray<string>): string {
   return resolve(here, "..", "data", "fellows.db");
 }
 
+// Unconditional startup line — appears in Claude Desktop's per-server
+// log (~/Library/Logs/Claude/mcp-server-<name>.log on macOS) so any
+// future startup failure has a trace of what was tried, not just
+// "Server transport closed unexpectedly".
+process.stderr.write(
+  `shared-data-ops: boot node=${process.version} cwd=${process.cwd()}\n`,
+);
+
 const DB_PATH = resolveDbPath(process.argv.slice(2));
+process.stderr.write(`shared-data-ops: resolved db=${DB_PATH}\n`);
 if (!existsSync(DB_PATH) || !statSync(DB_PATH).isFile()) {
   process.stderr.write(
     `shared-data-ops: fellows.db not found at ${DB_PATH}\n`,

--- a/plans/easy_mcp_install.md
+++ b/plans/easy_mcp_install.md
@@ -506,6 +506,8 @@ beyond this file.
 
 - **[#186](https://github.com/richbodo/fellows_local_db/issues/186) — install-warning disclosure UX.** Claude Desktop shows a red *"access to everything / not Anthropic-verified"* banner during `.mcpb` install. Apple Developer ID code signing does not address it (different trust layer). The realistic resolution is the PWA preamble previewing the warning so users aren't surprised; copy lives in § 7 above. Address in the `feat/mcpb-settings-ui` and `docs/mcpb-walkthrough-rewrite` PRs.
 
+- **Parity test should exercise the staged bundle layout, not just `dist/`.** Found-while-fixing in #187 (commits `2807bba`, `91525b5`): two bundle-layout bugs (missing `better-sqlite3` native binding, and `_shared/`/`data/` placed inside `server/` instead of as siblings) reached install because `tests/test_mcpb_parity.py` runs against `mcpb/node/dist/<name>/index.js` with `FELLOWS_DB_PATH` explicitly set. Both conditions are unrealistic — they mask path-resolution bugs that only fire in the staged bundle layout. Either (a) extend the parity test to also exercise `mcpb/node/.staging/<name>/server/index.js` with no env var, or (b) add a separate `tests/test_mcpb_bundle_layout.py` smoke that just spawns `node` against the staging dir and asserts a successful `initialize` + `tools/call get_directory_stats` round-trip. Address before Stage 1 ships — current state has known false-green coverage.
+
 (More items will land here as they emerge.)
 
 ---

--- a/plans/easy_mcp_install.md
+++ b/plans/easy_mcp_install.md
@@ -65,6 +65,15 @@ Desktop. Material facts:
 - Claude Desktop **does not** require `.mcpb` signing today.
 - The install writes Claude Desktop's internal config; no
   `claude_desktop_config.json` hand-editing.
+- **However, Claude Desktop has its own install-time warning** for
+  any extension that isn't Anthropic-verified — a prominent red
+  banner reading *"Installing will grant this extension access to
+  everything on your computer. Any developer information shown has
+  not been verified by Anthropic."* This is a separate trust layer
+  from Gatekeeper (Apple Developer ID signing doesn't address it).
+  Tracking the disclosure UX in [issue #186](https://github.com/richbodo/fellows_local_db/issues/186);
+  the PWA preamble (§ 7) previews the warning so users aren't
+  surprised. Discovered during smoke test of #185.
 
 Two gotchas for Python servers (see
 [Issue #84](https://github.com/modelcontextprotocol/mcpb/issues/84),
@@ -322,6 +331,15 @@ dialogs become a sequence they already understand.
 >    Claude never sends mail itself — drafts open in your mail app
 >    with To, Subject, and Body filled in, and you click Send.
 >
+> **One thing to expect during install:** Claude Desktop will show a
+> red warning banner for each of these extensions saying *"Installing
+> will grant this extension access to everything on your computer..."*
+> That warning fires for any extension that isn't Anthropic-verified —
+> it's not specific to ours and doesn't mean anything is wrong. The
+> extensions only read the fellows data files they were configured
+> with; they don't have wider access than you grant them. Click
+> **Install** to proceed.
+>
 > **What happens next:** four files will download to your
 > Downloads folder (your saved groups + three installer files).
 > Claude Desktop will pop up an Install dialog for each installer
@@ -340,7 +358,11 @@ and the *Cloud LLM caveat* in `mcp_servers/README.md`.
 
 Copy will be reviewed in implementation; the structure (the
 three-bundle boundary + the consent moment + the per-bundle
-opt-in) is the load-bearing part.
+opt-in + the install-warning preview) is the load-bearing part.
+The install-warning preview specifically is tracked in
+[issue #186](https://github.com/richbodo/fellows_local_db/issues/186) —
+the wording above is a first draft to be refined with a real
+screenshot once the Settings UI is in implementation.
 
 ## 8. Interactions with in-flight plans
 
@@ -472,6 +494,19 @@ level):
 
 Each PR is independently reviewable + revertable. The parity test
 grows incrementally across PRs 2-4.
+
+## 13. End-of-Stage-1 polish checklist
+
+Working scratchpad for found-in-implementation realities and small
+documentation items that should land before Stage 1 ships. Items
+accumulate as work proceeds — when the list stabilizes, it becomes
+the work-plan for the final-polish PR (somewhere around § 12 step
+8). Each item should link a GH issue if it warrants tracking
+beyond this file.
+
+- **[#186](https://github.com/richbodo/fellows_local_db/issues/186) — install-warning disclosure UX.** Claude Desktop shows a red *"access to everything / not Anthropic-verified"* banner during `.mcpb` install. Apple Developer ID code signing does not address it (different trust layer). The realistic resolution is the PWA preamble previewing the warning so users aren't surprised; copy lives in § 7 above. Address in the `feat/mcpb-settings-ui` and `docs/mcpb-walkthrough-rewrite` PRs.
+
+(More items will land here as they emerge.)
 
 ---
 

--- a/tests/test_mcpb_parity.py
+++ b/tests/test_mcpb_parity.py
@@ -44,28 +44,53 @@ import pytest
 
 REPO_ROOT = Path(__file__).resolve().parent.parent
 PY_VENV_PYTHON = REPO_ROOT / "mcp_servers" / ".venv" / "bin" / "python"
-NODE_COMMS_JS = REPO_ROOT / "mcpb" / "node" / "dist" / "comms" / "index.js"
+FELLOWS_DB = REPO_ROOT / "app" / "fellows.db"
+
 PY_COMMS = REPO_ROOT / "mcp_servers" / "comms.py"
+NODE_COMMS_JS = REPO_ROOT / "mcpb" / "node" / "dist" / "comms" / "index.js"
+
+PY_SHARED = REPO_ROOT / "mcp_servers" / "shared_data_ops.py"
+NODE_SHARED_JS = REPO_ROOT / "mcpb" / "node" / "dist" / "shared_data_ops" / "index.js"
 
 
-def _have_python_server() -> bool:
-    return PY_VENV_PYTHON.is_file() and PY_COMMS.is_file()
+def _have_python_venv() -> bool:
+    return PY_VENV_PYTHON.is_file()
 
 
-def _have_node_server() -> bool:
-    return NODE_COMMS_JS.is_file()
+def _have_python(server: Path) -> bool:
+    return _have_python_venv() and server.is_file()
 
 
-needs_both = pytest.mark.skipif(
-    not (_have_python_server() and _have_node_server()),
+def _have_node(server: Path) -> bool:
+    return server.is_file()
+
+
+needs_both_comms = pytest.mark.skipif(
+    not (_have_python(PY_COMMS) and _have_node(NODE_COMMS_JS)),
     reason=(
-        "Parity test needs both implementations available. "
+        "comms parity needs both implementations. "
         "Run `just mcp-install-deps` and `just build-mcpb comms` first."
     ),
 )
 
 
-def _call_tool(cmd: list[str], tool_name: str, arguments: dict) -> dict:
+needs_both_shared = pytest.mark.skipif(
+    not (
+        _have_python(PY_SHARED)
+        and _have_node(NODE_SHARED_JS)
+        and FELLOWS_DB.is_file()
+    ),
+    reason=(
+        "shared-data-ops parity needs both implementations + fellows.db. "
+        "Run `just mcp-install-deps`, `just build-mcpb shared_data_ops`, "
+        "and `just db-rebuild`."
+    ),
+)
+
+
+def _call_tool(
+    cmd: list[str], tool_name: str, arguments: dict, env: dict | None = None,
+) -> dict:
     """Spawn an MCP server, send the init handshake, call one tool, return the
     parsed JSON payload from the tool's text content. Raises on protocol
     error or non-zero exit.
@@ -90,12 +115,17 @@ def _call_tool(cmd: list[str], tool_name: str, arguments: dict) -> dict:
         },
     ]
     stdin = "\n".join(json.dumps(f) for f in frames) + "\n"
+    import os as _os
+    run_env = dict(_os.environ)
+    if env:
+        run_env.update(env)
     proc = subprocess.run(
         cmd,
         input=stdin,
         capture_output=True,
         text=True,
         timeout=30,
+        env=run_env,
     )
     if proc.returncode != 0:
         raise AssertionError(
@@ -124,7 +154,14 @@ def _call_tool(cmd: list[str], tool_name: str, arguments: dict) -> dict:
             f"tools/call returned no result: {response}"
         )
     content = result.get("content", [])
-    if not content or content[0].get("type") != "text":
+    # Tolerant "no result" handling: Python's fastmcp returns an empty
+    # content array when a tool returns None; the Node SDK serializes
+    # null as content=[{"type":"text","text":"null"}]. Both mean
+    # "tool returned nothing" — collapse to a single Python None so
+    # parity callers can compare straightforwardly.
+    if not content:
+        return None
+    if content[0].get("type") != "text":
         raise AssertionError(f"unexpected content shape: {content}")
     # Tool returns a JSON-encoded payload as text. Parse it so the parity
     # comparison doesn't trip on indent/whitespace differences between
@@ -134,6 +171,7 @@ def _call_tool(cmd: list[str], tool_name: str, arguments: dict) -> dict:
 
 
 def _call_both(tool_name: str, arguments: dict) -> tuple[dict, dict]:
+    """Comms-flavored helper: spawns both comms servers and compares."""
     py = _call_tool(
         [str(PY_VENV_PYTHON), str(PY_COMMS)],
         tool_name,
@@ -143,6 +181,28 @@ def _call_both(tool_name: str, arguments: dict) -> tuple[dict, dict]:
         ["node", str(NODE_COMMS_JS)],
         tool_name,
         arguments,
+    )
+    return py, node
+
+
+def _call_both_shared(tool_name: str, arguments: dict) -> tuple[dict, dict]:
+    """Shared-data-ops-flavored helper: spawns both shared servers against the
+    repo's app/fellows.db. Uses FELLOWS_DB_PATH env so both implementations
+    take the same code path for resolving the DB (Node would otherwise default
+    to its bundled path inside the .mcpb staging dir).
+    """
+    env = {"FELLOWS_DB_PATH": str(FELLOWS_DB)}
+    py = _call_tool(
+        [str(PY_VENV_PYTHON), str(PY_SHARED), "--db", str(FELLOWS_DB)],
+        tool_name,
+        arguments,
+        env=env,
+    )
+    node = _call_tool(
+        ["node", str(NODE_SHARED_JS)],
+        tool_name,
+        arguments,
+        env=env,
     )
     return py, node
 
@@ -167,7 +227,7 @@ def _scrub_volatile(payload: dict) -> dict:
     return out
 
 
-@needs_both
+@needs_both_comms
 class TestCommsStageEmail:
     """``stage_email`` is the load-bearing tool — any drift here either
     breaks the flagship demo or, worse, lets the addresses-visible warning
@@ -229,3 +289,94 @@ class TestCommsStageEmail:
             f"mailto encoding diverged.\n  py:   {py['mailto_url']}\n  node: {node['mailto_url']}"
         )
         assert py["preview"]["url_byte_length"] == node["preview"]["url_byte_length"]
+
+
+@needs_both_shared
+class TestSharedDataOps:
+    """``shared-data-ops`` is the load-bearing read surface — divergence here
+    means Claude tells fellows different things depending on which
+    implementation runs. The full record shape (including extra_json merge)
+    + the FTS5 query semantics are the things most likely to drift.
+    """
+
+    def test_search_fellows_returns_identical_summaries(self):
+        """FTS5 query against the real fellows.db. Both implementations should
+        rank, slice, and trim identically.
+        """
+        py, node = _call_both_shared(
+            "search_fellows", {"query": "climate", "limit": 5}
+        )
+        assert py == node, (
+            f"search divergence:\n  py.total={py.get('total')} node.total={node.get('total')}\n"
+            f"  py.results[0]={py.get('results',[None])[0]}\n  node.results[0]={node.get('results',[None])[0]}"
+        )
+
+    def test_search_fellows_empty_query_returns_zero(self):
+        py, node = _call_both_shared("search_fellows", {"query": "   "})
+        assert py == node
+        assert py["total"] == 0
+
+    def test_get_fellow_by_slug_full_shape(self):
+        """A real fellow's slug; assert the full shape matches including the
+        extra_json overflow merge. Pick a known-stable slug — the search
+        result above gave us ``andy_sack`` as a deterministic entry.
+        """
+        py, node = _call_both_shared("get_fellow", {"id": "andy_sack"})
+        assert py == node, (
+            f"get_fellow shape divergence:\n  diff keys:"
+            f" py-only={set(py.keys()) - set(node.keys())}"
+            f" node-only={set(node.keys()) - set(py.keys())}"
+        )
+
+    def test_get_fellow_missing_returns_null(self):
+        py, node = _call_both_shared("get_fellow", {"id": "no-such-slug-xyz"})
+        assert py is None
+        assert node is None
+
+    def test_list_fellows_minimal(self):
+        """No filters, small page. Both implementations should return the
+        same SummaryFellow ordering (ORDER BY name ASC + same OFFSET/LIMIT).
+        """
+        py, node = _call_both_shared(
+            "list_fellows", {"limit": 10, "offset": 0}
+        )
+        # Reasonable structural assert; ordering should be deterministic.
+        assert py == node, (
+            "list_fellows divergence at minimal-filter case."
+        )
+
+    def test_list_fellows_with_filters(self):
+        """Exercise the WHERE-clause assembly for a multi-filter call."""
+        args = {
+            "fellow_type": "International Investor",
+            "has_contact_email": True,
+            "limit": 5,
+        }
+        py, node = _call_both_shared("list_fellows", args)
+        assert py == node, "list_fellows divergence under multi-filter."
+
+    def test_get_directory_stats_aggregates_identical(self):
+        """The biggest, most-likely-to-drift surface: 14 column completeness
+        counts + 12 extra_json key counts + region splitting + group-by
+        aggregates. Byte-identical means the SQL paths in both implementations
+        agree on every aggregation rule.
+        """
+        py, node = _call_both_shared("get_directory_stats", {})
+        # `total` should be a single integer — sanity check first.
+        assert py["total"] == node["total"]
+        # `by_fellow_type`, `by_cohort` should match exactly (Python's
+        # ORDER BY COUNT(*) DESC + SQLite's tie behavior = deterministic).
+        assert py["by_fellow_type"] == node["by_fellow_type"]
+        assert py["by_cohort"] == node["by_cohort"]
+        # Region splitting: order may differ on ties because Counter.most_common
+        # preserves insertion order whereas JS Map iteration is also
+        # insertion-order — should still match, but compare as sorted lists
+        # as a safety net.
+        py_regions = sorted(py["by_region"], key=lambda r: (-r["count"], r["label"]))
+        node_regions = sorted(node["by_region"], key=lambda r: (-r["count"], r["label"]))
+        assert py_regions == node_regions
+        # `field_completeness` is sorted by count DESC; tie ordering depends
+        # on dict-insertion stability. Compare as sorted lists.
+        py_fc = sorted(py["field_completeness"], key=lambda r: (-r["count"], r["label"]))
+        node_fc = sorted(node["field_completeness"], key=lambda r: (-r["count"], r["label"]))
+        assert py_fc == node_fc


### PR DESCRIPTION
## Summary

Second implementation PR of [`plans/easy_mcp_install.md`](https://github.com/richbodo/fellows_local_db/blob/main/plans/easy_mcp_install.md) — Stage 1, step 3 in § 12. Ports the four `shared-data-ops` tools (`search_fellows`, `get_fellow`, `list_fellows`, `get_directory_stats`) to TypeScript and bundles `fellows.db` inside the resulting `.mcpb` per § 5 of the plan — no separate file picker needed for the Shared half of the integration.

Also includes a small plan-update commit (`eaeb0e8`) folding in the install-warning finding from #185's smoke test and issue #186 — see commit message for details.

## What ships

- **`mcpb/node/src/_shared/fellows_queries.ts`** — port of `app/fellows_queries.py`. `rowToFellow` merges `extra_json` overflow; FTS5 search and stats aggregation match Python row-for-row.
- **`mcpb/node/src/shared_data_ops/index.ts`** — port of `mcp_servers/shared_data_ops.py`. `better-sqlite3` with `readonly:true` enforces the read-only invariant at the SQLite layer (mirrors Python's `mode=ro` URI flag). DB path: `--db` → `FELLOWS_DB_PATH` → `${__dirname}/../data/fellows.db` (the bundled location inside an installed `.mcpb`).
- **`mcpb/node/manifests/shared_data_ops.json`** — Anthropic MCPB manifest declaring the four tools. `server.type "node"`, darwin-pinned per v1.
- **`build/build_mcpb.py`** — extended to (a) carry compiled `_shared/` helpers across into `server/_shared/` so cross-module imports resolve, and (b) copy `app/fellows.db` into `server/data/` for bundles in `BUNDLES_NEEDING_FELLOWS_DB`.
- **`tests/test_mcpb_parity.py`** — adds `TestSharedDataOps` with **7 new cases**, all green. Also fixes the helper to tolerate fastmcp's empty-content-for-`None` convention vs the Node SDK's null-as-text serialization.

### `just test-mcpb-parity` output

```
TestCommsStageEmail (5)                ........ PASSED
TestSharedDataOps::test_search_fellows_returns_identical_summaries  PASSED
TestSharedDataOps::test_search_fellows_empty_query_returns_zero     PASSED
TestSharedDataOps::test_get_fellow_by_slug_full_shape               PASSED
TestSharedDataOps::test_get_fellow_missing_returns_null             PASSED
TestSharedDataOps::test_list_fellows_minimal                        PASSED
TestSharedDataOps::test_list_fellows_with_filters                   PASSED
TestSharedDataOps::test_get_directory_stats_aggregates_identical    PASSED
========================= 12 passed in 6.13s =========================
```

The `get_directory_stats` parity is the heaviest: 26 field-completeness counts (14 explicit columns + 12 `extra_json` keys) + group-by-fellow_type + group-by-cohort + region splitting — Python and Node agree on every SQL path.

### `just build-mcpb shared_data_ops` output

```
=== Building shared_data_ops.mcpb ===
  Bundled fellows.db (2.2 MB) into staging/server/data/
  $ npm install --omit=dev --no-package-lock --ignore-scripts
  $ npx --yes @anthropic-ai/mcpb pack ...
Validating manifest...
Manifest schema validation passes!
📦  fellows-shared-data-ops@0.1.0
  package size: 6.7MB
  unpacked size: 23.2MB
  -> deploy/dist/mcpb/shared_data_ops.mcpb (6848 KB)
```

## What does NOT ship in this PR

Per § 12 of the plan, kept narrow:

- `private_data_ops` port — its own PR (`feat/mcpb-private-data-ops`).
- `deploy/server.py` `/mcpb/<name>.mcpb` routes — its own PR (`feat/mcpb-prod-routes`).
- PWA Settings UI + preamble dialog — its own PR (`feat/mcpb-settings-ui`), where issue #186 (install-warning disclosure) lands.
- `docs/use_with_claude_desktop.md` rewrite — its own PR.
- CI wiring for the parity test as a hard merge gate — separate concern.

## Manual test plan

Same shape as #185:

- [ ] Pull, run `just build-mcpb shared_data_ops`, confirm the 6.7 MB bundle builds.
- [ ] Run `just test-mcpb-parity` — confirm 12 passed.
- [ ] (Optional, but recommended) Disable the Python `shared-data-ops` server in `claude_desktop_config.json` to avoid the tool-name collision during testing.
- [ ] Double-click `deploy/dist/mcpb/shared_data_ops.mcpb` in Finder. Claude Desktop install dialog should show **"Fellows: Directory (Shared)"** with the four tools listed. Click Install (expect the same red unverified-developer banner as #185 — that's issue #186).
- [ ] Quit + reopen Claude Desktop.
- [ ] In a new chat:
   - *"How many fellows are in the directory?"* → uses `get_directory_stats`
   - *"Find fellows working on climate."* → uses `search_fellows`
   - *"Show me the International Investors with contact emails."* → uses `list_fellows`
   - *"Tell me about Andy Sack."* → uses `get_fellow`

## Next PR

`feat/mcpb-private-data-ops` — port `private_data_ops.py` to TS. This is the one that requires `user_config` for the `relationships_db_path` prompt (DB is per-user OPFS export, not bundled). Extends parity test with the three private-data-ops tools.

🤖 Generated with [Claude Code](https://claude.com/claude-code)