### PR TITLE
test(mobile): add interaction tests + layout audits (#179 PR-A)

### DIFF
--- a/justfile
+++ b/justfile
@@ -245,6 +245,13 @@ test-fast:
 test-mobile *args="tests/e2e/mobile/ -v":
     ./scripts/ensure_port_8765_free.sh {{args}}
 
+# Mobile interaction + layout audits only — the functional tests that catch
+# "can't use this on a phone" bugs. Faster than `just test-mobile` because it
+# skips the screenshot smoke suite. See plans/mobile_redesign/ + issue #179.
+[group('test')]
+test-mobile-functional *args="-v":
+    ./scripts/ensure_port_8765_free.sh tests/e2e/mobile/test_mobile_layout.py tests/e2e/mobile/test_mobile_interactions.py tests/e2e/mobile/test_edit_mode_layout.py {{args}}
+
 # Promote the latest mobile captures to baselines. Run after deliberate UI
 # changes; review the visual diff in git before committing.
 [group('test')]

--- a/tests/e2e/mobile/conftest.py
+++ b/tests/e2e/mobile/conftest.py
@@ -10,6 +10,21 @@ Runs each test against three viewport profiles:
                    user reported overlap on was a similar-width Android.
 
 Phase 4 (real-device + BrowserStack) covers the engine-specific gap.
+
+Two fixtures here:
+
+  * mobile_page          — read-only / snapshot-only. PWA standalone is faked
+                           so the directory renders; no other shims. Used by
+                           the screenshot smoke tests.
+  * mobile_interaction_page — full-shim mobile page for interaction testing.
+                           Adds the showSaveFilePicker delete that the desktop
+                           conftest does (avoids download-dialog hangs) so the
+                           same e2e patterns desktop tests use work at mobile
+                           viewport.
+
+The interaction fixture pairs with mobile_worker_data (below) to drive
+window.__dataProvider RPCs for test setup (groups, settings), mirroring the
+desktop worker_data pattern.
 """
 from __future__ import annotations
 
@@ -32,8 +47,9 @@ _NARROW_360 = {
 }
 
 
-# The app gates the directory behind PWA standalone mode for non-installed
-# browsers. Mobile screenshots want the directory, not the install landing.
+# Standalone shim only — matches what mobile_page has always done. The
+# snapshot suite is read-only and doesn't need the showSaveFilePicker
+# delete (no downloads). Interaction tests use the richer shim below.
 _STANDALONE_DISPLAY_INIT = """
 (function () {
   var orig = window.matchMedia.bind(window);
@@ -49,6 +65,32 @@ _STANDALONE_DISPLAY_INIT = """
     }
     return orig(q);
   };
+})();
+"""
+
+# Interaction-fixture shim: same standalone fake PLUS the showSaveFilePicker
+# delete from the desktop conftest. The picker fires a native OS save
+# dialog that Playwright's page.expect_download doesn't see, hanging any
+# test that exports / downloads. Removing it forces the anchor-download
+# fallback, which Playwright catches reliably.
+_INTERACTION_INIT = """
+(function () {
+  var orig = window.matchMedia.bind(window);
+  window.matchMedia = function (q) {
+    q = String(q);
+    if (q.indexOf('display-mode: standalone') !== -1) {
+      return {
+        matches: true,
+        media: q,
+        addEventListener: function () {},
+        removeEventListener: function () {}
+      };
+    }
+    return orig(q);
+  };
+  try { delete window.showSaveFilePicker; } catch (e) {
+    try { window.showSaveFilePicker = undefined; } catch (e2) {}
+  }
 })();
 """
 
@@ -75,3 +117,41 @@ def mobile_page(playwright, browser, device_name):
         yield page
     finally:
         context.close()
+
+
+@pytest.fixture
+def mobile_interaction_page(playwright, browser, device_name):
+    """Mobile page configured for full interaction testing.
+
+    Same device matrix as mobile_page but the init script also removes
+    window.showSaveFilePicker so tests that trigger downloads (settings
+    backup, group export) don't hang on the native save dialog.
+    """
+    context = browser.new_context(**_device_kwargs(playwright, device_name))
+    page = context.new_page()
+    page.add_init_script(_INTERACTION_INIT)
+    try:
+        yield page
+    finally:
+        context.close()
+
+
+@pytest.fixture
+def mobile_worker_data(mobile_interaction_page, base_url_fixture):
+    """WorkerDataHelper bound to the mobile-emulated page.
+
+    Mirrors the desktop worker_data fixture: navigate to /, wait for
+    window.__dataProvider, wipe relationships state on entry + exit so
+    tests are order-independent. Use this fixture for tests that need
+    groups / settings pre-seeded (or need to assert post-state).
+    """
+    from tests.e2e.conftest import make_worker_data
+    helper = make_worker_data(mobile_interaction_page, base_url_fixture)
+    helper.wipe_relationships()
+    try:
+        yield helper
+    finally:
+        try:
+            helper.wipe_relationships()
+        except Exception:
+            pass

--- a/tests/e2e/mobile/test_mobile_interactions.py
+++ b/tests/e2e/mobile/test_mobile_interactions.py
@@ -1,0 +1,352 @@
+"""Mobile interaction tests.
+
+Drives real user flows at mobile viewports — taps, form submits,
+sheet open/close, navigation. Catches the class of bug that
+screenshot-only smoke tests miss ("button doesn't actually do
+anything when tapped on a phone"). Parametrized across the device
+matrix (Pixel 5 / iPhone 13 / narrow-360) via the existing
+device_name fixture in conftest.
+
+The headline test for the discovery PR is
+``test_can_create_group_from_directory_route`` — it exercises the
+mobile group-creation flow end to end and fails when the reported
+bug (no path to the composer on mobile) is present.
+
+Tests use the ``mobile_interaction_page`` fixture (full shim) or
+``mobile_worker_data`` (when worker-RPC setup or assertion is
+needed). Both live in ``conftest.py``.
+"""
+from __future__ import annotations
+
+import re
+
+import pytest
+from playwright.sync_api import expect
+
+
+def _wait_for_app_boot(page, timeout: int = 10000) -> None:
+    page.locator("#loading").wait_for(state="hidden", timeout=timeout)
+    page.wait_for_timeout(400)
+
+
+# ===== Directory route =====================================================
+
+
+def test_directory_loads_and_shows_fellow_names(
+    mobile_interaction_page, device_name, base_url_fixture
+):
+    """Directory at mobile should render a list of fellow names. Sanity
+    check that the route boots cleanly at mobile viewports."""
+    page = mobile_interaction_page
+    page.goto(base_url_fixture + "/", wait_until="domcontentloaded")
+    _wait_for_app_boot(page)
+    rows = page.locator("#directory li.dir-row")
+    assert rows.count() > 0, (
+        f"no directory rows rendered at {device_name}"
+    )
+    first_link = rows.first.locator(".dir-link")
+    expect(first_link).to_be_visible()
+    name = first_link.text_content()
+    assert name and name.strip(), (
+        f"first directory row has no name text at {device_name}"
+    )
+
+
+def test_tap_fellow_name_navigates_to_detail(
+    mobile_interaction_page, device_name, base_url_fixture
+):
+    """Tapping a fellow's name should navigate to their detail page.
+    The detail route must then render visible content."""
+    page = mobile_interaction_page
+    page.goto(base_url_fixture + "/", wait_until="domcontentloaded")
+    _wait_for_app_boot(page)
+    first_link = page.locator("#directory li.dir-row .dir-link").first
+    expect(first_link).to_be_visible()
+    first_link.click()
+    page.wait_for_function(
+        "() => window.location.hash.indexOf('#/fellow/') === 0",
+        timeout=5000,
+    )
+    # The body picks up route-fellow once the route() handler runs.
+    expect(page.locator("body")).to_have_class(
+        re.compile(r"\broute-fellow\b"),
+        timeout=3000,
+    )
+    # #detail is the main pane where the fellow's content renders.
+    expect(page.locator("#detail")).to_be_visible()
+
+
+def test_selecting_fellow_reveals_fab(
+    mobile_interaction_page, device_name, base_url_fixture
+):
+    """Tapping the +/× marker on a directory row should add the fellow
+    to the selection draft and reveal the composer FAB so the user has
+    a path to actually create a group on mobile.
+
+    Root of the user-reported "no way to create a group" bug — if this
+    fails, the rail-driven group-creation flow has no mobile entry
+    point at all."""
+    page = mobile_interaction_page
+    page.goto(base_url_fixture + "/", wait_until="domcontentloaded")
+    _wait_for_app_boot(page)
+    mark = page.locator("#directory li.dir-row .dir-mark").first
+    expect(mark).to_be_visible()
+    mark.click()
+    # Body picks up .has-selection once the draft is non-empty.
+    expect(page.locator("body")).to_have_class(
+        re.compile(r"\bhas-selection\b"),
+        timeout=3000,
+    )
+    # FAB is hidden initially via .hidden; should become visible on
+    # selection at mobile widths.
+    fab = page.locator("#composer-fab")
+    expect(fab).to_be_visible(timeout=3000)
+
+
+def test_can_open_and_close_composer_sheet(
+    mobile_interaction_page, device_name, base_url_fixture
+):
+    """Tap the FAB → composer rail slides up as a bottom sheet
+    (body.composer-open). Closing the composer should remove the
+    class and put the rail back off-screen."""
+    page = mobile_interaction_page
+    page.goto(base_url_fixture + "/", wait_until="domcontentloaded")
+    _wait_for_app_boot(page)
+    page.locator("#directory li.dir-row .dir-mark").first.click()
+    fab = page.locator("#composer-fab")
+    expect(fab).to_be_visible(timeout=3000)
+    fab.click()
+    expect(page.locator("body")).to_have_class(
+        re.compile(r"\bcomposer-open\b"),
+        timeout=3000,
+    )
+    # The composer rail itself must now be visible on-screen.
+    rail = page.locator("#group-rail")
+    expect(rail).to_be_visible()
+    rail_metrics = page.evaluate(
+        """
+        () => {
+          const r = document.getElementById('group-rail').getBoundingClientRect();
+          return {top: r.top, bottom: r.bottom, vh: window.innerHeight};
+        }
+        """
+    )
+    assert rail_metrics["top"] < rail_metrics["vh"], (
+        f"composer rail not on-screen after open at {device_name}: "
+        f"top={rail_metrics['top']}, vh={rail_metrics['vh']}"
+    )
+
+
+def test_can_create_group_from_directory_route(
+    mobile_worker_data, device_name, base_url_fixture
+):
+    """Headline test: a user at mobile should be able to create a group
+    end to end without leaving the directory route.
+
+    Flow: select one fellow → tap FAB → fill name → tap Create new
+    group → assert the group was persisted via the worker.
+
+    Failure here = the user's reported bug ("no way to create a group
+    on mobile") is reproduced."""
+    helper = mobile_worker_data
+    page = helper.page
+    # mobile_worker_data already navigated + waited; ensure we're on directory.
+    page.evaluate("location.hash = '#/'")
+    _wait_for_app_boot(page)
+    # Select the first fellow.
+    page.locator("#directory li.dir-row .dir-mark").first.click()
+    # Open composer.
+    fab = page.locator("#composer-fab")
+    expect(fab).to_be_visible(timeout=3000)
+    fab.click()
+    expect(page.locator("body")).to_have_class(
+        re.compile(r"\bcomposer-open\b"),
+        timeout=3000,
+    )
+    # Fill the group name. The title input is contenteditable in the
+    # current shipping rail. Fall back to typing if it's a regular input.
+    title = page.locator("#group-rail-title")
+    expect(title).to_be_visible()
+    group_name = f"Mobile created at {device_name}"
+    is_editable = page.evaluate(
+        "() => document.getElementById('group-rail-title').isContentEditable"
+    )
+    if is_editable:
+        title.click()
+        page.keyboard.type(group_name)
+    else:
+        title.fill(group_name)
+    # Submit.
+    create_btn = page.locator("#group-rail-create")
+    expect(create_btn).to_be_enabled(timeout=3000)
+    create_btn.click()
+    # Worker should now report the group exists.
+    page.wait_for_function(
+        f"() => window.__dataProvider.listGroups().then(gs => "
+        f"gs.some(g => g.name === {group_name!r}))",
+        timeout=5000,
+    )
+    groups = helper.list_groups()
+    names = [g["name"] for g in groups]
+    assert group_name in names, (
+        f"group not persisted via mobile composer at {device_name}; "
+        f"got names={names!r}"
+    )
+
+
+# ===== Kebab menu (app-bar) ================================================
+
+
+def test_kebab_menu_opens_and_dismisses(
+    mobile_interaction_page, device_name, base_url_fixture
+):
+    """Top-right kebab button should open the bottom sheet; close
+    button (or scrim tap) should dismiss it."""
+    page = mobile_interaction_page
+    page.goto(base_url_fixture + "/", wait_until="domcontentloaded")
+    _wait_for_app_boot(page)
+    kebab = page.locator(".appbar__kebab").first
+    expect(kebab).to_be_visible(timeout=5000)
+    kebab.click()
+    # The kebab sheet has id="kebab-sheet" or similar — look for the
+    # generic .sheet that becomes visible after the click. Use whichever
+    # of the known kebab sheet ids exists in the DOM.
+    sheet_visible = page.evaluate(
+        """
+        () => {
+          const sheets = document.querySelectorAll('.sheet');
+          for (const s of sheets) {
+            if (!s.classList.contains('hidden')
+                && getComputedStyle(s).display !== 'none') {
+              return {id: s.id, cls: s.className};
+            }
+          }
+          return null;
+        }
+        """
+    )
+    assert sheet_visible is not None, (
+        f"kebab tap did not open any .sheet at {device_name}"
+    )
+
+
+# ===== About page (post-#205 two-button layout) ============================
+
+
+def test_about_page_two_check_buttons_present(
+    mobile_interaction_page, device_name, base_url_fixture
+):
+    """After #205, About has two explicit check buttons. Both must be
+    visible and tappable on mobile."""
+    page = mobile_interaction_page
+    page.goto(base_url_fixture + "/#/about", wait_until="domcontentloaded")
+    _wait_for_app_boot(page)
+    app_btn = page.locator("#about-check-app-update")
+    data_btn = page.locator("#about-check-data-update")
+    expect(app_btn).to_be_visible()
+    expect(app_btn).to_have_text("Check for application updates")
+    expect(data_btn).to_be_visible()
+    expect(data_btn).to_have_text("Check for directory data updates")
+    # The install codename moved inside the App row in #205; confirm
+    # the inline element renders on mobile too.
+    codename = page.locator(".about-install-name-inline")
+    expect(codename).to_be_visible()
+
+
+def test_about_check_application_updates_button_taps(
+    mobile_interaction_page, device_name, base_url_fixture
+):
+    """Tapping Check for application updates should run the check and
+    populate the app-row status. We don't assert the specific result
+    (depends on server build label) — only that the button is
+    interactive at mobile widths and produces a status update."""
+    page = mobile_interaction_page
+    page.goto(base_url_fixture + "/#/about", wait_until="domcontentloaded")
+    _wait_for_app_boot(page)
+    app_status = page.locator("#about-app-status")
+    initial = app_status.text_content() or ""
+    page.locator("#about-check-app-update").click()
+    # Either the status text changes (most likely) or the button gets
+    # relabeled. Wait for either.
+    page.wait_for_function(
+        f"() => document.getElementById('about-app-status').textContent !== {initial!r}"
+        f" || document.getElementById('about-check-app-update').textContent !== 'Check for application updates'",
+        timeout=5000,
+    )
+
+
+# ===== Settings page (post-#205 private-data-folder layout) ================
+
+
+def test_settings_email_field_saves(
+    mobile_worker_data, device_name, base_url_fixture
+):
+    """Settings → Your email saves to relationships.db via the worker.
+    Catches mobile-keyboard-covers-the-input + tap-the-save-button
+    failures at narrow widths."""
+    helper = mobile_worker_data
+    page = helper.page
+    page.evaluate("location.hash = '#/settings'")
+    _wait_for_app_boot(page)
+    email_input = page.locator("#settings-self-email")
+    expect(email_input).to_be_visible()
+    email_input.fill(f"mobile-{device_name.replace(' ', '-').lower()}@example.com")
+    page.locator(".settings-save").click()
+    # The setting lands via worker RPC.
+    page.wait_for_function(
+        f"() => window.__dataProvider.getSetting('self_email')"
+        f"  .then(v => v && v.indexOf('mobile-') === 0)",
+        timeout=5000,
+    )
+    saved = helper.get_setting("self_email")
+    assert saved and saved.startswith("mobile-"), (
+        f"settings did not persist via mobile UI at {device_name}; got {saved!r}"
+    )
+
+
+# ===== Groups index + fellow detail ========================================
+
+
+def test_groups_index_renders_card_list_on_mobile(
+    mobile_worker_data, device_name, base_url_fixture
+):
+    """At mobile widths the groups index renders as cards (the
+    .groups-table is hidden). With at least one group seeded, at least
+    one card must render and be visible."""
+    helper = mobile_worker_data
+    helper.create_group(name="Mobile index card", fellow_record_ids=[])
+    page = helper.page
+    page.evaluate("location.hash = '#/groups'")
+    _wait_for_app_boot(page)
+    # .groups-table is hidden at mobile; .groups-card-list takes over.
+    card_list = page.locator(".groups-card-list")
+    expect(card_list).to_be_visible()
+    cards = page.locator(".groups-card-list .groups-card")
+    assert cards.count() > 0, (
+        f"groups card list rendered no cards at {device_name}"
+    )
+
+
+def test_fellow_detail_renders_useful_content(
+    mobile_interaction_page, device_name, base_url_fixture
+):
+    """Fellow detail route at mobile must render the fellow's name in
+    the central pane. Sanity check for the route the user described as
+    'looked okay' — guards the working state."""
+    page = mobile_interaction_page
+    page.goto(
+        base_url_fixture + "/#/fellow/aaron_bird",
+        wait_until="domcontentloaded",
+    )
+    _wait_for_app_boot(page)
+    expect(page.locator("body")).to_have_class(
+        re.compile(r"\broute-fellow\b"),
+        timeout=3000,
+    )
+    detail = page.locator("#detail")
+    expect(detail).to_be_visible()
+    # The fellow's name should be in the detail pane.
+    text = detail.text_content() or ""
+    assert text.strip(), (
+        f"#detail is empty on fellow-detail route at {device_name}"
+    )

--- a/tests/e2e/mobile/test_mobile_layout.py
+++ b/tests/e2e/mobile/test_mobile_layout.py
@@ -1,0 +1,248 @@
+"""Layout audits at mobile viewports.
+
+Structural checks that catch a class of "can't use this on a phone"
+bugs without relying on pixel comparison or interaction. Each test
+runs across the device matrix (Pixel 5 / iPhone 13 / narrow-360) and
+each static route in turn.
+
+These tests are designed to fail loudly when the mobile layout has
+known-bad geometry — that's the point of the discovery PR (#179
+follow-up). Failures here become the bug surface to fix; once green,
+the tests act as regression guards.
+
+Three audits:
+
+  1. No horizontal overflow (the page doesn't scroll sideways).
+  2. Touch targets meet the iOS HIG 44x44 minimum.
+  3. No fixed / sticky element anchored at the bottom consumes more
+     than 40% of the viewport height.
+
+Plus one route-specific test for the directory route's content area
+visibility (catches the "names rail squeezed to a sliver by the
+bottom bar" bug reported in the issue thread).
+"""
+from __future__ import annotations
+
+import json
+
+import pytest
+from playwright.sync_api import expect
+
+
+# Static routes covered by the audits. Group-scoped routes need
+# mobile_worker_data setup and are exercised in test_mobile_interactions.py.
+STATIC_ROUTES = [
+    ("#/", "directory"),
+    ("#/about", "about"),
+    ("#/settings", "settings"),
+    ("#/groups", "groups-index"),
+    ("#/fellow/aaron_bird", "fellow-detail"),
+]
+
+
+def _wait_for_app_boot(page, timeout: int = 10000) -> None:
+    """Wait for the loader to vanish + a brief settle for late layout shifts."""
+    page.locator("#loading").wait_for(state="hidden", timeout=timeout)
+    page.wait_for_timeout(400)
+
+
+@pytest.mark.parametrize("hash_route,label", STATIC_ROUTES)
+def test_no_horizontal_overflow(
+    mobile_page, device_name, base_url_fixture, hash_route, label
+):
+    """Page must not scroll sideways at mobile viewports.
+
+    `document.documentElement.scrollWidth > clientWidth` means content
+    overflows the viewport horizontally — content runs off the right edge
+    and the user can swipe sideways to find it. That's a layout bug
+    that bites on every mobile width. +1px tolerance absorbs rounding.
+    """
+    page = mobile_page
+    page.goto(base_url_fixture + "/" + hash_route, wait_until="domcontentloaded")
+    _wait_for_app_boot(page)
+    metrics = page.evaluate(
+        """
+        () => ({
+          scrollWidth: document.documentElement.scrollWidth,
+          clientWidth: document.documentElement.clientWidth,
+          innerWidth: window.innerWidth,
+        })
+        """
+    )
+    assert metrics["scrollWidth"] <= metrics["clientWidth"] + 1, (
+        f"horizontal overflow on {label} at {device_name}: "
+        f"scrollWidth={metrics['scrollWidth']}, clientWidth={metrics['clientWidth']}, "
+        f"innerWidth={metrics['innerWidth']}"
+    )
+
+
+@pytest.mark.parametrize("hash_route,label", STATIC_ROUTES)
+def test_touch_targets_meet_minimum_size(
+    mobile_page, device_name, base_url_fixture, hash_route, label
+):
+    """Interactive elements must be at least 44x44 (iOS HIG).
+
+    Walks the DOM for clickable elements, asserts each visible one
+    meets the minimum bounding box. Failure message is the full list
+    of sub-44 elements as JSON — so the test output itself is the
+    fix list.
+
+    Skipped: hidden elements (display:none / visibility:hidden /
+    opacity:0 / .hidden class / aria-hidden="true") and zero-size
+    elements (typically purely-styled wrappers).
+    """
+    page = mobile_page
+    page.goto(base_url_fixture + "/" + hash_route, wait_until="domcontentloaded")
+    _wait_for_app_boot(page)
+    findings = page.evaluate(
+        r"""
+        () => {
+          const sel = [
+            'button',
+            'a[href]',
+            '[role=button]',
+            'input[type=button]',
+            'input[type=submit]',
+            'input[type=checkbox]',
+            'input[type=radio]',
+            'summary',
+          ].join(', ');
+          const small = [];
+          document.querySelectorAll(sel).forEach(el => {
+            const r = el.getBoundingClientRect();
+            if (r.width === 0 && r.height === 0) return;
+            const styles = getComputedStyle(el);
+            if (styles.display === 'none' || styles.visibility === 'hidden') return;
+            if (parseFloat(styles.opacity) === 0) return;
+            if (el.getAttribute('aria-hidden') === 'true') return;
+            if (el.classList.contains('hidden')) return;
+            if (r.width < 44 || r.height < 44) {
+              small.push({
+                tag: el.tagName,
+                id: el.id || null,
+                cls: el.className || null,
+                text: (el.textContent || '').replace(/\s+/g, ' ').trim().slice(0, 40),
+                w: Math.round(r.width),
+                h: Math.round(r.height),
+              });
+            }
+          });
+          return small;
+        }
+        """
+    )
+    assert findings == [], (
+        f"sub-44 touch targets on {label} at {device_name} "
+        f"({len(findings)} elements):\n" + json.dumps(findings, indent=2)
+    )
+
+
+@pytest.mark.parametrize("hash_route,label", STATIC_ROUTES)
+def test_no_fixed_element_dominates_viewport(
+    mobile_page, device_name, base_url_fixture, hash_route, label
+):
+    """No fixed/sticky element anchored at the bottom should take more
+    than 40% of the viewport height.
+
+    Geometric signature of the "bottom bar takes half the screen" bug:
+    fixed or sticky positioning, height > 40% of vh, bottom edge past
+    50% of vh. Catches sheets that are permanently up when they
+    shouldn't be (composer rail with broken translate, kebab sheet
+    stuck open, group-detail action bar misconfigured).
+    """
+    page = mobile_page
+    page.goto(base_url_fixture + "/" + hash_route, wait_until="domcontentloaded")
+    _wait_for_app_boot(page)
+    findings = page.evaluate(
+        """
+        () => {
+          const vh = window.innerHeight;
+          const oversized = [];
+          document.querySelectorAll('*').forEach(el => {
+            const styles = getComputedStyle(el);
+            if (styles.position !== 'fixed' && styles.position !== 'sticky') return;
+            if (styles.display === 'none' || styles.visibility === 'hidden') return;
+            if (parseFloat(styles.opacity) === 0) return;
+            if (el.classList.contains('hidden')) return;
+            const r = el.getBoundingClientRect();
+            if (r.width === 0 || r.height === 0) return;
+            if (r.bottom <= 0 || r.top >= vh) return;
+            const heightPct = r.height / vh;
+            const bottomPct = r.bottom / vh;
+            if (heightPct > 0.4 && bottomPct > 0.5) {
+              oversized.push({
+                tag: el.tagName,
+                id: el.id || null,
+                cls: el.className || null,
+                position: styles.position,
+                h: Math.round(r.height),
+                heightPctOfVh: Math.round(heightPct * 100),
+                top: Math.round(r.top),
+                bottom: Math.round(r.bottom),
+              });
+            }
+          });
+          return oversized;
+        }
+        """
+    )
+    assert findings == [], (
+        f"oversized bottom-anchored element on {label} at {device_name}:\n"
+        + json.dumps(findings, indent=2)
+    )
+
+
+def test_directory_route_has_visible_content(
+    mobile_page, device_name, base_url_fixture
+):
+    """Directory route at mobile must show a usable list of fellows.
+
+    Targets the reported bug: on mobile the directory page is broken —
+    "only the left column with the names in the center" is visible, and
+    "about half the screen is just the gray bar." That collapses to
+    three structural claims this test checks:
+
+      1. #directory is visible and renders > 0 fellow rows.
+      2. #directory occupies at least 40% of the viewport height.
+      3. The directory list's top is above 50% of the viewport (it
+         isn't pushed off-screen by other chrome).
+
+    Failure on any clause means the directory route's mobile layout is
+    structurally broken.
+    """
+    page = mobile_page
+    page.goto(base_url_fixture + "/", wait_until="domcontentloaded")
+    _wait_for_app_boot(page)
+    expect(page.locator("#directory")).to_be_visible()
+    rows = page.locator("#directory li.dir-row")
+    row_count = rows.count()
+    assert row_count > 0, (
+        f"directory has no rendered fellow rows at {device_name}"
+    )
+    metrics = page.evaluate(
+        """
+        () => {
+          const d = document.getElementById('directory');
+          const r = d.getBoundingClientRect();
+          return {
+            height: Math.round(r.height),
+            top: Math.round(r.top),
+            bottom: Math.round(r.bottom),
+            vh: window.innerHeight,
+            heightPctOfVh: Math.round(r.height / window.innerHeight * 100),
+            topPctOfVh: Math.round(r.top / window.innerHeight * 100),
+          };
+        }
+        """
+    )
+    assert metrics["heightPctOfVh"] >= 40, (
+        f"directory list squeezed at {device_name}: "
+        f"{metrics['heightPctOfVh']}% of viewport "
+        f"({metrics['height']}px of {metrics['vh']}px). "
+        f"top={metrics['top']}, bottom={metrics['bottom']}"
+    )
+    assert metrics["topPctOfVh"] <= 50, (
+        f"directory list pushed off-screen at {device_name}: "
+        f"top is {metrics['topPctOfVh']}% down the viewport "
+        f"({metrics['top']}px of {metrics['vh']}px)"
+    )


### PR DESCRIPTION
## Summary

Discovery PR for the mobile-testing automation plan in #179. Adds Playwright-emulated functional coverage of mobile flows so manual phone testing becomes a periodic audit rather than the only thing catching real bugs.

**What's in this PR:**
- `mobile_interaction_page` + `mobile_worker_data` fixtures (mirror the desktop `standalone_page` + `worker_data` patterns at mobile viewports)
- `test_mobile_layout.py` — 4 structural audits (horizontal overflow, touch-target size, fixed-element-dominates-viewport, directory route content visibility)
- `test_mobile_interactions.py` — 10 real-user-flow tests (group creation end-to-end, kebab menu, settings, About post-#205, etc.)
- `just test-mobile-functional` recipe — runs only the new functional suites (skips the slow screenshot smoke)

**Discovery output (the point of this PR):** 24 new test cases fail on first run. They reproduce real bugs that exist on `main` today. No fixes in this PR — fixes are scoped to PR-B per the #179 plan.

## Failures that surfaced

### 🔴 Composer FAB hidden after fellow selection on mobile (9 cases)

This reproduces the user-reported *"no way to create a group on mobile"* bug. Tapping `.dir-mark` to select a fellow does **not** reveal `#composer-fab` — the button keeps both the HTML `hidden` attribute AND the `.hidden` CSS class. Likely root cause: the FAB show handler only removes the class, not the attribute (or only runs at desktop widths). The CSS rule `body.route-directory.has-selection .fab--composer { display: flex; }` is overridden by the `[hidden]` attribute's `display: none`.

Failing tests:
- `test_selecting_fellow_reveals_fab` × Pixel 5 / iPhone 13 / narrow-360
- `test_can_open_and_close_composer_sheet` × 3 devices
- `test_can_create_group_from_directory_route` × 3 devices

This is the headline bug for PR-B to fix.

### 🔴 Sub-44 touch targets across every route (15 cases)

iOS Human Interface Guidelines specify a 44×44 minimum tap target. Many interactive elements miss it. Sample offenders (from `#/fellow/aaron_bird` at narrow-360):

```json
[
  {"tag": "BUTTON", "cls": "copy-btn", "text": "📋", "w": 21, "h": 12},
  {"tag": "A", "text": "LinkedIn", "w": 55, "h": 17},
  {"tag": "A", "text": "Twitter", "w": 46, "h": 17},
  {"tag": "A", "text": "aaronbird@gmail.com", "w": 144, "h": 17},
  {"tag": "A", "cls": "tabs__tab tabs__tab--active", "h": 40}
]
```

Plus `.dir-mark` (24×24) on every directory row across every route.

Failing tests: `test_touch_targets_meet_minimum_size` × 5 routes × 3 devices.

PR-B walks this list; each fix flips a red test green.

## What passes (regression guards now in place)

57 of the new test cases pass. Notable green checks:

- **No horizontal overflow** on any route at any mobile viewport.
- **No fixed/sticky element dominating** the viewport (no oversized bottom-anchored elements found in Chromium emulation).
- **Directory route content is structurally visible** (#directory occupies ≥40% of viewport height, top is above 50% vh) at every emulated mobile width.
- Tap-to-navigate, kebab open, About two-button layout (post-#205), Settings email persist, groups card-list render, fellow-detail content render — all work at mobile widths.

## What didn't reproduce in emulation

The *"bottom bar takes half the screen"* symptom from the user's report did **not** reproduce in Chromium emulation. The `test_no_fixed_element_dominates_viewport` audit returned no findings on any route. Two possibilities:

1. **Real-device-specific** — iOS Safari has well-known viewport-unit quirks (`100vh` includes the address-bar area, which collapses on scroll) that desktop Chromium with mobile-shaped viewport doesn't reproduce. The "secondary path" real-phone capture in #206 would catch this.
2. **State-dependent** — the bug might require some interaction sequence we're not triggering (open the composer once, dismiss it, the layout breaks; etc.).

Either way, the FAB bug is the immediate blocker; the "bottom bar" symptom can be investigated as part of PR-B's mobile pass.

## Side note — pre-existing test skips

`tests/e2e/mobile/test_routes.py` and `test_edit_mode_layout.py` both create groups via `POST /api/groups`, which was retired in Phase 1 of the local-first worker cutover. Their `try/except URLError` swallows the 404 and the tests silently skip (12 skips in the run). Not blocking for this PR but worth a separate cleanup — porting them to `mobile_worker_data` would restore coverage.

## Test plan

- [x] All new tests pass / fail as documented above; failures are the bug surface.
- [x] Existing snapshot smoke (`test_routes.py`) + `test_edit_mode_layout.py` still behave the same (15 passed, 12 skipped — unchanged).
- [x] `just test-mobile` runs the full mobile suite (smoke + new).
- [x] `just test-mobile-functional` runs only the new functional suites.

## Refs

- Plan: comment thread on #179
- Snapshot refresh from prior UX work: #206

🤖 Generated with [Claude Code](https://claude.com/claude-code)