### PR TITLE
feat(mcpb): Settings UI + walkthrough rewrite + migrate-from-browser hint (steps 6/7/8)

### DIFF
--- a/app/static/app.js
+++ b/app/static/app.js
@@ -404,6 +404,57 @@
     } catch (e) {}
   }
 
+  // MCP bundle setup state. Tracks (a) whether the user has run the
+  // Claude Desktop integration setup at least once so the Settings UI
+  // can flip from "Set up…" to a refresh flow, and (b) the
+  // fellows_db_sha that was current at setup time so we can detect
+  // a server-side directory snapshot change and prompt for a re-install
+  // of just shared_data_ops.mcpb. Plan:
+  // plans/easy_mcp_install.md § 4 + § 8.
+  var MCPB_SETUP_KEY = 'fellows_mcpb_setup';
+  // Three-bundle layout — names match the .mcpb filenames served by
+  // deploy/server.py (Handler.MCPB_NAMES whitelist) and the manifest
+  // filenames in mcpb/node/manifests/. Order is the install order
+  // shown in the preamble UI: directory first (recommended), private
+  // second (per-call consent boundary), comms last (no DB).
+  var MCPB_BUNDLE_NAMES = ['shared_data_ops', 'private_data_ops', 'comms'];
+
+  function getMcpbSetupState() {
+    try {
+      var raw = localStorage.getItem(MCPB_SETUP_KEY);
+      if (!raw) return null;
+      var parsed = JSON.parse(raw);
+      return (parsed && typeof parsed === 'object') ? parsed : null;
+    } catch (e) { return null; }
+  }
+
+  function persistMcpbSetupState(state) {
+    try { localStorage.setItem(MCPB_SETUP_KEY, JSON.stringify(state)); }
+    catch (e) {}
+  }
+
+  function recordMcpbSetup(fellowsDbSha) {
+    var now = new Date().toISOString();
+    var state = getMcpbSetupState() || {};
+    if (!state.setupAt) state.setupAt = now;
+    state.refreshedAt = now;
+    state.fellowsDbSha = fellowsDbSha || null;
+    persistMcpbSetupState(state);
+  }
+
+  function recordMcpbDirectoryRefresh(fellowsDbSha) {
+    var state = getMcpbSetupState();
+    if (!state) {
+      // No setup record — directory refresh-only is meaningless on its
+      // own. Treat as a full setup.
+      recordMcpbSetup(fellowsDbSha);
+      return;
+    }
+    state.fellowsDbSha = fellowsDbSha || null;
+    state.refreshedAt = new Date().toISOString();
+    persistMcpbSetupState(state);
+  }
+
   function initBuildBadge() {
     var clientEl = document.getElementById('build-badge-client');
     if (clientEl) clientEl.textContent = 'app: ' + FELLOWS_UI_DIAG;
@@ -8487,6 +8538,11 @@
           'into the auto-backup rotation before each restore, so the recent-backups ' +
           'list below always lets you undo.' +
         '</p>' +
+        '<p class="settings-hint settings-restore-migrate-hint">' +
+          'Migrating from another browser? ' +
+          '<a href="https://github.com/richbodo/fellows_local_db/blob/main/docs/users_manual.md#migrating-from-another-browser" target="_blank" rel="noopener">See the recipe</a> ' +
+          '(it\'s the same Download / Restore flow on this page, but in a deliberate order).' +
+        '</p>' +
         '<input type="file" id="settings-restore-file" accept=".db,.sqlite,application/octet-stream" hidden />' +
         '<button type="button" id="settings-restore-pick" class="settings-download">' +
           '⬆ Restore from a file…' +
@@ -8498,6 +8554,101 @@
         '</p>' +
         '<ul id="settings-backup-list" class="settings-backup-list" hidden></ul>' +
       '</div>' +
+      '<div class="settings-section" id="settings-mcpb-section">' +
+        '<h3 class="settings-section-title">Claude Desktop integration (beta)</h3>' +
+        '<p class="settings-hint" id="settings-mcpb-intro">' +
+          'Plug the directory into Claude Desktop so you can ask things like ' +
+          '<em>"draft an invite email to my Climate Action group, don\'t send."</em> ' +
+          'Three small extensions, installed in one go. ' +
+          '<a href="https://github.com/richbodo/fellows_local_db/blob/main/docs/use_with_claude_desktop.md" target="_blank" rel="noopener">Walkthrough</a>.' +
+        '</p>' +
+        '<div id="settings-mcpb-update-row" class="settings-mcpb-update-row" hidden>' +
+          '<p class="settings-hint">' +
+            '<strong>Directory data update available.</strong> ' +
+            'A newer snapshot of the public fellows directory is on the server. ' +
+            'Re-install the Fellows directory extension to pick it up.' +
+          '</p>' +
+          '<button type="button" id="settings-mcpb-refresh-directory" class="settings-download">' +
+            '⬇ Re-install Fellows directory' +
+          '</button>' +
+        '</div>' +
+        '<div class="settings-mcpb-actions">' +
+          '<button type="button" id="settings-mcpb-setup" class="settings-download">' +
+            'Set up Claude Desktop integration' +
+          '</button>' +
+        '</div>' +
+        '<p id="settings-mcpb-setup-meta" class="settings-hint settings-mcpb-meta" hidden></p>' +
+        '<span id="settings-mcpb-status" class="settings-status" aria-live="polite"></span>' +
+        '<div id="settings-mcpb-post-install" class="settings-mcpb-post-install" hidden>' +
+          '<h4 class="settings-section-subtitle">After the downloads finish</h4>' +
+          '<ol class="settings-mcpb-next-steps">' +
+            '<li>Open each <code>.mcpb</code> file you just downloaded. Claude Desktop will pop up an Install dialog for each.</li>' +
+            '<li>For <strong>Your saved groups (Private)</strong>, the install dialog will ask you to pick a file: navigate to your data folder → <code>Fellows</code> → <code>relationships.db</code>.</li>' +
+            '<li>Quit Claude Desktop (⌘Q) and reopen it.</li>' +
+            '<li>Try it: ask Claude <em>"how many fellows are in the directory?"</em></li>' +
+          '</ol>' +
+          '<p class="settings-hint">' +
+            'Stuck? See the <a href="https://github.com/richbodo/fellows_local_db/blob/main/docs/use_with_claude_desktop.md" target="_blank" rel="noopener">walkthrough</a>.' +
+          '</p>' +
+        '</div>' +
+      '</div>' +
+      '<dialog id="settings-mcpb-preamble-dialog" class="settings-folder-dialog settings-mcpb-dialog">' +
+        '<form method="dialog">' +
+          '<h4>Set up Claude Desktop integration</h4>' +
+          '<p id="settings-mcpb-preamble-folder-warning" class="settings-mcpb-warning" hidden>' +
+            '<strong>Heads up.</strong> You haven\'t set up a data folder yet. ' +
+            'The integration works best when your fellows data lives at a stable path on your disk, ' +
+            'so the install dialog can find <code>relationships.db</code> reliably. ' +
+            'We recommend setting that up first: <em>Settings → Data folder → Choose data folder…</em> ' +
+            '(takes about ten seconds). ' +
+            'You can also proceed without a folder, but the file picker in Claude Desktop will land in your Downloads, ' +
+            'and you\'ll need to repeat this whole setup every time the file changes.' +
+          '</p>' +
+          '<p id="settings-mcpb-preamble-browser-warning" class="settings-mcpb-warning" hidden>' +
+            '<strong>Your browser:</strong> the easy install works on Chrome, Edge, Brave, and Arc. ' +
+            'Safari and Firefox need a manual setup — see the link at the bottom of this dialog.' +
+          '</p>' +
+          '<p>' +
+            'This will install <strong>three small extensions</strong> into Claude Desktop so it can read your fellows data and help you compose group emails. ' +
+            'Each extension covers a different boundary; you can install just the ones you want.' +
+          '</p>' +
+          '<ol class="settings-mcpb-bundles">' +
+            '<li>' +
+              '<strong>Fellows directory (Shared).</strong> Lets Claude read the public fellows directory: names, bios, contact info, search. ' +
+              '<em>Recommended.</em>' +
+            '</li>' +
+            '<li>' +
+              '<strong>Your saved groups (Private).</strong> Lets Claude read your saved groups, group members, and any notes you\'ve added. ' +
+              'This data is private to you and never leaves your device through the Fellows app — but when Claude reads it, it goes to Claude\'s servers (Anthropic). ' +
+              'If that\'s not OK for you, skip this extension and Claude will only have access to the directory.' +
+            '</li>' +
+            '<li>' +
+              '<strong>Email staging (Communications).</strong> Lets Claude prepare draft emails to your groups and hand them back to you for review. ' +
+              'Claude never sends mail itself — drafts open in your mail app with To, Subject, and Body filled in, and you click Send.' +
+            '</li>' +
+          '</ol>' +
+          '<div class="settings-mcpb-warning settings-mcpb-warning--banner">' +
+            '<strong>One thing to expect during install:</strong> ' +
+            'Claude Desktop will show a red warning banner for each extension saying <em>"Installing will grant this extension access to everything on your computer..."</em> ' +
+            'That warning fires for any extension that isn\'t Anthropic-verified — it\'s not specific to ours and doesn\'t mean anything is wrong. ' +
+            'The extensions only read the fellows data files they were configured with; they don\'t have wider access than you grant them. ' +
+            'Click <strong>Install</strong> to proceed past it.' +
+          '</div>' +
+          '<p>' +
+            '<strong>What happens next:</strong> three <code>.mcpb</code> installer files will download. ' +
+            'Claude Desktop will pop up an Install dialog for each in turn — approve the ones you want, skip the ones you don\'t. ' +
+            'For the <strong>Your saved groups</strong> extension, the install dialog will ask you to pick a file: navigate to your data folder → <strong>Fellows</strong> → <code>relationships.db</code>. ' +
+            'When all three install dialogs are done, quit Claude Desktop (⌘Q) and reopen it.' +
+          '</p>' +
+          '<menu class="settings-folder-dialog-actions">' +
+            '<button type="submit" value="continue" class="settings-folder-dialog-primary" id="settings-mcpb-preamble-continue">Continue — start downloads</button>' +
+            '<button type="submit" value="cancel" class="settings-folder-dialog-cancel">Cancel</button>' +
+          '</menu>' +
+          '<p class="settings-mcpb-manual-link">' +
+            '<a href="https://github.com/richbodo/fellows_local_db/blob/main/docs/use_with_claude_desktop.md" target="_blank" rel="noopener">Manual setup walkthrough (Safari / Firefox / other browsers)</a>' +
+          '</p>' +
+        '</form>' +
+      '</dialog>' +
       '</div>';
     detailEl.innerHTML = html;
     var input = document.getElementById('settings-self-email');
@@ -8875,6 +9026,192 @@
     }
 
     wireFolderSection();
+    wireMcpbSection();
+  }
+
+  // Settings → Claude Desktop integration. Pure glue between the DOM
+  // nodes injected by renderSettingsPage, the MCPB setup state
+  // (localStorage `fellows_mcpb_setup`), and the auth-gated
+  // `/mcpb/<name>.mcpb` routes served by deploy/server.py. Plan:
+  // plans/easy_mcp_install.md § 4 + § 7.
+  function wireMcpbSection() {
+    var sectionEl = document.getElementById('settings-mcpb-section');
+    if (!sectionEl) return;
+    var setupBtn = document.getElementById('settings-mcpb-setup');
+    var statusEl = document.getElementById('settings-mcpb-status');
+    var metaEl = document.getElementById('settings-mcpb-setup-meta');
+    var postInstall = document.getElementById('settings-mcpb-post-install');
+    var updateRow = document.getElementById('settings-mcpb-update-row');
+    var refreshDirBtn = document.getElementById('settings-mcpb-refresh-directory');
+    var dialog = document.getElementById('settings-mcpb-preamble-dialog');
+    var folderWarning = document.getElementById('settings-mcpb-preamble-folder-warning');
+    var browserWarning = document.getElementById('settings-mcpb-preamble-browser-warning');
+    var continueBtn = document.getElementById('settings-mcpb-preamble-continue');
+    if (!setupBtn || !dialog) return;
+
+    function setStatus(text) {
+      if (statusEl) statusEl.textContent = text || '';
+    }
+
+    function browserIsChromium() {
+      // Conservative — only the four browsers we explicitly support on
+      // the easy path. Brave / Arc / other Chromium derivatives advertise
+      // "Chrome/..." in UA so they fall through into this set. Safari /
+      // Firefox are deliberately excluded; they get the manual-setup link
+      // in the preamble dialog and the no-easy-path messaging in the
+      // walkthrough doc. The same caveat that lives in
+      // detectBrowserBestEffort() applies here — UA can be spoofed.
+      var ua = (navigator && navigator.userAgent) || '';
+      if (/Firefox\//.test(ua)) return false;
+      if (/Edg\//.test(ua)) return true;
+      if (/Chrome\//.test(ua)) return true;
+      if (/Safari\//.test(ua) && /Version\//.test(ua)) return false;
+      return false;
+    }
+
+    function refreshUiFromState() {
+      var state = getMcpbSetupState();
+      var serverSha = (bootBuildMeta && bootBuildMeta.fellows_db_sha) || null;
+      if (state && state.setupAt) {
+        setupBtn.textContent = 'Re-download all extensions';
+        if (metaEl) {
+          metaEl.hidden = false;
+          metaEl.textContent = 'Last set up: ' +
+            formatRelativeTime(state.refreshedAt || state.setupAt) +
+            '. Re-downloading replaces the extensions you have installed in Claude Desktop.';
+        }
+        if (postInstall) postInstall.hidden = false;
+      } else {
+        setupBtn.textContent = 'Set up Claude Desktop integration';
+        if (metaEl) {
+          metaEl.hidden = true;
+          metaEl.textContent = '';
+        }
+        if (postInstall) postInstall.hidden = true;
+      }
+      // Directory-data-update affordance — only meaningful after at
+      // least one prior setup AND when the server's current fellows.db
+      // snapshot differs from the one bundled at last setup.
+      if (updateRow && refreshDirBtn) {
+        if (state && state.setupAt && serverSha && state.fellowsDbSha && state.fellowsDbSha !== serverSha) {
+          updateRow.hidden = false;
+        } else {
+          updateRow.hidden = true;
+        }
+      }
+    }
+
+    function openPreamble() {
+      if (!dialog) return;
+      // Decide which warnings to surface BEFORE opening so first
+      // render is correct. The folder check is async (worker RPC); the
+      // browser check is sync.
+      if (browserWarning) browserWarning.hidden = browserIsChromium();
+      // Default: hide the folder warning; flip it on if folder mode
+      // isn't active. The check uses FOLDER_CONTROLLER which surfaces
+      // the worker's `getFolderState` RPC. Failing the check (e.g.,
+      // unsupported browser) leaves the warning hidden — the browser
+      // warning already covers that audience.
+      if (folderWarning) folderWarning.hidden = true;
+      try {
+        if (window.__folderController && typeof window.__folderController.getState === 'function') {
+          window.__folderController.getState().then(function (state) {
+            if (!folderWarning) return;
+            var folderActive = state && state.hasHandle &&
+              (state.permission === 'granted');
+            // Only Chromium users benefit from this nudge — Safari /
+            // Firefox got the browser warning instead.
+            folderWarning.hidden = folderActive || !browserIsChromium();
+          }, function () {});
+        }
+      } catch (e) {}
+      try { dialog.showModal(); }
+      catch (e) {
+        // Fallback for browsers without <dialog> support — surface as
+        // a confirm() so the user can at least proceed past the
+        // preamble. The actual download trigger still works.
+        if (window.confirm('Set up Claude Desktop integration — three .mcpb files will download. Proceed?')) {
+          runMcpbDownloads();
+        }
+      }
+    }
+
+    function downloadFromUrl(url, filename) {
+      // Trigger a download via a synthetic <a click()>. The browser
+      // sends the existing session cookie (same-origin), so the auth
+      // gate accepts. A short setTimeout between calls keeps Chrome
+      // from coalescing the downloads into a "this site is downloading
+      // multiple files" prompt; if the user denies the prompt the rest
+      // of the chain is best-effort.
+      return new Promise(function (resolve) {
+        var a = document.createElement('a');
+        a.href = url;
+        if (filename) a.download = filename;
+        a.rel = 'noopener';
+        a.style.display = 'none';
+        document.body.appendChild(a);
+        try { a.click(); } catch (e) {}
+        setTimeout(function () {
+          try { document.body.removeChild(a); } catch (e) {}
+          resolve();
+        }, 250);
+      });
+    }
+
+    function downloadBundles(bundleNames) {
+      var seq = Promise.resolve();
+      bundleNames.forEach(function (name) {
+        seq = seq.then(function () {
+          return downloadFromUrl('/mcpb/' + name + '.mcpb', name + '.mcpb');
+        });
+      });
+      return seq;
+    }
+
+    function runMcpbDownloads() {
+      setStatus('Downloading three .mcpb files…');
+      setupBtn.disabled = true;
+      return downloadBundles(MCPB_BUNDLE_NAMES).then(function () {
+        var serverSha = (bootBuildMeta && bootBuildMeta.fellows_db_sha) || null;
+        recordMcpbSetup(serverSha);
+        setStatus('Downloads triggered. Check your Downloads folder.');
+        refreshUiFromState();
+      }).catch(function (e) {
+        setStatus('Download failed: ' + (e && e.message ? e.message : String(e)));
+      }).then(function () {
+        setupBtn.disabled = false;
+      });
+    }
+
+    function runDirectoryRefresh() {
+      if (!refreshDirBtn) return;
+      setStatus('Re-downloading Fellows directory extension…');
+      refreshDirBtn.disabled = true;
+      return downloadFromUrl('/mcpb/shared_data_ops.mcpb', 'shared_data_ops.mcpb').then(function () {
+        var serverSha = (bootBuildMeta && bootBuildMeta.fellows_db_sha) || null;
+        recordMcpbDirectoryRefresh(serverSha);
+        setStatus('Fellows directory extension re-downloaded. Open the file to re-install in Claude Desktop.');
+        refreshUiFromState();
+      }).catch(function (e) {
+        setStatus('Download failed: ' + (e && e.message ? e.message : String(e)));
+      }).then(function () {
+        refreshDirBtn.disabled = false;
+      });
+    }
+
+    setupBtn.addEventListener('click', openPreamble);
+    if (refreshDirBtn) refreshDirBtn.addEventListener('click', runDirectoryRefresh);
+    if (dialog) {
+      dialog.addEventListener('close', function () {
+        // <dialog>'s close event fires for any submit (including the
+        // primary "Continue" button). returnValue carries the button's
+        // value attribute — "continue" / "cancel" / empty (Esc).
+        if (dialog.returnValue === 'continue') {
+          runMcpbDownloads();
+        }
+      });
+    }
+    refreshUiFromState();
   }
 
   // Settings → Data folder section: badge, action buttons, collision

--- a/app/static/styles.css
+++ b/app/static/styles.css
@@ -3422,6 +3422,112 @@ a.group-action-btn--primary {
   color: #64748b !important;
 }
 
+/* ===== Claude Desktop integration =====================================
+   Settings-page section that drives the .mcpb download flow + the
+   preamble dialog. The dialog inherits .settings-folder-dialog above
+   for chrome; .settings-mcpb-dialog overrides max-width because the
+   preamble has substantially more content (three bundle descriptions
+   + install-warning preview + next-steps paragraph) than the folder
+   collision dialog. Plan: plans/easy_mcp_install.md § 4 + § 7. */
+.settings-mcpb-actions {
+  display: flex;
+  flex-wrap: wrap;
+  gap: 0.5rem;
+  margin-top: 0.5rem;
+}
+
+.settings-mcpb-meta {
+  margin-top: 0.5rem;
+  font-size: 0.85rem;
+  color: #6b7280;
+}
+
+.settings-mcpb-update-row {
+  margin: 0.75rem 0;
+  padding: 0.75rem 1rem;
+  border: 1px solid #e7c873;
+  border-radius: 6px;
+  background: #fff8e1;
+  color: #3a3a3a;
+}
+
+.settings-mcpb-update-row p {
+  margin: 0 0 0.5rem;
+}
+
+.settings-mcpb-post-install {
+  margin-top: 1rem;
+  padding: 0.75rem 1rem;
+  border: 1px solid #d8d2e8;
+  border-radius: 6px;
+  background: #f7f4fb;
+}
+
+.settings-mcpb-post-install h4 {
+  margin: 0 0 0.5rem;
+  font-size: 1rem;
+}
+
+.settings-mcpb-next-steps {
+  margin: 0 0 0.5rem;
+  padding-left: 1.25rem;
+  font-size: 0.92rem;
+  line-height: 1.5;
+  color: #334155;
+}
+
+.settings-mcpb-next-steps li {
+  margin-bottom: 0.35rem;
+}
+
+/* Preamble dialog overrides — wider, with structured warnings. */
+.settings-mcpb-dialog {
+  max-width: 36rem;
+}
+
+.settings-mcpb-dialog ol.settings-mcpb-bundles {
+  margin: 0 0 1rem;
+  padding-left: 1.25rem;
+  font-size: 0.92rem;
+  line-height: 1.5;
+  color: #334155;
+}
+
+.settings-mcpb-dialog ol.settings-mcpb-bundles li {
+  margin-bottom: 0.5rem;
+}
+
+.settings-mcpb-warning {
+  margin: 0 0 1rem;
+  padding: 0.6rem 0.85rem;
+  border: 1px solid #e7c873;
+  border-left-width: 3px;
+  border-radius: 4px;
+  background: #fff8e1;
+  font-size: 0.9rem;
+  line-height: 1.45;
+  color: #3a3a3a;
+}
+
+.settings-mcpb-warning--banner {
+  border-color: #dc2626;
+  border-left-color: #dc2626;
+  background: #fef2f2;
+}
+
+.settings-mcpb-manual-link {
+  margin: 0.75rem 0 0;
+  font-size: 0.85rem;
+  color: #64748b;
+  text-align: right;
+}
+
+.settings-restore-migrate-hint {
+  font-size: 0.85rem;
+  margin-top: 0.5rem;
+  color: #475569;
+}
+
 .settings-backup-restore:disabled {
   opacity: 0.5;
   cursor: not-allowed;

--- a/docs/use_with_claude_desktop.md
+++ b/docs/use_with_claude_desktop.md
@@ -1,18 +1,20 @@
 # Use with Claude Desktop
 
-This is an optional add-on to the EHF Fellows Directory app. Once set up,
-you can ask **Claude Desktop** questions about the directory and your
-saved groups, and have it draft outreach emails for you to review and
-send.
+This is an optional add-on to the EHF Fellows Directory app. Once set
+up, you can ask **Claude Desktop** questions about the directory and
+your saved groups, and have it draft outreach emails for you to
+review and send.
 
 Example things you can ask:
 
 - *"How many fellows are based in Aotearoa?"*
-- *"Find the fellow who runs that climate finance fund — I forget the name."*
+- *"Find the fellow who runs that climate finance fund — I forget the
+  name."*
 - *"List my saved groups."*
 - *"Who's in my Climate Action group?"*
 - *"Draft an email to my Climate Action group inviting them to meet
-  Thursday at 1pm NZ time — don't send, just stage it for me to review."*
+  Thursday at 1pm NZ time — don't send, just stage it for me to
+  review."*
 
 Claude reads your **local** copy of the directory to answer. For the
 email demo, it hands the draft back to you as a pre-filled compose
@@ -26,313 +28,254 @@ This is optional. The Fellows app works perfectly well without it.
 
 You should already have:
 
-- The **Fellows Directory app** installed and working (you've used it, you have
-  groups).
+- The **Fellows Directory app** installed and working (you've used it,
+  you have groups saved).
 - **Claude Desktop** installed.
-- A Mac.
-- About 15 minutes.
+- A **data folder set up** in the Fellows app (Settings → Data folder
+  → Choose data folder…). See *[Where your data is stored](users_manual.md#where-your-data-is-stored)*.
+- About **5 minutes**.
 
-You'll also need **GitHub access** to download the project files — if you
-don't have it, ask Rich first.
+### Best with: Chrome, Edge, Brave, Arc on macOS
 
----
+The easy install path works on Chromium-family browsers (Chrome,
+Edge, Brave, Arc) running on macOS Sonoma 14 or newer. This is the
+combination that supports the data-folder feature the integration
+depends on.
 
-## What you're going to do (overview)
+**Safari and Firefox:** keep reading — there's a [secondary path](#secondary-path-safari-firefox-and-other-browsers)
+below. It works but needs a few extra steps.
 
-1. Download a small folder of connector files.
-2. Drop two copies of your data into that folder (the fellows directory
-   + your groups).
-3. Run one Terminal command to install the connector's helpers.
-4. Tell Claude Desktop where the folder lives.
-5. Quit and reopen Claude Desktop. Done.
-
-The connectors only run when Claude calls them. Nothing extra runs in
-the background.
-
----
-
-## Step 1 — Download the connector files
-
-1. Open <https://github.com/richbodo/fellows_local_db> in your browser.
-   (If you see "404 Not Found," ask Rich for repo access.)
-2. Click the green **Code** button → **Download ZIP**.
-3. Open the downloaded zip — it creates a folder called
-   `fellows_local_db-main` in your **Downloads** folder.
-4. In Finder, **drag that folder into your home folder** (the one with the
-   little house icon in the sidebar, named after you).
-5. **Rename** it from `fellows_local_db-main` to just `fellows_local_db`.
-
-When you're done, in Finder you should see a folder called
-`fellows_local_db` directly inside your home folder.
-
-> **What's my Mac username?** Open Finder → menu bar → **Go → Home**. The
-> window title is your username. You'll need it again in Step 4.
+**Already installed the Fellows app in two browsers on the same Mac?**
+Each browser has its own data store; see *[Multiple installs on the
+same device](users_manual.md#multiple-installs-on-the-same-device)*
+to consolidate before you set up Claude Desktop integration.
 
 ---
 
-## Step 2 — Copy your data into the folder
+## The 3-step easy path
 
-You need two data files: **the fellows directory** (everyone's profile)
-and **your private groups**.
+The Fellows app downloads three small extensions for Claude Desktop;
+Claude Desktop installs them with two clicks each. Total active time
+~3 minutes.
 
-### 2A. The fellows directory
+### Step 1 — Open Settings → "Set up Claude Desktop integration"
 
-1. Open your usual browser (whichever you signed into the Fellows app with).
-2. Go to <https://fellows.globaldonut.com/fellows.db>
-3. The browser downloads a file called `fellows.db`.
-   - If Safari asks whether to keep an unrecognized file type, click **Keep**.
-4. In Finder, move that `fellows.db` into the `app` subfolder of your
-   project folder. The final location should be:
+In the Fellows app:
 
-   `~/fellows_local_db/app/fellows.db`
+1. Click **Settings** (gear icon, or `#/settings`).
+2. Scroll to **Claude Desktop integration (beta)**.
+3. Click **Set up Claude Desktop integration**.
 
-   (i.e. Home → `fellows_local_db` → `app` → `fellows.db`)
+A dialog opens explaining what the three extensions do and previews
+the warning banner Claude Desktop will show during install (see
+*[About that red warning banner](#about-that-red-warning-banner)*
+below).
 
-If a `fellows.db` is already there, replace it.
+### Step 2 — Read the preamble, click Continue
 
-### 2B. Your private groups
+The dialog covers three extensions:
 
-1. Open the Fellows Directory app.
-2. Tap/click **Settings**.
-3. Click **Download a backup**.
-4. A file called `relationships.db` downloads.
-5. In Finder, move it into the **same** `app` subfolder:
+- **Fellows directory (Shared)** — Claude reads the public fellows
+  directory (names, bios, contact info).
+- **Your saved groups (Private)** — Claude reads your saved groups
+  and notes. *Privacy note*: this data is private to you and never
+  leaves your device through the Fellows app — but when Claude reads
+  it, it goes to Claude's servers. If that's not OK for you, skip
+  this extension and Claude will only have access to the directory.
+- **Email staging (Communications)** — Claude prepares draft emails
+  and hands them back to your mail app. Claude never sends mail
+  itself.
 
-   `~/fellows_local_db/app/relationships.db`
+When you click **Continue**, three `.mcpb` installer files download
+into your Downloads folder:
 
-If a `relationships.db` is already there, replace it.
+- `shared_data_ops.mcpb`
+- `private_data_ops.mcpb`
+- `comms.mcpb`
 
-> Whenever you make new groups in the app and want Claude to see them,
-> just redo this step.
+### Step 3 — Open each .mcpb, approve in Claude Desktop, restart
 
----
+For each of the three files:
 
-## Step 3 — Install the connector's helpers
+1. **Open the file** (Finder → double-click, or `Downloads → open`).
+   Claude Desktop pops up an Install dialog.
+2. **For `private_data_ops.mcpb` only**: the install dialog asks you
+   to pick a file. Navigate to your **data folder → Fellows →
+   `relationships.db`** and select it. (This is the file the
+   extension reads to find your saved groups; the data folder you
+   set up in *Before you start* is where it lives.)
+3. **Click Install**. Approve the red warning banner — see below.
 
-This is the only step that uses Terminal. We do it once.
+When all three are done:
 
-1. Open the **Terminal** app: press **⌘+Space**, type "Terminal", press Return.
-   A window opens with a `$` prompt.
-2. Copy this whole line, paste it into Terminal, press Return:
+4. **Quit Claude Desktop** (⌘Q) and reopen it. (This is the only
+   reliable way to get it to load freshly-installed extensions.)
+5. Open a new chat and ask: *"How many fellows are in the
+   directory?"*
 
-   ```
-   cd ~/fellows_local_db && python3 -m venv mcp_servers/.venv && mcp_servers/.venv/bin/pip install -r mcp_servers/requirements.txt
-   ```
-
-3. You'll see lines about downloading and installing. When the `$` prompt
-   comes back (usually under a minute), it's done.
-
-You can close Terminal now.
-
-> **If Terminal says `python3: command not found`:** macOS will pop up an
-> "Install Command Line Developer Tools" dialog. Click **Install**, wait
-> for it to finish (a few minutes), then rerun the command above. This
-> is a one-time Apple install — it's the developer toolkit Apple ships
-> for any program that needs Python.
-
----
-
-## Step 4 — Tell Claude Desktop where the connectors live
-
-1. Open **Claude Desktop**.
-2. Menu bar: **Claude → Settings…** → **Developer** tab → click
-   **Edit Config**.
-3. A text file opens in your default editor (TextEdit, usually).
-
-What you do next depends on what's already in the file.
-
-### If the file is empty or just shows `{}`
-
-Replace whatever's there with this — but **change `richbodo` to your own
-Mac username everywhere** (8 places):
-
-```json
-{
-  "mcpServers": {
-    "shared-data-ops": {
-      "command": "/Users/richbodo/fellows_local_db/mcp_servers/.venv/bin/python",
-      "args": [
-        "/Users/richbodo/fellows_local_db/mcp_servers/shared_data_ops.py",
-        "--db",
-        "/Users/richbodo/fellows_local_db/app/fellows.db"
-      ]
-    },
-    "private-data-ops": {
-      "command": "/Users/richbodo/fellows_local_db/mcp_servers/.venv/bin/python",
-      "args": [
-        "/Users/richbodo/fellows_local_db/mcp_servers/private_data_ops.py",
-        "--db",
-        "/Users/richbodo/fellows_local_db/app/relationships.db",
-        "--fellows-db",
-        "/Users/richbodo/fellows_local_db/app/fellows.db"
-      ]
-    },
-    "comms": {
-      "command": "/Users/richbodo/fellows_local_db/mcp_servers/.venv/bin/python",
-      "args": [
-        "/Users/richbodo/fellows_local_db/mcp_servers/comms.py"
-      ]
-    }
-  }
-}
-```
-
-Save the file (**⌘S**) and close the editor.
-
-### If the file already has stuff in it
-
-You'll see something like `{ "preferences": { … } }`. You need to **add**
-`mcpServers` as a second top-level item next to `preferences`.
-
-Step-by-step:
-
-1. Find the **last `}`** in the file. That's the outermost closing brace.
-2. Just **before** that final `}`, add a **comma** to the line above it
-   (if there isn't one already).
-3. Then paste this block (with `richbodo` changed to your Mac username
-   everywhere):
-
-   ```json
-   "mcpServers": {
-     "shared-data-ops": {
-       "command": "/Users/richbodo/fellows_local_db/mcp_servers/.venv/bin/python",
-       "args": [
-         "/Users/richbodo/fellows_local_db/mcp_servers/shared_data_ops.py",
-         "--db",
-         "/Users/richbodo/fellows_local_db/app/fellows.db"
-       ]
-     },
-     "private-data-ops": {
-       "command": "/Users/richbodo/fellows_local_db/mcp_servers/.venv/bin/python",
-       "args": [
-         "/Users/richbodo/fellows_local_db/mcp_servers/private_data_ops.py",
-         "--db",
-         "/Users/richbodo/fellows_local_db/app/relationships.db",
-         "--fellows-db",
-         "/Users/richbodo/fellows_local_db/app/fellows.db"
-       ]
-     },
-     "comms": {
-       "command": "/Users/richbodo/fellows_local_db/mcp_servers/.venv/bin/python",
-       "args": [
-         "/Users/richbodo/fellows_local_db/mcp_servers/comms.py"
-       ]
-     }
-   }
-   ```
-
-4. Save (**⌘S**) and close.
-
-> JSON is picky about commas and brackets. If Claude Desktop later says
-> the config has an error, the comma in step 2 is the most common
-> culprit. When in doubt, ask in the fellows channel — a screenshot of
-> the file goes a long way.
+If you get a count back, you're set up.
 
 ---
 
-## Step 5 — Quit and reopen Claude Desktop
+## About that red warning banner
 
-This part matters. Closing the window isn't enough — Claude Desktop
-keeps running.
+When you click **Install** in Claude Desktop, you'll see a red banner
+that says:
 
-1. With Claude Desktop in front, press **⌘Q** to fully quit.
-2. Wait a few seconds.
-3. Open Claude Desktop again.
+> "Installing will grant this extension access to everything on your
+> computer. Any developer information shown has not been verified by
+> Anthropic."
 
-To check the connectors loaded: **Claude → Settings… → Developer**. You
-should see three entries listed: `shared-data-ops`, `private-data-ops`,
-`comms`. If the page says "No servers added," go back to Step 4 — the
-config file didn't load. (Usually a missing comma, or `mcpServers` got
-nested inside `preferences` by accident instead of sitting next to it.)
+That banner fires for **any extension that isn't Anthropic-verified**
+— it's not specific to ours and doesn't mean anything is wrong with
+the Fellows integration. The extensions only read the data files
+they were configured with; they don't have wider access than you
+grant them in the install dialog.
 
----
-
-## Step 6 — Try it
-
-Start a new chat in Claude Desktop. Try these in order:
-
-1. *"How many fellows are in the directory?"* — confirms the directory
-   connector works.
-2. *"List my saved groups."* — confirms the groups connector works.
-3. *"Who's in my [your group name] group?"* — confirms the groups
-   connector can pull member details.
-4. *"Draft an email to my [your group name] group inviting them to meet
-   Thursday at 1pm NZ time. Don't send — stage it for me to review."* —
-   the flagship demo.
-
-**The first time** Claude wants to use a connector, it'll pop up a
-permission prompt asking you to approve the tool call. Read what it's
-about to do and click **Allow**. After the first time per connector,
-it won't ask again.
-
-For the email demo, Claude will hand you back a `mailto:` link. Clicking
-it opens your default mail app with **To**, **Subject**, and **Body**
-pre-filled. You review, edit, and click Send — Claude never sends mail
-itself.
+Click **Install** to proceed past the banner. This is tracked
+upstream as [issue #186](https://github.com/richbodo/fellows_local_db/issues/186)
+— we'd prefer a less alarming UX but it's Claude Desktop's
+load-bearing trust check, so it stays until Anthropic ships
+verification for community extensions.
 
 ---
 
-## If something doesn't work
+## Refreshing your data
 
-| Symptom | Most likely cause / fix |
-|---|---|
-| **"No servers added"** in Settings → Developer. | The config file didn't parse. Open it again, check that `mcpServers` is at the top level (a sibling of `preferences`, not nested inside it), and that every `{` has a matching `}` and every list of items is separated by commas. |
-| Claude says it can't find the directory or your groups. | Either you didn't fully quit Claude Desktop with ⌘Q, or one of the paths still has the placeholder `richbodo` in it instead of your Mac username. |
-| Claude tries to answer from memory and gets it wrong (e.g. wrong fellow count). | Ask again, more explicitly: *"Use the fellows database to count …"* Once it picks the connector up in a chat, it'll keep using it. |
-| Terminal in Step 3 said `python3: command not found`. | Click **Install** on the Command Line Developer Tools popup, wait for it to finish, rerun the command. |
-| Safari opens the `fellows.db` link as a page of gibberish instead of downloading. | Right-click (or Control-click) the link → **Download Linked File**. Or hold **Option** while clicking. |
-| Your groups in Claude look out of date. | Re-do Step 2B. The connectors read whatever was in your backup at the moment you exported it. |
-| Worked yesterday, broken today after a Claude Desktop update. | Quit and reopen Claude Desktop again. If still broken, re-check Step 4. |
+You don't need to redo this setup for normal updates. Three
+scenarios:
 
-If you're stuck, post in the fellows channel or email Rich — a screenshot
-of Claude Desktop's Developer settings panel and of your config file is
-the fastest way to get help.
+### You changed your saved groups
 
----
+Nothing to do. The **Your saved groups** extension reads
+`relationships.db` directly from your data folder. The Fellows app
+auto-saves to that folder whenever you change a group, so Claude
+sees your latest groups on its next read.
 
-## A note on privacy
+### The Fellows directory has new fellows
 
-When Claude Desktop uses these connectors, **the parts of your fellows
-data that Claude reads get sent to Claude's servers** (Anthropic's),
-because that's where Claude does its thinking. This is the same as if
-you'd copy-pasted that info into a Claude chat by hand — just easier to
-forget you're doing it.
+The Fellows app surfaces a *"Directory data update available"*
+status in the About page. When you click *Update directory data*,
+the app downloads a new `fellows.db`. **You'll also need to
+re-install the `shared_data_ops` extension** so Claude sees the new
+snapshot.
 
-- The **fellows directory** (names, bios, contact info) goes over the
-  network when you ask Claude about specific fellows.
-- Your **private groups** (names, members, any notes you've added) go
-  over the network when you ask Claude about your groups.
-- The **email connector** only stages a draft locally — but the email
-  body Claude writes was composed using the fellow info above, so the
-  same boundary applies.
+Settings → Claude Desktop integration (beta) shows a banner when
+this is needed:
 
-Nothing happens unless you ask. Claude only reads what it needs to
-answer the prompt you typed.
+> **Directory data update available.** A newer snapshot of the
+> public fellows directory is on the server. Re-install the Fellows
+> directory extension to pick it up.
 
-If a particular question feels too sensitive to send to Claude, just
-don't use Claude for that question — the Fellows app itself shows you
-the same info without any of it leaving your Mac.
+Click **Re-install Fellows directory** to download just
+`shared_data_ops.mcpb`. Open the file when it downloads to re-install
+in Claude Desktop, then restart Claude Desktop.
 
-You can disable any of the three connectors at any time in **Claude
-Desktop → Settings → Developer**.
+### You want to fully re-download everything
+
+Click **Re-download all extensions** in Settings → Claude Desktop
+integration (beta). Repeats Steps 2-3 above.
 
 ---
 
-## Updating later
+## Secondary path (Safari, Firefox, and other browsers)
 
-- **Newer fellows directory** (when Rich announces a directory update):
-  redo **Step 2A**.
-- **Newer copy of your groups** (any time you've added or changed groups
-  in the Fellows app): redo **Step 2B**.
-- **Newer connector tools** (when there are improvements to announce):
-  download the latest ZIP per **Step 1**, but before replacing the
-  folder, copy your `app/fellows.db` and `app/relationships.db` aside
-  so you can drop them back into the fresh `app/` subfolder. Then redo
-  **Step 3**.
+Safari and Firefox don't support the data-folder feature
+(`window.showDirectoryPicker`) the easy path depends on, so the file
+picker in Claude Desktop's `private_data_ops` install dialog has no
+stable location to land on. You can still set it up; you just need
+to manage the `relationships.db` file by hand.
+
+### Once-only setup
+
+1. In the Fellows app: **Settings → ⬇ Download my user data**.
+   Save the file somewhere stable on your disk — `~/Documents/`
+   works well. Note the file's location.
+2. Visit each of these URLs in turn while signed in to the Fellows
+   app (the magic-link gate must already be open in this browser):
+   - <https://fellows.globaldonut.com/mcpb/shared_data_ops.mcpb>
+   - <https://fellows.globaldonut.com/mcpb/private_data_ops.mcpb>
+   - <https://fellows.globaldonut.com/mcpb/comms.mcpb>
+
+   Each one downloads as an `.mcpb` file.
+3. Follow **Step 3** of the easy path above (open each, approve,
+   restart Claude Desktop). For `private_data_ops.mcpb`'s file
+   picker, navigate to wherever you saved `relationships.db` in
+   step 1.
+
+### Re-export discipline
+
+**Every time you change a group**, you need to redo step 1 (download
+your user data, save it over the previous `relationships.db`).
+Otherwise Claude sees the version that was current at install time.
+
+The Chromium easy path doesn't have this problem because the data
+folder *is* `relationships.db` — auto-save handles it. If you find
+yourself doing this re-export more than once or twice a week, the
+honest answer is: try the Fellows app in Chrome instead. See
+*[Migrating from another browser](users_manual.md#migrating-from-another-browser)*
+for how to bring your data along.
 
 ---
 
-For developers / curious readers: the technical reference for these
-connectors (what tools each one exposes, where the typed contracts
-live, how to run them standalone) is in
-[`../mcp_servers/README.md`](../mcp_servers/README.md).
+## Troubleshooting
+
+### Claude Desktop doesn't see my groups
+
+Most likely cause: `private_data_ops.mcpb` was pointed at the wrong
+`relationships.db` during install (or you're on the secondary path
+and your exported file is stale).
+
+1. In Claude Desktop: **Settings → Extensions**. Find *Your saved
+   groups* (or `private_data_ops`).
+2. Confirm the **Configuration** field points at the
+   `relationships.db` from your current data folder (Chromium) or
+   your latest export (Safari/Firefox).
+3. If wrong, uninstall and re-run the appropriate setup step.
+
+### "Extension failed to start"
+
+Usually means Claude Desktop's bundled Node runtime had trouble
+loading the extension. Quit Claude Desktop fully (⌘Q, then check
+Activity Monitor for stray processes), reopen, and try again. If
+that doesn't help, file a bug report from the Fellows app
+(Settings → Report a bug…); the diagnostics include your
+[install name](users_manual.md#install-name) so the maintainer can
+correlate.
+
+### I'm not sure which install of the Fellows app I'm using
+
+Check the **About** page — it shows the install name
+(`giraffe-gorilla-mouse` or similar). See *[Install name](users_manual.md#install-name)*.
+
+### Other issues
+
+The integration is in beta — if something doesn't work and isn't
+covered above, file a [GitHub issue](https://github.com/richbodo/fellows_local_db/issues)
+or use the in-app **Report a bug** button.
+
+---
+
+## What gets installed where
+
+For the curious (or for cleanup):
+
+- The three `.mcpb` files unpack into Claude Desktop's internal
+  extensions directory. **Settings → Extensions** in Claude Desktop
+  lists them with **Uninstall** buttons.
+- `relationships.db` lives in **your data folder** (Chromium easy
+  path) or wherever you saved it (Safari/Firefox secondary path).
+  Uninstalling Claude Desktop doesn't touch this file — it's yours.
+- `fellows.db` ships **inside** `shared_data_ops.mcpb` (~3 MB).
+  Uninstalling that extension removes it.
+- No environment variables, no Terminal commands, no
+  hand-edited config files. The `claude_desktop_config.json` flow
+  the previous version of this doc used is gone.
+
+---
+
+## Removing the integration
+
+**Settings → Extensions** in Claude Desktop → click **Uninstall** on
+each of the three extensions. That fully removes them. Your data
+folder is untouched.

--- a/docs/users_manual.md
+++ b/docs/users_manual.md
@@ -186,6 +186,51 @@ browser tab.
 
 ---
 
+## Migrating from another browser
+
+If you've been using the app in one browser (say, Safari) and want
+to switch to another (Chrome, for the Claude Desktop integration —
+see *[Use with Claude Desktop](use_with_claude_desktop.md)*), your
+saved groups and notes don't follow automatically. Browsers don't
+share storage; each install starts empty.
+
+Bringing your data across is a two-step copy:
+
+### Step 1 — Export from the source browser
+
+1. Open the app **in the browser where your data currently lives**
+   (Safari, in this example).
+2. **Settings → ⬇ Download my user data**. Save the `relationships.db`
+   file somewhere stable on your disk — `~/Documents/` works well,
+   or anywhere you can find again. **Don't put it in Downloads** if
+   you regularly empty that folder.
+
+### Step 2 — Import into the new browser
+
+1. Open the app **in the new browser** (Chrome, in this example). If
+   you haven't installed there yet, do that first.
+2. *(Recommended, Chromium browsers only)* **Settings → Data folder →
+   Choose data folder…**. Pick a folder under your home directory.
+   This sets up the new browser to keep its `relationships.db` at a
+   stable path on your disk — which makes the Claude Desktop
+   integration much easier and survives clearing site data.
+3. **Settings → ⬆ Restore from a file…**, then pick the
+   `relationships.db` you saved in Step 1.
+
+That's it. Your groups, notes, and tags are now visible in the new
+browser. The source browser still has its copy — you can keep both
+in sync by re-exporting / re-importing, but it's usually simpler to
+[uninstall the source copy](#uninstall-a-copy) once you're confident
+the new one is working.
+
+**A note for the future.** Doing this two-step migration regularly
+is a sign you should pick one browser and stay there. PWAs don't
+have a cross-browser sync API, so there's no automatic way to keep
+two installs aligned. Pick whichever browser you prefer and treat
+the other as a backup.
+
+---
+
 ## Where your data is stored
 
 Your groups, notes, and settings live **on your device only** —

--- a/tests/e2e/test_mcpb_settings.py
+++ b/tests/e2e/test_mcpb_settings.py
@@ -1,0 +1,257 @@
+"""E2E for the Claude Desktop integration Settings UI.
+
+The Settings page gains a "Claude Desktop integration (beta)" section
+with a primary button that opens a preamble dialog. On preamble
+Continue, the page sequentially triggers downloads of the three
+``.mcpb`` files from the auth-gated routes added in
+``deploy/server.py``. State is tracked in
+``localStorage[fellows_mcpb_setup]`` so subsequent visits flip the
+button to a refresh flow and reveal a "Directory data update
+available" affordance when ``/build-meta.json``'s
+``fellows_db_sha`` has changed since the last setup.
+
+Plan: ``plans/easy_mcp_install.md`` § 4 + § 7.
+"""
+from __future__ import annotations
+
+import re
+
+from playwright.sync_api import expect
+
+
+EXPECTED_BUNDLES = ["shared_data_ops", "private_data_ops", "comms"]
+
+
+def _boot_to_settings(page, base_url: str) -> None:
+    """Boot to the directory, wait for the worker, then navigate to
+    Settings via hash. Mirrors the pattern used in the other Settings
+    E2Es — initial boot from the directory route avoids a race where
+    settings renders before the worker is ready."""
+    page.goto(base_url + "/", wait_until="domcontentloaded")
+    page.wait_for_function(
+        "() => window.__dataProvider && window.__dataProvider.kind === 'worker'",
+        timeout=15000,
+    )
+    page.evaluate("location.hash = '#/settings'")
+    page.wait_for_selector("#settings-mcpb-section", timeout=10000)
+
+
+_MCPB_CLICK_INTERCEPT = """
+// Install before the IIFE runs: capture every <a download> click on
+// any anchor whose href starts with /mcpb/, and *prevent* the actual
+// download navigation. This is more reliable than page.route for
+// anchor-initiated downloads — Chromium routes anchor-with-download
+// clicks through its internal downloads dispatcher, which page.route
+// does not always intercept. The interception preserves order so the
+// test can assert sequential dispatch.
+window.__capturedMcpbClicks = [];
+(function () {
+  const origClick = HTMLAnchorElement.prototype.click;
+  HTMLAnchorElement.prototype.click = function () {
+    const href = this.getAttribute('href') || '';
+    if (href.indexOf('/mcpb/') !== -1) {
+      window.__capturedMcpbClicks.push(href);
+      return;
+    }
+    return origClick.call(this);
+  };
+})();
+"""
+
+
+def _install_anchor_intercept(page):
+    """Patch HTMLAnchorElement.prototype.click to capture (and swallow)
+    any anchor click whose href targets ``/mcpb/``. Returns nothing —
+    captured hrefs accumulate in ``window.__capturedMcpbClicks`` and
+    are read via ``page.evaluate``.
+    """
+    page.add_init_script(_MCPB_CLICK_INTERCEPT)
+
+
+def _captured_clicks(page) -> list[str]:
+    return page.evaluate("window.__capturedMcpbClicks || []")
+
+
+class TestMcpbSection:
+    def test_section_renders_with_intro_and_setup_button(self, standalone_page, base_url_fixture):
+        page = standalone_page
+        _boot_to_settings(page, base_url_fixture)
+        section = page.locator("#settings-mcpb-section")
+        expect(section).to_be_visible()
+        expect(section.locator("#settings-mcpb-intro")).to_contain_text(
+            "Plug the directory into Claude Desktop"
+        )
+        btn = page.locator("#settings-mcpb-setup")
+        expect(btn).to_be_visible()
+        expect(btn).to_have_text("Set up Claude Desktop integration")
+
+    def test_post_install_section_is_hidden_initially(self, standalone_page, base_url_fixture):
+        page = standalone_page
+        _boot_to_settings(page, base_url_fixture)
+        post = page.locator("#settings-mcpb-post-install")
+        expect(post).to_be_hidden()
+
+    def test_directory_update_row_is_hidden_initially(self, standalone_page, base_url_fixture):
+        page = standalone_page
+        _boot_to_settings(page, base_url_fixture)
+        row = page.locator("#settings-mcpb-update-row")
+        expect(row).to_be_hidden()
+
+
+class TestPreambleDialog:
+    def test_setup_button_opens_preamble(self, standalone_page, base_url_fixture):
+        page = standalone_page
+        _boot_to_settings(page, base_url_fixture)
+        page.click("#settings-mcpb-setup")
+        dialog = page.locator("#settings-mcpb-preamble-dialog")
+        expect(dialog).to_be_visible()
+
+    def test_preamble_describes_three_bundles(self, standalone_page, base_url_fixture):
+        page = standalone_page
+        _boot_to_settings(page, base_url_fixture)
+        page.click("#settings-mcpb-setup")
+        bundles = page.locator(
+            "#settings-mcpb-preamble-dialog .settings-mcpb-bundles li"
+        )
+        expect(bundles).to_have_count(3)
+        # Each bundle's bold heading must be present.
+        expect(bundles.nth(0)).to_contain_text("Fellows directory (Shared)")
+        expect(bundles.nth(1)).to_contain_text("Your saved groups (Private)")
+        expect(bundles.nth(2)).to_contain_text("Email staging (Communications)")
+
+    def test_preamble_previews_install_warning_banner(self, standalone_page, base_url_fixture):
+        """Issue #186 — the preamble previews Claude Desktop's red
+        "unverified" banner so users aren't surprised."""
+        page = standalone_page
+        _boot_to_settings(page, base_url_fixture)
+        page.click("#settings-mcpb-setup")
+        banner = page.locator(".settings-mcpb-warning--banner")
+        expect(banner).to_be_visible()
+        expect(banner).to_contain_text(
+            "Installing will grant this extension access to everything on your computer"
+        )
+
+    def test_preamble_has_manual_setup_link(self, standalone_page, base_url_fixture):
+        page = standalone_page
+        _boot_to_settings(page, base_url_fixture)
+        page.click("#settings-mcpb-setup")
+        link = page.locator(".settings-mcpb-manual-link a")
+        expect(link).to_be_visible()
+        expect(link).to_have_attribute(
+            "href",
+            re.compile(r"use_with_claude_desktop\.md$"),
+        )
+
+
+class TestPreambleActions:
+    def test_cancel_closes_dialog_without_downloads(self, standalone_page, base_url_fixture):
+        page = standalone_page
+        _install_anchor_intercept(page)
+        _boot_to_settings(page, base_url_fixture)
+        page.click("#settings-mcpb-setup")
+        dialog = page.locator("#settings-mcpb-preamble-dialog")
+        expect(dialog).to_be_visible()
+        page.locator(
+            "#settings-mcpb-preamble-dialog .settings-folder-dialog-cancel"
+        ).click()
+        expect(dialog).not_to_be_visible()
+        # Wait briefly to confirm no late downloads fire.
+        page.wait_for_timeout(500)
+        clicks = _captured_clicks(page)
+        assert clicks == [], f"unexpected downloads fired on cancel: {clicks}"
+
+    def test_continue_triggers_three_downloads_in_order(self, standalone_page, base_url_fixture):
+        page = standalone_page
+        _install_anchor_intercept(page)
+        _boot_to_settings(page, base_url_fixture)
+        page.click("#settings-mcpb-setup")
+        page.click("#settings-mcpb-preamble-continue")
+
+        # downloadFromUrl uses a 250ms inter-anchor delay; three downloads
+        # need ~750ms. Wait for the status to flip past "Downloading" so
+        # we know the chain completed.
+        page.wait_for_function(
+            """() => {
+              const s = document.getElementById('settings-mcpb-status');
+              return s && s.textContent && /Downloads triggered/.test(s.textContent);
+            }""",
+            timeout=5000,
+        )
+        clicks = _captured_clicks(page)
+        assert len(clicks) == 3, f"expected 3 downloads, got: {clicks}"
+        for url, name in zip(clicks, EXPECTED_BUNDLES):
+            assert url.endswith(f"/mcpb/{name}.mcpb"), (
+                f"expected {name}.mcpb URL, got: {url}"
+            )
+
+
+class TestPostSetupState:
+    def test_button_relabels_after_first_setup(self, standalone_page, base_url_fixture):
+        page = standalone_page
+        _install_anchor_intercept(page)
+        _boot_to_settings(page, base_url_fixture)
+        page.click("#settings-mcpb-setup")
+        page.click("#settings-mcpb-preamble-continue")
+        page.wait_for_function(
+            """() => {
+              const s = document.getElementById('settings-mcpb-status');
+              return s && /Downloads triggered/.test(s.textContent || '');
+            }""",
+            timeout=5000,
+        )
+        expect(page.locator("#settings-mcpb-setup")).to_have_text(
+            "Re-download all extensions"
+        )
+        expect(page.locator("#settings-mcpb-post-install")).to_be_visible()
+        expect(page.locator("#settings-mcpb-setup-meta")).to_be_visible()
+
+    def test_setup_state_persists_in_localstorage(self, standalone_page, base_url_fixture):
+        page = standalone_page
+        _install_anchor_intercept(page)
+        _boot_to_settings(page, base_url_fixture)
+        page.click("#settings-mcpb-setup")
+        page.click("#settings-mcpb-preamble-continue")
+        page.wait_for_function(
+            """() => {
+              const s = document.getElementById('settings-mcpb-status');
+              return s && /Downloads triggered/.test(s.textContent || '');
+            }""",
+            timeout=5000,
+        )
+        raw = page.evaluate("localStorage.getItem('fellows_mcpb_setup')")
+        assert raw is not None
+        import json as _json
+        record = _json.loads(raw)
+        assert record["setupAt"]
+        assert record["refreshedAt"]
+
+    def test_directory_update_row_shows_when_sha_changes(self, standalone_page, base_url_fixture):
+        """If the user has set up before but the server now reports a
+        different ``fellows_db_sha``, the Settings UI exposes the
+        re-install-directory button."""
+        page = standalone_page
+        _boot_to_settings(page, base_url_fixture)
+        # Seed localStorage with a setup record that pins a stale sha,
+        # then re-render the settings page (via hash bounce) so
+        # refreshUiFromState runs.
+        page.evaluate(
+            """() => {
+              localStorage.setItem('fellows_mcpb_setup', JSON.stringify({
+                setupAt: new Date().toISOString(),
+                refreshedAt: new Date().toISOString(),
+                fellowsDbSha: 'stale-sha-not-on-server'
+              }));
+              window.bootBuildMeta = window.bootBuildMeta || {};
+              window.bootBuildMeta.fellows_db_sha = 'fresh-server-sha';
+            }"""
+        )
+        # Bounce off then back to trigger re-render.
+        page.evaluate("location.hash = '#/about'")
+        page.wait_for_function(
+            "() => !document.getElementById('settings-mcpb-section')",
+            timeout=5000,
+        )
+        page.evaluate("location.hash = '#/settings'")
+        page.wait_for_selector("#settings-mcpb-section", timeout=5000)
+        expect(page.locator("#settings-mcpb-update-row")).to_be_visible()
+        expect(page.locator("#settings-mcpb-refresh-directory")).to_be_visible()


### PR DESCRIPTION
## Summary

Bundles plan steps 6, 7, 8 from `plans/easy_mcp_install.md` § 12 into a single PR. They share tightly coupled cross-links — the Settings UI references the walkthrough, the walkthrough references the migrate recipe, the Settings → Restore migrate hint links to the same recipe. Splitting would leave each PR in a half-broken state.

Stacks on top of #197 (`/mcpb/<name>.mcpb` prod routes). The Settings UI's Continue button hits those routes; without #197 merged the dev server 404s the requests and the downloads fail in prod testing — but the UI flow itself works locally and is covered by E2Es that intercept the anchor clicks.

## Step 6 — Claude Desktop integration Settings UI

New "Claude Desktop integration (beta)" section in Settings (above the existing folder/saved-data/restore stack) with a single primary button. Clicking it opens a preamble dialog carrying the full informed-consent copy from § 7 of the plan:

- Three-bundle description with per-bundle privacy boundary (directory shared, groups private, comms staging)
- Preview of Claude Desktop's red "unverified developer" warning banner (issue #186 — addressed via preview, not elimination)
- Manual-setup link for Safari/Firefox users at the bottom

Context-aware warnings shown before opening based on environment:
- **No data folder yet** → recommends setting one up first; user can still proceed
- **Non-Chromium browser** → highlights the manual-setup link

On preamble Continue: sequentially triggers downloads of `/mcpb/shared_data_ops.mcpb`, `/mcpb/private_data_ops.mcpb`, `/mcpb/comms.mcpb` via synthetic `<a download>` elements with 250ms delay between each (so Chrome doesn't coalesce them into a single allow prompt).

State persists in `localStorage[fellows_mcpb_setup]`:
- `setupAt` / `refreshedAt` → drives the "Re-download all extensions" relabel and the post-install "next steps" panel on subsequent visits
- `fellowsDbSha` → drives the "Directory data update available" affordance comparing against current `bootBuildMeta.fellows_db_sha` and offering a single-bundle re-download (just `shared_data_ops.mcpb`)

E2E coverage in `tests/e2e/test_mcpb_settings.py` — **12 new cases**:
- Section + button render correctly
- Preamble shows three-bundle copy + install-warning preview + manual-setup link
- Cancel doesn't trigger downloads
- Continue triggers exactly 3 downloads in expected order
- Setup state persists in localStorage
- Button relabels after first setup
- Directory-update row shows when sha differs

Download interception is via `add_init_script` anchor-click hook — Playwright's `page.route` doesn't reliably intercept Chromium's anchor-download dispatcher.

## Step 7 — `docs/use_with_claude_desktop.md` rewrite

Complete rewrite. Gone: the 6-step Terminal/JSON-editing walkthrough that asked non-technical fellows to hand-substitute their username in 8 places. New shape:

1. **Open Settings → "Set up Claude Desktop integration"**
2. **Read preamble, click Continue** (three `.mcpb` files download)
3. **Open each `.mcpb`, approve in Claude Desktop, restart**

Per the 2026-05-22 plan revision:
- Leads with the Chromium-only recommendation (Chrome / Edge / Brave / Arc on macOS Sonoma+)
- Documents the Safari/Firefox secondary path with explicit re-export discipline (every group change requires manually re-downloading `relationships.db` — no data folder to anchor on)
- Honest-disclosure section about Claude Desktop's red warning banner
- Refreshing-your-data covers all three scenarios (group changes, new directory data, full re-download)
- Cross-links to the codename install-name + multiple-installs sections shipped earlier

## Step 8 — Migrate-from-another-browser affordance

New users-manual section "Migrating from another browser" with the two-step Download / Restore recipe.

Inline link added to Settings → Restore from backup:
> Migrating from another browser? See the recipe (it's the same Download / Restore flow on this page, but in a deliberate order).

No detection logic. Pure discoverability per the plan's § 13 polish note — there's no API to detect another install in another browser, so the link is the affordance.

## Test plan

- [x] 12 new MCPB Settings E2Es: all pass
- [x] 16 Settings + MCPB tests: regression-clean
- [x] 26 Settings + folder-storage + codename tests: regression-clean
- [ ] After merging #197 + this: deploy, smoke-test the full Settings → preamble → 3 downloads → install → restart flow against real prod
- [ ] Issue #186 — the warning-banner preview copy gets reviewed against an actual screenshot from Claude Desktop's install dialog

🤖 Generated with [Claude Code](https://claude.com/claude-code)