### PR TITLE
feat(install-identity): auto-generated codename + users-manual debugging

### DIFF
--- a/app/static/app.js
+++ b/app/static/app.js
@@ -302,6 +302,108 @@
     try { return localStorage.getItem(AUTH_ONCE_KEY) === '1'; } catch (e) { return false; }
   }
 
+  // Install identity — per-browser-storage codename + browser/OS metadata.
+  // Generated once on first launch, persisted in localStorage. Survives
+  // Clear App Cache; reset by Reset Everything (intentional — a fresh
+  // reset deserves a fresh identity). Surfaces in document.title, the
+  // About page, and bug-report diagnostics so users with multiple installs
+  // (different browsers on the same Mac, multiple Chrome profiles, etc.)
+  // can identify which install they're in. Rationale in docs/never-saas.md
+  // § Stretched fit; user-facing explanation in
+  // docs/users_manual.md § Install name / Multiple installs on the same
+  // device.
+  var INSTALL_IDENTITY_KEY = 'fellows_install_identity';
+  var CODENAME_WORDS = [
+    'giraffe', 'gorilla', 'mouse', 'panda', 'otter', 'koala', 'badger',
+    'beaver', 'raccoon', 'squirrel', 'hamster', 'rabbit', 'fox', 'wolf',
+    'bear', 'deer', 'moose', 'elk', 'bison', 'zebra', 'hippo', 'rhino',
+    'elephant', 'camel', 'llama', 'alpaca', 'sloth', 'lemur', 'monkey',
+    'baboon', 'gibbon', 'chimp', 'lynx', 'bobcat', 'puma', 'jaguar',
+    'leopard', 'cheetah', 'lion', 'tiger', 'ocelot', 'mongoose', 'meerkat',
+    'hedgehog', 'porcupine', 'armadillo', 'anteater', 'capybara',
+    'marmot', 'wombat', 'possum', 'platypus', 'kangaroo', 'wallaby',
+    'dingo', 'hyena', 'jackal', 'coyote', 'falcon', 'hawk', 'eagle',
+    'owl', 'raven', 'sparrow', 'robin', 'finch', 'heron', 'crane',
+    'pelican', 'flamingo', 'ostrich', 'penguin', 'puffin', 'parrot',
+    'toucan', 'magpie', 'dolphin', 'whale', 'narwhal', 'walrus', 'seal',
+    'manatee', 'octopus', 'turtle', 'tortoise', 'gecko', 'iguana',
+    'chameleon', 'frog', 'salamander'
+  ];
+  var INSTALL_IDENTITY_CACHE = null;
+
+  function detectBrowserBestEffort() {
+    var ua = (navigator && navigator.userAgent) || '';
+    if (/Edg\//.test(ua)) return 'Edge';
+    if (/Firefox\//.test(ua)) return 'Firefox';
+    if (/OPR\//.test(ua) || /Opera\//.test(ua)) return 'Opera';
+    // Chrome match also covers Brave / Arc / other Chromium derivatives;
+    // they all advertise "Chrome/..." in UA. The users-manual explains
+    // the detection is best-effort and may collapse derivatives under
+    // "Chrome".
+    if (/Chrome\//.test(ua)) return 'Chrome';
+    if (/Safari\//.test(ua) && /Version\//.test(ua)) return 'Safari';
+    return 'Unknown';
+  }
+
+  function detectOSBestEffort() {
+    var ua = (navigator && navigator.userAgent) || '';
+    if (/Android/.test(ua)) return 'Android';
+    if (/iPhone|iPad|iPod/.test(ua)) return 'iOS';
+    if (/Macintosh|Mac OS X/.test(ua)) return 'macOS';
+    if (/Windows/.test(ua)) return 'Windows';
+    if (/Linux/.test(ua)) return 'Linux';
+    return 'Unknown';
+  }
+
+  function generateCodename() {
+    var n = CODENAME_WORDS.length;
+    function pick() {
+      return CODENAME_WORDS[Math.floor(Math.random() * n)];
+    }
+    // Three words picked independently. Repeat-allowed: the pool is
+    // large enough that per-user collisions across a handful of
+    // installs are vanishingly rare, and distinct-by-index would feel
+    // hand-curated rather than auto-generated.
+    return pick() + '-' + pick() + '-' + pick();
+  }
+
+  function getOrCreateInstallIdentity() {
+    if (INSTALL_IDENTITY_CACHE) return INSTALL_IDENTITY_CACHE;
+    try {
+      var raw = localStorage.getItem(INSTALL_IDENTITY_KEY);
+      if (raw) {
+        var parsed = JSON.parse(raw);
+        if (parsed && typeof parsed.codename === 'string' && parsed.codename) {
+          INSTALL_IDENTITY_CACHE = parsed;
+          return parsed;
+        }
+      }
+    } catch (e) {}
+    var identity = {
+      codename: generateCodename(),
+      browser: detectBrowserBestEffort(),
+      os: detectOSBestEffort(),
+      installedAt: new Date().toISOString()
+    };
+    try {
+      localStorage.setItem(INSTALL_IDENTITY_KEY, JSON.stringify(identity));
+    } catch (e) {}
+    INSTALL_IDENTITY_CACHE = identity;
+    return identity;
+  }
+
+  function initInstallIdentityTitle() {
+    try {
+      var identity = getOrCreateInstallIdentity();
+      // Append the codename to the existing window/tab title so it's
+      // visible in OS window chrome, browser tab strips, command-tab
+      // labels, and macOS Mission Control. Sticky enough that users
+      // notice it without needing to navigate anywhere.
+      document.title = (document.title || 'EHF Fellows Directory') +
+        ' · ' + identity.codename;
+    } catch (e) {}
+  }
+
   function initBuildBadge() {
     var clientEl = document.getElementById('build-badge-client');
     if (clientEl) clientEl.textContent = 'app: ' + FELLOWS_UI_DIAG;
@@ -348,6 +450,7 @@
   }
 
   initBuildBadge();
+  initInstallIdentityTitle();
   // Install early so the ring buffer captures errors thrown during the rest
   // of the IIFE setup. Function declaration is hoisted; definition lives
   // further down with the rest of the bug-report module.
@@ -2266,6 +2369,20 @@
     lines.push('=== Fellows client diagnostics (UI mark: ' + FELLOWS_UI_DIAG + ') ===');
     lines.push('time (ISO): ' + new Date().toISOString());
     lines.push('href: ' + String(location.href));
+    // Per-install identity — auto-generated codename + best-effort
+    // browser/OS detection + first-launch timestamp. Lets a maintainer
+    // disambiguate which install of the app a bug report came from when
+    // a user has more than one (e.g., Safari + Chrome on the same Mac).
+    try {
+      var diagIdentity = getOrCreateInstallIdentity();
+      lines.push('install codename: ' + diagIdentity.codename);
+      lines.push('install detected browser/OS: ' +
+        (diagIdentity.browser || '?') + ' on ' + (diagIdentity.os || '?'));
+      lines.push('install first launched (ISO): ' +
+        (diagIdentity.installedAt || '(unknown)'));
+    } catch (e) {
+      lines.push('install identity: (unavailable — ' + String(e && e.message) + ')');
+    }
     lines.push(
       'document.cookie length (HttpOnly cookies are NOT visible to JS): ' +
         String((document.cookie || '').length)
@@ -6368,7 +6485,15 @@
     aboutHtml += 'There is no API, login, or web app, so this can only be shared intentionally. ';
     aboutHtml += 'For support, request to join the github repository or just ask on one of the fellows channels.</p>';
     aboutHtml += '<p class="about-support">Having trouble with the app? Contact the EHF Communications Working Group.</p>';
-    aboutHtml += '<p class="about-users-manual"><a href="https://github.com/richbodo/fellows_local_db/blob/main/docs/users_manual.md" target="_blank" rel="noopener">User Guide</a> \u2014 how to install, browse, save groups, export, and manage settings.</p>';
+    aboutHtml += '<p class="about-users-manual"><a href="https://github.com/richbodo/fellows_local_db/blob/main/docs/users_manual.md" target="_blank" rel="noopener">Help from the user manual</a> \u2014 how to install, use the app, fix common issues, and uninstall.</p>';
+    // Install name surfaces the per-install codename so a user with
+    // multiple installs (Safari + Chrome on the same Mac, multiple
+    // Chrome profiles, etc.) can tell instances apart. Intentionally
+    // small + unalarming \u2014 the explanation lives in the users-manual.
+    var aboutIdentity = getOrCreateInstallIdentity();
+    aboutHtml += '<p class="about-install-name">This install: <strong>' +
+      escapeHtml(aboutIdentity.codename) +
+      '</strong> <a href="https://github.com/richbodo/fellows_local_db/blob/main/docs/users_manual.md#install-name" target="_blank" rel="noopener">(What\u2019s this?)</a></p>';
     // Two-row update status block. App and Directory data are
     // independently versioned (build/build_pwa.py emits both `git_sha`
     // and `fellows_db_sha` into /build-meta.json); the user can act on

--- a/app/static/styles.css
+++ b/app/static/styles.css
@@ -1576,6 +1576,21 @@ h1 {
   font-size: 0.95rem;
 }
 
+.about-install-name {
+  margin-top: 0.5rem;
+  font-size: 0.9rem;
+  color: var(--muted, #6b6480);
+}
+
+.about-install-name strong {
+  font-family: ui-monospace, SFMono-Regular, Menlo, Consolas, monospace;
+  color: var(--text, #1a1a2e);
+}
+
+.about-install-name a {
+  font-size: 0.85rem;
+}
+
 .about-update-block {
   margin: 1rem 0 0.75rem;
   padding: 0.75rem 1rem;

--- a/docs/users_manual.md
+++ b/docs/users_manual.md
@@ -103,6 +103,89 @@ directory.
 
 ---
 
+## Multiple installs on the same device
+
+Each browser installs the app as its own copy with its own private
+data. If you install in **Safari**, then later in **Chrome**, your
+Mac has *two* "EHF Fellows Directory" apps — same name, same icon,
+different homes on disk, different data.
+
+This is intentional browser isolation, not a bug: there's no API
+that lets a PWA reach across browser sandboxes. But it can be
+confusing if you weren't expecting it.
+
+### What you'll see
+
+- **Spotlight (`⌘-Space → "EHF"`)** shows two (or more) results,
+  all identical-looking.
+- **Each install has its own data.** Groups, notes, and tags you
+  created in Safari aren't visible to the Chrome copy and vice
+  versa.
+- **The window title** (and the **About** page) shows a unique
+  *install name* per copy — something like `giraffe-gorilla-mouse`.
+  That's the easiest way to tell which one you opened.
+
+### Tell installs apart in Finder
+
+Each browser puts the `.app` bundle in a different folder, so you
+can rename them visibly:
+
+- **Safari** → `~/Applications/EHF Fellows Directory.app`
+- **Chrome / Brave / Edge** → `~/Applications/Chrome Apps/EHF Fellows Directory.app`
+- **Arc** → managed by Arc, accessed through Arc's sidebar
+
+Right-click each bundle in Finder → **Rename** → give them
+distinctive labels like `EHF Fellows — Safari.app` and
+`EHF Fellows — Chrome.app`. The renamed labels surface in Spotlight
+on subsequent searches.
+
+### Consolidate to one install
+
+If you've accumulated copies and want to keep just one:
+
+1. Open each copy in turn. The **About** page shows its install
+   name (and so does the window title).
+2. Identify the copy with the data you want to keep (groups
+   visible, notes intact).
+3. From the copy you're keeping, **Settings → Data folder →
+   Choose data folder…**, and pick a folder under your home
+   directory. This creates a stable file you can later re-attach
+   from any new install. (Folder mode also makes
+   [Use with Claude Desktop](use_with_claude_desktop.md) easier.)
+4. Uninstall the other copies (steps below).
+
+### Uninstall a copy
+
+Each browser uninstalls its own PWA differently. Below is the short
+form; if a step is out of date for your browser version, check the
+browser's official help — that's always the canonical reference:
+
+- **Safari (macOS)** — drag `~/Applications/EHF Fellows Directory.app`
+  to the Trash. →
+  [Apple's Web Apps doc](https://support.apple.com/guide/safari/manage-web-apps-pdsuc1d62cd4/mac)
+- **Chrome** — visit `chrome://apps`, right-click the app, **Remove
+  from Chrome…**. →
+  [Google's PWA management doc](https://support.google.com/chrome/answer/9658361)
+- **Edge** — visit `edge://apps`, click **⋯** on the app,
+  **Uninstall**.
+- **Brave** — same as Chrome but at `brave://apps`.
+- **Arc** — right-click in Arc's sidebar, **Delete**.
+- **Firefox** — no PWA install on desktop; close the tab and remove
+  the bookmark.
+
+**Important:** uninstalling a copy does **not** delete a data folder
+you set up. The folder lives on your disk and stays put. To remove
+the data too, separately drag the `Fellows/` subfolder you picked
+to the Trash. (Auto-backups inside it go with it.)
+
+If you've uninstalled what you thought was the last copy and now
+the app appears to be gone, see *Where the installed app lives*
+above — Spotlight may surface a copy you forgot about, and the
+`https://fellows.globaldonut.com` URL always opens fresh in a
+browser tab.
+
+---
+
 ## Where your data is stored
 
 Your groups, notes, and settings live **on your device only** —
@@ -434,6 +517,39 @@ data?".
 
 ![About page.](images/users_manual/12_about_page.png)
 
+### Install name
+
+Below the support and help links, the About page shows a line like:
+
+> This install: **giraffe-gorilla-mouse**
+
+That's an auto-generated name unique to this copy of the app. It's
+also tacked onto the window title bar, so it's visible without
+opening the About page.
+
+**Why it's there.** If you install the app in more than one browser
+(or more than one browser profile), each install has its own data
+and its own name. The install name is the easiest way to confirm
+which copy you have open when something looks off. See
+[Multiple installs on the same device](#multiple-installs-on-the-same-device)
+above for the rest of the story.
+
+**What changes the name:**
+
+- *Reset Everything* generates a new name (it's a fresh start in
+  every other respect, too).
+- *Clear App Cache* keeps your name.
+- Reloading the page, restarting the browser, app updates — all
+  keep your name.
+- The name doesn't carry over to a different browser or device —
+  each install gets its own.
+
+The name is entirely local. It isn't sent anywhere, doesn't identify
+you, and isn't tied to any account. If you ever
+[file a bug report](#reporting-a-bug), the install name is
+automatically included so the maintainer can join the report to the
+right install.
+
 ---
 
 ## Use with Claude Desktop (optional)
@@ -571,8 +687,9 @@ report if both fail — that's the case where we want to hear about it.
 
 Click **Report a bug** (small button bottom-left on desktop; kebab →
 *Report a bug…* on mobile). The dialog pre-fills your browser, OS,
-build SHA, and the most recent app errors. Add a one-line description
-and submit; it lands in the maintainer's log.
+build SHA, [install name](#install-name), and the most recent app
+errors. Add a one-line description and submit; it lands in the
+maintainer's log.
 
 If you're stuck at the email-gate page (no link arriving, error on
 submit), the gate has its own diagnostics block:

--- a/tests/e2e/test_install_codename.py
+++ b/tests/e2e/test_install_codename.py
@@ -1,0 +1,166 @@
+"""E2E: per-install codename + browser/OS/install-date identity.
+
+The codename is generated on first launch, persisted in localStorage
+under `fellows_install_identity`, and surfaced in `document.title`,
+the About page, and the diagnostics block (and therefore the bug
+report). The goal is to let a user with multiple installs on the
+same device (Safari + Chrome on macOS, multiple Chrome profiles,
+etc.) tell instances apart.
+
+These tests pin the visible contract:
+
+  - First launch persists an identity object with `codename`,
+    `browser`, `os`, `installedAt`.
+  - `document.title` includes ` · <codename>` so window/tab chrome
+    shows it.
+  - About page renders "This install: <codename>" with a
+    "(What's this?)" link to the users-manual section.
+  - About page user-guide link is relabeled "Help from the user
+    manual".
+  - Diagnostics include codename + browser/OS + install timestamp
+    (so the in-app *Report a bug* dialog picks them up).
+  - Reload keeps the same codename — it does not regenerate per
+    session.
+"""
+from __future__ import annotations
+
+import re
+
+from playwright.sync_api import expect
+
+
+CODENAME_PATTERN = re.compile(r"^[a-z]+-[a-z]+-[a-z]+$")
+ISO_PREFIX = re.compile(r"^\d{4}-\d{2}-\d{2}T")
+
+
+def _boot_to_directory(page, base_url: str) -> None:
+    page.goto(base_url + "/", wait_until="domcontentloaded")
+    page.wait_for_function(
+        "() => window.__dataProvider && window.__dataProvider.kind === 'worker'",
+        timeout=15000,
+    )
+
+
+def _read_identity(page) -> dict:
+    return page.evaluate(
+        """
+        () => {
+          const raw = localStorage.getItem('fellows_install_identity');
+          return raw ? JSON.parse(raw) : null;
+        }
+        """
+    )
+
+
+def test_codename_generated_and_persisted_on_first_launch(standalone_page, base_url_fixture):
+    page = standalone_page
+    _boot_to_directory(page, base_url_fixture)
+
+    identity = _read_identity(page)
+    assert identity is not None, "first launch should persist an install identity"
+    assert CODENAME_PATTERN.match(identity["codename"]), (
+        f"codename {identity['codename']!r} should match {CODENAME_PATTERN.pattern}"
+    )
+    # Browser/OS detection is best-effort — accept the values the helper can
+    # produce, including Unknown for headless/exotic UAs.
+    assert identity["browser"] in {
+        "Chrome", "Edge", "Firefox", "Safari", "Opera", "Unknown",
+    }
+    assert identity["os"] in {
+        "macOS", "Windows", "Linux", "Android", "iOS", "Unknown",
+    }
+    assert ISO_PREFIX.match(identity["installedAt"]), (
+        f"installedAt {identity['installedAt']!r} should be an ISO timestamp"
+    )
+
+
+def test_codename_persists_across_reload(standalone_page, base_url_fixture):
+    """Codename lives in localStorage so it survives reload. The reload
+    intentionally does NOT wait for the worker — chromium's OPFS lock
+    handoff between the old worker and the new one is racy enough that
+    we'd flake on the wait. The identity read only needs localStorage,
+    which is available as soon as the new page document loads.
+    """
+    page = standalone_page
+    _boot_to_directory(page, base_url_fixture)
+    first = _read_identity(page)["codename"]
+
+    page.reload(wait_until="domcontentloaded")
+    # Wait for app.js to have set document.title — that's the cheapest
+    # post-load signal that the install-identity init has run.
+    page.wait_for_function(
+        f"() => document.title.indexOf(' · {first}') !== -1",
+        timeout=10000,
+    )
+    second = _read_identity(page)["codename"]
+    assert first == second, "codename must not regenerate on reload"
+
+
+def test_codename_appears_in_document_title(standalone_page, base_url_fixture):
+    page = standalone_page
+    _boot_to_directory(page, base_url_fixture)
+    codename = _read_identity(page)["codename"]
+    title = page.title()
+    assert codename in title, f"title {title!r} should include codename"
+    assert " · " in title, f"title {title!r} should include separator"
+    assert title.startswith("EHF Fellows Directory"), (
+        f"title {title!r} should preserve the base app name"
+    )
+
+
+def test_codename_appears_on_about_page(standalone_page, base_url_fixture):
+    page = standalone_page
+    _boot_to_directory(page, base_url_fixture)
+    codename = _read_identity(page)["codename"]
+
+    page.evaluate("location.hash = '#/about'")
+    page.wait_for_selector(".about-install-name", timeout=10000)
+    install_p = page.locator(".about-install-name")
+    expect(install_p).to_contain_text("This install:")
+    expect(install_p).to_contain_text(codename)
+    # "(What's this?)" links to the users-manual install-name anchor.
+    expect(install_p.locator("a")).to_have_attribute(
+        "href",
+        re.compile(r"users_manual\.md#install-name$"),
+    )
+
+
+def test_about_page_help_link_relabeled(standalone_page, base_url_fixture):
+    page = standalone_page
+    _boot_to_directory(page, base_url_fixture)
+    page.evaluate("location.hash = '#/about'")
+    page.wait_for_selector(".about-users-manual", timeout=10000)
+    link = page.locator(".about-users-manual a")
+    expect(link).to_have_text("Help from the user manual")
+
+
+def test_codename_in_diagnostics_output(standalone_page, base_url_fixture):
+    """Diagnostics output is what `Report a bug` ships — codename should
+    flow in automatically so the maintainer can join the report to a
+    specific install.
+    """
+    page = standalone_page
+    page.goto(base_url_fixture + "/?diag=1", wait_until="domcontentloaded")
+    page.wait_for_function(
+        "() => window.__dataProvider && window.__dataProvider.kind === 'worker'",
+        timeout=15000,
+    )
+
+    text = page.evaluate(
+        """
+        async () => {
+          const deadline = Date.now() + 10000;
+          while (Date.now() < deadline) {
+            const pre = document.getElementById('diag-pre');
+            const t = pre ? (pre.textContent || '') : '';
+            if (t.length > 1000) return t;
+            await new Promise((r) => setTimeout(r, 100));
+          }
+          throw new Error('diag did not populate within 10s');
+        }
+        """
+    )
+    codename = _read_identity(page)["codename"]
+    assert f"install codename: {codename}" in text
+    assert "install detected browser/OS:" in text
+    assert "install first launched (ISO):" in text


### PR DESCRIPTION
## Summary

- Adds a per-install codename (e.g., `giraffe-gorilla-mouse`) generated on first launch, persisted in `localStorage[fellows_install_identity]` along with best-effort browser/OS detection + install timestamp. Surfaces in `document.title`, the About page, and the diagnostics block (so it auto-flows into the in-app `Report a bug` dialog).
- Recasts the About-page link to the users-manual as **Help from the user manual** (was *User Guide*), positioning the users-manual as the user's debugging/help system.
- Users-manual gains a **Multiple installs on the same device** section (Spotlight confusion, Finder-rename trick, per-browser uninstall pointers with canonical links) and an **Install name** subsection under About.
- About-page treatment is intentionally minimal per the agreed UX shape: `This install: giraffe-gorilla-mouse (What's this?)`, with the full reassuring explanation in the users-manual rather than inline.

Folds into the broader work on multi-install UX from the discussion preceding this PR. Companion to #195 (`docs/never-saas`, working-draft definition of the architectural posture) and the still-open #194 (MCP install plan revision anchoring on folder mode + multi-browser silo acceptance).

## Behavioral contract pinned by tests

`tests/e2e/test_install_codename.py` — 6 new cases:

- First launch generates and persists an identity (`codename`, `browser`, `os`, `installedAt`)
- Codename survives page reload (does not regenerate per session)
- `document.title` includes ` · <codename>`
- About page renders `This install: <codename>` with a `(What's this?)` link to the users-manual install-name anchor
- About-page user-guide link is relabeled `Help from the user manual`
- Diagnostics output includes codename + browser/OS + install timestamp (so `Report a bug` picks them up)

All neighboring E2Es (`about_stats`, `diagnostics_panel`, `bug_report`, `user_folder_storage`, `settings`) regress-clean — 38 cases.

## What changes the codename

- *Reset Everything* generates a new one (fresh start posture)
- *Clear App Cache*, browser updates, app updates, page reloads — all keep it
- Different browsers / browser profiles each get their own (by design — different localStorage namespaces)

The codename is entirely local: never sent anywhere, doesn't identify the user, not tied to any account.

## Test plan

- [x] All 6 new E2E cases pass
- [x] 38 neighboring E2Es pass (no regression in About / diag / bug-report / user-folder-storage / settings)
- [ ] Maintainer smoke: open the app, verify codename appears in window title bar, confirm About page renders the line, click `(What's this?)` and confirm the users-manual section renders properly on GitHub
- [ ] Maintainer review: word-list curation — current list is 90 common animal names; flag any combinations that read poorly
- [ ] Maintainer smoke: install in a second browser, verify each install gets a distinct codename (the same `localStorage` key namespace is per-browser, so this should Just Work)

🤖 Generated with [Claude Code](https://claude.com/claude-code)