### PR TITLE
feat(folder-storage): move auto-backup ring to folder + retire OPFS shadow

### DIFF
--- a/app/static/vendor/sqlite-worker.js
+++ b/app/static/vendor/sqlite-worker.js
@@ -380,6 +380,94 @@ async function _rotateRelationshipsBackups() {
   }
 }
 
+// ----- Backup store routing (Phase 2 pivot) ---------------------------------
+//
+// In folder mode the auto-backup ring lives in the user's folder
+// (siblings of relationships.db). In OPFS-only mode it stays in
+// OPFS, unchanged. The dynamic check below mirrors the per-commit
+// hook in _maybeWriteFolderAfterCommit — a user who attached a
+// folder mid-session sees subsequent backups land in the folder
+// alongside the per-commit writes; a user whose permission lapsed
+// gets OPFS-resident backups as a fallback. Source of truth for
+// the ring at any moment is whichever store the per-commit hook
+// would also be writing to.
+//
+// Dependencies (defined later in the user-folder-storage section
+// — JS function-declaration hoisting means call order is fine,
+// but they're noted here for orientation):
+//   _listFolderBackups, _folderReadBackup, _rotateFolderBackups,
+//   _writeBytesToFolder, _folderQueryPermission, folderRecord.
+
+async function _isFolderBackupActive() {
+  if (!folderRecord.parentHandle || !folderRecord.subfolderName) return false;
+  var perm = await _folderQueryPermission();
+  return perm === 'granted';
+}
+
+async function _listActiveBackups() {
+  if (await _isFolderBackupActive()) return await _listFolderBackups();
+  return await listRelationshipsBackups();
+}
+
+async function _writeBackupToActiveStore(name, bytes) {
+  if (await _isFolderBackupActive()) {
+    // Reuse _writeBytesToFolder — it handles atomic write semantics
+    // and only updates folderRecord.lastSavedAt for the canonical
+    // relationships.db filename, so backup writes don't muddy that
+    // signal.
+    await _writeBytesToFolder(bytes, name);
+    return;
+  }
+  await _opfsWriteBinary(name, bytes);
+}
+
+async function _rotateActiveBackups() {
+  if (await _isFolderBackupActive()) {
+    await _rotateFolderBackups();
+    return;
+  }
+  await _rotateRelationshipsBackups();
+}
+
+async function _readActiveBackup(name) {
+  if (await _isFolderBackupActive()) return await _folderReadBackup(name);
+  return await _opfsReadBinary(name);
+}
+
+// One-time migration of the OPFS-resident backup ring into the
+// user's folder. Runs whenever we boot in folder mode AND find
+// stragglers in OPFS (opportunistic — naturally idempotent because
+// the migration deletes the OPFS originals, so subsequent boots
+// find nothing left to move). Per Rich's "rip the band-aid off"
+// call (2026-05-22 conversation): we DO delete the OPFS originals,
+// but we copy the bytes to the folder first so backup history is
+// preserved in a discoverable place.
+async function _maybeMigrateOpfsBackupsToFolder() {
+  if (!(await _isFolderBackupActive())) return;
+  var opfsBackups = await listRelationshipsBackups();
+  if (!opfsBackups.length) return;
+  trace('backup-ring: migrating ' + opfsBackups.length +
+    ' OPFS bak.* file(s) into folder/' + folderRecord.subfolderName + '/');
+  var migrated = 0;
+  for (var i = 0; i < opfsBackups.length; i++) {
+    var entry = opfsBackups[i];
+    try {
+      var bytes = await _opfsReadBinary(entry.name);
+      await _writeBytesToFolder(bytes, entry.name);
+      await _opfsRemoveEntry(entry.name);
+      migrated++;
+    } catch (e) {
+      trace('backup-ring: migrate ' + entry.name + ' failed (' +
+        (e && e.message || e) + ') — leaving OPFS copy in place for safety');
+    }
+  }
+  if (migrated) {
+    trace('backup-ring: migrated ' + migrated + '/' + opfsBackups.length +
+      ' OPFS backups → folder; rotating to ' + BACKUP_KEEP + ' newest');
+    await _rotateFolderBackups();
+  }
+}
+
 // ===== Auto-backup (debounced per-boot) =====================================
 
 // Per Phase 0 Q-C: trigger flips from "build-SHA differs" to "newest
@@ -394,7 +482,12 @@ async function maybeBackupRelationshipsDb() {
     trace('backup: skipped (no relationships.db yet — first install)');
     return { backedUp: false, reason: 'first install' };
   }
-  var backups = await listRelationshipsBackups();
+  // Active store is folder when folder-mode permission is granted,
+  // otherwise OPFS. The debounce timer reads "newest bak.<ISO>" from
+  // whichever store we're actually writing to, so it stays consistent
+  // across mode transitions (e.g., a user who attached a folder
+  // mid-session and just migrated existing OPFS backups into it).
+  var backups = await _listActiveBackups();
   if (backups.length) {
     var newest = backups[backups.length - 1];
     var ageMs = Date.now() - newest.lastModified;
@@ -416,13 +509,14 @@ async function maybeBackupRelationshipsDb() {
   }
   var ts = new Date().toISOString().replace(/[:.]/g, '-');
   var backupName = BACKUP_PREFIX + ts;
-  try { await _opfsWriteBinary(backupName, bytes); }
+  try { await _writeBackupToActiveStore(backupName, bytes); }
   catch (e) {
     trace('backup: write failed: ' + (e && e.message || e));
     return { backedUp: false, reason: 'write failed' };
   }
-  await _rotateRelationshipsBackups();
-  trace('backup: wrote ' + backupName + ' (' + bytes.byteLength + ' bytes)');
+  await _rotateActiveBackups();
+  var storeLabel = (await _isFolderBackupActive()) ? 'folder' : 'opfs';
+  trace('backup: wrote ' + backupName + ' to ' + storeLabel + ' (' + bytes.byteLength + ' bytes)');
   return { backedUp: true, name: backupName, size: bytes.byteLength };
 }
 
@@ -438,10 +532,11 @@ async function snapshotRelationshipsDbToBackup() {
   if (!bytes || !bytes.byteLength) return { backedUp: false, reason: 'empty file' };
   var ts = new Date().toISOString().replace(/[:.]/g, '-');
   var backupName = BACKUP_PREFIX + ts;
-  try { await _opfsWriteBinary(backupName, bytes); }
+  try { await _writeBackupToActiveStore(backupName, bytes); }
   catch (e) { return { backedUp: false, reason: 'write failed: ' + (e && e.message || e) }; }
-  await _rotateRelationshipsBackups();
-  trace('snapshot: wrote ' + backupName + ' (' + bytes.byteLength + ' bytes)');
+  await _rotateActiveBackups();
+  var storeLabel = (await _isFolderBackupActive()) ? 'folder' : 'opfs';
+  trace('snapshot: wrote ' + backupName + ' to ' + storeLabel + ' (' + bytes.byteLength + ' bytes)');
   return { backedUp: true, name: backupName, size: bytes.byteLength };
 }
 
@@ -602,15 +697,6 @@ handlers.init = async function () {
   var sentinelRemoved = await _opfsRemoveEntry(LEGACY_SENTINEL);
   if (sentinelRemoved) trace('cleanup: removed legacy ' + LEGACY_SENTINEL);
 
-  // Auto-backup runs before opening relationships.db for app use, so the
-  // snapshot reflects the user's last-saved state, not anything mutated
-  // this session. Failure is non-fatal — logged via bootTrace.
-  // NOTE: This is the OPFS-resident auto-backup ring. Under the pivot,
-  // folder-mode users get a folder-resident backup ring in a follow-up
-  // PR; until that lands, both rings coexist (folder-mode users
-  // effectively get backups in two places — harmless redundancy).
-  await maybeBackupRelationshipsDb();
-
   // Hydrate the user-folder handle from IDB so we know which storage
   // mode applies BEFORE opening relDb. (Phase 1 hydrated after relDb
   // was open; the pivot needs the order reversed so we can populate
@@ -637,15 +723,24 @@ handlers.init = async function () {
     ' permission=' + folderPermission + ')');
 
   // Folder mode: one-time migration (if Phase 1 hybrid state exists)
-  // and then hydrate the OPFS working buffer from folder bytes. After
-  // this block, the OPFS slot reflects the folder file's content —
-  // opening relDb against the slot gives us the folder's data.
+  // for relationships.db, then OPFS→folder backup-ring migration, then
+  // hydrate the OPFS working buffer from folder bytes. After this
+  // block, the OPFS slot reflects the folder file's content — opening
+  // relDb against the slot gives us the folder's data, and the
+  // auto-backup that fires next lands in the correct store (folder).
   if (_storageMode === 'folder') {
     try {
       await _maybeRunPivotMigration();
     } catch (migrateErr) {
       trace('pivot-migration: FAILED — ' + ((migrateErr && migrateErr.message) || migrateErr) +
         ' (continuing in folder mode; user can recover via Settings)');
+    }
+    try {
+      await _maybeMigrateOpfsBackupsToFolder();
+    } catch (backupMigErr) {
+      trace('backup-ring migration: FAILED — ' +
+        ((backupMigErr && backupMigErr.message) || backupMigErr) +
+        ' (OPFS backups stay in place; new backups go to folder)');
     }
     try {
       await _hydrateOpfsBufferFromFolder();
@@ -658,6 +753,15 @@ handlers.init = async function () {
       // an empty DB). The page-side badge surfaces the lastError.
     }
   }
+
+  // Auto-backup runs before opening relationships.db for app use, so the
+  // snapshot reflects the user's last-saved state, not anything mutated
+  // this session. Failure is non-fatal — logged via bootTrace. The
+  // routing inside maybeBackupRelationshipsDb sends the snapshot to
+  // whichever store is active for this session: folder when folder mode
+  // resolved successfully above, OPFS otherwise. Folder-mode users no
+  // longer accumulate OPFS-resident backups after this PR.
+  await maybeBackupRelationshipsDb();
 
   var hasRelationshipsDb = false;
   try {
@@ -883,13 +987,16 @@ handlers.importRelationshipsBytes = async function (args) {
 
 handlers.listRelationshipsBackups = async function () {
   if (!poolUtil) return [];
-  var raw = await listRelationshipsBackups();
+  // Active store is folder when folder-mode permission is granted,
+  // otherwise OPFS. After PR backup-ring migration, folder-mode
+  // users never see OPFS-resident backups here (migrated + cleared).
+  var raw = await _listActiveBackups();
   var out = [];
   // Sequential — staging slot is shared across inspects.
   for (var i = 0; i < raw.length; i++) {
     var entry = raw[i];
     try {
-      var bytes = await _opfsReadBinary(entry.name);
+      var bytes = await _readActiveBackup(entry.name);
       var insp = await inspectBytes(bytes);
       out.push({
         name: entry.name, size: entry.size, lastModified: entry.lastModified,
@@ -910,13 +1017,13 @@ handlers.listRelationshipsBackups = async function () {
 handlers.restoreRelationshipsBackup = async function (args) {
   if (!poolUtil) throw new Error('pool util unavailable');
   var name = args && args.name;
-  var backups = await listRelationshipsBackups();
+  var backups = await _listActiveBackups();
   var match = null;
   for (var i = 0; i < backups.length; i++) {
     if (backups[i].name === name) { match = backups[i]; break; }
   }
   if (!match) throw new Error('Backup not found: ' + name);
-  var bytes = await _opfsReadBinary(name);
+  var bytes = await _readActiveBackup(name);
   return await handlers.importRelationshipsBytes({ bytes: bytes });
 };
 
@@ -2116,9 +2223,74 @@ async function _writeBytesToFolder(bytes, filename) {
   }
 }
 
-// Post-commit hook called at the end of each mutating RPC. If a folder
-// is currently attached AND has granted readwrite permission, exports
-// the OPFS buffer and writes atomically to the folder. Otherwise no-op.
+// ----- Folder-resident backup ring helpers ---------------------------------
+//
+// In folder mode the auto-backup ring lives alongside relationships.db
+// in the user's Fellows/ subfolder, as `relationships.db.bak.<ISO>`
+// siblings. Visible in Finder; the user can see + recover their own
+// backups without opening the app. OPFS-only-mode users keep today's
+// OPFS-resident ring, unchanged. See plans/user_folder_storage.md
+// § Architecture → Auto-backup ring (folder mode).
+
+async function _listFolderBackups() {
+  if (!folderRecord.parentHandle || !folderRecord.subfolderName) return [];
+  var sub;
+  try {
+    sub = await folderRecord.parentHandle.getDirectoryHandle(folderRecord.subfolderName);
+  } catch (e) {
+    return [];
+  }
+  var out = [];
+  try {
+    for await (var entry of sub.values()) {
+      if (entry.kind === 'file' && entry.name.indexOf(BACKUP_PREFIX) === 0) {
+        try {
+          var f = await entry.getFile();
+          out.push({ name: entry.name, size: f.size, lastModified: f.lastModified });
+        } catch (e) {
+          // File disappeared between iteration and getFile — skip.
+        }
+      }
+    }
+  } catch (e) {
+    return [];
+  }
+  // Sort lexicographically — backup filenames embed an ISO timestamp
+  // after BACKUP_PREFIX so this is also chronological order.
+  out.sort(function (a, b) { return a.name < b.name ? -1 : a.name > b.name ? 1 : 0; });
+  return out;
+}
+
+async function _folderReadBackup(name) {
+  if (!folderRecord.parentHandle || !folderRecord.subfolderName) {
+    throw new Error('no folder configured');
+  }
+  var sub = await folderRecord.parentHandle.getDirectoryHandle(folderRecord.subfolderName);
+  var fh = await sub.getFileHandle(name);
+  var f = await fh.getFile();
+  return new Uint8Array(await f.arrayBuffer());
+}
+
+async function _rotateFolderBackups() {
+  if (!folderRecord.parentHandle || !folderRecord.subfolderName) return;
+  var backups = await _listFolderBackups();
+  if (backups.length <= BACKUP_KEEP) return;
+  var sub;
+  try {
+    sub = await folderRecord.parentHandle.getDirectoryHandle(folderRecord.subfolderName);
+  } catch (e) { return; }
+  while (backups.length > BACKUP_KEEP) {
+    var oldest = backups.shift();
+    try {
+      await sub.removeEntry(oldest.name);
+      trace('folder-backup: rotated out ' + oldest.name);
+    } catch (e) {
+      trace('folder-backup: rotate removeEntry failed for ' + oldest.name);
+    }
+  }
+}
+
+// ----- Post-commit folder write (Phase 2 pivot) -----------------------------
 //
 // Dynamic check (vs. the boot-time `_storageMode` global) is intentional:
 // a user who booted without a folder handle and then attached one

--- a/tests/e2e/test_user_folder_storage.py
+++ b/tests/e2e/test_user_folder_storage.py
@@ -44,10 +44,10 @@ _STUB_DIRECTORY_PICKER = """
   };
   // Test affordance: read back a probe of what landed in the stub
   // folder. Returns { hasFellows: bool, hasFellows2: bool,
-  // relSize: int|null }.
+  // relSize: int|null, folderBackupNames: string[] }.
   window.__probeE2EUserFolder = async function () {
     var root = await navigator.storage.getDirectory();
-    var out = { hasFellows: false, hasFellows2: false, relSize: null };
+    var out = { hasFellows: false, hasFellows2: false, relSize: null, folderBackupNames: [] };
     var stub;
     try { stub = await root.getDirectoryHandle(STUB_NAME); }
     catch (e) { return out; }
@@ -59,12 +59,51 @@ _STUB_DIRECTORY_PICKER = """
         var file = await fh.getFile();
         out.relSize = file.size;
       } catch (e) {}
+      // Enumerate bak.* siblings of relationships.db. These are the
+      // folder-resident backup ring (Phase 2 PR backup-ring-move).
+      try {
+        for await (var entry of f.values()) {
+          if (entry.kind === 'file' && entry.name.indexOf('relationships.db.bak.') === 0) {
+            out.folderBackupNames.push(entry.name);
+          }
+        }
+        out.folderBackupNames.sort();
+      } catch (e) {}
     } catch (e) {}
     try {
       await stub.getDirectoryHandle('Fellows 2');
       out.hasFellows2 = true;
     } catch (e) {}
     return out;
+  };
+  // Test affordance: count OPFS-resident bak.* files. Used to verify
+  // (a) that backups land in OPFS when folder mode is inactive, and
+  // (b) that the OPFS→folder migration deletes them after migrating.
+  window.__listE2EOpfsBackups = async function () {
+    var root = await navigator.storage.getDirectory();
+    var names = [];
+    try {
+      for await (var entry of root.values()) {
+        if (entry.kind === 'file' && entry.name.indexOf('relationships.db.bak.') === 0) {
+          names.push(entry.name);
+        }
+      }
+    } catch (e) {}
+    names.sort();
+    return names;
+  };
+  // Test affordance: write a synthetic bak.* file directly to OPFS
+  // root, so a test can pre-seed the state before triggering a
+  // folder-mode boot (to verify the OPFS→folder migration path).
+  window.__seedE2EOpfsBackup = async function (name, contentBase64) {
+    var root = await navigator.storage.getDirectory();
+    var fh = await root.getFileHandle(name, { create: true });
+    var w = await fh.createWritable();
+    var bin = atob(contentBase64);
+    var bytes = new Uint8Array(bin.length);
+    for (var i = 0; i < bin.length; i++) bytes[i] = bin.charCodeAt(i);
+    await w.write(bytes);
+    await w.close();
   };
   // Test affordance: clear the worker's IDB-persisted handle so the
   // next page load boots fresh. Same DB the worker uses internally.
@@ -377,3 +416,121 @@ class TestPhase2Pivot:
         # ("just now" / "X min ago") — verify it stayed in Saved state
         # rather than flipping to a warning state.
         expect(badge_text).to_contain_text("Saved to")
+
+    def test_snapshot_lands_in_folder_when_folder_mode_active(
+        self, folder_page, base_url_fixture
+    ):
+        """When a folder is active, the pre-import snapshot (taken
+        inside importRelationshipsBytes) lands in the folder's
+        Fellows/ subdirectory as a bak.<ISO> sibling — not in OPFS.
+        Verifies _writeBackupToActiveStore routes correctly under
+        the folder-mode dynamic check.
+        """
+        _open_settings(folder_page, base_url_fixture)
+        folder_page.locator("#settings-folder-choose").click()
+        badge_text = folder_page.locator("#settings-folder-badge .settings-folder-badge-text")
+        expect(badge_text).to_contain_text("Saved to", timeout=10000)
+        # Export the current relationships.db bytes, then re-import them.
+        # importRelationshipsBytes always snapshots-before-import, so this
+        # round-trip generates exactly one new bak.* file in whichever
+        # store is active.
+        folder_page.evaluate("""
+          async () => {
+            var dp = window.__dataProvider;
+            var bytes = await dp.exportRelationshipsBytes();
+            await dp.importRelationshipsBytes(bytes);
+          }
+        """)
+        probe = folder_page.evaluate("() => window.__probeE2EUserFolder()")
+        assert probe["folderBackupNames"], (
+            f"folder mode should write the snapshot to folder/Fellows/; "
+            f"probe.folderBackupNames={probe['folderBackupNames']!r}"
+        )
+        assert probe["folderBackupNames"][0].startswith("relationships.db.bak."), (
+            f"backup filename should follow the bak prefix; got {probe['folderBackupNames'][0]!r}"
+        )
+        # OPFS should NOT have accumulated a backup for this snapshot —
+        # folder-mode users no longer write to the OPFS shadow ring.
+        opfs_backups = folder_page.evaluate("() => window.__listE2EOpfsBackups()")
+        assert opfs_backups == [], (
+            f"folder mode should not write backups to OPFS; OPFS backups={opfs_backups!r}"
+        )
+
+    def test_opfs_to_folder_backup_migration_on_folder_boot(
+        self, folder_page, base_url_fixture
+    ):
+        """Pre-seed an OPFS-resident bak.* file (the state a Phase 1
+        user would arrive with), pick a folder, then reload the page.
+        Worker re-init runs _maybeMigrateOpfsBackupsToFolder, which
+        moves the OPFS bak to the folder's Fellows/ subdir and deletes
+        the OPFS original. Rip-the-band-aid-off per Rich's call.
+        """
+        _open_settings(folder_page, base_url_fixture)
+        # Step 1: pick the folder (creates handle in IDB). Initial
+        # save populates Fellows/relationships.db.
+        folder_page.locator("#settings-folder-choose").click()
+        badge_text = folder_page.locator("#settings-folder-badge .settings-folder-badge-text")
+        expect(badge_text).to_contain_text("Saved to", timeout=10000)
+        # Step 2: pre-seed an OPFS-resident bak file. Use a real
+        # SQLite database header so any future strict-validation code
+        # paths don't reject it. The bak file's content doesn't
+        # matter for the migration — we're testing that the bytes
+        # land in the folder and the OPFS file is removed.
+        SAMPLE_SQLITE_HEADER_B64 = (
+            "U1FMaXRlIGZvcm1hdCAzAA=="  # "SQLite format 3\0"
+        )
+        seeded_name = "relationships.db.bak.2026-05-22T01-00-00-000Z"
+        folder_page.evaluate(
+            "(args) => window.__seedE2EOpfsBackup(args[0], args[1])",
+            [seeded_name, SAMPLE_SQLITE_HEADER_B64],
+        )
+        # Sanity: OPFS now has our seeded backup.
+        opfs_before = folder_page.evaluate("() => window.__listE2EOpfsBackups()")
+        assert seeded_name in opfs_before, (
+            f"sanity: seed didn't land; OPFS backups={opfs_before!r}"
+        )
+        # Step 3: reload the page. Worker re-init runs in folder
+        # mode (handle persisted in IDB + permission still granted
+        # via the OPFS-backed stub). Migration fires.
+        folder_page.reload(wait_until="domcontentloaded")
+        folder_page.wait_for_function(
+            "() => window.__dataProvider && typeof window.__dataProvider.listGroups === 'function'",
+            timeout=10000,
+        )
+        # Step 4: OPFS bak is gone; folder bak is present.
+        opfs_after = folder_page.evaluate("() => window.__listE2EOpfsBackups()")
+        assert seeded_name not in opfs_after, (
+            f"migration should have deleted OPFS bak; OPFS still has it: {opfs_after!r}"
+        )
+        probe = folder_page.evaluate("() => window.__probeE2EUserFolder()")
+        assert seeded_name in probe["folderBackupNames"], (
+            f"migration should have copied OPFS bak to folder; "
+            f"folder bak files: {probe['folderBackupNames']!r}"
+        )
+
+    def test_opfs_only_mode_keeps_backups_in_opfs(
+        self, folder_page, base_url_fixture
+    ):
+        """Regression check: a user who has NOT picked a folder still
+        gets OPFS-resident backups. Migration only kicks in when
+        folder mode is active.
+        """
+        _open_settings(folder_page, base_url_fixture)
+        # Don't pick a folder. Trigger a snapshot via the same
+        # export/import round-trip used in the folder-mode test.
+        folder_page.evaluate("""
+          async () => {
+            var dp = window.__dataProvider;
+            var bytes = await dp.exportRelationshipsBytes();
+            await dp.importRelationshipsBytes(bytes);
+          }
+        """)
+        opfs_backups = folder_page.evaluate("() => window.__listE2EOpfsBackups()")
+        assert opfs_backups, (
+            f"OPFS-only mode should write snapshots to OPFS; OPFS backups={opfs_backups!r}"
+        )
+        # No folder was picked, so the stub folder shouldn't exist at all.
+        probe = folder_page.evaluate("() => window.__probeE2EUserFolder()")
+        assert probe["hasFellows"] is False, (
+            "no folder mode → no Fellows/ subfolder should exist"
+        )


### PR DESCRIPTION
## Summary

Second Phase 2 implementation PR. Folder-mode users' auto-backup ring now lives in the user's filesystem folder (visible in Finder as `<parent>/Fellows/relationships.db.bak.<ISO>` siblings of `relationships.db`). The OPFS shadow ring is retired for folder-mode users — existing OPFS backups are migrated to the folder on first folder-mode boot, and the OPFS originals are deleted (per your "rip the band-aid off / earlier is fine" call).

OPFS-only-mode users (Safari / Firefox / iOS) keep today's OPFS backup ring unchanged.

## What ships

**Worker (`app/static/vendor/sqlite-worker.js`, +201 lines)**

Folder-side primitives (in the user-folder-storage section):
- `_listFolderBackups()` — enumerate `bak.*` siblings of `relationships.db` in `Fellows/`.
- `_folderReadBackup(name)` — read a single bak's bytes.
- `_rotateFolderBackups()` — keep newest `BACKUP_KEEP`, delete older.

Active-store routing layer (in the auto-backup section):
- `_isFolderBackupActive()` — dynamic check: handle attached AND permission granted. Mirrors `_maybeWriteFolderAfterCommit`'s dynamic posture so backups follow the same store as per-commit writes.
- `_listActiveBackups`, `_writeBackupToActiveStore`, `_rotateActiveBackups`, `_readActiveBackup` — single dispatch surface that every backup-touching function below routes through.
- `_maybeMigrateOpfsBackupsToFolder()` — opportunistic + idempotent. Lists OPFS bak files, copies each to folder, deletes OPFS original, rotates folder ring. Runs in init when in folder mode.

Functions modified to use the routing:
- `maybeBackupRelationshipsDb` — debounce timer reads the active store's newest `bak.<ISO>` (so a user who just migrated 5 OPFS backups into folder doesn't immediately re-snapshot).
- `snapshotRelationshipsDbToBackup` — same routing.
- `handlers.listRelationshipsBackups` — reads + inspects active store.
- `handlers.restoreRelationshipsBackup` — reads from active store.

`init` handler restructured:
- `maybeBackupRelationshipsDb` call moved AFTER mode resolution + pivot migration + backup-ring migration + buffer hydration. First per-session backup lands in the correct store.
- New `_maybeMigrateOpfsBackupsToFolder` call inserted in the folder-mode boot path.

**E2E (`tests/e2e/test_user_folder_storage.py`, +143 lines)**

- `__probeE2EUserFolder` extended with `folderBackupNames` (lists `Fellows/relationships.db.bak.*` files).
- New `__listE2EOpfsBackups` affordance — lists OPFS-root `bak.*` files.
- New `__seedE2EOpfsBackup(name, base64)` affordance — pre-seeds OPFS-resident bak files for migration tests.

Three new test cases:
1. **`test_snapshot_lands_in_folder_when_folder_mode_active`** — after picking a folder, a snapshot-triggering `importRelationshipsBytes` round-trip writes the bak to `Fellows/` and OPFS stays empty.
2. **`test_opfs_to_folder_backup_migration_on_folder_boot`** — pre-seed an OPFS bak with a real SQLite header, pick folder, reload page, verify the bak moved to folder and was deleted from OPFS.
3. **`test_opfs_only_mode_keeps_backups_in_opfs`** — regression: no folder picked → snapshots stay in OPFS. Stub folder isn't created.

```
======================= 10 passed in 9.50s =======================
```

(6 Phase 1 + 1 PR-1 Phase 2 post-commit + 3 new backup-ring tests.)

## What does NOT ship in this PR

Per the plan's Phase 2 follow-ups, still ahead:

- **Settings UI / banner** to actively push existing OPFS-only users to pick a data folder (per "rip the band-aid off"). The worker is now fully ready; this is a UX PR.
- **`docs/users_manual.md` rewrite** — the "Where your data is stored" copy can shed its apologetic tone now that folder mode is the canonical durable home. Docs-only PR.
- **More migration coverage** — divergent-state edge cases for `_maybeRunPivotMigration` (the `relationships.db` migration from PR #190). Code path is correct by inspection; structural E2E coverage can land if/when a real user hits a divergence.

## Test plan

- [x] `pytest tests/e2e/test_user_folder_storage.py -v` — 10/10 pass locally.
- [ ] Pull, run e2e, confirm 10/10 pass on your machine.
- [ ] Manual smoke: pick a data folder via Settings, then use the app for a few minutes (create groups, edit them, etc.). After ≥ 1 hour, restart the app — a fresh `relationships.db.bak.<ISO>` should appear in your folder's `Fellows/` directory. The OPFS-resident backup ring (visible via DevTools → Application → Storage → IndexedDB / OPFS) should NOT accumulate new bak files for the same user.
- [ ] Manual smoke (Phase 1 user migration): if you have any pre-pivot OPFS backups left from earlier testing, opening the app in folder mode should move them into your data folder + remove them from OPFS. (DevTools' OPFS inspector should show no `relationships.db.bak.*` files at OPFS root after the boot.)

## Next PR

`feat/folder-storage-settings-ui-push` — the Settings UI banner pushing OPFS-only users to set up a folder. Small UX PR. After that, the easy_mcp_install plan can be revised to anchor on the folder path, and the remaining MCP install plan PRs (#5-8 in plan § 12) can resume.

🤖 Generated with [Claude Code](https://claude.com/claude-code)