### PR TITLE
feat(mcpb): preamble warning rewrite + drop redundant post-install panel (round 2)

### DIFF
--- a/app/static/app.js
+++ b/app/static/app.js
@@ -8579,18 +8579,6 @@
         '</div>' +
         '<p id="settings-mcpb-setup-meta" class="settings-hint settings-mcpb-meta" hidden></p>' +
         '<span id="settings-mcpb-status" class="settings-status" aria-live="polite"></span>' +
-        '<div id="settings-mcpb-post-install" class="settings-mcpb-post-install" hidden>' +
-          '<h4 class="settings-section-subtitle">After the downloads finish</h4>' +
-          '<ol class="settings-mcpb-next-steps">' +
-            '<li>Open each <code>.mcpb</code> file you just downloaded. Claude Desktop will pop up an Install dialog for each.</li>' +
-            '<li>For <strong>Your saved groups (Private)</strong>, the install dialog will ask you to pick a file: navigate to your data folder → <code>Fellows</code> → <code>relationships.db</code>.</li>' +
-            '<li>Quit Claude Desktop (⌘Q) and reopen it.</li>' +
-            '<li>Try it: ask Claude <em>"how many fellows are in the directory?"</em></li>' +
-          '</ol>' +
-          '<p class="settings-hint">' +
-            'Stuck? See the <a href="https://github.com/richbodo/fellows_local_db/blob/main/docs/use_with_claude_desktop.md" target="_blank" rel="noopener">walkthrough</a>.' +
-          '</p>' +
-        '</div>' +
       '</div>' +
       '<dialog id="settings-mcpb-preamble-dialog" class="settings-folder-dialog settings-mcpb-dialog">' +
         '<form method="dialog">' +
@@ -8610,8 +8598,10 @@
             'Safari and Firefox need the manual setup linked above.' +
           '</p>' +
           '<div class="settings-mcpb-warning settings-mcpb-warning--banner">' +
-            '<strong>Installing will grant this extension access to everything on your computer.</strong> ' +
-            'Nothing is wrong. The extensions only read fellows data. Click <strong>Install</strong> to proceed.' +
+            '<strong>You will see three scary warnings from Claude Desktop.</strong> ' +
+            'They say <em>"Installing will grant this extension access to everything on your computer…"</em> ' +
+            'Nothing is wrong. The extensions only read fellows data. Anthropic just had to add these warnings. ' +
+            'Click <strong>Install</strong> to proceed on each.' +
           '</div>' +
           '<h5 class="settings-mcpb-section-title">What happens next</h5>' +
           '<ol class="settings-mcpb-steps">' +
@@ -9038,7 +9028,6 @@
     var setupBtn = document.getElementById('settings-mcpb-setup');
     var statusEl = document.getElementById('settings-mcpb-status');
     var metaEl = document.getElementById('settings-mcpb-setup-meta');
-    var postInstall = document.getElementById('settings-mcpb-post-install');
     var updateRow = document.getElementById('settings-mcpb-update-row');
     var refreshDirBtn = document.getElementById('settings-mcpb-refresh-directory');
     var dialog = document.getElementById('settings-mcpb-preamble-dialog');
@@ -9070,22 +9059,24 @@
     function refreshUiFromState() {
       var state = getMcpbSetupState();
       var serverSha = (bootBuildMeta && bootBuildMeta.fellows_db_sha) || null;
+      // Button label stays constant — "Set up Claude Desktop integration" —
+      // for both first-time and re-run. The meta line below carries the
+      // state distinction (whether the user has set up before, and when).
+      // Earlier iteration relabelled the button to "Re-download all
+      // extensions"; maintainer feedback was that the label was awkward
+      // and the meta line already conveyed the same info.
       if (state && state.setupAt) {
-        setupBtn.textContent = 'Re-download all extensions';
         if (metaEl) {
           metaEl.hidden = false;
-          metaEl.textContent = 'Last set up: ' +
-            formatRelativeTime(state.refreshedAt || state.setupAt) +
-            '. Re-downloading replaces the extensions you have installed in Claude Desktop.';
+          metaEl.innerHTML = 'Last set up: <strong>' +
+            escapeHtml(formatRelativeTime(state.refreshedAt || state.setupAt)) +
+            '</strong>. Re-running this will replace the extensions you have installed in Claude Desktop.';
         }
-        if (postInstall) postInstall.hidden = false;
       } else {
-        setupBtn.textContent = 'Set up Claude Desktop integration';
         if (metaEl) {
           metaEl.hidden = true;
           metaEl.textContent = '';
         }
-        if (postInstall) postInstall.hidden = true;
       }
       // Directory-data-update affordance — only meaningful after at
       // least one prior setup AND when the server's current fellows.db

--- a/app/static/styles.css
+++ b/app/static/styles.css
@@ -3455,31 +3455,6 @@ a.group-action-btn--primary {
   margin: 0 0 0.5rem;
 }
 
-.settings-mcpb-post-install {
-  margin-top: 1rem;
-  padding: 0.75rem 1rem;
-  border: 1px solid #d8d2e8;
-  border-radius: 6px;
-  background: #f7f4fb;
-}
-
-.settings-mcpb-post-install h4 {
-  margin: 0 0 0.5rem;
-  font-size: 1rem;
-}
-
-.settings-mcpb-next-steps {
-  margin: 0 0 0.5rem;
-  padding-left: 1.25rem;
-  font-size: 0.92rem;
-  line-height: 1.5;
-  color: #334155;
-}
-
-.settings-mcpb-next-steps li {
-  margin-bottom: 0.35rem;
-}
-
 /* Preamble dialog overrides — wider, with structured warnings. */
 .settings-mcpb-dialog {
   max-width: 36rem;

--- a/plans/maintainer_test_plan_through_pr_200.md
+++ b/plans/maintainer_test_plan_through_pr_200.md
@@ -15,7 +15,9 @@
 | #197 | `feat/mcpb-prod-routes` | merged | Auth-gated `GET /mcpb/<name>.mcpb` routes in `deploy/server.py` |
 | #198 | `feat/mcpb-settings-ui` | merged | Settings UI + preamble dialog + walkthrough rewrite + migrate-from-browser hint (steps 6 / 7 / 8 of `plans/easy_mcp_install.md` § 12) |
 | #199 | `fix/e2e-stale-ui-assertions` | merged | Unblocks 10 pre-existing e2e failures (build-badge removal aftermath + Playwright + showSaveFilePicker + User Guide rename) |
-| #200 | `fix/about-update-check-flake` | this PR | Fixes the last pre-existing e2e flake (TestAboutUpdateCheck — boot's `getFull` re-render clobbered `paintAppRow` output) |
+| #200 | `fix/about-update-check-flake` | merged | Fixes the last pre-existing e2e flake (TestAboutUpdateCheck — boot's `getFull` re-render clobbered `paintAppRow` output) |
+| #201 | `feat/onboarding-clarity-pr200-followup` | open | Recommended-platform intro on users-manual, feature ↔ platform matrix doc, MCPB preamble restructure (warning to top, 6-step what-happens-next, three-extensions detail collapsed), Never-SaaS image |
+| #202 | `feat/mcpb-preamble-feedback-pr202` | open | Round-2 preamble polish: new warning wording, removed redundant post-install panel, button label stays "Set up…", meta line bolded. Plus the test-plan section 4d/4e clarifications below. Files [GH issue #202](https://github.com/richbodo/fellows_local_db/issues/202) for the data-folder "reveal in Finder" affordance discovered during testing. |
 
 After #200 merges, `just test` should run clean against `main` with no known failures or flakes from this 24-hour window.
 
@@ -93,17 +95,27 @@ Open the app, navigate to `#/settings`.
 
 ### 4d. Continue flow (dev server returns 404 — that's expected locally)
 - [ ] Click **Set up** → **Continue**. Status flips to *Downloading three .mcpb files…* then *Downloads triggered.*
-- [ ] Browser pops up 3 download notifications (or starts 3 downloads). Each is a 404 / empty file from the dev server. **Don't worry — that's expected; real bundles are served from prod.**
-- [ ] **Setup button** relabels to "Re-download all extensions."
-- [ ] **Post-install panel** ("After the downloads finish") now visible with 4-step next-steps list.
-- [ ] **Setup-meta line** says "Last set up: a few seconds ago."
-- [ ] **Reload** the page — state persists; button still says "Re-download all extensions."
+- [ ] Browser pops up 3 download notifications (or starts 3 downloads). Each is a 404 / "File wasn't available on site" from the dev server. **Don't worry — that's expected; real bundles are served from prod.**
+- [ ] **Setup button label is unchanged** — still says "Set up Claude Desktop integration." (This was a maintainer-flagged regression; the post-setup state lives in the meta line below the button now, not in a relabel.)
+- [ ] **Setup-meta line** below the button is now visible: "Last set up: **just now**. Re-running this will replace the extensions you have installed in Claude Desktop." (The "just now" fragment is bold.)
+- [ ] **Reload** the page — meta line persists with updated relative time ("Last set up: **a minute ago**").
 
 ### 4e. Directory-data-update affordance
-- [ ] In DevTools console: `localStorage.setItem('fellows_mcpb_setup', JSON.stringify({setupAt: new Date().toISOString(), refreshedAt: new Date().toISOString(), fellowsDbSha: 'stale-sha'}))`. Reload Settings page.
-- [ ] **Directory data update row** is now visible with a *Re-install Fellows directory* button.
-- [ ] Click the button — single download fires (`shared_data_ops.mcpb`).
-- [ ] Clear the localStorage key to reset.
+
+> **Order matters** — the row only renders during `renderSettingsPage`, which runs on hash navigation. Don't expect the row to appear *on the same page view* where you set localStorage; navigate away and back.
+
+- [ ] First confirm 4d above has been done so a `fellows_mcpb_setup` record exists (with a real `fellowsDbSha`).
+- [ ] Open DevTools console (⌥⌘I) and run:
+  ```js
+  const s = JSON.parse(localStorage.getItem('fellows_mcpb_setup'));
+  s.fellowsDbSha = 'stale-sha';
+  localStorage.setItem('fellows_mcpb_setup', JSON.stringify(s));
+  ```
+  (Or if no setup record exists yet: `localStorage.setItem('fellows_mcpb_setup', JSON.stringify({setupAt: new Date().toISOString(), refreshedAt: new Date().toISOString(), fellowsDbSha: 'stale-sha'}))`)
+- [ ] **Navigate away** from Settings (`#/about` works) then **navigate back** (`#/settings`). This triggers re-render; just clicking *Settings* in the nav also works.
+- [ ] **Directory data update row** is now visible above the *Set up Claude Desktop integration* button, with a *Re-install Fellows directory* button.
+- [ ] Click *Re-install Fellows directory* — single download fires (`shared_data_ops.mcpb`).
+- [ ] To clean up: `localStorage.removeItem('fellows_mcpb_setup')` + reload.
 
 ## 5. Migrate-from-another-browser hint (PR #198) — (L)
 

--- a/plans/maintainer_test_plan_through_pr_200.md
+++ b/plans/maintainer_test_plan_through_pr_200.md
@@ -17,7 +17,7 @@
 | #199 | `fix/e2e-stale-ui-assertions` | merged | Unblocks 10 pre-existing e2e failures (build-badge removal aftermath + Playwright + showSaveFilePicker + User Guide rename) |
 | #200 | `fix/about-update-check-flake` | merged | Fixes the last pre-existing e2e flake (TestAboutUpdateCheck — boot's `getFull` re-render clobbered `paintAppRow` output) |
 | #201 | `feat/onboarding-clarity-pr200-followup` | open | Recommended-platform intro on users-manual, feature ↔ platform matrix doc, MCPB preamble restructure (warning to top, 6-step what-happens-next, three-extensions detail collapsed), Never-SaaS image |
-| #202 | `feat/mcpb-preamble-feedback-pr202` | open | Round-2 preamble polish: new warning wording, removed redundant post-install panel, button label stays "Set up…", meta line bolded. Plus the test-plan section 4d/4e clarifications below. Files [GH issue #202](https://github.com/richbodo/fellows_local_db/issues/202) for the data-folder "reveal in Finder" affordance discovered during testing. |
+| #203 | `feat/mcpb-preamble-feedback-pr202` | open | Round-2 preamble polish: new warning wording, removed redundant post-install panel, button label stays "Set up…", meta line bolded. Plus the test-plan section 4d/4e clarifications below. Stacked on #201. (Branch name says "pr202" because [GH issue #202](https://github.com/richbodo/fellows_local_db/issues/202) — data-folder "reveal in Finder" — took the number first.) |
 
 After #200 merges, `just test` should run clean against `main` with no known failures or flakes from this 24-hour window.
 

--- a/tests/e2e/test_mcpb_settings.py
+++ b/tests/e2e/test_mcpb_settings.py
@@ -85,11 +85,17 @@ class TestMcpbSection:
         expect(btn).to_be_visible()
         expect(btn).to_have_text("Set up Claude Desktop integration")
 
-    def test_post_install_section_is_hidden_initially(self, standalone_page, base_url_fixture):
+    def test_setup_meta_line_is_hidden_initially(self, standalone_page, base_url_fixture):
+        """The meta line ("Last set up: X ago...") only appears once the
+        user has run setup at least once. Previously this assertion was
+        on the now-removed "After the downloads finish" post-install
+        panel; the meta line is its successor as the post-setup state
+        indicator.
+        """
         page = standalone_page
         _boot_to_settings(page, base_url_fixture)
-        post = page.locator("#settings-mcpb-post-install")
-        expect(post).to_be_hidden()
+        meta = page.locator("#settings-mcpb-setup-meta")
+        expect(meta).to_be_hidden()
 
     def test_directory_update_row_is_hidden_initially(self, standalone_page, base_url_fixture):
         page = standalone_page
@@ -214,7 +220,16 @@ class TestPreambleActions:
 
 
 class TestPostSetupState:
-    def test_button_relabels_after_first_setup(self, standalone_page, base_url_fixture):
+    def test_meta_line_appears_after_first_setup(self, standalone_page, base_url_fixture):
+        """After Continue → downloads triggered, the meta line below the
+        button surfaces (with the bolded relative-time fragment). The
+        button label itself does NOT change — it stays "Set up Claude
+        Desktop integration" — because the meta line carries the
+        post-setup state. Earlier iteration relabelled the button to
+        "Re-download all extensions"; maintainer feedback was that the
+        label was awkward and the meta line already conveyed the same
+        info.
+        """
         page = standalone_page
         _install_anchor_intercept(page)
         _boot_to_settings(page, base_url_fixture)
@@ -227,11 +242,16 @@ class TestPostSetupState:
             }""",
             timeout=5000,
         )
+        # Button label is unchanged.
         expect(page.locator("#settings-mcpb-setup")).to_have_text(
-            "Re-download all extensions"
+            "Set up Claude Desktop integration"
         )
-        expect(page.locator("#settings-mcpb-post-install")).to_be_visible()
-        expect(page.locator("#settings-mcpb-setup-meta")).to_be_visible()
+        meta = page.locator("#settings-mcpb-setup-meta")
+        expect(meta).to_be_visible()
+        expect(meta).to_contain_text("Last set up:")
+        # The relative-time fragment is wrapped in <strong> so the
+        # "just now" / "5 minutes ago" lands as the scannable element.
+        expect(meta.locator("strong")).to_be_visible()
 
     def test_setup_state_persists_in_localstorage(self, standalone_page, base_url_fixture):
         page = standalone_page


### PR DESCRIPTION
## Summary

Round-2 feedback on the MCPB Settings UI from the maintainer's live walk-through of PR #201. **Stacks on top of #201** — merge #201 first.

## What changes

### 1. Preamble red warning — new wording

Replaces the previous two-sentence warning with the maintainer's preferred framing that names the failure mode (three warnings, scary, from Claude Desktop) and explicitly blames Anthropic for the disclosure UX rather than implying anything is wrong with our extensions:

> **You will see three scary warnings from Claude Desktop.** They say *"Installing will grant this extension access to everything on your computer…"* Nothing is wrong. The extensions only read fellows data. Anthropic just had to add these warnings. Click **Install** to proceed on each.

Same [Issue #186](https://github.com/richbodo/fellows_local_db/issues/186) mitigation; better honest copy.

### 2. Removed the post-install "After the downloads finish" panel

The panel duplicated the dialog's "What happens next" 6-step list. Two paths describing the same flow, in adjacent screen real-estate — exactly the ambiguous-redundant UX the maintainer flagged. The dialog covers it. The panel goes (markup + CSS + JS state).

### 3. Button label stays constant + meta line is the state

Previous iteration relabelled the button to "Re-download all extensions" once setup had been done. Maintainer flagged the relabel as awkward. New behavior: button label is always "Set up Claude Desktop integration." The meta line below carries the post-setup state:

> Last set up: **just now**. Re-running this will replace the extensions you have installed in Claude Desktop.

The relative-time fragment is bold so the scannable bit is "when."

## Tests

`tests/e2e/test_mcpb_settings.py`:

- `test_setup_meta_line_is_hidden_initially` (replaces `test_post_install_section_is_hidden_initially`)
- `test_meta_line_appears_after_first_setup` (replaces `test_button_relabels_after_first_setup`) — pins button label unchanged + meta line visible + `<strong>` for the time fragment

13/13 MCPB cases pass. 23 across MCPB + Settings + codename regression-clean.

## Test-plan updates

`plans/maintainer_test_plan_through_pr_200.md`:

- 4d updated for the new UI (button unchanged, meta line carries state, "just now" bold)
- 4e rewritten with explicit "navigate away + back to trigger re-render" sequence — the maintainer hit confusion when they set localStorage on the same page view and expected the Directory Data update row to appear in place. (Reason: `refreshUiFromState` only runs on settings-page render.)
- Top-of-file PR table extended with #200 / #201 / #202

## Adjacent issue filed

[GH #202](https://github.com/richbodo/fellows_local_db/issues/202) — data-folder "reveal in Finder" affordance. Surfaced during testing; browsers don't expose absolute paths via `showDirectoryPicker`. Out of scope for this PR; tracked for after the MCP install settles.

## Maintainer's other observations (no code action needed)

- **3 downloads firing as "File wasn't available on site"** — confirmed expected behavior on dev server (no `.mcpb` bundles served locally). Real bundles are served from prod via PR #197's auth-gated routes.
- **Couldn't reach 4d post-install panel** — by design; you can only verify it once `.mcpb` files actually install. After this PR, the panel is gone anyway and the meta line is the post-setup indicator.
- **OPFS error in console at boot** — pre-existing, unrelated to MCP install work. Not addressed here.

🤖 Generated with [Claude Code](https://claude.com/claude-code)