### PR TITLE
plan(easy-mcp-install): folder-anchor revision + Chromium-desktop Pareto + cross-browser silo

### DIFF
--- a/docs/ac_decisions_log.md
+++ b/docs/ac_decisions_log.md
@@ -18,6 +18,160 @@ link to the newer entry. Newest first.
 
 ---
 
+## 2026-05-22 — MCP easy install is Chromium-desktop-first; Safari / Firefox get a documented secondary path; cross-browser-on-one-device data silos are accepted, not engineered around
+
+**Why this is worth recording.** A future contributor reading
+`plans/easy_mcp_install.md` and the user-folder-storage code will
+reasonably ask: *"why don't we support easy MCP install for Safari
+users?"* and *"why doesn't installing the PWA in a second browser
+pick up the user's existing data?"* The answer to both is the same
+shape: **browser storage is per-origin per-browser, and only
+Chromium has the `showDirectoryPicker` API that lets a PWA hold
+ongoing read/write access to a folder.** This constraint is
+fundamental to the browser platform, not something our code
+chose. Without this entry, a contributor might either (a) try to
+engineer around it (cross-browser sync, server-side storage,
+periodic-re-export prompts on Safari) — each of which violates a
+different architectural commitment — or (b) silently let the user
+experience drift toward "works in Chrome, mysteriously broken in
+Safari" without documenting why.
+
+**Context.** The MCP install plan
+([`plans/easy_mcp_install.md`](../plans/easy_mcp_install.md))
+needs a stable filesystem path that the `.mcpb`'s `user_config`
+can default to, so the user picks their `relationships.db` once
+and it stays current going forward. The post-Phase-2 design
+anchors this on the user-folder storage feature: the user picks
+a data folder, the PWA writes `<folder>/Fellows/relationships.db`
+on every commit, and the `.mcpb` install dialog file-picker
+points at that stable file.
+
+This works because the PWA can write to a user-picked folder
+continuously via `showDirectoryPicker` + the persistent handle
+stored in IDB. The browsers that ship the API as of 2026:
+Chrome 86+, Edge, Brave, Arc, Opera. The browsers that don't:
+**Safari** (single-file `showOpenFilePicker` / `showSaveFilePicker`
+only, since 15.2 — no directory access), **Firefox** (no File
+System Access API at all), and Safari/Chrome on iOS (mobile
+browsers).
+
+For Safari and Firefox users, the only way to get
+`relationships.db` onto the filesystem is the existing
+*Download my user data* button, which emits a one-shot snapshot
+into `~/Downloads/`. The `.mcpb` install dialog can point at that
+snapshot — but the snapshot goes stale the moment the user makes
+any further mutation in the PWA, and there is no API for the PWA
+to silently re-export.
+
+A separate constraint surfaced during the conversation that
+produced this entry: **browser storage is per-origin per-browser
+on the same device.** A fellow who installs the PWA in Safari,
+uses it for a month, then opens the same URL in Chrome will see a
+fresh empty state — Chrome's OPFS namespace for the origin is
+empty, and the `fellows_authenticated_once` localStorage marker
+is also per-browser. There is no API to detect "this user has
+data for this origin in another browser on this device"; storage
+isolation is the whole point of per-browser sandboxes. Manual
+export-from-Safari + import-into-Chrome via the existing
+*Restore from a file* button is the only migration path.
+
+**Alternatives considered.**
+
+1. **Auto-export on Safari/Firefox.** Some kind of
+   `beforeunload` or periodic export that lands a fresh
+   `relationships.db` in `~/Downloads`. **Rejected**: the
+   File System Access API the PWA would need (`showSaveFilePicker`)
+   requires explicit user-gesture activation for each write. There
+   is no headless "save my data automatically" mechanism for
+   non-OPFS files on Safari/Firefox. Trying to fake it (prompt on
+   every commit) is worse UX than the current stale-after-export
+   reality.
+
+2. **Server-side mirror of relationships.db.** Persist the user's
+   private DB on prod so the MCP can fetch from there. **Rejected**:
+   violates AC-2 *(no SaaS surface — `deploy/server.py` has no
+   per-user RW endpoints)* and the entire never-SaaS stance the app
+   is built on. Worth re-evaluating only if AC-2 itself is
+   revisited.
+
+3. **Cross-browser data sync via shared filesystem location.**
+   Have the PWA write to a known absolute path that any browser
+   could read. **Rejected**: Safari/Firefox have no API to write
+   to a user-chosen path at all (let alone a hardcoded one). Even
+   on Chromium, two browsers picking the same folder produces
+   dueling writes — Web Locks API scope is per-origin-per-browser
+   and can't coordinate cross-browser. Plan already calls this
+   out in § Non-goals.
+
+4. **Document the constraints + recommend Chromium for fellows
+   who want MCP.** **Chosen.** The MCP install walkthrough makes
+   the Chromium requirement explicit. Safari/Firefox users see a
+   documented secondary path (manual re-export). The plan accepts
+   cross-browser data silos as a user-visible reality and
+   provides a "migrate from another browser" affordance in
+   Settings (export-from-A → import-to-B) for users who want to
+   consolidate.
+
+**Decision.**
+
+- **Easy MCP install (set-it-up-once UX)** is supported on
+  Chromium desktop browsers (Chrome / Edge / Brave / Arc) on
+  macOS, Windows, Linux. This is the Pareto slice; the
+  `plans/easy_mcp_install.md` § 2 v1 scope.
+
+- **Safari / Firefox desktop**: documented secondary path. The
+  `.mcpb` install dialog file-picker accepts a one-shot
+  `Download my user data` snapshot; the MCP's view is whatever
+  was exported last. Users who want a live MCP view are
+  recommended to switch to a Chromium browser for the fellows
+  app.
+
+- **Cross-browser-on-one-device data silos**: accepted as a
+  user-visible reality, not engineered around. Documented in the
+  users-manual + addressed via a *"migrate from another
+  browser"* affordance (link to the export/import recipe) in
+  Settings → Restore from backup. No attempt to detect the
+  cross-browser case in the PWA (no API for it).
+
+- **Forward-looking**: when WebKit ships `showDirectoryPicker`
+  (currently "in development" on
+  [webkit.org/status](https://webkit.org/status)), Safari users
+  automatically join the green path with zero code change. Same
+  for Firefox if/when they ship the API. No special migration —
+  they pick a folder and they're in folder mode.
+
+**Consequences.**
+
+- Pro: the MCP install UX is honest, scoped, and shippable. No
+  attempt to hide the constraint behind awkward workarounds that
+  would feel broken in production.
+- Pro: the implementation roadmap stays small. Stage 1 of the
+  MCP install plan (Chromium-desktop only) is the v1 ship; the
+  Safari/Firefox secondary path is documentation + reuse of
+  existing UI, not new code.
+- Pro: free upgrade for Safari/Firefox users when WebKit / Gecko
+  ship the API. Their migration is automatic.
+- Con: the test group includes Safari-primary users who will
+  have a degraded MCP experience until they either switch
+  browsers for the fellows app or wait for WebKit to ship FSA.
+  The honest framing is *"MCP is a Chromium-desktop bonus
+  feature"* — not a universal one — and the install walkthrough
+  has to be upfront about that.
+- Con: users who install the PWA in multiple browsers on the
+  same Mac will discover their data is per-browser. The
+  *"migrate from another browser"* affordance mitigates but
+  doesn't fully resolve the surprise. Some friction is
+  unavoidable here.
+
+**Links.**
+
+- [`plans/easy_mcp_install.md`](../plans/easy_mcp_install.md) — § 2 Pareto slice (Chromium desktop), § 5 folder-anchor handoff, § 5b browser compatibility matrix (where this analysis lives in the plan).
+- [`plans/user_folder_storage.md`](../plans/user_folder_storage.md) — § Browser compatibility matrix + § Non-goals (single-writer assumption).
+- MDN — [`Window.showDirectoryPicker` compatibility](https://developer.mozilla.org/en-US/docs/Web/API/Window/showDirectoryPicker#browser_compatibility).
+- WebKit feature status — [webkit.org/status](https://webkit.org/status) (search "File System Access").
+
+---
+
 ## 2026-05-22 — User-folder storage uses pure-folder semantics for folder-mode users, not a hybrid OPFS+folder mirror
 
 **Why this is worth recording.** The original `plans/user_folder_storage.md` (and the Phase 1 code shipped in #181) was built on a **hybrid** model: OPFS is the working store, the user's folder is a debounced mirror, and the worker synchronizes them after every committed mutation. A future contributor reading that code — particularly the auto-sync timers, the `markRelationshipsDirty` hook the plan was about to add in Phase 2, and the boot-time "read folder into OPFS" path — would reasonably conclude this is the canonical design and continue extending it. **It is not.** Phase 2 was the moment to pivot to pure-folder, because the hybrid's sync complexity buys us nothing at our DB scale and introduces a silent-data-loss failure mode.

--- a/plans/easy_mcp_install.md
+++ b/plans/easy_mcp_install.md
@@ -1,11 +1,22 @@
 # Easy MCP install for non-technical Mac users
 
-> **Status: ACTIVE.** Decisions locked 2026-05-21 after the planning
-> conversation that produced this file and
-> [`docs/ac_decisions_log.md`](../docs/ac_decisions_log.md). This plan
-> supersedes the rough "two-stage installer with scary-warning UX"
-> shape sketched earlier in the conversation; research into MCP
-> packaging standards reframed the problem (see § 3).
+> **Status: ACTIVE.** Decisions locked 2026-05-21; folder-anchor
+> revision 2026-05-22 after user_folder_storage Phase 2 shipped.
+> Architectural commitments in
+> [`docs/ac_decisions_log.md`](../docs/ac_decisions_log.md)
+> (see the 2026-05-22 entries).
+>
+> **What the revision changes**: § 5 was *"PWA exports to Downloads,
+> .mcpb's user_config defaults to ~/Downloads/relationships.db"* —
+> a workaround for Phase-1 OPFS-only storage. Now that the user's
+> data lives at a stable path (`<picked folder>/Fellows/relationships.db`)
+> after Phase 2 shipped (#190–#192), the handoff collapses to *"the
+> .mcpb's user_config file picker points at the user's data folder."*
+> § 2 Pareto slice tightens to **Chromium desktop** (Chrome / Edge /
+> Brave / Arc) — Safari/Firefox don't ship `showDirectoryPicker` and
+> can't host the stable-folder anchor; they're a documented
+> secondary path. New § 5b covers the browser compatibility matrix
+> and the cross-browser-on-one-device data silo.
 
 ## 1. Why
 
@@ -34,18 +45,31 @@ gives them a path to the same flagship demo.
 
 ## 2. Pareto slice (v1 scope)
 
-- **Mac desktop only.** Aligns with where most EHF fellows live and
-  matches the slice Rich called out in planning.
+- **Chromium desktop only** (Chrome, Edge, Brave, Arc, Opera) on
+  macOS / Windows / Linux. The "easy" experience hinges on a stable
+  filesystem path for `relationships.db`, which requires
+  `showDirectoryPicker`. Only Chromium ships it as of 2026. See § 5b
+  for the full browser compatibility matrix.
 - **Claude Desktop only.** No Cursor, Continue.dev, Ollama, or other
   MCP clients in v1.
-- **Single user, single Mac.** No multi-device sync, no shared MCP
-  install across users on one Mac.
+- **Single user, single Mac/PC.** No multi-device sync, no shared
+  MCP install across users on one machine.
 - **Apple Silicon + Intel both** — incidental; the chosen mechanism
   doesn't ship CPU-specific binaries.
 
+**Safari / Firefox desktop users** get a documented *secondary path*
+(see § 5b) — they can install the `.mcpb`s but the MCP's view of
+their private data is whatever they last manually exported. Not a
+"set it up once and forget" experience. Easy MCP for them is gated
+on WebKit / Gecko shipping `showDirectoryPicker`; tracked but not
+something we can engineer around. Architectural rationale in
+[`docs/ac_decisions_log.md` § 2026-05-22 — MCP easy install is Chromium-desktop-first](../docs/ac_decisions_log.md).
+
 Out of scope: rewriting the privacy boundary, supporting users
 without the PWA installed, Apple Developer Program enrollment as a
-prerequisite (see § 3 — `.mcpb` install bypasses Gatekeeper).
+prerequisite (see § 3 — `.mcpb` install bypasses Gatekeeper),
+cross-browser sync of the same user's data on the same device (no
+browser API supports it; see § 5b).
 
 ## 3. Research finding: Anthropic's `.mcpb` (Desktop Extensions)
 
@@ -215,16 +239,16 @@ Stage 1 delivers the non-tech goal. Stage 2 is incremental:
   probably not, because our bundles include a private fellows.db
   snapshot. Distribution from our prod stays the right call.
 
-## 5. The OPFS data-handoff resolution
+## 5. The data-handoff resolution (folder anchor)
 
 The single biggest technical question the plan answers is *"how
-does data in browser-managed OPFS get to a process Claude Desktop
+does the user's private data get to a process Claude Desktop
 spawns?"* — because the current
 `docs/use_with_claude_desktop.md` walkthrough handwaves it (it
 assumes the user has a developer copy of `fellows.db` on disk,
 which no end user does).
 
-**Resolution.**
+**Resolution (post-user_folder_storage-Phase-2).**
 
 - **`fellows.db` is bundled inside `shared-data-ops.mcpb` at build
   time.** It's the public shared snapshot per the Two-DB boundary;
@@ -232,25 +256,130 @@ which no end user does).
   the directory = re-downloading the shared bundle (PWA prompts
   when its existing `/build-meta.json` `fellows_db_sha` check
   detects a new snapshot).
-- **`relationships.db` is exported from OPFS to `~/Downloads/` by
-  the PWA** when the user clicks the Settings button. Re-uses the
-  existing `dataProvider.exportRelationshipsBytes()` plumbing. The
-  `private-data-ops.mcpb`'s `user_config` block defaults
-  `relationships_db_path` to `~/Downloads/relationships.db`; most
-  users hit Enter. Refreshing = clicking the same Settings button
-  again.
-- **No File System Access API** (Safari support is patchy).
-  Standard blob-URL `a.click()` download works in every supported
-  browser.
+- **`relationships.db` lives at `<picked folder>/Fellows/relationships.db`**
+  on the user's filesystem. The PWA writes there atomically on
+  every committed mutation (per user-folder-storage Phase 2, shipped
+  in PR #190). The `private-data-ops.mcpb`'s `user_config` exposes
+  a `relationships_db_path` file-picker; the user navigates to
+  their data folder once during install and points it at
+  `Fellows/relationships.db`. From that moment on, the MCP server
+  reads the same file the PWA writes — always current, no
+  re-export rituals.
+- **The MCP install flow no longer needs to export anything.** The
+  file the MCP picker points at IS the user's data. This collapses
+  the original plan's `dataProvider.exportRelationshipsBytes →
+  blob URL → ~/Downloads → user picks the timestamped file → manual
+  re-export when stale` dance into a single user_config navigation
+  during install.
 
-This is shippable **without** waiting for
-[`user_folder_storage` Phase 2](./user_folder_storage.md) — the
-PWA's OPFS remains the source of truth for `relationships.db`; we
-provide a recurring export-to-Downloads action. When
-`user_folder_storage` Phase 2+ lands and `relationships.db` has a
-real filesystem home, the `.mcpb`'s `user_config` default switches
-from `~/Downloads/relationships.db` to that path. Zero rework on
-the `.mcpb` itself.
+**For Chromium desktop users with a data folder** (the Pareto
+slice in § 2): this is the green path. The PWA prompts via the
+folder-push banner (shipped in PR #192) on first launch; user
+picks a folder; subsequent MCP install points at that stable
+location. The MCP "set it up once and forget" promise holds.
+
+**For Safari / Firefox users**: see § 5b. They get a documented
+secondary path that uses the existing `Download my user data`
+button + a periodic-re-export discipline.
+
+## 5b. Browser compatibility matrix + cross-browser data silos
+
+| Browser (desktop) | `showDirectoryPicker` | Folder-mode in the app | MCP install path | MCP view stays current? |
+|---|---|---|---|---|
+| **Chrome / Edge / Brave / Arc / Opera** | ✓ | ✓ | Set up data folder once → `.mcpb` install file-picker points at `<folder>/Fellows/relationships.db`. | ✓ Every PWA commit auto-writes; MCP reads live state. |
+| **Safari (macOS)** | ✗ | ✗ — OPFS-only | Click *Download my user data* → file lands in `~/Downloads/relationships-<ISO>.db` → `.mcpb` install file-picker points at that file. | ✗ Stale immediately after any further mutation. User must re-export + re-point. |
+| **Firefox (any desktop OS)** | ✗ | ✗ — OPFS-only | Same as Safari. | ✗ Same staleness. |
+| **iOS / Android browsers** | n/a | n/a | Claude Desktop doesn't run on these platforms. | n/a |
+
+### Why Safari and Firefox can't host the easy path
+
+The File System Access API the green path depends on
+(`showDirectoryPicker` plus the persistent IDB-stored handle
+plumbing in `vendor/sqlite-worker.js`'s user-folder-storage
+section) only ships in Chromium-based browsers. Safari has
+shipped the single-file half of the spec
+(`showOpenFilePicker` / `showSaveFilePicker`, Safari 15.2+) but
+**not** the directory half. Firefox has shipped none of it.
+There is no shipped JS API in either browser that gives a PWA
+ongoing read/write access to a user-picked folder. WebKit lists
+the directory API as ["in development"](https://webkit.org/status)
+but with no announced shipping target as of 2026.
+
+The PWA cannot work around this. The only ways to get
+`relationships.db` onto a Safari/Firefox user's filesystem are
+(a) the existing `Download my user data` button — a one-shot
+snapshot to `~/Downloads/` — and (b) the user dragging the file
+out of the auto-backup ring (which only exists in folder mode,
+which Safari/Firefox can't enter — so not actually an option).
+
+For the MCP install, the `.mcpb` install dialog's file-picker
+accepts any filesystem path. Safari/Firefox users CAN point it
+at a downloaded snapshot. The bundle then works against that
+snapshot. The catch: the snapshot is frozen at the moment it was
+downloaded. Any further PWA mutation diverges the snapshot from
+the user's live data. The MCP returns stale results until the
+user manually exports again and re-points the install.
+
+### Cross-browser-on-one-device data silos
+
+A separate, related constraint surfaced during the conversation
+that produced this revision: **browser storage is per-origin
+per-browser on the same device.** A fellow who installs the PWA
+in Safari, uses it for a month, then opens the same URL in
+Chrome will see a fresh-install empty state — Chrome's OPFS
+namespace for `fellows.globaldonut.com` is independent of
+Safari's, and the `fellows_authenticated_once` localStorage
+marker is also per-browser.
+
+There is no JS API to detect "this user has data for this
+origin in another browser on this device." Storage isolation is
+the point of per-browser sandboxes. So the PWA cannot
+automatically notice cross-browser state — and cannot
+automatically migrate it.
+
+What this looks like in practice for a Mac user who installs in
+multiple browsers:
+
+| Install order | What they see |
+|---|---|
+| Safari → Chrome | Chrome appears empty. Safari groups are invisible there. To migrate: Safari → Settings → *Download my user data* → save the file → Chrome → Settings → *Restore from a file* → pick that file. From then on, the two browsers diverge again. |
+| Chrome (with folder mode) → Safari | Safari appears empty. Safari can't read Chrome's folder file (no API). To migrate: same export-from-A → import-into-B recipe. Safari then has a frozen copy of Chrome's state at export time. |
+| Two Chromium browsers (Chrome + Brave) on the same folder | Both browsers' OPFS buffers diverge from the folder file; both write atomically; last-write-wins. **Single-writer assumption per [`plans/user_folder_storage.md` § Non-goals](./user_folder_storage.md). Real data loss possible.** Don't share folders across browsers in one session. |
+| Two Chromium browsers on DIFFERENT folders | Each browser has its own folder + its own data. No conflict, but also no sync. Same export-from-A → import-into-B recipe to consolidate. |
+
+### What we DO (and don't) build to mitigate this
+
+**Build** (Phase 2-follow-up scope — separate small PR after this
+plan revision):
+
+- A *"Migrate from another browser"* affordance in Settings →
+  Restore from backup, linking to a docs recipe (export from
+  source browser, restore in this browser).
+- Updated `docs/users_manual.md` "Where your data is stored"
+  section explicitly warning about per-browser silos +
+  recommending Chromium for fellows who want MCP.
+- The folder-push banner already covers the "you haven't picked
+  a folder yet" case for Chromium users; no change needed there.
+
+**Don't build** (architectural commitment per the AC log entry):
+
+- No auto-detection of cross-browser state (no API).
+- No server-side mirror (violates AC-2).
+- No periodic-re-export-prompt for Safari (worse UX than the
+  current stale-after-export reality).
+- No cross-browser file-sync hack (every approach we sketched
+  produces dueling writes; Web Locks can't coordinate
+  cross-browser).
+
+### Recommended browser for fellows who want MCP
+
+Chrome, Edge, Brave, or Arc on desktop. The install walkthrough
+(written in `docs/use_with_claude_desktop.md`, rewritten in a
+follow-up PR) leads with this recommendation. Fellows on Safari
+who want MCP face a clear choice: switch to a Chromium browser
+for the fellows app (and accept that their data lives in that
+browser's storage going forward), or stay on Safari and accept
+the manual-re-export grind.
 
 ## 6. Dual-codebase governance (Python + Node)
 
@@ -310,6 +439,12 @@ dialogs become a sequence they already understand.
 
 > ### Set up Claude Desktop integration
 >
+> **Before you start:** make sure you've set up a data folder
+> (Settings → Data folder → Choose data folder…) and you're on
+> Chrome, Edge, Brave, or Arc. If you're on Safari or Firefox, the
+> MCP integration works differently — see the *Manual setup* link
+> at the bottom of this dialog.
+>
 > This will install three extensions into Claude Desktop so it can
 > read your fellows data and help you compose group emails. Each
 > extension covers a different boundary; you can install just the
@@ -340,14 +475,15 @@ dialogs become a sequence they already understand.
 > with; they don't have wider access than you grant them. Click
 > **Install** to proceed.
 >
-> **What happens next:** four files will download to your
-> Downloads folder (your saved groups + three installer files).
-> Claude Desktop will pop up an Install dialog for each installer
-> in turn — approve the ones you want, skip the ones you don't.
-> When all three install dialogs are done, quit Claude Desktop
-> (⌘Q) and reopen it.
+> **What happens next:** three `.mcpb` installer files will download.
+> Claude Desktop will pop up an Install dialog for each in turn —
+> approve the ones you want, skip the ones you don't. For the
+> **Your saved groups** extension, the install dialog will ask you
+> to pick a file: navigate to your data folder → **Fellows** →
+> **relationships.db**. When all three install dialogs are done,
+> quit Claude Desktop (⌘Q) and reopen it.
 >
-> [Continue] [Cancel]
+> [Continue] [Cancel] [Manual setup (Safari / Firefox)]
 
 This dialog is the AC-MCP-A informed-consent moment translated
 into plain language. It's also where we honestly disclose that the
@@ -368,7 +504,7 @@ screenshot once the Settings UI is in implementation.
 
 | Plan | Interaction |
 |---|---|
-| [`user_folder_storage.md`](./user_folder_storage.md) | Independent. When Phase 2+ moves `relationships.db` to a user-chosen folder, the `private-data-ops.mcpb`'s `user_config` default changes; no other code change. `.mcpb` can ship before, during, or after. |
+| [`user_folder_storage.md`](./user_folder_storage.md) | **Load-bearing prerequisite** (post-2026-05-22 revision). Phase 2 shipped (#190 per-commit folder writes, #191 backup ring move, #192 settings UI push). The MCP install plan now anchors `relationships.db` discoverability on the user's data folder — see § 5 and § 5b. For Chromium-desktop users the `.mcpb` install file-picker just navigates to `<folder>/Fellows/relationships.db`; for Safari/Firefox users (no folder mode available) the secondary path uses the existing *Download my user data* button. |
 | [`opt_in_directory_data_updates.md`](./opt_in_directory_data_updates.md) | Tight coupling on the refresh signal. When the PWA detects a new `fellows.db` on the server, the Settings-page integration row mirrors the *"Directory Data update available"* affordance, with a button that re-downloads only `shared-data-ops.mcpb` (which carries the new snapshot). Both flows read `/build-meta.json`'s `fellows_db_sha`. |
 | [`local_first_worker_architecture.md`](./local_first_worker_architecture.md) | Already-shipped Phase 1 cutover means `exportRelationshipsBytes` lives in the worker, not the page. Stage 1 reuses the existing worker RPC — no new surface required. |
 | [`multi_tab_ownership_takeover.md`](./multi_tab_ownership_takeover.md) | Independent. `.mcpb` servers run as Claude Desktop subprocesses, fully outside the browser-tab worker-ownership model. |
@@ -438,6 +574,7 @@ Captured in the architectural decisions log:
 
 - [2026-05-21 — MCP servers ship as three separate `.mcpb` files,
   not one consolidated bundle](../docs/ac_decisions_log.md#2026-05-21--mcp-servers-ship-as-three-separate-mcpb-files-not-one-consolidated-bundle)
+- [2026-05-22 — MCP easy install is Chromium-desktop-first; Safari / Firefox get a documented secondary path; cross-browser-on-one-device data silos are accepted, not engineered around](../docs/ac_decisions_log.md#2026-05-22--mcp-easy-install-is-chromium-desktop-first-safari--firefox-get-a-documented-secondary-path-cross-browser-on-one-device-data-silos-are-accepted-not-engineered-around)
 
 Decisions internal to this plan (don't rise to architectural-log
 level):
@@ -486,11 +623,26 @@ level):
    `feat/mcpb-prod-routes`. Auth-gated.
 6. **PWA Settings UI + preamble dialog.** Branch
    `feat/mcpb-settings-ui`. Includes the user-facing wiring and the
-   refresh-flow indicators.
+   refresh-flow indicators. Per the 2026-05-22 revision: the
+   preamble checks for a configured data folder + a Chromium
+   browser before offering the easy path; Safari/Firefox users get
+   the secondary-path link instead. The `user_config.relationships_db`
+   default uses the path the PWA knows about (`<folder>/Fellows/relationships.db`)
+   for the Chromium user. Addresses [#186](https://github.com/richbodo/fellows_local_db/issues/186)
+   install-warning preview in the same PR.
 7. **`docs/use_with_claude_desktop.md` rewrite.** Branch
    `docs/mcpb-walkthrough-rewrite`. Replaces the current
-   Terminal-heavy walkthrough with the three-click flow.
-8. **E2E test.** Branch `test/e2e-mcpb-setup`. Final gate.
+   Terminal-heavy walkthrough with the three-click flow. Per the
+   2026-05-22 revision: leads with the Chromium-only recommendation,
+   documents the Safari/Firefox secondary path with re-export
+   discipline, references the *"migrate from another browser"*
+   recipe.
+8. **"Migrate from another browser" affordance** (small, separable).
+   Branch `feat/migrate-from-another-browser`. Adds the inline link
+   in Settings → Restore from backup pointing to the
+   `docs/users_manual.md` recipe. No detection logic — just
+   discoverability for users who installed in multiple browsers.
+9. **E2E test.** Branch `test/e2e-mcpb-setup`. Final gate.
 
 Each PR is independently reviewable + revertable. The parity test
 grows incrementally across PRs 2-4.
@@ -507,6 +659,10 @@ beyond this file.
 - **[#186](https://github.com/richbodo/fellows_local_db/issues/186) — install-warning disclosure UX.** Claude Desktop shows a red *"access to everything / not Anthropic-verified"* banner during `.mcpb` install. Apple Developer ID code signing does not address it (different trust layer). The realistic resolution is the PWA preamble previewing the warning so users aren't surprised; copy lives in § 7 above. Address in the `feat/mcpb-settings-ui` and `docs/mcpb-walkthrough-rewrite` PRs.
 
 - ✅ **Parity test exercises the staged bundle layout.** Resolved in the private-data-ops PR. `tests/test_mcpb_parity.py` now includes `test_staged_shared_bundle_default_resolution` and `test_staged_private_bundle_default_resolution` which spawn `mcpb/node/.staging/<name>/server/index.js` with no env-var overrides and assert default path resolution Just Works. Both bugs from #187 would have been caught here.
+
+- **"Migrate from another browser" affordance.** Browser storage is per-origin-per-browser; a user who installs the PWA in Safari then opens it in Chrome sees an empty state. § 5b documents the workaround (export-from-source-browser → import-into-this-browser via existing Settings → Restore from a file). The affordance: a small inline link in Settings → Restore from backup labeled *"Migrating from another browser? See the recipe"* that points at the docs section. No detection (no API for it), just discoverability. Address as a small standalone PR before the MCP install walkthrough rewrite.
+
+- **`docs/use_with_claude_desktop.md` rewrite** — the existing 6-step Terminal walkthrough becomes a 3-step click-button-and-open-files flow. Must reflect the Chromium-only easy path + the Safari/Firefox secondary path explicitly. Tracked as PR step 7 in § 12 above.
 
 (More items will land here as they emerge.)
 

--- a/plans/easy_mcp_install.md
+++ b/plans/easy_mcp_install.md
@@ -347,6 +347,38 @@ multiple browsers:
 | Two Chromium browsers (Chrome + Brave) on the same folder | Both browsers' OPFS buffers diverge from the folder file; both write atomically; last-write-wins. **Single-writer assumption per [`plans/user_folder_storage.md` § Non-goals](./user_folder_storage.md). Real data loss possible.** Don't share folders across browsers in one session. |
 | Two Chromium browsers on DIFFERENT folders | Each browser has its own folder + its own data. No conflict, but also no sync. Same export-from-A → import-into-B recipe to consolidate. |
 
+### macOS Spotlight: multiple installs = multiple identical entries
+
+A related practical wrinkle for the Mac users in the test group: each
+browser's PWA install creates a separate `.app` bundle on disk, and
+Spotlight indexes them all under the same display name (`EHF Fellows
+Directory`) with the same manifest icon. The user can't visually tell
+them apart.
+
+| Browser | `.app` location on macOS |
+|---|---|
+| Safari (macOS 14+, *File → Add to Dock*) | `~/Applications/EHF Fellows Directory.app` |
+| Chrome (*Install app…*) | `~/Applications/Chrome Apps/EHF Fellows Directory.app` |
+| Edge (Chromium) | `~/Applications/Edge Apps/EHF Fellows Directory.app` |
+| Brave | `~/Applications/Brave Apps/EHF Fellows Directory.app` |
+| Arc | varies (often inside Arc's library folder under *Save as App*) |
+| Firefox | **no `.app` created** — Firefox dropped PWA install on desktop in 2021 ([bug 1748503](https://bugzilla.mozilla.org/show_bug.cgi?id=1748503)). Just a bookmark/tab. |
+
+A fellow who installs in Safari + Chrome sees **two identical
+results** in Spotlight when they search "EHF" or "Fellows
+Directory." Spotlight ranks by MRU + alphabetical fallback; new
+users often click the wrong one on first try and see an empty
+state — which they then mistake for data loss.
+
+**We can't distinguish the bundles per browser** — `manifest.webmanifest`
+is one URL the server serves; the bundle name is baked in at
+install time from `name` in that manifest; there's no API to
+differentiate per-browser at manifest-fetch time without breaking
+caching. The user-facing mitigation is the same as the cross-
+browser silo mitigation: document it + recommend one browser.
+Power users can right-click → Rename the bundle in Finder for
+clarity.
+
 ### What we DO (and don't) build to mitigate this
 
 **Build** (Phase 2-follow-up scope — separate small PR after this


### PR DESCRIPTION
## Summary

Substantial revision of `plans/easy_mcp_install.md` triggered by your post-#192 testing + the multi-browser question. Pure planning artifact (no code changes). Two related architectural decisions baked in, both recorded in `docs/ac_decisions_log.md`:

1. **Easy MCP install is Chromium-desktop-first.** Chrome / Edge / Brave / Arc / Opera on macOS, Windows, Linux. Safari and Firefox get a documented secondary path — they can install the `.mcpb`s but their data view is whatever they last manually exported. Forward-looking: Safari/Firefox automatically join the green path when WebKit / Gecko ship `showDirectoryPicker`. No code change needed for that future.

2. **Cross-browser-on-one-device data silos are accepted, not engineered around.** Browser storage is per-origin per-browser. A fellow who installs in Safari then opens the URL in Chrome will see an empty Chrome — and there's no JS API to detect "this user has data in another browser on this device." The only migration path is manual export-from-A → import-into-B via the existing *Restore from a file* button. Mitigation is a small in-app affordance pointing at a docs recipe + users-manual updates — not detection, not sync.

## Why this revision now

- **user_folder_storage Phase 2 has shipped** (#190 per-commit folder writes, #191 backup ring move, #192 settings UI push + UI clarifications). The previous § 5 of the MCP plan was a workaround for Phase-1-OPFS-only storage: PWA exports to `~/Downloads`, `.mcpb` defaults to that path, user re-clicks Settings to refresh. That's all obsolete now — the user's data lives at a stable filesystem path (`<picked folder>/Fellows/relationships.db`), continuously updated. The `.mcpb` install dialog can just file-pick that file once.

- **You asked the cross-browser question** in PR-conversation: what happens if a user installs the PWA in Safari then Chrome then Firefox? I owe you (and any future contributor) a clear answer in the plan. § 5b now spells it out.

## Key plan changes

### § 2 Pareto slice — Chromium desktop only
Tightened from "Mac desktop only" to explicit Chromium browsers. Safari/Firefox are documented as secondary path (with the staleness caveat). Cross-browser sync explicitly out of scope.

### § 5 Data-handoff resolution (folder anchor)
The old "export-to-Downloads dance" replaced with the post-Phase-2 reality:
- `fellows.db` bundled inside `shared-data-ops.mcpb` (unchanged).
- `relationships.db` is the file at `<folder>/Fellows/relationships.db` that the Phase-2 worker writes on every commit. The `.mcpb` install dialog navigates there once and stays current.
- Three paragraphs instead of the previous workaround.

### § 5b Browser compatibility matrix + cross-browser silos (new)
Two tables:
- Per-browser matrix: which support easy MCP install, which need secondary path, "MCP view stays current?" column.
- Multi-browser-on-one-Mac scenarios: what users see for each install combination (Safari→Chrome, Chrome→Safari, two Chromium on same folder, two Chromium on different folders).
- Explicit "What we DO build" / "Don't build" lists with rationale for each.
- Recommendation: Chromium for fellows who want MCP.

### § 7 Preamble copy
Updated to reflect folder-anchor flow. New "Before you start" note about data folder + Chromium requirement. New "Manual setup (Safari/Firefox)" affordance link in the dialog.

### § 8 Interactions
`user_folder_storage.md` upgraded from "Independent / when Phase 2 lands" to **"Load-bearing prerequisite (post-2026-05-22)."** Phase 2 has shipped.

### § 12 PR sequence
Step 6 (Settings UI) acknowledges Chromium gating + Safari secondary-path link. Step 7 (docs rewrite) acknowledges new browser-recommendation framing. New step 8 (migrate-from-another-browser affordance). E2E moved to step 9.

### § 13 Polish checklist
Adds the migration-from-another-browser affordance as a tracked item + users-manual update.

## AC log entry

New dated entry in `docs/ac_decisions_log.md`:
**2026-05-22 — MCP easy install is Chromium-desktop-first; Safari / Firefox get a documented secondary path; cross-browser-on-one-device data silos are accepted, not engineered around.**

Format mirrors the existing entries: *why this is worth recording / context / alternatives considered (4 of them, each rejected with reasoning) / decision / consequences (pros + cons) / links.* The "alternatives considered" section explicitly addresses the engineering instincts that would otherwise be tempted to re-litigate this:
- auto-export on Safari (rejected: no headless write API)
- server-side mirror (rejected: violates AC-2)
- cross-browser sync via shared filesystem (rejected: dueling writes, Web Locks can't coordinate cross-browser)
- document + recommend Chromium (chosen)

## Test plan

- [ ] Read § 5b end-to-end and confirm the cross-browser-on-one-Mac scenarios match your mental model (this is the most user-visible part of the revision).
- [ ] Confirm the new § 13 items (migrate-from-another-browser affordance, users-manual update) are correctly scoped as small follow-up PRs.
- [ ] Confirm the AC log entry covers enough alternative-options ground to discourage future re-litigation.
- [ ] Spot-check § 12 PR sequence step numbering — Steps 5 (prod-routes), 6 (Settings UI), 7 (docs rewrite), 8 (migrate affordance), 9 (E2E) — and confirm the dependency ordering is right.

## After this merges

Implementation work resumes from § 12 step 5: **`feat/mcpb-prod-routes`** — adds the `GET /mcpb/<name>.mcpb` routes to `deploy/server.py`, auth-gated like `/fellows.db`. Small focused PR. Then step 6 (Settings UI), then the docs rewrite + migrate affordance + E2E.

🤖 Generated with [Claude Code](https://claude.com/claude-code)