### PR TITLE
feat(folder-storage): folder-push banner + users-manual update

### DIFF
--- a/app/static/app.js
+++ b/app/static/app.js
@@ -8207,6 +8207,83 @@
   // Exposed for tests + diag panel.
   window.__folderController = FOLDER_CONTROLLER;
 
+  // ===== Folder-push banner (Phase 2 PR 3) =================================
+  // Top-of-page banner that surfaces to capable browsers in OPFS-only mode,
+  // pushing the user to pick a data folder. Hidden when:
+  //   - The browser doesn't support showDirectoryPicker (Safari, Firefox,
+  //     iOS) — the user manual explains the OPFS-only fallback for them.
+  //   - A folder is already picked (folderRecord.parentHandle present).
+  //   - The user clicked "Not now" this session (sessionStorage flag —
+  //     re-appears on next browser session).
+  // Re-evaluated after any folder operation via wireFolderSection's
+  // renderState hook + on an initial post-boot delay so the worker has
+  // time to load folderRecord from IDB.
+  var FOLDER_PUSH_DISMISS_KEY = 'fellows_folder_push_dismissed';
+
+  function isFolderPushDismissed() {
+    try { return sessionStorage.getItem(FOLDER_PUSH_DISMISS_KEY) === '1'; }
+    catch (e) { return false; }
+  }
+
+  function refreshFolderPushBanner() {
+    var bannerEl = document.getElementById('folder-push-banner');
+    if (!bannerEl) return;
+    if (isFolderPushDismissed()) {
+      bannerEl.classList.add('hidden');
+      return;
+    }
+    if (!FOLDER_CONTROLLER) {
+      bannerEl.classList.add('hidden');
+      return;
+    }
+    FOLDER_CONTROLLER.getState().then(function (state) {
+      // Hide for: incapable browser, worker not yet ready (avoids flash),
+      // or folder already picked. Show otherwise (i.e., capable + OPFS-only).
+      if (!state.supported || !state.workerAvailable || state.hasHandle) {
+        bannerEl.classList.add('hidden');
+        return;
+      }
+      bannerEl.classList.remove('hidden');
+    }).catch(function () {
+      bannerEl.classList.add('hidden');
+    });
+  }
+
+  (function bindFolderPushBanner() {
+    var ctaBtn = document.getElementById('folder-push-cta');
+    var dismissBtn = document.getElementById('folder-push-dismiss');
+    if (ctaBtn) {
+      ctaBtn.addEventListener('click', function () {
+        // Navigate to Settings → focus the Data folder section so the
+        // user lands on the Choose button. Use a small post-hashchange
+        // delay so the section markup is mounted before scrolling.
+        location.hash = '#/settings';
+        setTimeout(function () {
+          var section = document.getElementById('settings-folder-section');
+          var chooseBtn = document.getElementById('settings-folder-choose');
+          if (section) section.scrollIntoView({ behavior: 'smooth', block: 'center' });
+          if (chooseBtn) {
+            try { chooseBtn.focus(); } catch (e) {}
+          }
+        }, 200);
+      });
+    }
+    if (dismissBtn) {
+      dismissBtn.addEventListener('click', function () {
+        try { sessionStorage.setItem(FOLDER_PUSH_DISMISS_KEY, '1'); }
+        catch (e) {}
+        var bannerEl = document.getElementById('folder-push-banner');
+        if (bannerEl) bannerEl.classList.add('hidden');
+      });
+    }
+    // Initial evaluation. The worker may still be initializing — that
+    // case returns workerAvailable:false and the banner stays hidden.
+    // Subsequent re-evaluations happen on Settings page render and on
+    // a small delay below as a safety net for users who never open
+    // Settings.
+    setTimeout(refreshFolderPushBanner, 1500);
+  })();
+
   // ===== Settings page (PR 5) ==============================================
 
   function renderSettingsPage() {
@@ -8760,6 +8837,10 @@
       showBtn(btnRefresh,    supported && b === 'saved');
       showBtn(btnReconnect,  supported && b === 'inaccessible');
       showBtn(btnDisconnect, supported && state.hasHandle);
+      // Cascade: state change here may also affect whether the top-of-
+      // page folder-push banner is visible (e.g., user just picked a
+      // folder → badge becomes 'saved' → banner should hide).
+      refreshFolderPushBanner();
     }
 
     function refresh() {

--- a/app/static/index.html
+++ b/app/static/index.html
@@ -120,6 +120,17 @@
     <button type="button" id="sw-update-reload" class="sw-update-reload">Reload</button>
   </div>
 
+  <div id="folder-push-banner" class="folder-push-banner hidden" role="status" aria-live="polite">
+    <span class="folder-push-banner-text">
+      <strong>Save your fellows data to disk.</strong>
+      Your groups and notes are only in browser storage right now. Pick a folder for durable storage.
+    </span>
+    <span class="folder-push-banner-actions">
+      <button type="button" id="folder-push-cta" class="folder-push-cta">Set up data folder</button>
+      <button type="button" id="folder-push-dismiss" class="folder-push-dismiss" aria-label="Dismiss for this session">Not now</button>
+    </span>
+  </div>
+
   <div id="install-gate-private" class="install-landing install-gate-private hidden" aria-label="Request access">
     <div class="install-landing-inner">
       <div class="install-brand" aria-hidden="true">EHF</div>

--- a/app/static/styles.css
+++ b/app/static/styles.css
@@ -1544,6 +1544,58 @@ h1 {
   cursor: pointer;
 }
 
+/* Folder-push banner — shown to capable browsers in OPFS-only mode
+   to encourage picking a data folder. Hidden once a folder is picked
+   or once the user dismisses for the session. Yellow/warning palette
+   to distinguish from the blue sw-update-banner. */
+.folder-push-banner {
+  margin: 0 0 0.75rem;
+  padding: 0.5rem 0.75rem;
+  font-size: 0.9rem;
+  background: #fff7e6;
+  color: #6b4500;
+  border: 1px solid #f3d8a0;
+  border-radius: 6px;
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+  gap: 0.75rem;
+  flex-wrap: wrap;
+}
+
+.folder-push-banner.hidden { display: none; }
+
+.folder-push-banner-text { flex: 1 1 280px; min-width: 0; }
+.folder-push-banner-text strong { font-weight: 600; margin-right: 0.25rem; }
+
+.folder-push-banner-actions {
+  display: flex;
+  gap: 0.5rem;
+  flex-wrap: wrap;
+  align-items: center;
+}
+
+.folder-push-cta,
+.folder-push-dismiss {
+  padding: 0.35rem 0.75rem;
+  font-size: 0.85rem;
+  border-radius: 4px;
+  cursor: pointer;
+}
+
+.folder-push-cta {
+  border: 1px solid #6b4500;
+  background: #6b4500;
+  color: #fff;
+  font-weight: 500;
+}
+
+.folder-push-dismiss {
+  border: 1px solid #c2a36b;
+  background: transparent;
+  color: #6b4500;
+}
+
 .about-support {
   margin-top: 1rem;
   font-size: 0.95rem;

--- a/docs/users_manual.md
+++ b/docs/users_manual.md
@@ -108,36 +108,30 @@ directory.
 Your groups, notes, and settings live **on your device only** —
 never sent to any server, never visible to other apps or websites.
 
-There are two places they can sit, and you choose which:
+**The recommended setup is a data folder on your disk** — a real
+file at a path you pick, visible in Finder/Explorer, durable across
+clearing site data or switching browsers. The app prompts you to
+set this up via a banner at the top of the screen on first launch.
 
-1. **In your browser** (default). The data file (`relationships.db`)
-   lives in a private storage area your browser manages. Survives
-   updates and **Clear App Cache**, but you can't see the file from
-   Finder/Explorer, and clearing site data or switching browsers
-   wipes it.
-2. **In a folder on your disk** (Settings → *Data folder*). A real
-   file at a path you pick — visible in Finder/Explorer, copyable,
-   syncable through Dropbox / iCloud Drive / Syncthing if you put it
-   there, durable across clearing site data or switching browsers.
-   Available in Chrome / Edge / Brave / Arc on desktop today.
-
-The browser is always your **working store** either way — that's
-where the app reads and writes during use. When you pick a data
-folder, the app keeps a copy of your data there too and updates it
-when you click *Save now*.
+If you skip the prompt or you're on a browser that doesn't support
+folder selection (Safari, Firefox, iOS, Android), the app falls
+back to **browser-only mode** — your data still works, but it lives
+in private browser storage that can be lost when you clear site
+data or switch browsers. Use the **Download a backup** feature
+(below) to make file copies you can save anywhere.
 
 ### Setting up a data folder (Chrome / Edge / Brave on desktop)
 
-1. Go to **Settings → Data folder**.
-2. Click **Choose data folder…**.
-3. Your OS pops a folder picker. Pick any folder you like —
+1. Click **Set up data folder** on the banner at the top of the app
+   (or go to **Settings → Data folder** → **Choose data folder…**).
+2. Your OS pops a folder picker. Pick any folder you like —
    `Documents`, a Dropbox / iCloud / Syncthing folder, anywhere.
-4. The app creates a `Fellows/` subfolder inside it and saves
+3. The app creates a `Fellows/` subfolder inside it and saves
    `relationships.db` there.
 
 The badge at the top of the section flips to **Saved** with the
 path and a timestamp, and your data is now a real file you can
-browse to.
+browse to. The banner at the top of the screen disappears.
 
 **If `Fellows/` already exists in the folder you picked**, the app
 asks before doing anything: open the existing data (the typical
@@ -146,11 +140,18 @@ folder), or save your current data into a new `Fellows 2/`
 subfolder (the safe choice when you don't recognize what's there).
 Cancel leaves both untouched.
 
-After setup, every time you make changes you'll see the *Save now*
-button. (Phase 1 is manual save; automatic background sync ships
-in Phase 2.) **Refresh from folder** does the reverse: replace the
-browser's copy with whatever's currently in the folder — useful
-after editing in another browser or restoring a synced file.
+After setup, **every change you make is automatically saved to the
+folder** — no Save button to remember. You'll see the badge update
+each time. The *Save now* button stays as a manual retry if a write
+ever fails (badge flips to *Last save failed*). **Refresh from
+folder** does the reverse: replace your working data with whatever's
+currently in the folder — useful after editing in another browser
+or restoring a synced file.
+
+Backups (the `relationships.db.bak.<timestamp>` files in the same
+`Fellows/` subfolder) are also automatic — the app keeps the most
+recent few alongside the live file. Visible in Finder so you can
+copy them out if you want extra safety.
 
 ### Badge states
 

--- a/tests/e2e/test_user_folder_storage.py
+++ b/tests/e2e/test_user_folder_storage.py
@@ -508,6 +508,113 @@ class TestPhase2Pivot:
             f"folder bak files: {probe['folderBackupNames']!r}"
         )
 
+    def test_folder_push_banner_appears_until_folder_picked(
+        self, folder_page, base_url_fixture
+    ):
+        """The top-of-page banner pushes capable-browser OPFS-only users
+        to pick a data folder. Phase 2 PR 3 (settings UI push).
+
+        On a fresh load with no folder handle, banner is visible.
+        After picking a folder it hides immediately (Settings page's
+        renderState cascade calls refreshFolderPushBanner).
+
+        Note: the banner has an initial 1.5s delay so the worker has
+        time to report workerAvailable=true. Test waits for that.
+
+        Uses the page state established by the folder_page fixture —
+        no re-navigation, which would trigger an OPFS-pool ownership
+        conflict against the still-warm worker.
+        """
+        folder_page.wait_for_function(
+            "() => document.getElementById('folder-push-banner') !== null",
+            timeout=10000,
+        )
+        banner = folder_page.locator("#folder-push-banner")
+        # Wait for the initial-load delayed evaluation to fire and the
+        # banner to become visible. The banner reads
+        # window.__folderController.getState() which returns
+        # workerAvailable=false until init completes; in this fixture
+        # the worker provider is already up (the fixture asserts it),
+        # so once the 1.5s setTimeout fires the banner appears.
+        # Wait for the banner to NOT have the hidden class (it has other
+        # classes too — folder-push-banner — so to_have_class can't be
+        # used for "contains hidden"; use a wait_for_function instead).
+        folder_page.wait_for_function(
+            "() => { var el = document.getElementById('folder-push-banner');"
+            "        return el && !el.classList.contains('hidden'); }",
+            timeout=10000,
+        )
+        # Both buttons are present.
+        expect(folder_page.locator("#folder-push-cta")).to_be_visible()
+        expect(folder_page.locator("#folder-push-dismiss")).to_be_visible()
+        # Pick a folder via the Settings UI. This is the same flow a
+        # user would follow after clicking the banner CTA.
+        _open_settings(folder_page, base_url_fixture)
+        folder_page.locator("#settings-folder-choose").click()
+        badge_text = folder_page.locator("#settings-folder-badge .settings-folder-badge-text")
+        expect(badge_text).to_contain_text("Saved to", timeout=10000)
+        # The Settings page's renderState cascades to refreshFolderPushBanner;
+        # banner should now be hidden.
+        folder_page.wait_for_function(
+            "() => { var el = document.getElementById('folder-push-banner');"
+            "        return el && el.classList.contains('hidden'); }",
+            timeout=5000,
+        )
+
+    def test_folder_push_banner_dismiss_persists_within_session(
+        self, folder_page, base_url_fixture
+    ):
+        """'Not now' sets a sessionStorage flag; the banner stays hidden
+        for the rest of the browser session even on reload. Re-appearing
+        after browser close is the next-session behavior (out of scope
+        for sessionStorage-based testing).
+        """
+        folder_page.wait_for_function(
+            "() => { var el = document.getElementById('folder-push-banner');"
+            "        return el && !el.classList.contains('hidden'); }",
+            timeout=10000,
+        )
+        folder_page.locator("#folder-push-dismiss").click()
+        # Hides immediately on dismiss.
+        folder_page.wait_for_function(
+            "() => { var el = document.getElementById('folder-push-banner');"
+            "        return el && el.classList.contains('hidden'); }",
+            timeout=2000,
+        )
+        # Reload — sessionStorage survives reload-within-the-same-tab.
+        folder_page.reload(wait_until="domcontentloaded")
+        folder_page.wait_for_function(
+            "() => document.getElementById('folder-push-banner') !== null",
+            timeout=10000,
+        )
+        # Give the initial-load setTimeout a chance to fire. Banner
+        # should still be hidden because the sessionStorage flag is set.
+        folder_page.wait_for_timeout(2000)
+        assert folder_page.evaluate(
+            "() => document.getElementById('folder-push-banner').classList.contains('hidden')"
+        ), "banner should remain hidden across reload-within-session"
+
+    def test_folder_push_banner_cta_navigates_to_settings(
+        self, folder_page, base_url_fixture
+    ):
+        """Clicking 'Set up data folder' navigates to #/settings and the
+        Data folder section becomes visible (the user lands on the
+        actionable surface).
+        """
+        folder_page.wait_for_function(
+            "() => { var el = document.getElementById('folder-push-banner');"
+            "        return el && !el.classList.contains('hidden'); }",
+            timeout=10000,
+        )
+        folder_page.locator("#folder-push-cta").click()
+        # Hash navigation happens synchronously; verify we landed in
+        # Settings + the Data folder section is now visible.
+        folder_page.wait_for_function(
+            "() => window.location.hash === '#/settings'", timeout=5000
+        )
+        expect(folder_page.locator("#settings-folder-section")).to_be_visible(timeout=5000)
+        expect(folder_page.locator("#settings-folder-choose")).to_be_visible()
+
     def test_opfs_only_mode_keeps_backups_in_opfs(
         self, folder_page, base_url_fixture
     ):


### PR DESCRIPTION
## Summary

Third Phase 2 follow-up PR. Adds a top-of-page banner that proactively pushes capable-browser OPFS-only users to set up a data folder — closing the loop on "rip the band-aid off" so users don't silently stay on the OPFS fallback. The Phase 2 worker code has been ready since #190 + #191; this PR makes the upgrade discoverable from the main app surface, not buried in Settings.

Also updates `docs/users_manual.md` to reflect the post-pivot reality: folder is recommended, automatic per-mutation saves are live, OPFS-only is the fallback.

## What the user sees

**Capable browsers (Chromium desktop) without a folder picked**: a yellow banner at the top of every screen on every load that says:

> **Save your fellows data to disk.** Your groups and notes are only in browser storage right now. Pick a folder for durable storage. **[Set up data folder]** **[Not now]**

Clicking **Set up data folder** navigates to Settings → Data folder and focuses the Choose button. Clicking **Not now** sets a `sessionStorage` flag — banner stays hidden for the rest of the browser session (including page reloads), reappears on next browser session.

**Once a folder is picked**: banner hides immediately (the Settings page's `renderState` cascade re-evaluates `refreshFolderPushBanner`). Never appears again as long as the folder handle stays valid.

**Incapable browsers (Safari / Firefox / iOS / Android)**: banner doesn't appear. Today's OPFS-only flow is unchanged — they keep the existing Settings → Data folder *"this browser doesn't support saving to a folder"* badge.

## What ships

**UI (`app/static/index.html` + `styles.css`)**

- New `<div id="folder-push-banner">` at top of body, above the existing `sw-update-banner`. Yellow/warning palette to distinguish from the blue "new version available" banner.
- CSS matches the established banner layout pattern (flex / padding / border-radius / `.hidden` semantics).

**JS (`app/static/app.js`)**

- `refreshFolderPushBanner()` — reads `FOLDER_CONTROLLER.getState()` and toggles visibility based on: `showDirectoryPicker` available, worker provider ready, no folder picked, no `sessionStorage` dismissal flag.
- CTA / Dismiss button handlers (navigate to Settings + scroll-into-view, or set session flag).
- Initial 1.5s `setTimeout` for first evaluation (gives the worker time to load `folderRecord` from IDB before checking state).
- Re-evaluation cascades from the Settings page's `renderState(state)` — so picking a folder via Settings hides the banner instantly.

**Tests (`tests/e2e/test_user_folder_storage.py`, +97 lines)**

Three new test cases:
- `test_folder_push_banner_appears_until_folder_picked` — banner visible on first load; picking a folder hides it immediately.
- `test_folder_push_banner_dismiss_persists_within_session` — Not now hides; reload-within-session keeps it hidden (`sessionStorage` survives reload).
- `test_folder_push_banner_cta_navigates_to_settings` — CTA click lands on `#/settings` with Data folder section visible.

```
======================= 13 passed in 16.91s =======================
```

(10 prior + 3 new banner tests.)

**Docs (`docs/users_manual.md`)**

The "Where your data is stored" section rewritten:
- Drop the apologetic "two equal options" framing for "folder is recommended; browser-only is fallback."
- Document the banner as the discovery surface.
- Drop the obsolete *"Phase 1 is manual save; automatic background sync ships in Phase 2"* line — automatic per-mutation saves landed in #190.
- Reframe "Save now" as a manual retry, not the primary save mechanism.
- Document that backup files land in the same `Fellows/` subfolder automatically (visible in Finder).

## What does NOT ship in this PR

Phase 2 is functionally complete with this PR. Next up:

- **Revise `plans/easy_mcp_install.md`** to anchor on the folder path (now that `<parent>/Fellows/relationships.db` is the stable canonical path for folder-mode users). Will simplify the MCP install plan's § 5 (data handoff) substantially.
- **Resume MCP install PR sequence** from plan § 12: prod-routes → PWA Settings UI for MCP setup → walkthrough rewrite → E2E.

## Test plan

- [x] `pytest tests/e2e/test_user_folder_storage.py -v` — 13/13 pass locally.
- [ ] Pull, run e2e, confirm 13/13 on your machine.
- [ ] Manual: open the app in a fresh Chrome profile (or after Clear Site Data). Banner should appear within ~2s of load. Click **Set up data folder**, walk through the picker, verify banner disappears once Saved. Open the app in a new tab — banner should NOT re-appear (folder handle persisted in IDB).
- [ ] Manual: open the app, click **Not now**. Reload. Banner stays hidden. Close the tab + reopen — banner re-appears (sessionStorage cleared on session close).
- [ ] Manual on Safari (incapable browser): no banner appears at all. Settings → Data folder section shows *"this browser doesn't support saving to a folder"* — unchanged.
- [ ] Skim the users-manual diff to confirm the new copy reads cleanly.

## Next PR

Revise `plans/easy_mcp_install.md` to anchor MCP install on the now-stable folder path. Small planning PR; then the implementation PRs from § 12 resume (`feat/mcpb-prod-routes`, `feat/mcpb-settings-ui`, etc.).

🤖 Generated with [Claude Code](https://claude.com/claude-code)