### PR TITLE
fix(e2e): unbreak 10 pre-existing test failures (build-badge + showSaveFilePicker + User Guide rename)

### DIFF
--- a/tests/e2e/conftest.py
+++ b/tests/e2e/conftest.py
@@ -11,6 +11,15 @@ from app.server import PORT
 
 # App treats non-standalone browser tabs as install-only (no directory). E2E that
 # needs the directory must emulate installed PWA display mode before navigation.
+#
+# Also forces the anchor-download fallback in ``downloadBlob`` by removing
+# ``window.showSaveFilePicker``. The picker triggers a native OS save dialog
+# that Playwright's ``page.expect_download`` does not fire for — so any test
+# using ``expect_download`` (group exports, reset-everything backup) hangs
+# until timeout. Removing the picker forces ``downloadBlob``'s
+# ``triggerAnchorDownload`` fallback path, which Playwright reliably catches.
+# No e2e test specifically asserts picker UX; this stub keeps the suite
+# deterministic across Playwright/Chromium upgrades.
 _STANDALONE_DISPLAY_INIT = """
 (function () {
   var orig = window.matchMedia.bind(window);
@@ -26,6 +35,9 @@ _STANDALONE_DISPLAY_INIT = """
     }
     return orig(q);
   };
+  try { delete window.showSaveFilePicker; } catch (e) {
+    try { window.showSaveFilePicker = undefined; } catch (e2) {}
+  }
 })();
 """
 

--- a/tests/e2e/test_directory.py
+++ b/tests/e2e/test_directory.py
@@ -34,23 +34,6 @@ class TestDirectoryPage:
         imgs_in_directory = page.locator("#directory img")
         assert imgs_in_directory.count() == 0
 
-    def test_build_badge_is_visible_with_client_constant(self, standalone_page, base_url_fixture):
-        """Always-visible build badge renders the client constant on boot, before any async response."""
-        page = standalone_page
-        page.goto(base_url_fixture + "/", wait_until="domcontentloaded")
-        badge = page.locator("#build-badge")
-        expect(badge).to_be_visible()
-        client_line = page.locator("#build-badge-client")
-        # FELLOWS_UI_DIAG format is <YYYY-MM-DD>-<short-sha>[-<label>]
-        # since PR #80; assert structure rather than a specific tag so
-        # this stays green across bumps.
-        import re
-        text = client_line.inner_text()
-        assert re.match(r"^app: \d{4}-\d{2}-\d{2}-[0-9a-f]+", text), \
-            "build badge should show 'app: <YYYY-MM-DD>-<sha>' format, got: " + repr(text)
-        server_line = page.locator("#build-badge-server")
-        expect(server_line).to_be_visible()
-
     def test_has_email_filter_default_on_and_toggles(self, standalone_page, base_url_fixture):
         """'has email' filter is checked by default, hides fellows without email, and persists across reload."""
         page = standalone_page

--- a/tests/e2e/test_email_gate.py
+++ b/tests/e2e/test_email_gate.py
@@ -209,8 +209,11 @@ class TestEmailGate:
             assert page.locator("#auth-error-panel").is_hidden(), (
                 "Auth-error panel surfaced despite marker being set."
             )
-            server_line = page.locator("#build-badge-server")
-            expect(server_line).to_contain_text("unreachable")
+            # The previous assertion checked `#build-badge-server`'s text
+            # for "unreachable" — load-bearing signal that the boot path
+            # entered offline-only mode. The floating build badge was
+            # removed in commit 0ac562d, so the gate-visible + no-error-
+            # panel assertions above carry the contract on their own.
         finally:
             page.close()
 

--- a/tests/e2e/test_offline_only_mode.py
+++ b/tests/e2e/test_offline_only_mode.py
@@ -129,9 +129,16 @@ class TestOfflineOnlyMode:
             directory.wait_for(state="visible", timeout=5000)
             expect(page.get_by_role("link", name="Ada Cached")).to_be_visible()
 
-            # Build badge signals offline-only mode.
-            badge_server = page.locator("#build-badge-server")
-            expect(badge_server).to_contain_text("offline", timeout=3000)
+            # Data provider has fallen back to the api+idb path (the cached
+            # data source), which is the load-bearing signal for offline-only
+            # mode. Previously this used `#build-badge-server`'s text, but
+            # the floating build badge was removed in commit 0ac562d.
+            provider_kind = page.evaluate(
+                "() => (window.__dataProvider && window.__dataProvider.kind) || null"
+            )
+            assert provider_kind == "api+idb", (
+                f"expected api+idb fallback, got provider kind={provider_kind!r}"
+            )
 
             # Email-gate / install-landing / auth-error panels all stay hidden.
             expect(page.locator("#install-gate-private")).to_be_hidden()

--- a/tests/e2e/test_reset_everything.py
+++ b/tests/e2e/test_reset_everything.py
@@ -91,6 +91,13 @@ class TestResetEverythingBackupPrompt:
         page.add_init_script(
             "window.localStorage.setItem('fellows_authenticated_once', '1');"
         )
+        # Force downloadBlob's anchor-fallback path so page.expect_download
+        # fires. See the matching stub in tests/e2e/conftest.py's
+        # _STANDALONE_DISPLAY_INIT for the longer rationale.
+        page.add_init_script(
+            "try { delete window.showSaveFilePicker; }"
+            " catch (e) { window.showSaveFilePicker = undefined; }"
+        )
         page.goto(base_url_fixture + "/", wait_until="domcontentloaded")
         page.locator("#loading").wait_for(state="hidden", timeout=10000)
         return page

--- a/tests/e2e/test_search_offline_fallback.py
+++ b/tests/e2e/test_search_offline_fallback.py
@@ -128,9 +128,11 @@ def _force_api_idb_fallback_with_cache(context, page, base_url):
     # If a future change makes the worker resilient to 401 on the bytes
     # fetch this assertion will start failing and we'll need a different
     # repro — better to fail loudly than to test the wrong code path.
-    expect(page.locator("#build-badge-server")).to_contain_text(
-        "offline", timeout=3000
-    )
+    #
+    # Previously this also asserted on `#build-badge-server`'s text
+    # containing "offline", but the floating build badge was removed
+    # in commit 0ac562d; the provider-kind check below is the
+    # load-bearing signal anyway.
     provider_kind = page.evaluate(
         "() => (window.__dataProvider && window.__dataProvider.kind) || null"
     )

--- a/tests/e2e/test_update_check.py
+++ b/tests/e2e/test_update_check.py
@@ -115,7 +115,7 @@ class TestAboutUpdateCheck:
         try:
             _route_build_meta(context, git_sha="abc123")
             page.goto(base_url_fixture + "/#/about", wait_until="domcontentloaded")
-            link = page.get_by_role("link", name="User Guide")
+            link = page.get_by_role("link", name="Help from the user manual")
             expect(link).to_be_visible()
             expect(link).to_have_attribute(
                 "href",


### PR DESCRIPTION
## Context

While running the full `just test` against `feat/mcpb-settings-ui`, the maintainer hit 11 e2e failures. Triage shows **all 11 are pre-existing on main** — none were caused by the recent MCP install work — but they've been hiding under the radar because they aren't in the smaller regression sets I usually rerun after a PR.

This PR cleanly fixes 10 of the 11. The remaining one is a known pre-existing intra-suite flake unrelated to the MCP install work (documented below).

## Root causes

### 1. Build-badge removal aftermath (5 tests)

Commit `0ac562d` removed the floating `#build-badge` element from `index.html` because it overlapped the folder-push banner CTA. Five tests still asserted on the badge element or its text:

- `test_directory.py::test_build_badge_is_visible_with_client_constant` — whole test deleted. Badge is intentionally gone.
- `test_email_gate.py::test_marker_set_api_unreachable_falls_back_to_gate` — badge "unreachable" text was a secondary signal; the gate-visible + no-error-panel assertions carry the contract.
- `test_offline_only_mode.py::test_401_with_cached_data_shows_directory_from_cache` — replaced badge "offline" check with direct `window.__dataProvider.kind === 'api+idb'` (what the badge text was reflecting anyway).
- `test_search_offline_fallback.py` (helper used by 2 tests) — same fix; the existing provider-kind assertion already in the helper carries the contract.

### 2. Playwright + `showSaveFilePicker` (4 tests)

`downloadBlob` in `app.js` prefers `window.showSaveFilePicker` when available — a native OS save dialog. Playwright's `page.expect_download` does NOT fire for the picker, so any e2e wrapping a click in `expect_download` hangs until timeout. The anchor-fallback path in `downloadBlob` (`triggerAnchorDownload`) DOES fire reliably.

Fix: delete `window.showSaveFilePicker` in the e2e init script, forcing the fallback path:

- `tests/e2e/conftest.py::_STANDALONE_DISPLAY_INIT` — covers all tests using the `standalone_page` fixture.
- `tests/e2e/test_reset_everything.py::_open_app` — covers the one test using `context.new_page` directly with its own init script.

Affected suites: `test_groups_export.py` (3 tests), `test_reset_everything.py::test_download_triggers_export_then_proceeds_to_reset`. No e2e test specifically asserts picker UX, so the stub is safe across the suite.

### 3. User Guide → Help link rename (1 test)

PR #196 renamed the About-page link from "User Guide" to "Help from the user manual" but missed updating `test_update_check.py::test_users_manual_link_on_about_page`. Updated to the new label.

## Known pre-existing flake NOT fixed

`test_update_check.py`'s `test_up_to_date_shows_reassuring_status` and `test_server_drift_surfaces_banner_and_status` are intra-suite flaky — both pass in isolation but one of the two fails in a full file run, with the failing one switching between runs (the maintainer saw `test_server_drift` fail; my repro showed `test_up_to_date` fail). Pre-existing on main. Likely a service-worker cache state carryover between tests using `_route_build_meta`. Tracking separately; not in scope for this cleanup.

## Test plan

- [x] Run the 7 affected suites — `tests/e2e/test_directory.py tests/e2e/test_update_check.py tests/e2e/test_offline_only_mode.py tests/e2e/test_search_offline_fallback.py tests/e2e/test_email_gate.py tests/e2e/test_groups_export.py tests/e2e/test_reset_everything.py` — 45 of 46 pass (the 46th is the known flake above)
- [x] Confirmed all 10 failures fixed are pre-existing on main (not caused by recent MCP install PRs #197, #198)
- [ ] Maintainer reruns `just test` on `main` after this lands → expect 1 flaky failure in `test_update_check.py` (acceptable noise pending the SW-cache fix)

🤖 Generated with [Claude Code](https://claude.com/claude-code)