### PR TITLE
feat(mcpb+about): move directory-refresh affordance to About; preamble copy polish (round 3)

### DIFF
--- a/app/static/app.js
+++ b/app/static/app.js
@@ -455,6 +455,29 @@
     persistMcpbSetupState(state);
   }
 
+  // Trigger a same-origin file download via synthetic <a click()>. The
+  // browser sends the existing session cookie automatically; the
+  // auth-gated /mcpb/<name>.mcpb route accepts. A short setTimeout
+  // between calls keeps Chrome from coalescing multiple sequential
+  // downloads into one "this site is downloading multiple files" prompt
+  // beyond the first. Used by both the MCPB Settings full-setup flow
+  // and the About-page directory-refresh button.
+  function triggerSameOriginDownload(url, filename) {
+    return new Promise(function (resolve) {
+      var a = document.createElement('a');
+      a.href = url;
+      if (filename) a.download = filename;
+      a.rel = 'noopener';
+      a.style.display = 'none';
+      document.body.appendChild(a);
+      try { a.click(); } catch (e) {}
+      setTimeout(function () {
+        try { document.body.removeChild(a); } catch (e) {}
+        resolve();
+      }, 250);
+    });
+  }
+
   function initBuildBadge() {
     var clientEl = document.getElementById('build-badge-client');
     if (clientEl) clientEl.textContent = 'app: ' + FELLOWS_UI_DIAG;
@@ -6677,6 +6700,23 @@
       function paintDataRow(res) {
         if (!dataStatusEl) return;
         var statusText = '', actionHtml = '';
+        // MCPB integration is set up AND its bundled fellows.db sha is
+        // out of step with what the server reports now. Two trigger
+        // cases: (a) local fellows.db is also behind server (the user
+        // hasn't run "Update directory data" yet either), and (b) local
+        // fellows.db has been updated already but the .mcpb extension
+        // installed in Claude Desktop still carries the old snapshot.
+        // The button surfaces in both, since the user action is the
+        // same: re-download shared_data_ops.mcpb. Pre-PR-#204 this
+        // lived in the MCPB Settings section; consolidated here per
+        // maintainer feedback so all "your data versions need
+        // refreshing" affordances live in one place.
+        var mcpState = getMcpbSetupState();
+        var mcpStaleVsServer = !!(mcpState && mcpState.setupAt &&
+          res.serverSha && mcpState.fellowsDbSha &&
+          mcpState.fellowsDbSha !== res.serverSha);
+        var mcpRefreshBtnHtml = '<button type="button" class="about-update-action-btn" id="about-data-mcpb-refresh-btn">Re-install Fellows directory extension</button>';
+
         if (res.status === 'unsupported') {
           statusText = 'Directory data updates aren\u2019t available in this browser.';
         } else if (res.status === 'no-local-data') {
@@ -6691,9 +6731,14 @@
         } else if (res.status === 'update-available') {
           statusText = 'Directory Data update available';
           actionHtml = '<button type="button" class="about-update-action-btn" id="about-data-update-btn">Update directory data</button>';
+          if (mcpStaleVsServer) actionHtml += ' ' + mcpRefreshBtnHtml;
         } else if (res.status === 'up-to-date') {
           var snap = res.fetchedAt ? ' (snapshot from ' + escapeHtml(String(res.fetchedAt)) + ')' : '';
           statusText = 'up to date' + snap;
+          if (mcpStaleVsServer) {
+            statusText += ' \u2014 Claude Desktop extension is older';
+            actionHtml = mcpRefreshBtnHtml;
+          }
         } else {
           statusText = 'Couldn\u2019t check (offline?)';
         }
@@ -6708,6 +6753,21 @@
         var reloadBtn = document.getElementById('about-data-reload-btn');
         if (reloadBtn) {
           reloadBtn.addEventListener('click', function () { window.location.reload(); });
+        }
+        var mcpbBtn = document.getElementById('about-data-mcpb-refresh-btn');
+        if (mcpbBtn) {
+          mcpbBtn.addEventListener('click', function () {
+            mcpbBtn.disabled = true;
+            var originalText = mcpbBtn.textContent;
+            mcpbBtn.textContent = 'Downloading\u2026';
+            triggerSameOriginDownload('/mcpb/shared_data_ops.mcpb', 'shared_data_ops.mcpb').then(function () {
+              recordMcpbDirectoryRefresh(res.serverSha);
+              mcpbBtn.textContent = 'Downloaded \u2014 open the file to re-install';
+            }).catch(function () {
+              mcpbBtn.disabled = false;
+              mcpbBtn.textContent = originalText;
+            });
+          });
         }
       }
 
@@ -8562,16 +8622,6 @@
           'Three small extensions, installed in one go. ' +
           '<a href="https://github.com/richbodo/fellows_local_db/blob/main/docs/use_with_claude_desktop.md" target="_blank" rel="noopener">Walkthrough</a>.' +
         '</p>' +
-        '<div id="settings-mcpb-update-row" class="settings-mcpb-update-row" hidden>' +
-          '<p class="settings-hint">' +
-            '<strong>Directory data update available.</strong> ' +
-            'A newer snapshot of the public fellows directory is on the server. ' +
-            'Re-install the Fellows directory extension to pick it up.' +
-          '</p>' +
-          '<button type="button" id="settings-mcpb-refresh-directory" class="settings-download">' +
-            '⬇ Re-install Fellows directory' +
-          '</button>' +
-        '</div>' +
         '<div class="settings-mcpb-actions">' +
           '<button type="button" id="settings-mcpb-setup" class="settings-download">' +
             'Set up Claude Desktop integration' +
@@ -8585,7 +8635,7 @@
           '<h4>Set up Claude Desktop integration</h4>' +
           '<p class="settings-mcpb-platform-note">' +
             'This easy path is for <strong>Chrome and Chrome-derived browsers</strong> (Edge, Brave, Arc). ' +
-            'Safari, Firefox, and developers integrating other tools should use the ' +
+            'If you\'re using Safari, Firefox, or another browser, use the ' +
             '<a href="https://github.com/richbodo/fellows_local_db/blob/main/docs/use_with_claude_desktop.md" target="_blank" rel="noopener">manual walkthrough</a>.' +
           '</p>' +
           '<p id="settings-mcpb-preamble-folder-warning" class="settings-mcpb-warning" hidden>' +
@@ -9028,8 +9078,6 @@
     var setupBtn = document.getElementById('settings-mcpb-setup');
     var statusEl = document.getElementById('settings-mcpb-status');
     var metaEl = document.getElementById('settings-mcpb-setup-meta');
-    var updateRow = document.getElementById('settings-mcpb-update-row');
-    var refreshDirBtn = document.getElementById('settings-mcpb-refresh-directory');
     var dialog = document.getElementById('settings-mcpb-preamble-dialog');
     var folderWarning = document.getElementById('settings-mcpb-preamble-folder-warning');
     var browserWarning = document.getElementById('settings-mcpb-preamble-browser-warning');
@@ -9058,13 +9106,18 @@
 
     function refreshUiFromState() {
       var state = getMcpbSetupState();
-      var serverSha = (bootBuildMeta && bootBuildMeta.fellows_db_sha) || null;
       // Button label stays constant — "Set up Claude Desktop integration" —
       // for both first-time and re-run. The meta line below carries the
       // state distinction (whether the user has set up before, and when).
       // Earlier iteration relabelled the button to "Re-download all
       // extensions"; maintainer feedback was that the label was awkward
       // and the meta line already conveyed the same info.
+      //
+      // Directory-data refresh affordance used to live in this section
+      // too. As of PR #204 it lives on the About page next to the
+      // existing "Update directory data" button — all "your data
+      // versions need updating" affordances in one place. paintDataRow
+      // owns it.
       if (state && state.setupAt) {
         if (metaEl) {
           metaEl.hidden = false;
@@ -9076,16 +9129,6 @@
         if (metaEl) {
           metaEl.hidden = true;
           metaEl.textContent = '';
-        }
-      }
-      // Directory-data-update affordance — only meaningful after at
-      // least one prior setup AND when the server's current fellows.db
-      // snapshot differs from the one bundled at last setup.
-      if (updateRow && refreshDirBtn) {
-        if (state && state.setupAt && serverSha && state.fellowsDbSha && state.fellowsDbSha !== serverSha) {
-          updateRow.hidden = false;
-        } else {
-          updateRow.hidden = true;
         }
       }
     }
@@ -9125,33 +9168,11 @@
       }
     }
 
-    function downloadFromUrl(url, filename) {
-      // Trigger a download via a synthetic <a click()>. The browser
-      // sends the existing session cookie (same-origin), so the auth
-      // gate accepts. A short setTimeout between calls keeps Chrome
-      // from coalescing the downloads into a "this site is downloading
-      // multiple files" prompt; if the user denies the prompt the rest
-      // of the chain is best-effort.
-      return new Promise(function (resolve) {
-        var a = document.createElement('a');
-        a.href = url;
-        if (filename) a.download = filename;
-        a.rel = 'noopener';
-        a.style.display = 'none';
-        document.body.appendChild(a);
-        try { a.click(); } catch (e) {}
-        setTimeout(function () {
-          try { document.body.removeChild(a); } catch (e) {}
-          resolve();
-        }, 250);
-      });
-    }
-
     function downloadBundles(bundleNames) {
       var seq = Promise.resolve();
       bundleNames.forEach(function (name) {
         seq = seq.then(function () {
-          return downloadFromUrl('/mcpb/' + name + '.mcpb', name + '.mcpb');
+          return triggerSameOriginDownload('/mcpb/' + name + '.mcpb', name + '.mcpb');
         });
       });
       return seq;
@@ -9172,24 +9193,7 @@
       });
     }
 
-    function runDirectoryRefresh() {
-      if (!refreshDirBtn) return;
-      setStatus('Re-downloading Fellows directory extension…');
-      refreshDirBtn.disabled = true;
-      return downloadFromUrl('/mcpb/shared_data_ops.mcpb', 'shared_data_ops.mcpb').then(function () {
-        var serverSha = (bootBuildMeta && bootBuildMeta.fellows_db_sha) || null;
-        recordMcpbDirectoryRefresh(serverSha);
-        setStatus('Fellows directory extension re-downloaded. Open the file to re-install in Claude Desktop.');
-        refreshUiFromState();
-      }).catch(function (e) {
-        setStatus('Download failed: ' + (e && e.message ? e.message : String(e)));
-      }).then(function () {
-        refreshDirBtn.disabled = false;
-      });
-    }
-
     setupBtn.addEventListener('click', openPreamble);
-    if (refreshDirBtn) refreshDirBtn.addEventListener('click', runDirectoryRefresh);
     if (dialog) {
       dialog.addEventListener('close', function () {
         // <dialog>'s close event fires for any submit (including the

--- a/app/static/styles.css
+++ b/app/static/styles.css
@@ -3442,19 +3442,6 @@ a.group-action-btn--primary {
   color: #6b7280;
 }
 
-.settings-mcpb-update-row {
-  margin: 0.75rem 0;
-  padding: 0.75rem 1rem;
-  border: 1px solid #e7c873;
-  border-radius: 6px;
-  background: #fff8e1;
-  color: #3a3a3a;
-}
-
-.settings-mcpb-update-row p {
-  margin: 0 0 0.5rem;
-}
-
 /* Preamble dialog overrides — wider, with structured warnings. */
 .settings-mcpb-dialog {
   max-width: 36rem;

--- a/plans/maintainer_test_plan_through_pr_200.md
+++ b/plans/maintainer_test_plan_through_pr_200.md
@@ -17,7 +17,8 @@
 | #199 | `fix/e2e-stale-ui-assertions` | merged | Unblocks 10 pre-existing e2e failures (build-badge removal aftermath + Playwright + showSaveFilePicker + User Guide rename) |
 | #200 | `fix/about-update-check-flake` | merged | Fixes the last pre-existing e2e flake (TestAboutUpdateCheck — boot's `getFull` re-render clobbered `paintAppRow` output) |
 | #201 | `feat/onboarding-clarity-pr200-followup` | open | Recommended-platform intro on users-manual, feature ↔ platform matrix doc, MCPB preamble restructure (warning to top, 6-step what-happens-next, three-extensions detail collapsed), Never-SaaS image |
-| #203 | `feat/mcpb-preamble-feedback-pr202` | open | Round-2 preamble polish: new warning wording, removed redundant post-install panel, button label stays "Set up…", meta line bolded. Plus the test-plan section 4d/4e clarifications below. Stacked on #201. (Branch name says "pr202" because [GH issue #202](https://github.com/richbodo/fellows_local_db/issues/202) — data-folder "reveal in Finder" — took the number first.) |
+| #203 | `feat/mcpb-preamble-feedback-pr202` | open | Round-2 preamble polish: new warning wording, removed redundant post-install panel, button label stays "Set up…", meta line bolded. Stacked on #201. (Branch name says "pr202" because [GH issue #202](https://github.com/richbodo/fellows_local_db/issues/202) — now broader *Data folder section UX non-functional* — took the number first.) |
+| #204 | `feat/about-mcpb-refresh-pr204` | open | Round-3: moves the MCPB "Re-install Fellows directory" affordance out of Settings into the About page's Directory data action cell (logical home for all "your data is out of date" controls). Drops "developers integrating other tools" from preamble blue box. Stacked on #203. |
 
 After #200 merges, `just test` should run clean against `main` with no known failures or flakes from this 24-hour window.
 
@@ -100,9 +101,9 @@ Open the app, navigate to `#/settings`.
 - [ ] **Setup-meta line** below the button is now visible: "Last set up: **just now**. Re-running this will replace the extensions you have installed in Claude Desktop." (The "just now" fragment is bold.)
 - [ ] **Reload** the page — meta line persists with updated relative time ("Last set up: **a minute ago**").
 
-### 4e. Directory-data-update affordance
+### 4e. Directory-data-update affordance (MOVED to About page in PR #204)
 
-> **Order matters** — the row only renders during `renderSettingsPage`, which runs on hash navigation. Don't expect the row to appear *on the same page view* where you set localStorage; navigate away and back.
+> **As of PR #204, this lives on the About page** next to the existing *Update directory data* button — all "your data is out of date" affordances in one logical place. The yellow row in the MCPB Settings section is gone.
 
 - [ ] First confirm 4d above has been done so a `fellows_mcpb_setup` record exists (with a real `fellowsDbSha`).
 - [ ] Open DevTools console (⌥⌘I) and run:
@@ -111,10 +112,10 @@ Open the app, navigate to `#/settings`.
   s.fellowsDbSha = 'stale-sha';
   localStorage.setItem('fellows_mcpb_setup', JSON.stringify(s));
   ```
-  (Or if no setup record exists yet: `localStorage.setItem('fellows_mcpb_setup', JSON.stringify({setupAt: new Date().toISOString(), refreshedAt: new Date().toISOString(), fellowsDbSha: 'stale-sha'}))`)
-- [ ] **Navigate away** from Settings (`#/about` works) then **navigate back** (`#/settings`). This triggers re-render; just clicking *Settings* in the nav also works.
-- [ ] **Directory data update row** is now visible above the *Set up Claude Desktop integration* button, with a *Re-install Fellows directory* button.
-- [ ] Click *Re-install Fellows directory* — single download fires (`shared_data_ops.mcpb`).
+- [ ] Navigate to **About** (`#/about`).
+- [ ] Click **Check for updates** in the update block.
+- [ ] In the *Directory data* row's action cell, you should see a **Re-install Fellows directory extension** button (alongside *Update directory data* if local data is also behind server, or alone if only the MCPB extension is behind).
+- [ ] Click it — single download fires (`shared_data_ops.mcpb`). Button flips to *"Downloaded — open the file to re-install"*.
 - [ ] To clean up: `localStorage.removeItem('fellows_mcpb_setup')` + reload.
 
 ## 5. Migrate-from-another-browser hint (PR #198) — (L)

--- a/tests/e2e/test_mcpb_settings.py
+++ b/tests/e2e/test_mcpb_settings.py
@@ -97,13 +97,6 @@ class TestMcpbSection:
         meta = page.locator("#settings-mcpb-setup-meta")
         expect(meta).to_be_hidden()
 
-    def test_directory_update_row_is_hidden_initially(self, standalone_page, base_url_fixture):
-        page = standalone_page
-        _boot_to_settings(page, base_url_fixture)
-        row = page.locator("#settings-mcpb-update-row")
-        expect(row).to_be_hidden()
-
-
 class TestPreambleDialog:
     def test_setup_button_opens_preamble(self, standalone_page, base_url_fixture):
         page = standalone_page
@@ -273,33 +266,7 @@ class TestPostSetupState:
         assert record["setupAt"]
         assert record["refreshedAt"]
 
-    def test_directory_update_row_shows_when_sha_changes(self, standalone_page, base_url_fixture):
-        """If the user has set up before but the server now reports a
-        different ``fellows_db_sha``, the Settings UI exposes the
-        re-install-directory button."""
-        page = standalone_page
-        _boot_to_settings(page, base_url_fixture)
-        # Seed localStorage with a setup record that pins a stale sha,
-        # then re-render the settings page (via hash bounce) so
-        # refreshUiFromState runs.
-        page.evaluate(
-            """() => {
-              localStorage.setItem('fellows_mcpb_setup', JSON.stringify({
-                setupAt: new Date().toISOString(),
-                refreshedAt: new Date().toISOString(),
-                fellowsDbSha: 'stale-sha-not-on-server'
-              }));
-              window.bootBuildMeta = window.bootBuildMeta || {};
-              window.bootBuildMeta.fellows_db_sha = 'fresh-server-sha';
-            }"""
-        )
-        # Bounce off then back to trigger re-render.
-        page.evaluate("location.hash = '#/about'")
-        page.wait_for_function(
-            "() => !document.getElementById('settings-mcpb-section')",
-            timeout=5000,
-        )
-        page.evaluate("location.hash = '#/settings'")
-        page.wait_for_selector("#settings-mcpb-section", timeout=5000)
-        expect(page.locator("#settings-mcpb-update-row")).to_be_visible()
-        expect(page.locator("#settings-mcpb-refresh-directory")).to_be_visible()
+    # NB: directory-data refresh affordance moved out of the MCPB
+    # Settings section in PR #204. It now lives on the About page next
+    # to the existing "Update directory data" button. See
+    # tests/e2e/test_update_check.py::TestAboutDirectoryRefreshForMcpb.

--- a/tests/e2e/test_update_check.py
+++ b/tests/e2e/test_update_check.py
@@ -141,3 +141,106 @@ class TestAboutUpdateCheck:
         finally:
             context.unroute(BUILD_META_PATH)
             page.close()
+
+
+class TestAboutDirectoryRefreshForMcpb:
+    """The MCPB "Re-install Fellows directory extension" affordance
+    lives in the About-page Directory data action cell (PR #204 moved
+    it out of the MCPB Settings section). It surfaces only when the
+    user has set up MCPB AND the bundled fellows.db sha is older than
+    the server's current sha. Two visible scenarios:
+
+      1. ``res.status === 'update-available'`` — local fellows.db is
+         also behind server. Both buttons render side by side:
+         "Update directory data" + "Re-install Fellows directory
+         extension".
+      2. ``res.status === 'up-to-date'`` but MCPB is still behind —
+         local fellows.db has been refreshed already, MCPB extension
+         in Claude Desktop has not. Only the MCPB refresh button
+         renders, with explanatory status text.
+    """
+
+    def test_mcpb_button_hidden_when_no_mcpb_setup(self, context, base_url_fixture):
+        """No localStorage record → no MCPB refresh button, even when
+        directory data is out of date."""
+        page = _make_standalone_page(context)
+        try:
+            _route_build_meta(context, git_sha="abc123", fellows_db_sha="server-sha-A")
+            page.goto(base_url_fixture + "/#/about", wait_until="domcontentloaded")
+            _wait_for_boot_settled(page)
+            page.evaluate("localStorage.removeItem('fellows_mcpb_setup')")
+            page.locator("#about-check-updates").click()
+            # Allow either status to settle; button must NOT appear.
+            page.wait_for_function(
+                """() => {
+                  const s = document.getElementById('about-data-status');
+                  return s && s.textContent && !/Checking/.test(s.textContent);
+                }""",
+                timeout=5000,
+            )
+            assert page.locator("#about-data-mcpb-refresh-btn").count() == 0
+        finally:
+            context.unroute(BUILD_META_PATH)
+            page.close()
+
+    def test_mcpb_button_appears_when_mcpb_sha_stale_vs_server(self, context, base_url_fixture):
+        """MCPB set up with a stale fellows.db sha + server reports a
+        different sha → the refresh button appears in the action cell."""
+        page = _make_standalone_page(context)
+        try:
+            # MCPB recorded a setup with sha "stale-mcpb" — server now
+            # returns "fresh-server". Status is 'up-to-date' or 'error'
+            # depending on what compareFellowsDbSha returns from the
+            # local worker; what matters for this test is that the MCPB
+            # button surfaces regardless of the local-vs-server status.
+            _route_build_meta(context, git_sha="abc123", fellows_db_sha="fresh-server")
+            page.goto(base_url_fixture + "/#/about", wait_until="domcontentloaded")
+            _wait_for_boot_settled(page)
+            page.evaluate(
+                """() => {
+                  localStorage.setItem('fellows_mcpb_setup', JSON.stringify({
+                    setupAt: new Date().toISOString(),
+                    refreshedAt: new Date().toISOString(),
+                    fellowsDbSha: 'stale-mcpb'
+                  }));
+                }"""
+            )
+            page.locator("#about-check-updates").click()
+            # Button shows up once Check-for-updates completes.
+            page.wait_for_selector("#about-data-mcpb-refresh-btn", timeout=5000)
+            btn = page.locator("#about-data-mcpb-refresh-btn")
+            expect(btn).to_be_visible()
+            expect(btn).to_contain_text("Re-install Fellows directory extension")
+        finally:
+            context.unroute(BUILD_META_PATH)
+            page.close()
+
+    def test_mcpb_button_hidden_when_mcpb_in_sync_with_server(self, context, base_url_fixture):
+        """MCPB recorded the same fellows.db sha that the server now
+        reports → no refresh needed → button stays hidden."""
+        page = _make_standalone_page(context)
+        try:
+            _route_build_meta(context, git_sha="abc123", fellows_db_sha="same-sha")
+            page.goto(base_url_fixture + "/#/about", wait_until="domcontentloaded")
+            _wait_for_boot_settled(page)
+            page.evaluate(
+                """() => {
+                  localStorage.setItem('fellows_mcpb_setup', JSON.stringify({
+                    setupAt: new Date().toISOString(),
+                    refreshedAt: new Date().toISOString(),
+                    fellowsDbSha: 'same-sha'
+                  }));
+                }"""
+            )
+            page.locator("#about-check-updates").click()
+            page.wait_for_function(
+                """() => {
+                  const s = document.getElementById('about-data-status');
+                  return s && s.textContent && !/Checking/.test(s.textContent);
+                }""",
+                timeout=5000,
+            )
+            assert page.locator("#about-data-mcpb-refresh-btn").count() == 0
+        finally:
+            context.unroute(BUILD_META_PATH)
+            page.close()


### PR DESCRIPTION
## Summary

Round-3 feedback from the live walk-through. **Stacks on top of #203** (which stacks on #201). Merge order: #201 → #203 → #204.

## What changes

### 1. MCPB directory-refresh affordance moves out of Settings, into About page

Your read: the *"Directory data update available"* yellow row in Settings → Claude Desktop integration didn't belong there. All "your data version is out of step" affordances should live in one place — the About-page blue update block — where the existing *Check for updates* / *App update available* / *Update directory data* controls already live.

- **Removed** `#settings-mcpb-update-row` markup + JS + CSS from the MCPB Settings section.
- **Hoisted** the download helper from `wireMcpbSection` to module scope as `triggerSameOriginDownload(url, filename)` so the About page can reuse it.
- **`paintDataRow`** in `renderAboutPage` now conditionally appends a **Re-install Fellows directory extension** button to the Directory data action cell whenever MCPB is set up AND `mcpState.fellowsDbSha !== res.serverSha`.

Two contexts:
- Local fellows.db is also behind server → both buttons side by side (*Update directory data* + *Re-install Fellows directory extension*).
- Local up to date, MCPB still behind → only the MCPB button renders, with status *"up to date (snapshot from X) — Claude Desktop extension is older"*.

Click handler downloads `/mcpb/shared_data_ops.mcpb`, advances `mcpState.fellowsDbSha` to the new server sha in localStorage, and flips the button to *"Downloaded — open the file to re-install"*.

### 2. Preamble blue-box copy

Drops the "developers integrating other tools" clause per your read:

> Before: "Safari, Firefox, and developers integrating other tools should use the manual walkthrough."
>
> After: "If you're using Safari, Firefox, or another browser, use the manual walkthrough."

## Tests

- `tests/e2e/test_mcpb_settings.py` — removed the two tests asserting on the now-gone `#settings-mcpb-update-row`, left a pointer comment to the new test class.
- `tests/e2e/test_update_check.py` — new `TestAboutDirectoryRefreshForMcpb` with three cases:
  - `test_mcpb_button_hidden_when_no_mcpb_setup` — no record → no button regardless of server sha.
  - `test_mcpb_button_appears_when_mcpb_sha_stale_vs_server` — record + stale sha → button visible.
  - `test_mcpb_button_hidden_when_mcpb_in_sync_with_server` — record + matching sha → no button.

**18/18 MCPB + update-check pass. 35 across Settings / about_stats / install_codename / MCPB / update-check regression-clean.**

## Test-plan updates

Section 4e rewritten to walk you through the new About-page location. PR table extended with #204.

## Adjacent issue rewritten

[GH #202](https://github.com/richbodo/fellows_local_db/issues/202) expanded from the narrow "Reveal in Finder" ask to **Data folder section UX is non-functional — needs overhaul**, with your full critique captured:

- Rename to **Private data folder**
- Replace Save now / Reload / Disconnect with a single **Change folder…**
- Reconcile users-manual *Migrating from another browser* recipe with the actual UI (the *Download my user data* button is hidden in folder mode but the manual references it)
- Capture parent folder name on first pick so the user has a starting breadcrumb
- Investigate (and document) the absent first-party "Reveal in Finder" JS API

Out of scope for this PR; tracked for after MCP install settles.

🤖 Generated with [Claude Code](https://claude.com/claude-code)