### PR TITLE
feat(folder-storage): UI clarifications — path, reload-label, hide redundant download

### DIFF
--- a/app/static/app.js
+++ b/app/static/app.js
@@ -8315,10 +8315,16 @@
           '<span class="settings-folder-badge-dot"></span>' +
           '<span class="settings-folder-badge-text">Checking…</span>' +
         '</div>' +
+        '<p id="settings-folder-path" class="settings-hint settings-folder-path" hidden>' +
+          'File: <code id="settings-folder-path-value"></code> ' +
+          '<span class="settings-folder-path-note">(your browser doesn\'t expose absolute system paths — find this in Finder / Explorer to see the full path)</span>' +
+        '</p>' +
         '<div id="settings-folder-actions" class="settings-folder-actions">' +
           '<button type="button" id="settings-folder-choose" class="settings-download" hidden>Choose data folder…</button>' +
-          '<button type="button" id="settings-folder-save-now" class="settings-download" hidden>Save now</button>' +
-          '<button type="button" id="settings-folder-refresh" class="settings-download" hidden>Refresh from folder</button>' +
+          '<button type="button" id="settings-folder-save-now" class="settings-download" hidden ' +
+            'title="Manually re-save your current data to the folder. Auto-save runs after every change; this is a retry button for when auto-save fails.">Save now</button>' +
+          '<button type="button" id="settings-folder-refresh" class="settings-download" hidden ' +
+            'title="Replace your current working data with whatever is in the folder right now. Useful if you edited the file in another browser, or your cloud-sync service pulled in a new version. Your current data is captured as an auto-backup first, so this is undoable.">Reload from folder</button>' +
           '<button type="button" id="settings-folder-reconnect" class="settings-download" hidden>Reconnect folder…</button>' +
           '<button type="button" id="settings-folder-disconnect" class="settings-download settings-folder-disconnect" hidden>Disconnect folder</button>' +
         '</div>' +
@@ -8825,6 +8831,19 @@
         detailEl2.textContent = 'Last error: ' + state.lastError.reason;
         detailEl2.hidden = false;
       }
+      // Path detail line — show the parent/Fellows/relationships.db
+      // relative path so forgetful users have a reminder of where their
+      // file lives. The File System Access API does NOT expose absolute
+      // system paths (security by design), so we show the best we can
+      // and direct the user to Finder for the full path.
+      var pathLineEl = document.getElementById('settings-folder-path');
+      var pathValueEl = document.getElementById('settings-folder-path-value');
+      var showPath = state.hasHandle && state.parentName && state.subfolderName;
+      if (pathLineEl) pathLineEl.hidden = !showPath;
+      if (pathValueEl && showPath) {
+        pathValueEl.textContent =
+          state.parentName + ' / ' + state.subfolderName + ' / relationships.db';
+      }
       // Wire which buttons are visible to the badge state.
       var supported = !!state.supported && (state.workerAvailable !== false);
       function showBtn(btn, on) { if (btn) btn.hidden = !on; }
@@ -8833,6 +8852,18 @@
       showBtn(btnRefresh,    supported && b === 'saved');
       showBtn(btnReconnect,  supported && b === 'inaccessible');
       showBtn(btnDisconnect, supported && state.hasHandle);
+      // The "Your saved data" / Download my user data section is
+      // redundant when folder mode is actively writing to the user's
+      // disk — they can just grab the file from Finder. Hide it in
+      // that case. Keep it visible for OPFS-only-mode users (their
+      // only path to a backup file) and for degraded folder-mode
+      // sessions where permission has lapsed (the folder file may
+      // be stale; the in-browser data is what they'd want to grab).
+      var exportSectionEl = document.getElementById('settings-export-section');
+      if (exportSectionEl) {
+        var folderActive = b === 'saved' || b === 'pending';
+        exportSectionEl.hidden = folderActive;
+      }
       // Cascade: state change here may also affect whether the top-of-
       // page folder-push banner is visible (e.g., user just picked a
       // folder → badge becomes 'saved' → banner should hide).
@@ -8985,8 +9016,8 @@
     if (btnRefresh) {
       btnRefresh.addEventListener('click', function () {
         var ok = window.confirm(
-          'Replace this browser\'s saved data with whatever\'s in the folder?\n\n' +
-          'Your current data is captured as an auto-backup first, so this is undoable.'
+          'Reload your working data from the folder file?\n\n' +
+          'This replaces what you\'re currently looking at with whatever is in the folder right now — useful if the file was edited elsewhere (another browser, cloud sync, or a manual restore). Your current data is captured as an auto-backup first, so this is undoable.'
         );
         if (!ok) return;
         btnRefresh.disabled = true;

--- a/app/static/styles.css
+++ b/app/static/styles.css
@@ -3321,6 +3321,26 @@ a.group-action-btn--primary {
   margin-top: 0.5rem;
 }
 
+.settings-folder-path {
+  margin: 0.5rem 0 0;
+}
+
+.settings-folder-path code {
+  font-family: ui-monospace, "Cascadia Code", Menlo, Monaco, Consolas, monospace;
+  font-size: 0.85em;
+  background: rgba(0,0,0,0.04);
+  padding: 0.1rem 0.35rem;
+  border-radius: 3px;
+}
+
+.settings-folder-path-note {
+  display: block;
+  margin-top: 0.15rem;
+  font-size: 0.85em;
+  color: var(--muted-soft, #666);
+  font-style: italic;
+}
+
 .settings-folder-detail {
   margin-top: 0.5rem;
   font-style: italic;

--- a/tests/e2e/test_user_folder_storage.py
+++ b/tests/e2e/test_user_folder_storage.py
@@ -615,6 +615,72 @@ class TestPhase2Pivot:
         expect(folder_page.locator("#settings-folder-section")).to_be_visible(timeout=5000)
         expect(folder_page.locator("#settings-folder-choose")).to_be_visible()
 
+    def test_path_detail_line_shows_after_folder_picked(
+        self, folder_page, base_url_fixture
+    ):
+        """After picking a folder, the Settings page surfaces the
+        relative path (parent / Fellows / relationships.db) below the
+        green Saved badge — handy for users who forget where their
+        data lives. File System Access API doesn't expose absolute
+        paths; the in-app text says to look in Finder for the full one.
+        """
+        _open_settings(folder_page, base_url_fixture)
+        # No folder picked yet — path line is hidden.
+        expect(folder_page.locator("#settings-folder-path")).to_be_hidden()
+        folder_page.locator("#settings-folder-choose").click()
+        badge_text = folder_page.locator("#settings-folder-badge .settings-folder-badge-text")
+        expect(badge_text).to_contain_text("Saved to", timeout=10000)
+        # Path line shows the parent / subfolder / filename.
+        path_value = folder_page.locator("#settings-folder-path-value")
+        expect(path_value).to_be_visible(timeout=5000)
+        expect(path_value).to_contain_text("Fellows / relationships.db")
+        # And the muted hint about absolute paths is there.
+        expect(folder_page.locator(".settings-folder-path-note")).to_contain_text(
+            "absolute system paths"
+        )
+
+    def test_reload_from_folder_button_relabeled(
+        self, folder_page, base_url_fixture
+    ):
+        """The previously-named 'Refresh from folder' button is now
+        'Reload from folder' with an explanatory tooltip. The button
+        appears in the saved-state action row after a folder is
+        picked.
+        """
+        _open_settings(folder_page, base_url_fixture)
+        folder_page.locator("#settings-folder-choose").click()
+        badge_text = folder_page.locator("#settings-folder-badge .settings-folder-badge-text")
+        expect(badge_text).to_contain_text("Saved to", timeout=10000)
+        reload_btn = folder_page.locator("#settings-folder-refresh")
+        expect(reload_btn).to_be_visible()
+        expect(reload_btn).to_have_text("Reload from folder")
+        # Tooltip / title should hint at the use case.
+        tooltip = reload_btn.get_attribute("title") or ""
+        assert "another browser" in tooltip or "cloud-sync" in tooltip, (
+            f"Reload button tooltip should explain the use case; got {tooltip!r}"
+        )
+
+    def test_your_saved_data_section_hidden_in_folder_mode(
+        self, folder_page, base_url_fixture
+    ):
+        """The 'Your saved data' (Download my user data) section is
+        redundant in folder mode — the user can grab relationships.db
+        directly from Finder. It hides when folder mode is active +
+        permission granted. It re-shows in OPFS-only / degraded states
+        (those users need the Download button to extract a backup).
+        """
+        _open_settings(folder_page, base_url_fixture)
+        # No folder yet — Your saved data section is visible.
+        expect(folder_page.locator("#settings-export-section")).to_be_visible()
+        # Pick a folder → section should hide.
+        folder_page.locator("#settings-folder-choose").click()
+        badge_text = folder_page.locator("#settings-folder-badge .settings-folder-badge-text")
+        expect(badge_text).to_contain_text("Saved to", timeout=10000)
+        expect(folder_page.locator("#settings-export-section")).to_be_hidden()
+        # Restore-from-backup section stays visible in both modes
+        # (still useful in folder mode for undo from backup ring).
+        expect(folder_page.locator("#settings-restore-section")).to_be_visible()
+
     def test_opfs_only_mode_keeps_backups_in_opfs(
         self, folder_page, base_url_fixture
     ):


### PR DESCRIPTION
## Summary

Three UX improvements from testing the post-#192 Settings page:

1. **File path below the Saved badge** — forgetful users get a visible reminder of `<parentName> / Fellows / relationships.db`.
2. **"Refresh from folder" → "Reload from folder"** — clearer label + explanatory tooltip + better confirm-dialog copy.
3. **Hide "Your saved data" (Download) in active folder mode** — redundant when the user can grab the file from Finder directly. Stays visible in OPFS-only and degraded folder modes.

3 files changed, +121/-4 lines.

## What the user sees

### Before
> [● Saved to fellows data / Fellows · 4 min ago]
> [Save now] [Refresh from folder] [Disconnect folder]
>
> ─── Your saved data ───
> Download a copy of relationships.db…
> [⬇ Download my user data]

### After
> [● Saved to fellows data / Fellows · 4 min ago]
> File: `fellows data / Fellows / relationships.db`
> *(your browser doesn't expose absolute system paths — find this in Finder / Explorer to see the full path)*
>
> [Save now] [Reload from folder] [Disconnect folder]
>   ↑ hover tooltip on Reload from folder: "Replace your current working data with whatever is in the folder right now. Useful if you edited the file in another browser, or your cloud-sync service pulled in a new version. Your current data is captured as an auto-backup first, so this is undoable."

(The "Your saved data" / Download section is gone in folder mode — the data is already a file the user can grab. In OPFS-only mode it's still there.)

## Why no absolute path?

The File System Access API doesn't expose absolute system paths — by design, for security. `FileSystemDirectoryHandle.name` gives only the picked folder's display name (e.g., `"fellows data"`), not the full system path (e.g., `/Users/rich/Documents/fellows data`). We show the best we can and direct users to Finder for the full path. No way around this in the spec.

## Tests

```
tests/e2e/test_user_folder_storage.py::TestPhase2Pivot::test_path_detail_line_shows_after_folder_picked PASSED
tests/e2e/test_user_folder_storage.py::TestPhase2Pivot::test_reload_from_folder_button_relabeled PASSED
tests/e2e/test_user_folder_storage.py::TestPhase2Pivot::test_your_saved_data_section_hidden_in_folder_mode PASSED
========================= 16 passed in 18.49s =========================
```

(13 prior + 3 new clarification tests.)

## Test plan

- [x] `pytest tests/e2e/test_user_folder_storage.py` — 16/16 pass locally.
- [ ] Pull, refresh the app in your folder-mode session, navigate to Settings → Data folder. Verify:
  - The new path line appears under the green badge with the parent / Fellows / relationships.db relative path.
  - Hovering over **Reload from folder** shows the tooltip explaining the use case.
  - Clicking **Reload from folder** shows the reworded confirm dialog.
  - The **Your saved data** section is gone (your data is the folder file).
  - The **Restore from backup** section is still there (still useful for undo).
- [ ] In a fresh tab (no folder picked yet), verify Your saved data IS visible — OPFS-only users still need it.

🤖 Generated with [Claude Code](https://claude.com/claude-code)