### PR TITLE
plan(folder-storage): pivot Phase 2 to pure-folder, drop hybrid sync model

### DIFF
--- a/docs/ac_decisions_log.md
+++ b/docs/ac_decisions_log.md
@@ -18,6 +18,58 @@ link to the newer entry. Newest first.
 
 ---
 
+## 2026-05-22 — User-folder storage uses pure-folder semantics for folder-mode users, not a hybrid OPFS+folder mirror
+
+**Why this is worth recording.** The original `plans/user_folder_storage.md` (and the Phase 1 code shipped in #181) was built on a **hybrid** model: OPFS is the working store, the user's folder is a debounced mirror, and the worker synchronizes them after every committed mutation. A future contributor reading that code — particularly the auto-sync timers, the `markRelationshipsDirty` hook the plan was about to add in Phase 2, and the boot-time "read folder into OPFS" path — would reasonably conclude this is the canonical design and continue extending it. **It is not.** Phase 2 was the moment to pivot to pure-folder, because the hybrid's sync complexity buys us nothing at our DB scale and introduces a silent-data-loss failure mode.
+
+**Context.** During the Phase 2 (auto-sync) scoping conversation on 2026-05-22, the question came up: *"is the hybrid model genuinely more reliable and less complex than a pure folder model, given the trajectory of the project?"* Walking through the failure modes carefully, we found one that hadn't surfaced in the original plan review:
+
+1. User makes a mutation. OPFS commit succeeds. Debounced sync to folder scheduled.
+2. Within the debounce window (500 ms), folder permission briefly lapses (system sleep, app eviction, parent folder temporarily unmounted by a sync service, etc.). Sync fires, fails. `folderRecord.lastError` is set; OPFS now has new data that the folder does not.
+3. User closes the tab — or the browser crashes — before noticing the badge state.
+4. User re-opens. The plan's documented boot sequence reads `relationships.db` from the folder (the "Saved" semantics treat the folder as canonical), copies it into OPFS, **overwriting the unsaved OPFS data**.
+5. The user's recent mutations are silently gone, with no error indication.
+
+The bug is structural to the hybrid model — two storage substrates plus async sync means there are scenarios where the "less authoritative" copy quietly wins. Patching the boot sequence to detect divergence is *more* code paths, not fewer. And we found this bug in a half-hour conversation; production was likely to surface others.
+
+The hybrid model was chosen in the original plan because the canonical fast SQLite-wasm VFS (`OpfsSAHPoolVfs`) requires OPFS-resident `FileSystemSyncAccessHandle`s — folder files only expose async handles. Two arguments dismissed the pure-folder alternatives: (1) async-VFS is slow (Asyncify shim makes every read yield), (2) in-memory + rewrite-whole-file is "correctness risk on crash, thrashes the OS file cache." Both arguments are correct for medium/large databases. They do not apply at our scale (`relationships.db` is currently 98 KB and unlikely to exceed a few MB lifetime; mutations are user-paced, not high-frequency; storage I/O is not on any hot path). The browser's `FileSystemWritableFileStream.close()` is atomic per spec, so whole-file rewrite is crash-safe.
+
+**Alternatives considered.**
+
+1. **Hybrid OPFS + debounced folder sync** (the original plan). Performance preserved via sync-access handles. Cost: every divergence scenario must be reasoned about; silent-data-loss path exists; sync timers + dirty marker + in-flight guard + last-error tracking + boot-time divergence handling is real ongoing complexity. **Rejected.**
+
+2. **Pure folder via async-VFS** (Asyncify, async file handles). Single source of truth. Cost: Asyncify performance hit (2-5x slower in synthetic benchmarks), need to write/maintain a custom VFS, File System Access API's `FileSystemWritableFileStream` doesn't expose random-access writes (which standard SQLite expects), so it would effectively rewrite the whole file on close anyway. **Rejected — same I/O behavior as option 3 with more code complexity.**
+
+3. **Pure folder via mem-VFS + atomic full-file rewrite on commit.** Worker boots, reads folder file, `sqlite3_deserialize` into an in-memory DB. All reads/writes against the mem-DB synchronously. On committed mutation, `sqlite3_serialize` to bytes and atomic write to folder. Boot reads folder; close discards mem-DB. One source of truth (the folder), one storage path per session, no sync state, no divergence possible. Cost: per-mutation latency includes a whole-file folder write (sub-millisecond for our DB sizes). **Chosen.**
+
+For users without folder picker support (Safari, Firefox, iOS, Android where the picker is unreliable), today's OPFS-resident SAH-pool VFS remains the path. Those users have one source of truth too (OPFS), with backup-to-Downloads as their durability story. The pivot does NOT introduce a hybrid for them — it preserves their existing single-source-of-truth model.
+
+**Decision.** Phase 2 of `plans/user_folder_storage.md` pivots from "automatic debounced sync from OPFS to folder" to "swap the worker's VFS based on folder-handle presence: pure folder for folder-mode users, OPFS-only for the rest." Two storage modes, decided at boot per session. No sync between them.
+
+**Consequences.**
+
+- Pro: silent-data-loss failure mode eliminated. Every storage failure is either prevented or surfaces as a visible "your last change wasn't saved" UI state.
+- Pro: the folder file is the truth at all times for folder-mode users. External readers (MCP servers, command-line `sqlite3`, manual `cp`, sync services) can rely on it without "is the folder current?" reasoning.
+- Pro: dramatically simpler state machine in the worker. No sync timers, no dirty marker, no in-flight guard, no debounce, no last-sync-attempt tracking, no divergence detection.
+- Pro: Phase 1's UI/permission/IDB surface (~540 lines) survives intact. Phase 1's `writeRelationshipsToFolder` becomes the per-commit write path.
+- Pro: trajectory fit — MCP install plan (`plans/easy_mcp_install.md`) can anchor on the folder path as a current, authoritative file. Future multi-client support (Cursor, Continue, Ollama, etc.) inherits the same anchor.
+- Con: per-mutation latency now includes a folder write. For our DB sizes this is sub-millisecond; if `relationships.db` ever grows past several MB it becomes user-visible, at which point caching/incremental-write strategies become an optimization play. Not a v1 concern.
+- Con: in-memory mutation lost on tab crash is an HONEST failure mode (the user knows their change wasn't saved) rather than a SILENT one (the change appeared to save but didn't). This is the same posture as any non-syncing draft editor and is materially better than the hybrid's silent-divergence risk.
+- Con: requires a one-time migration for Phase 1 users with both OPFS and folder state. Designed in the Phase 2 implementation spec.
+- Con: Phase 2's engineering effort is ~1.5x the originally-scoped auto-sync work, because the worker's data path is genuinely rewritten. Phase 1 UI stays.
+
+**Auto-backup ring**: lives in the user's folder for folder-mode users (`<parent>/Fellows/relationships.db.bak.<ISO>` siblings of `relationships.db`). Visible in Finder, comforting to users. OPFS-only-mode users keep today's OPFS-resident auto-backup ring. There is no auto-backup-in-OPFS for folder-mode users — one place per user, by design.
+
+**OPFS-only users in the long term**: get a degraded experience (no MCP integration, no external visibility, browser-data-wipe-loses-everything). This is acceptable v2 floor; when those users want richer integration they switch browsers or get migrated to a future app variant. Out of scope for this decision.
+
+**Links.**
+
+- [`plans/user_folder_storage.md`](../plans/user_folder_storage.md) — the parent plan; § Architecture rewritten to reflect this decision.
+- [`plans/easy_mcp_install.md`](../plans/easy_mcp_install.md) — § 5 OPFS handoff resolution becomes "folder anchor" once this lands.
+- The full architectural analysis lives in the conversation that produced this entry (PR description for the plan-revision PR).
+
+---
+
 ## 2026-05-21 — `.mcpb` bundles do not ship native Node dependencies
 
 **Why this is worth recording.** A future contributor adding the

--- a/plans/user_folder_storage.md
+++ b/plans/user_folder_storage.md
@@ -2,6 +2,8 @@
 
 A plan to move the durable home of the user's private relationships data out of browser-managed OPFS and into a user-chosen folder on their filesystem, following the VS Code for Web pattern: **browser as runtime, filesystem as durable home.**
 
+> **Status: REVISED 2026-05-22.** Phase 1 has shipped (see § Phases). Phase 2 has pivoted from the original *"hybrid OPFS-working + debounced folder sync"* design to **pure folder for folder-mode users** (mem-resident SQLite + atomic full-file folder writes per commit). The pivot eliminates a silent-data-loss failure mode that surfaced during Phase 2 scoping and aligns the data path with the project's MCP + multi-client trajectory. The architectural decision is recorded in [`docs/ac_decisions_log.md` § 2026-05-22](../docs/ac_decisions_log.md). § Architecture below describes the new design; obsolete hybrid material has been removed (git history preserves the prior version).
+
 ## Context
 
 Today, `relationships.db` lives in OPFS (Origin Private File System), owned by `vendor/sqlite-worker.js` per the local-first plan. OPFS is fast (sqlite-wasm gets `FileSystemSyncAccessHandle`), private to the app's origin, and survives Clear App Cache. But it has three load-bearing user-experience problems:
@@ -20,9 +22,9 @@ G1. **A real file at a real path.** After first-run setup, `relationships.db` ex
 G2. **Durable across browser-data wipes.** Clearing site data, switching browsers (on the same machine), and switching browser profiles do not destroy the user's data — the folder survives.
 G3. **Persistent permission across sessions.** A `FileSystemDirectoryHandle` saved in IndexedDB is re-acquired on every launch without re-prompting the user, when the underlying OS permission is still granted.
 G4. **Honest "saved" semantics.** The UI displays "Saved to `<path>` at `<time>`" only after a successful write to the user's folder. Until then, status is explicit: "Pending save," "Browser-only (unsafe)," or "Folder inaccessible — re-select."
-G5. **No silent data loss on permission lapse.** If the OS revokes folder access (user moved the folder, denied permission on session restart, etc.), the app continues to operate against the OPFS working copy, surfaces a prominent reconnect prompt, and refuses to declare anything "saved" until the folder is reachable again.
-G6. **Graceful degradation on unsupported browsers.** On Safari, Firefox, and mobile (no `showDirectoryPicker`), the app continues to work in today's OPFS-only mode with an explicit "Browser-only (unsafe)" badge and a documented manual-backup workflow.
-G7. **Migration without data loss.** Existing users with OPFS-only data are walked through folder setup on their first launch of the new version; their current OPFS contents are exported into the chosen folder before anything changes.
+G5. **No silent data loss.** Under the pure-folder design, failures are surfaced honestly: a folder write that fails leaves the in-memory state with the un-persisted mutation and the badge displaying *"Last save failed — Retry to save again."* The user knows immediately. If they close the tab without retrying, the mutation is lost — same posture as any non-syncing draft editor. There is no scenario in which a stale storage substrate silently overwrites newer data.
+G6. **Graceful degradation on unsupported browsers.** On Safari, Firefox, and mobile (no `showDirectoryPicker`), the app continues to work in today's OPFS-only mode with an explicit "Browser-only (unsafe)" badge and a documented manual-backup workflow. These users have **one source of truth (OPFS)**; no hybrid for them either.
+G7. **Migration without data loss.** Existing Phase 1 users with both OPFS contents and a folder handle are migrated on first boot post-pivot to the pure-folder design — the newer of the two stores becomes canonical, the other is retired. See § Architecture → Migration.
 
 ## Non-goals
 
@@ -32,7 +34,7 @@ G7. **Migration without data loss.** Existing users with OPFS-only data are walk
 - **Live folder watching.** `FileSystemObserver` is landing in Chrome but we don't depend on it. Pure write-out; no read-on-external-change.
 - **Cross-device handle portability.** A directory handle is scoped to one browser on one machine. Moving to another machine requires re-picking a folder (typically a synced folder pointing at the same backing storage).
 - **Folder-first as the only mode.** Even on Chromium, "Browser-only" remains a valid (unsafe-flagged) state for users who decline to pick a folder. We surface the warning; we don't force the choice.
-- **Replacing OPFS as the working store.** sqlite-wasm performs best against OPFS-resident `FileSystemSyncAccessHandle`s. The working DB stays in OPFS; the user's folder is the durable mirror. See § Architecture.
+- **A hybrid OPFS-working + folder-mirror design.** The original plan had one. The revision dropped it for the reasons in [`docs/ac_decisions_log.md` § 2026-05-22](../docs/ac_decisions_log.md). The current design is two distinct storage modes, each with a single source of truth — see § Architecture.
 
 ## Refreshable assets (images, fellows.db, etc.)
 
@@ -65,55 +67,138 @@ Out of scope either way: a sync strategy for `fellows.db` itself. That's an exis
 
 Bright line: **the user-folder feature is opt-in and additive.** Today's OPFS-only flow continues to work on every supported browser. We never block boot on the API being available.
 
-## Architecture: hybrid storage (OPFS working, folder durable)
+## Architecture: two storage modes, one source of truth per user
+
+Each session resolves to exactly one of two modes at worker boot, decided by whether a usable `FileSystemDirectoryHandle` is persisted in IndexedDB. There is no hybrid; the two modes do not share state and there is no sync between them.
 
 ```
-┌─────────────────────────────────────────────────────────────────┐
-│  worker (sqlite-worker.js)                                       │
-│                                                                  │
-│  ┌───────────────────┐         ┌──────────────────────────────┐ │
-│  │ OPFS working DB    │ ──────► │ Sync-out (debounced):        │ │
-│  │ (today's location) │  every  │   read .db bytes from OPFS,  │ │
-│  │ relationships.db   │ commit  │   write to user's folder     │ │
-│  └───────────────────┘         │   via FileSystemFileHandle    │ │
-│           ▲                    └──────────────────────────────┘ │
-│           │                                                      │
-│           └─── boot: copy folder's .db into OPFS, then attach    │
-└─────────────────────────────────────────────────────────────────┘
+┌──────────────────────────────────────────────────────────────────┐
+│  worker (sqlite-worker.js) — mode resolved at boot                │
+│                                                                   │
+│  has folder handle + permission granted?                          │
+│   │                                                               │
+│   ├── YES ──► FOLDER MODE                                         │
+│   │           ┌──────────────────────────────────────────────┐    │
+│   │           │ relationships.db: mem-VFS (sqlite-wasm       │    │
+│   │           │   in-memory DB, hydrated from folder bytes)  │    │
+│   │           │                                              │    │
+│   │           │ boot   : read folder/Fellows/relationships.db│    │
+│   │           │          → sqlite3_deserialize into mem-VFS  │    │
+│   │           │                                              │    │
+│   │           │ commit : sqlite3_serialize → atomic write    │    │
+│   │           │          to folder/Fellows/relationships.db  │    │
+│   │           │          (createWritable → write → close)    │    │
+│   │           │                                              │    │
+│   │           │ backup : on successful commit, rotate the    │    │
+│   │           │          folder-resident bak.<ISO> ring      │    │
+│   │           │                                              │    │
+│   │           │ fellows.db: stays in OPFS (refreshable,      │    │
+│   │           │          read-only; not part of this mode)   │    │
+│   │           └──────────────────────────────────────────────┘    │
+│   │                                                               │
+│   └── NO  ──► OPFS-ONLY MODE                                      │
+│               ┌──────────────────────────────────────────────┐    │
+│               │ relationships.db: OPFS-resident SAH-pool VFS │    │
+│               │   (today's behavior, unchanged)              │    │
+│               │                                              │    │
+│               │ backup : OPFS-resident bak.<ISO> ring +      │    │
+│               │          manual download-to-Downloads        │    │
+│               │                                              │    │
+│               │ durability: bounded by browser storage —     │    │
+│               │   user is warned via the "Browser-only       │    │
+│               │   (unsafe)" badge.                           │    │
+│               └──────────────────────────────────────────────┘    │
+└──────────────────────────────────────────────────────────────────┘
 ```
 
-### Why hybrid, not pure-folder
+### Why pure folder, not hybrid
 
-- sqlite-wasm's fast VFS (`OpfsSAHPoolVfs`) needs `FileSystemSyncAccessHandle`. Sync access handles are **OPFS-only.** Files in user-picked folders only expose async `FileSystemFileHandle` / `FileSystemWritableFileStream`.
-- A pure-folder model would either need a custom async-only VFS (every read/write becomes a Promise — measurable hit even for small DBs; complex code) or have sqlite-wasm work entirely in-memory and rewrite the whole file on every commit (correctness risk on crash; thrashes the OS file cache).
-- Hybrid keeps today's working-store performance unchanged. The only new code path is "after a committed mutation, copy the .db bytes out to the user's folder." That's cheap (the DB is tens of KB), debounceable, and idempotent.
+The original plan chose a hybrid OPFS-working + debounced-folder-sync model. During Phase 2 scoping we identified a silent-data-loss failure mode (boot reads stale folder DB, overwrites unsynced OPFS data, recent mutations vanish without an error indication) and recognized that the hybrid's performance argument doesn't apply at our DB scale (sub-millisecond folder writes for our ~100 KB DB). Full reasoning lives in [`docs/ac_decisions_log.md` § 2026-05-22 — User-folder storage uses pure-folder semantics for folder-mode users, not a hybrid OPFS+folder mirror](../docs/ac_decisions_log.md).
 
-### Sync-out cadence
+Summary of the trade-offs we accepted:
 
-- **Trigger:** every committed write RPC the worker handles for `relationships.db` enqueues a sync.
-- **Debounce:** 500 ms after the last commit, or 5 s max wait, whichever fires first. Tunable.
-- **Atomicity:** write to `relationships.db.tmp`, then `move` to `relationships.db`. The user never sees a half-written file. The renaming pattern matches what `Atomics`-flavored save flows use elsewhere.
-- **Failure:** logged + surfaced as "Sync failed at `<time>`: `<reason>` — Retry?" in the status badge. **The committed change in OPFS is not rolled back** — the working DB and the durable mirror diverge until the next successful sync. This is the only state where they ever diverge, and it's visible.
+- **Per-mutation latency.** Each commit now waits on a folder write. Sub-ms for ~100 KB DBs; ~tens of ms even at 10 MB; only user-noticeable if `relationships.db` ever exceeds several MB. Optimization paths (incremental writes, write-coalescing) are available if/when the DB grows.
+- **In-memory state lost on tab crash.** If a user makes a mutation and the tab crashes before the folder write completes, the mutation is lost. The badge state reflects this honestly: "Pending save…" or "Last save failed — Retry to save again." Same UX posture as any non-syncing draft editor.
 
-### Auto-backup ring
+In exchange:
 
-- Existing auto-backup logic moves to the user's folder. Filenames continue to follow the `relationships.db.bak.<ISO timestamp>` pattern.
-- Rotation continues server-side-equivalent — keep the newest N (currently 3) backups; on each new backup, prune older ones in the folder.
-- If the user inspects the folder, the rotation is visible: `relationships.db`, `relationships.db.bak.2026-05-14T10-32Z`, etc.
+- One source of truth per session. No state-divergence bugs are possible because there is no second store to diverge from.
+- The folder file IS the user's data, at all times. External readers (MCP servers, command-line `sqlite3`, manual `cp`, sync services like Dropbox) see the current state without needing to reason about staleness.
+- Dramatically simpler worker state — no sync timers, dirty markers, in-flight guards, last-sync-attempt tracking, or boot-time divergence detection.
 
-### Boot sequence
+### sqlite-wasm details
+
+- **Folder-mode worker** opens `relationships.db` with sqlite-wasm's `:memory:` (or equivalent mem-VFS). On boot, the folder file's bytes are deserialized into the mem-DB via `sqlite3_deserialize`. On each committed mutation, `sqlite3_serialize` exports the current DB to bytes; those bytes are written atomically to the folder file via `FileSystemFileHandle.createWritable() → .write(bytes) → .close()` (close commits atomically per the FileSystem Access API spec).
+- **OPFS-only-mode worker** keeps today's behavior: `OpfsSAHPoolVfs` against an OPFS-resident slot; sync access handles for fast reads/writes; no folder involvement.
+- **`fellows.db` is unchanged in both modes**: OPFS-resident, read-only, refreshable from the server. The folder-mode worker still uses OPFS for `fellows.db` (it's not user-authored data).
+
+### Per-commit write path (folder mode)
+
+For each mutating RPC (`createGroup`, `updateGroup`, `deleteGroup`, `setSetting`, `importRelationshipsBytes`, `restoreRelationshipsBackup`):
+
+1. Mem-DB executes the SQL transaction; commits or rolls back as usual.
+2. If the transaction committed, serialize the DB and write to `<parent>/Fellows/relationships.db`.
+3. If the write succeeds, update `folderRecord.lastSavedAt`; badge stays "Saved."
+4. If the write fails, set `folderRecord.lastError`; badge flips to "Last save failed — Retry." The mem-DB still holds the committed change — the user can retry, make another mutation (which re-attempts the write), or close the tab (in which case the change is lost honestly).
+
+There is no debounce. There is no separate sync timer. Each commit attempts its own write. For very rapid-fire mutations (e.g., a multi-step bulk edit), the page-side code should batch into a single RPC where reasonable — but a series of sub-ms writes is also fine.
+
+A single-flight guard around the folder write prevents concurrent `createWritable` calls from racing if RPCs land overlappingly (the worker is single-threaded for JS but mutation handlers are async).
+
+### Auto-backup ring (folder mode)
+
+- **Location**: siblings of `relationships.db` inside the `Fellows/` subfolder. Filenames: `relationships.db.bak.<ISO-timestamp>` (matches today's OPFS pattern). Visible in Finder.
+- **Trigger**: same debounce as today's OPFS auto-backup — newest `bak.<ISO>` older than 1 hour means a new backup is due. Triggers from the per-commit write path: after a successful main-file write, check whether a backup is due; if so, write one and rotate.
+- **Rotation**: keep newest N (currently 3); delete older ones from the folder.
+- **Pre-import undo snapshot**: `importRelationshipsBytes` and `restoreRelationshipsBackup` still take a pre-restore snapshot first (today's behavior). In folder mode, that snapshot lands in the folder ring rather than OPFS.
+
+### Boot sequence (revised)
 
 1. Worker spawns.
-2. Worker opens OPFS pool, attaches `fellows.db` RO (unchanged from today).
-3. Worker reads the saved folder handle from IndexedDB.
-4. **If handle missing** → "Browser-only (unsafe)" state. OPFS working DB is the source of truth. Bootstrap schema if absent. Continue.
-5. **If handle present** → call `queryPermission({mode: 'readwrite'})`:
-   - `'granted'` → read `relationships.db` from the folder, copy into OPFS, attach. **"Saved" state.**
-   - `'prompt'` → don't auto-prompt. Continue against OPFS working DB but surface a "Reconnect data folder" CTA in the status badge that, on click, calls `requestPermission`.
-   - `'denied'` → same as `'prompt'` plus an explicit "Permission was denied; you'll need to pick the folder again."
-6. **If handle present but folder empty / file missing** → "Folder selected but empty: was your data moved?" with options to "Restore from this folder's backups" / "Restore from the auto-backups inside OPFS" / "Choose a different folder" / "Start fresh in this folder."
+2. Worker opens OPFS pool, attaches `fellows.db` RO (unchanged from today). This always happens; `fellows.db` lives in OPFS in both modes.
+3. Worker reads the saved folder handle from IndexedDB (`fellows-fs-handles` / `relationships-folder` — already shipped in Phase 1).
+4. **No handle persisted** → OPFS-only mode. Open `relationships.db` against `OpfsSAHPoolVfs`. Bootstrap schema if absent. Done.
+5. **Handle persisted** → call `queryPermission({mode: 'readwrite'})`:
+   - `'granted'` → **folder mode.** Read `<parent>/Fellows/relationships.db` bytes. If file exists, `sqlite3_deserialize` into mem-VFS. If folder is empty (handle present but no `relationships.db` yet) and OPFS contains a usable working copy from before the pivot, run migration (see below). Otherwise bootstrap schema into a fresh mem-DB and do an immediate folder write so the file exists. Set status to "Saved."
+   - `'prompt'` or `'denied'` → **degraded folder mode.** Open `relationships.db` against `OpfsSAHPoolVfs` (today's behavior, as a fallback working store). Surface "Reconnect data folder" CTA. **Do not auto-prompt for permission** — no user gesture available at boot. Once the user clicks Reconnect and permission flips to `'granted'`, the worker migrates the OPFS state into the folder (treating OPFS as the canonical "what we have right now"), then closes the OPFS handle and continues in folder mode for the rest of the session. The badge transitions Inaccessible → Saved without an intermediate "Browser-only" state.
+6. **Edge case: folder empty + no OPFS state** → bootstrap a fresh schema into mem-DB, immediately write to folder. New install.
+7. **Edge case: folder file is corrupt / unreadable** → surface "Folder data unreadable — would you like to restore from a backup or start fresh?" Use the folder-resident `bak.<ISO>` ring (or, for migrating users, the OPFS backup ring as a last-ditch source).
 
-A new mutation always lands in OPFS first, then syncs out. So a stale-permission session is still safe: the data is preserved in OPFS even if the folder write keeps failing.
+### Migration from Phase 1 (one-time)
+
+Existing Phase 1 users may have both an OPFS-resident `relationships.db` (Phase 1's working store) and a folder-resident copy (from manual saves). On first boot after the pivot:
+
+1. **Both present:**
+   - Read OPFS `relationships.db` bytes.
+   - Read folder `relationships.db` bytes.
+   - Compare: serialize each, hash, compare. If identical, use the folder copy (canonical going forward), close the OPFS slot.
+   - If different, compare timestamps. The original plan trusted the folder by default — under the pivot, **trust the newer of the two**, on the rationale that the Phase 1 hybrid's biggest failure mode was OPFS being newer than the folder due to a sync miss. Write the newer one to the folder, retire OPFS.
+   - In the unlikely case the user wants to inspect both, the just-retired OPFS state is preserved as an additional `relationships.db.bak.<ISO>` in the folder ring (with a `pre-pivot-` prefix to distinguish from normal rotation entries).
+2. **OPFS only (folder handle exists but folder file missing)**:
+   - The user picked a folder in Phase 1 but never manually saved. Write the OPFS state to the folder atomically, then retire OPFS.
+3. **Folder only (no OPFS `relationships.db`)**:
+   - A user who picked a folder, saved at least once, then had OPFS evicted. Load folder into mem. Done.
+4. **Neither**:
+   - Fresh install. Bootstrap schema into mem; immediate folder write.
+
+Migration runs once per session for users who haven't yet migrated. A flag in `folderRecord` (`pivotMigratedAt: ISO`) is set on completion; subsequent boots skip the migration check.
+
+### Multi-tab considerations
+
+Both modes need a single-writer guarantee: two tabs writing to the same `relationships.db` (whether in OPFS or in the folder) will produce dueling writes. Phase 1 inherits the existing `multi_tab_ownership_takeover.md` design — one tab owns the worker at a time. The pivot does not change this; if anything it simplifies the boundary (the worker holds an exclusive folder-file handle while writing; other tabs see a "Another tab is using this folder" error if they try to spawn a competing worker).
+
+### What stays from Phase 1
+
+The 540 lines of folder code shipped in PR #181 are mostly unchanged by the pivot. Specifically:
+
+- **IDB handle persistence** (`fellows-fs-handles` / `relationships-folder`) — unchanged.
+- **Subfolder layout** (`<parent>/Fellows/`) — unchanged.
+- **Subfolder collision handling** (auto / open-existing / create-new) — unchanged.
+- **Permission lifecycle** (queryPermission + user-gesture requestPermission) — unchanged.
+- **Status badge state machine** (6 states) — unchanged at the UI layer; the worker's state-snapshot RPC reports the same shape.
+- **Settings UI** (Choose / Save / Refresh / Reconnect / Disconnect buttons) — unchanged. "Save now" becomes a manual override / retry button rather than the primary save mechanism (which is now every commit).
+- **`writeRelationshipsToFolder` worker logic** — the actual atomic write is the same code, just called from a different place (per-commit rather than per-button-click).
+- **E2E test scaffolding** — extended for the new boot path + migration.
 
 ## UI / UX
 
@@ -140,15 +225,14 @@ Lives in Settings → top of the *Your saved data* section, and also as a small 
 
 Critical rule: **"Saved" is shown only after a write to the user's folder has been acknowledged by the OS.** OPFS writes alone are never "Saved" — they're "Pending" or "Browser-only," depending on whether a folder has ever been chosen.
 
-### First-launch wizard (Phase 3)
+### First-launch wizard (was Phase 3 — deferred / likely absorbed)
 
-When an existing user (OPFS data exists, no folder handle set) opens the new version:
+The original plan had a Phase 3 banner + flow for OPFS-only users to switch to folder mode. Status now: **deferred**; likely absorbed into the MCP install wizard described in [`plans/easy_mcp_install.md`](./easy_mcp_install.md), since folder setup is the prerequisite for MCP integration and the natural moment a user becomes interested in switching modes. If a standalone first-launch wizard is still wanted post-Phase-2, the original shape applies:
 
-1. Banner above the directory: *"Your data is currently only in this browser. Choose a folder to save it to disk."* Dismissible (continues "Browser-only"), one click to engage.
+1. Banner above the directory: *"Your data is currently only in this browser. Choose a folder to save it to disk."* Dismissible (continues OPFS-only mode), one click to engage.
 2. On click, native folder picker. User picks (or creates) a folder.
-3. App writes the current OPFS contents (relationships.db + the existing auto-backup ring) to the folder atomically.
-4. Status flips to "Saved to `<path>`."
-5. Subsequent launches from this browser auto-reconnect via the saved handle.
+3. App writes the current OPFS contents (relationships.db + the existing auto-backup ring) to the folder atomically — same migration path described in § Architecture → Migration.
+4. Worker swaps from OPFS-only mode to folder mode for the rest of the session and future sessions.
 
 ### Settings page additions
 
@@ -182,11 +266,11 @@ If the user explicitly clicks "Disconnect folder," we delete the IDB entry and r
 
 ### Phase 0 — Worker-direct export / import (pre-cursor, shippable now)
 
-**Independent of all the user-folder work below.** Decouples the page-side `dataProvider` from the worker's relationship-DB byte operations, which Phase 2's auto-sync needs anyway and which fixes a current production bug for free.
+**Independent of all the user-folder work below.** Decouples the page-side `dataProvider` from the worker's relationship-DB byte operations, which Phase 2's per-commit folder write needs anyway and which fixes a current production bug for free.
 
 The page-level `dataProvider` today exposes `exportRelationshipsBytes` / `importRelationshipsBytes` only when its `kind === 'worker'`. When the page falls back to `api+idb` (most commonly because the session-gated `/fellows.db` fetch returned 401/403 during boot), the warm worker is still alive with `relationships.db` open, but the Settings backup and restore controls can't reach it — so users on an expired session can't back up their data before reinstalling or switching browsers.
 
-Phase 2's debounced sync ("worker enqueues a sync after every committed mutation") is written from the worker's perspective and similarly cannot depend on the active page-level provider. The plumbing is the same: a worker-direct path to the bytes, addressable regardless of which provider the page picked at boot. Landing it here shortens Phase 2.
+Phase 2's per-commit folder write (under the revised pure-folder design) is written from the worker's perspective and similarly cannot depend on the active page-level provider. The plumbing is the same: a worker-direct path to the bytes, addressable regardless of which provider the page picked at boot. Landing it here shortens Phase 2.
 
 - New page-side helpers that reach `warmWorker.rpc` directly:
   - `warmWorkerExportRelationshipsBytes()`
@@ -208,88 +292,118 @@ Same shape as Phase 0, extended to the five groups RPCs (`listGroups`, `getGroup
 
 Out of scope for P0b: version-skew gating on mutating group ops in the api+idb path. The worker provider gates create/update/delete with `refuseIfVersionSkew`; the api+idb fallback doesn't, on the rationale that the fallback path is already exceptional and worker-vs-page version skew is a separate SW-upgrade-race concern surfaced by the existing reload banner. Worth revisiting if real-user telemetry shows skew-related failures.
 
-### Phase 1 — Folder picker + status UI + manual save/restore
+### Phase 1 — Folder picker + status UI + manual save/restore — **✅ SHIPPED**
 
-**Shippable on its own.** No automatic sync; the user explicitly hits "Save to folder" or "Refresh from folder" buttons in Settings. Validates the API surface, the handle-storage model, and the status UI before adding cadence logic.
+**Shipped in PR #181 (commit `a344c52`).** Validates the API surface, the handle-storage model, and the status UI. Originally framed as "no automatic sync — the user explicitly hits Save"; under the pivot, that manual Save button becomes a retry affordance and the per-commit auto-write lands in Phase 2.
 
-- New `vendor/sqlite-worker.js` RPCs: `getFolderHandle()`, `setFolderHandle(handle)`, `writeRelationshipsToFolder()`, `readRelationshipsFromFolder()`, `checkFolderPermission()`.
-- Settings page UI for choose / change / disconnect folder.
-- Status badge with the six states from § UI / UX (only the manual subset is wired — Saved / Pending / Browser-only / Folder inaccessible).
-- Unit test for the IndexedDB handle persistence.
-- E2E test (Chromium-only) using Playwright's `BrowserContext.grantPermissions(['fileSystem'])` and the underlying CDP to seed a directory handle.
+What shipped:
 
-Out of scope for P1: auto-sync, migration wizard, fellow.db.
+- `vendor/sqlite-worker.js` RPCs: `getFolderState`, `setFolderHandle`, `clearFolderHandle`, `checkFolderPermission`, `getFolderHandleForReconnect`, `writeRelationshipsToFolder`, `readRelationshipsFromFolder`.
+- IDB handle persistence (`fellows-fs-handles` / `relationships-folder`).
+- Subfolder collision dialog (open-existing vs. create-Fellows-N).
+- Settings UI: Choose / Save now / Refresh / Reconnect / Disconnect; 6-state badge.
+- Permission lifecycle + `FOLDER_CONTROLLER` glue on the page side.
+- Diagnostics panel `Data folder:` row.
+- E2E test (`tests/e2e/test_user_folder_storage.py`).
 
-### Phase 2 — Automatic debounced sync
+### Phase 2 — Pivot worker data path to pure folder (folder-mode users)
 
-- Worker enqueues a sync after every committed mutation to `relationships.db`.
-- Debounce: 500 ms quiet period, 5 s max wait.
-- Atomic write via `.tmp` + rename.
-- Sync-failed state surfaces in status badge with "Retry now."
-- Auto-backup rotation moves to the user's folder (Phase 1 leaves auto-backups in OPFS).
+**The pivot.** Replaces the originally-planned "automatic debounced sync from OPFS to folder" with a VFS swap: folder-mode users get an in-memory SQLite that's hydrated from the folder file on boot and serialized back atomically on every committed mutation. OPFS-only-mode users are untouched. The auto-backup ring moves to the folder for folder-mode (Option A — visible in Finder, comforting).
 
-### Phase 3 — First-launch migration wizard
+Engineering scope:
 
-- Banner for OPFS-only users on first launch after P3 ships.
+1. **Worker boot — VFS selection.**
+   - Decision point at line ~537 (top of RPC handlers) becomes "do we open the SAH-pool VFS for `relationships.db`, or a mem-VFS?" — based on folder-handle presence + permission state at boot.
+   - If folder mode: open mem-VFS, `sqlite3_deserialize(<folder bytes>)`, attach `fellows.db` from OPFS as today (cross-DB joins via `ATTACH` still work).
+   - If OPFS-only mode: today's `OpfsSAHPoolVfs` against `RELATIONSHIPS_DB_SLOT`, unchanged.
+2. **Per-commit write helper.**
+   - New worker-local function `writeFolderFromMem()` — calls `sqlite3_serialize` on the live mem-DB, atomic writes to `<parent>/Fellows/relationships.db` using the same `createWritable → write → close` path the existing `handlers.writeRelationshipsToFolder` uses. Single-flight guarded via a module-level Promise.
+   - Called at the end of each mutating RPC, **inside** the try block after the COMMIT statement succeeds. Failures populate `folderRecord.lastError` and re-throw (the page sees the RPC fail, which is honest — the change didn't fully persist).
+3. **Mutating RPC integration.**
+   - `createGroup`, `updateGroup`, `deleteGroup`, `setSetting`, `importRelationshipsBytes`, `restoreRelationshipsBackup` each get an `await writeFolderFromMem()` call in folder mode (no-op in OPFS-only mode, which keeps today's path).
+4. **Auto-backup ring (folder mode).**
+   - Migrate the existing `maybeBackupRelationshipsDb` debounce logic (the "newer than 1h" check) so it writes `bak.<ISO>` siblings into the folder's `Fellows/` subfolder.
+   - Rotation: keep newest N (today's 3) in the folder; delete older.
+   - In OPFS-only mode, the existing OPFS backup ring continues unchanged.
+5. **Migration from Phase 1 state.**
+   - Detect both-OPFS-and-folder-present at boot. Compare contents (hash). If different, trust the newer copy; preserve the loser as `pre-pivot-<ISO>.bak` in the folder ring.
+   - Set `folderRecord.pivotMigratedAt` on completion so the check runs once per user.
+6. **Status badge.**
+   - No new states; the existing `saved` / `pending` / `write-failed` / `inaccessible` cover everything. Phase 2 just changes which code paths transition between them.
+7. **Multi-tab guard.**
+   - Web Locks API around the folder write: `navigator.locks.request('fellows-relationships-folder', { mode: 'exclusive' }, async () => { ... })`. A second tab attempting a write yields (or fails fast); we wire the existing `multi_tab_ownership_takeover` UI to surface "Another tab is editing your data."
+
+Acceptance criteria for Phase 2:
+
+- A Chromium-desktop user with folder mode active makes 5 group edits in quick succession; the folder's `relationships.db` matches the in-memory state after every commit (verified via E2E).
+- A user revokes folder permission mid-session; the next mutation surfaces `write-failed`; the in-memory DB still has the change; clicking "Retry" after re-granting permission persists the change.
+- A user closes their tab with an unsaved (write-failed) mutation pending; on next boot, the folder still has the previous-known-good state; the in-memory mutation is honestly lost; badge shows "Saved" against the previous content (no silent overwrite).
+- A Phase 1 user (OPFS + folder both populated, different content) opens the app post-pivot; migration runs; the newer of the two becomes canonical; the loser lands in the folder backup ring with `pre-pivot-<ISO>` prefix.
+- A Safari / Firefox user sees no behavioral change (OPFS-only mode unchanged).
+- Parity test seed: existing `tests/e2e/test_user_folder_storage.py` extended with the multi-mutation + folder-write-failure + migration-from-hybrid scenarios.
+
+Out of scope for Phase 2:
+
+- A first-launch migration wizard for OPFS-only users who want to switch to folder mode (that's Phase 3 below).
+- Image sync to folder (held for a sibling plan / Phase 2.5).
+- "Show in Finder" / "Open data folder" affordances (Phase 4 polish).
+
+### Phase 3 — First-launch folder-setup wizard (deferred / absorbed)
+
+**Status: most likely absorbed into the MCP install wizard** (see [`plans/easy_mcp_install.md`](./easy_mcp_install.md) post-pivot). The original Phase 3 was a banner + flow for OPFS-only users to switch to folder mode. Under the new MCP-install plan, the MCP setup wizard is exactly the moment a user becomes interested in folder mode (so MCP can read their data). The standalone "I want to set up a folder for its own sake" flow may still be worth shipping — open question for after Phase 2 lands.
+
+If kept as a standalone Phase 3:
+
+- Banner for OPFS-only-mode users: *"Your data is currently only in this browser. Choose a folder to save it to disk."* Dismissible.
 - One-click "Choose folder & save now" flow.
-- Bulk export of current OPFS contents into the chosen folder (relationships.db + auto-backup ring).
+- Bulk export of current OPFS contents into the chosen folder (relationships.db + the OPFS-resident backup ring).
+- Once complete, the user is in folder mode for the rest of the session and future sessions.
 
 ### Phase 4 — Polish & accessibility (post-MVP)
 
 - "Show in Finder" via `showDirectoryPicker` round-trip when supported.
 - "Open data folder" deep link if any platform exposes it without re-picking.
-- Diagnostic panel additions (folder path, last sync time, sync-failure count, current permission state).
+- Diagnostic panel additions (resolved folder path, last write attempt + outcome, current permission state, migration status).
 - Maybe-eventual: `FileSystemObserver` watch on the folder so external edits surface as conflicts.
+- **Investigate retiring OPFS auto-backup ring entirely for folder-mode users** — under the pivot, folder-mode users have folder-resident backups; an OPFS shadow ring is dead weight and risks confusing future contributors. Track via a follow-up issue once Phase 2 is in production for a release cycle.
 
-## Plan-polish items (not blocking, worth resolving before code lands)
+## Plan-polish items
 
-Two gaps surfaced during a plan review. Neither blocks ship; both are worth a sentence each in the relevant phase before that phase starts.
+**G1 — Post-commit hook on relationships.db RPCs.** ~~Phase 2's spec says "Worker enqueues a sync after every committed mutation."~~ **Obsolete under the pivot.** Phase 2's per-commit write happens *inside* each mutating RPC handler (synchronously after the SQLite COMMIT, before the RPC returns). There is no separate debounced "sync queue" to mark dirty for. The simplification is one of the goals of the pivot, not an item to track.
 
-**G1 — Post-commit hook on relationships.db RPCs (Phase 2 dependency).** Phase 2's spec says "Worker enqueues a sync after every committed mutation to `relationships.db`." The worker's current RPC shape doesn't have a notion of "this RPC just committed a mutation" — most handlers read and write synchronously inside one function with no after-hook. P2 needs a small "post-commit" concept: each RPC that mutates `relationships.db` (createGroup, updateGroup, deleteGroup, setSetting, importRelationshipsBytes, …) flags the worker to schedule a debounced sync after the response is sent. Cleanest implementation is probably a small `markRelationshipsDirty()` helper called at the end of each mutating RPC, with the debounce timer living at module scope. Worth wiring in P2 the day P2 code starts.
+**G2 — `fellows.db.meta.json` sidecar location.** The SHA-keyed sidecar that drives the About → Check for updates flow lives in OPFS at `fellows.db.meta.json` (sibling of the SAH pool). **Resolution: stays in OPFS** under both modes. It tracks `fellows.db` freshness on this device — per-device by definition; a new device starts with an empty sidecar and re-fetches naturally. `fellows.db` itself stays OPFS-resident in both modes (it's refreshable shared data, not user-authored), so its sidecar belongs alongside it. No migration needed.
 
-**G2 — `fellows.db.meta.json` sidecar location and migration.** Today the SHA-keyed sidecar that drives the About → Check for updates flow lives in OPFS at `fellows.db.meta.json` (sibling of the SAH pool). The plan moves `relationships.db` to the user's folder but is silent on the sidecar. Decision needed: stays in OPFS (sidecar tracks the OPFS-resident `fellows.db`, which never moves under this plan), or moves to the folder alongside `relationships.db` (so a user copying their folder to a new machine sees the same update-state). Reco: **stays in OPFS** — it tracks `fellows.db` freshness on this device, which is per-device by definition. A new device starts with an empty sidecar and re-fetches naturally. Worth one sentence in § Architecture once decided, and a note in the migration wizard (Phase 3) confirming the wizard does NOT copy the sidecar.
+## Open questions — resolved during Phase 1 ship + pivot
 
-## Open questions for @richbodo
+All resolved; preserved here for traceability.
 
-Each one needs your call before phase 1 code lands.
+**Q1 ✅ Folder layout:** subfolder. User picks a *parent* folder; we own `Fellows/` (with N-suffix collision handling) inside it. Shipped in Phase 1. Subfolder name in code is `FOLDER_SUBFOLDER_DEFAULT = 'Fellows'`.
 
-**Q1: Folder layout — single file or directory?**
+**Q2 ✅ Pre-existing `relationships.db` in the picked folder:** confirm dialog with `open-existing` vs. `create Fellows N` choices, surfaced by the worker's `setFolderHandle({mode: 'auto'})` returning `{requiresChoice, existing, suggestion}` when a collision is detected. Shipped in Phase 1.
 
-Option A: drop `relationships.db` straight into the folder the user picks (alongside whatever's already there). Pros: matches "it's just a file" intuition. Cons: auto-backups (`relationships.db.bak.*`) and any future metadata clutter the user's folder.
+**Q3 ✅ Mobile:** unsupported in folder mode. iOS / Android default to OPFS-only mode. Revisit when the Android picker matures.
 
-Option B: require an empty folder, treat the folder as ours, manage all contents (`relationships.db`, backups, maybe a `.fellows-manifest.json`). Pros: clean ownership boundary. Cons: more friction on first setup; pickier about pre-existing folders.
+**Q4 ✅ Diagnostic surface:** "Data folder" subsection in the `?diag` panel. Phase 1 added the row at `app.js:2548`; Phase 4 polish will fill it out with permission + recent-write detail.
 
-Option C: drop a subfolder. User picks a parent folder; we make `EHF Fellows Data/` inside it and own that. Compromise; mirrors how VS Code creates `.vscode/`.
+**Q5 ✅ Naming:** "Data folder" — used consistently in the Settings UI shipped in Phase 1.
 
-**Recommendation:** C — clearest user mental model, no destructive collisions, naming visible in Finder.
+## New open questions (post-pivot)
 
-**Q2: What happens when the picked folder already contains a `relationships.db`?**
+**Q6 — Phase 3 standalone vs. absorbed by MCP install wizard?**
 
-Scenarios: user re-installs and points at their old folder (✓ we want to load that), user picks a colleague's folder by accident (✗ we should not silently merge), user picks the SAME folder another browser is also using (✗ split-brain).
+The original Phase 3 was a first-launch banner for OPFS-only users to switch to folder mode. Under the new sequencing (MCP install plan depends on Phase 2), the MCP install wizard becomes a folder-setup trigger for any user who wants Claude Desktop integration. Open question: does a *standalone* Phase 3 still ship, or do we say "folder mode is the implicit prerequisite for MCP integration; if you don't want MCP, OPFS-only mode is fine"?
 
-**Recommendation:** if the chosen folder contains `relationships.db`, show a confirm dialog: *"This folder already has fellows data — `<groups summary>`. Use it?* / Keep my browser's data and back this folder's data up first / Cancel". Don't silently merge.
+Lean: skip standalone Phase 3 in v1. Re-evaluate after Phase 2 + MCP install land based on real user feedback.
 
-**Q3: Mobile in the matrix — pretend unsupported, or partial Android support?**
+**Q7 — When to retire OPFS auto-backup ring for folder-mode users?**
 
-Android Chrome 121+ does support `showDirectoryPicker`, but with worse permission persistence and *Clear Storage* still nuking handles. v1 plan calls it unsupported; the alternative is "partial — works but bigger 'unsafe in Android Settings' warnings."
+Phase 2 adds a folder-resident backup ring. The OPFS-resident ring is dead weight for folder-mode users from that point. Plan above defers retirement to Phase 4; a separate GH issue tracks the investigation.
 
-**Recommendation:** v1 unsupported. Treat mobile as today's OPFS-only flow. Revisit when Android File System Access feels solid.
-
-**Q4: Diagnostic surface — how much state to expose?**
-
-The full permission lifecycle (handle present, last permission query result, last sync attempt + outcome, current path) is useful for support cases. Could land in the existing `?diag` panel.
-
-**Recommendation:** yes, add a "Data folder" subsection to the `?diag` panel. Low cost; high payoff when someone files a "I lost my data" issue.
-
-**Q5: Naming.**
-
-Settings UI calls it: data folder? backup folder? sync folder? save folder? Worth picking one and using it everywhere.
-
-**Recommendation:** "**Data folder**" — implies durability and ownership; doesn't mislead users into thinking it's a backup of something else.
+Lean: defer is fine. Wait until a release cycle of real folder-mode usage to confirm the folder backups are reliable before deleting the OPFS shadow.
 
 ## Testing approach
 
-- **Unit:** IndexedDB handle round-trip; sync-out write logic against a stubbed `FileSystemDirectoryHandle`.
+- **Unit:** IndexedDB handle round-trip; per-commit folder-write logic against a stubbed `FileSystemDirectoryHandle`; mem-VFS hydration round-trip (serialize → deserialize); migration-from-Phase-1 newer-copy detection.
 - **Playwright E2E (Chromium):** seed a folder handle via CDP, exercise full save / load / disconnect / reconnect flows. Verify status-badge state machine.
 - **Manual smoke:**
   - Chrome desktop PWA: full happy path.
@@ -315,14 +429,20 @@ This is also a good time to remember the AC-12 commitment in `docs/Architecture.
 
 ## Risks
 
-- **OPFS and folder drift permanently if sync keeps failing.** Mitigation: status badge surfaces the divergence loudly; auto-retry on next mutation; "Save now" button always available.
-- **User picks a folder inside a synced location (Dropbox/iCloud) and runs the app in two browsers.** Mitigation: Q2's "already has data here?" dialog catches the first case; multi-writer is documented as unsupported in `users_manual.md`.
-- **`Clear site data` still wipes the IDB-stored handle**, forcing re-pick. Mitigation: the FOLDER survives, so the user just re-picks and the data is unchanged. Document this in `users_manual.md` as the recovery path.
-- **Browser auto-revokes file system permissions on idle eviction.** Chrome does this for tabs that have been backgrounded for a long time. Mitigation: the `'prompt'` state and reconnect CTA already cover this. Tested.
+- ~~**OPFS and folder drift permanently if sync keeps failing.**~~ **Eliminated by the pivot** — there is no second store to drift from in folder mode. The OPFS-only and folder-mode users each have a single source of truth.
+- **User picks a folder inside a synced location (Dropbox/iCloud) and runs the app in two browsers.** Multi-writer is unsupported. Mitigation: Q2's "already has data here?" dialog catches first-attach; Web Locks API guard around folder writes (Phase 2) prevents in-browser races; multi-browser users see a "Another tab/browser is editing your data" error from the Web Locks rejection.
+- **`Clear site data` still wipes the IDB-stored handle**, forcing re-pick. Mitigation: the FOLDER survives, so the user just re-picks and the data is unchanged. Documented in `users_manual.md` as the recovery path.
+- **Browser auto-revokes file system permissions on idle eviction.** Chrome does this for tabs backgrounded for a long time. Mitigation: the `'prompt'` state and reconnect CTA cover this; the next mutation after re-grant succeeds and the badge transitions back to "Saved."
+- **In-memory state lost on tab crash mid-mutation (folder mode).** Honest failure mode — the user sees "Pending save…" or "Last save failed" before the crash and knows the change wasn't committed. Document in `users_manual.md`.
+- **Per-mutation folder-write latency at scale.** Sub-ms at current DB sizes; ~tens of ms at 10 MB. If `relationships.db` ever grows past several MB and users feel it, optimization paths (incremental writes via FileSystemSyncAccessHandle when the API lands for non-OPFS folders, write coalescing, etc.) become available. Not a v1 concern.
+- **Migration from Phase 1 hybrid state mis-detects which copy is newer.** Mitigation: preserve the "losing" copy in the folder backup ring as `pre-pivot-<ISO>.bak` so the user can recover manually. Migration runs once per session until completed; sets `folderRecord.pivotMigratedAt`.
 
 ## Links
 
 - File System Access API spec: <https://wicg.github.io/file-system-access/>
 - VS Code for Web architecture talk (the reference design): <https://code.visualstudio.com/blogs/2021/10/20/vscode-dev>
 - sqlite-wasm OPFS VFS docs: <https://sqlite.org/wasm/doc/trunk/persistence.md>
+- sqlite-wasm serialize / deserialize: <https://sqlite.org/wasm/doc/trunk/api-c-style.md#sqlite3_serialize>
 - Related plan: [`local_first_worker_architecture.md`](./local_first_worker_architecture.md)
+- Related plan: [`easy_mcp_install.md`](./easy_mcp_install.md) — depends on the pure-folder anchor from this plan
+- AC decision: [`docs/ac_decisions_log.md` § 2026-05-22](../docs/ac_decisions_log.md) — full reasoning for the pivot


### PR DESCRIPTION
## Summary

Pure planning artifact — no code changes. Pivots Phase 2 of `plans/user_folder_storage.md` from the originally-planned *"hybrid OPFS-working + debounced folder sync"* design to **pure folder for folder-mode users** (mem-resident SQLite, atomic folder writes per commit). OPFS-only-mode is preserved unchanged for users without folder picker support.

## The architectural concern that triggered the pivot

During Phase 2 scoping (the auto-sync work I was about to start), a silent-data-loss failure mode surfaced that didn't appear in the original plan review:

1. User makes a mutation. OPFS commit succeeds. Debounced sync to folder scheduled (500 ms).
2. Within the debounce window, folder permission briefly lapses (system sleep, app eviction, parent folder temporarily unmounted by a sync service). Sync fires, fails. `folderRecord.lastError` is set; OPFS now has new data the folder does not.
3. User closes the tab — or the browser crashes — before noticing the badge state.
4. User re-opens. The plan's documented boot sequence reads `relationships.db` from the folder (the "Saved" semantics treat the folder as canonical), copies it into OPFS, **overwriting the unsaved OPFS data**.
5. Recent mutations silently gone. No error indication.

The bug is structural to any "two storage substrates + async sync" model. Patching the boot sequence to detect divergence is more code paths, not fewer.

The hybrid was originally chosen because sqlite-wasm's fast VFS (`OpfsSAHPoolVfs`) needs OPFS-resident sync access handles, and async / mem-VFS alternatives were dismissed as too slow or too crash-risky. **Both arguments hold for medium/large databases and break at our scale** — `relationships.db` is currently 98 KB and unlikely to exceed several MB lifetime; whole-file folder writes are sub-millisecond and atomic per the FileSystem Access API spec.

## The pivot in one paragraph

Folder-mode users (Chromium desktop) get a mem-resident SQLite. On boot, the worker reads the folder file's bytes and `sqlite3_deserialize`s into the mem-DB. On each committed mutation, `sqlite3_serialize` produces bytes and atomic-writes them to the folder file (using Phase 1's already-shipped `createWritable → write → close` path). The folder file IS the user's data, at all times. OPFS-only-mode users (Safari / Firefox / iOS / no folder picker) keep today's OPFS-resident SAH-pool VFS unchanged — one source of truth per user.

## What's in the PR

- **New AC log entry** (`docs/ac_decisions_log.md` § 2026-05-22) capturing the decision with the failure-mode walkthrough, alternatives considered, consequences accepted, and the trajectory rationale (MCP install plan + future multi-client clients both want a stable, current folder file rather than a debounced mirror).
- **Substantial `plans/user_folder_storage.md` revision**:
  - Status banner at top noting the pivot.
  - `§ Architecture` rewritten end-to-end: two storage modes, ASCII diagram, per-commit write path, auto-backup ring placement, boot sequence, **migration from Phase 1 hybrid state** (newer-copy-wins with the loser preserved as `pre-pivot-<ISO>.bak`), multi-tab considerations via Web Locks API.
  - `§ Goals` G5 reframed ("no silent data loss" — broader than just permission lapse).
  - `§ Non-goals` updated to explicitly disclaim the hybrid model.
  - `§ Phases` updated: Phase 1 marked shipped (PR #181), Phase 2 redefined with concrete engineering scope + acceptance criteria, Phase 3 noted as deferred/likely-absorbed by the MCP install wizard.
  - `§ Plan-polish items` G1 (post-commit hook helper) marked obsolete; G2 (sidecar location) resolved in place — stays in OPFS.
  - `§ Open questions` Q1-Q5 marked resolved with traceability notes; two new post-pivot questions (Q6 standalone-vs-absorbed Phase 3, Q7 when to retire OPFS shadow ring).
  - `§ Risks` substantially revised: drift risk eliminated, in-memory loss documented as honest failure mode, per-mutation latency at scale called out, migration mis-detection mitigated via backup-ring preservation.
  - `§ Links` extended with the AC log entry, sqlite-wasm serialize/deserialize docs, and the easy_mcp_install plan link.

## Trade-off matrix (short version)

| | Hybrid (rejected) | Pure-folder (chosen) |
|---|---|---|
| Sources of truth in folder mode | 2 (OPFS + folder) | 1 (folder) |
| Sync state to manage | dirty marker, quiet timer, max timer, in-flight guard, last-saved-at, last-error, divergence detection | none |
| Silent data-loss failure modes | yes (boot overwrites newer OPFS) | no (lost work is visible) |
| Per-mutation folder latency | ms (debounced after commit) | sub-ms for our DB sizes (whole-file atomic write) |
| MCP / external-tool view | folder lags by 500ms-5s | folder = truth |
| Phase 2 engineering | smaller (sync logic only) | ~1.5x (VFS swap + migration) but no sync state |

## What does NOT ship in this PR

- Any code changes. The implementation work lands in a follow-up `feat/folder-storage-phase2-pivot` (or similar) branch.
- Phase 3 (standalone first-launch folder-setup wizard) — deferred pending MCP install wizard work.
- Image-folder-sync (plan § Refreshable Assets Option C) — separate concern.

## What this unlocks

The MCP install plan (`plans/easy_mcp_install.md`) was blocked on the fragile *"export to Downloads with a timestamped filename, then point Claude Desktop's user_config picker at it"* dance — which has been failing in real tests on this Mac. Once Phase 2 lands, the MCP `.mcpb` manifest's `user_config.relationships_db` default can be `<picked-parent>/Fellows/relationships.db` — a stable filesystem path the user can recognize in Finder. The PWA setup wizard becomes "set up your data folder once; everything else just points at it." Same anchor extends to future Cursor / Continue / Ollama / Claude Code MCP configs.

## Test plan

- [ ] Read § Architecture end-to-end and confirm the two-modes design is clear and the migration story handles all four Phase-1-user combinations (both, OPFS-only, folder-only, neither).
- [ ] Confirm the AC log entry captures enough reasoning that a future contributor seeing the simpler-than-they-expected Phase 2 code understands why it isn't a hybrid sync.
- [ ] Verify the new § Phase 2 acceptance criteria are testable as written (the 5 bullet points under "Acceptance criteria for Phase 2").
- [ ] Confirm Q6 + Q7 (the two new open questions) accurately reflect the open decisions; reply on this PR if either deserves an answer now rather than later.

## After this merges

Two parallel tracks:

1. **`feat/folder-storage-phase2-pivot`** — implement Phase 2 per the spec in § Phases. The worker's mode-switch + per-commit write + migration. Estimated 1.5x the original Phase 2 effort.
2. **Revise `plans/easy_mcp_install.md`** to remove the OPFS-export-to-Downloads workaround and replace it with a folder-anchored design — once Phase 2 is in flight or done, that revision is straightforward.

🤖 Generated with [Claude Code](https://claude.com/claude-code)