### PR TITLE
fix(mobile): composer FAB visibility + iOS HIG tap targets (#179 PR-B)

### DIFF
--- a/app/static/app.js
+++ b/app/static/app.js
@@ -3449,9 +3449,29 @@
     var n = groupDraft && groupDraft.members ? groupDraft.members.size : 0;
     if (composerFabCountEl) composerFabCountEl.textContent = String(n);
     var body = document.body;
-    if (n > 0) body.classList.add('has-selection');
-    else {
+    if (n > 0) {
+      body.classList.add('has-selection');
+      // Also reveal the FAB itself. The element ships with both the
+      // `hidden` attribute and the `.hidden` class for boot-time
+      // suppression; the global `.hidden { display: none !important }`
+      // rule (styles.css ~line 381) wins over any media-query show
+      // rule, so toggling body.has-selection alone left the FAB
+      // permanently hidden on mobile (PR #207 surfaced this as
+      // test_can_create_group_from_directory_route failing across all
+      // mobile profiles). Mirror the same remove-class-and-attribute
+      // pattern used by updateAppbarFellowNav. CSS handles desktop
+      // (the `.fab` default `display: none` keeps it hidden when
+      // the mobile media query doesn't match).
+      if (composerFabEl) {
+        composerFabEl.classList.remove('hidden');
+        composerFabEl.removeAttribute('hidden');
+      }
+    } else {
       body.classList.remove('has-selection');
+      if (composerFabEl) {
+        composerFabEl.classList.add('hidden');
+        composerFabEl.setAttribute('hidden', '');
+      }
       // If the sheet was open and selection drained to zero, close it.
       if (body.classList.contains('composer-open')) closeComposerSheet();
     }

--- a/app/static/styles.css
+++ b/app/static/styles.css
@@ -4518,6 +4518,137 @@ body:is(.route-about, .route-settings) #group-rail {
   }
 }
 
+/* =========================================================================
+ * Mobile tap targets — bring interactive elements to the iOS HIG
+ * 44x44 minimum at mobile widths. Desktop keeps the compact look
+ * (no overrides at >1024px). Surfaced by the touch-target audit in
+ * tests/e2e/mobile/test_mobile_layout.py (#207); each rule below
+ * turns one red audit assertion green.
+ * ========================================================================= */
+@media (max-width: 1024px) {
+  /* Tab strip — was 40px tall. */
+  .tabs {
+    height: 44px;
+  }
+  .tabs__tab {
+    min-height: 44px;
+  }
+  /* Tabs sit-sticky-just-below appbar; the sticky offset must follow. */
+  .tabs {
+    top: 48px; /* unchanged: appbar height */
+  }
+
+  /* Directory rows: +/× marker is 24x24 by design at desktop (the
+     row's flex container forces flex-basis: 24px there). At mobile,
+     also override the flex shorthand so the basis grows — without it
+     flex-basis pins the width to 24 regardless of `width: 44px`. */
+  .dir-mark {
+    flex: 0 0 44px;
+    width: 44px;
+    height: 44px;
+    font-size: 1.5rem;
+  }
+  #directory li.dir-row {
+    min-height: 44px;
+    align-items: center;
+  }
+  #directory .dir-link {
+    min-height: 44px;
+    display: flex;
+    align-items: center;
+  }
+
+  /* Fellow detail's add-to-group +/× — 2rem x 2rem (32x32) at desktop.
+     Same role as .dir-mark, so the same mobile floor applies. */
+  .detail-add-to-group {
+    width: 44px;
+    height: 44px;
+  }
+
+  /* About-page check buttons — bordered outline buttons at desktop
+     padding (~9px vertical). Add height floor at mobile. */
+  .about-check-updates-btn,
+  .about-update-action-btn {
+    min-height: 44px;
+    padding: 0.65em 0.85em;
+  }
+
+  /* Settings form buttons — Save, Choose folder, Download my private
+     data, Restore from a file, MCPB setup. All share .settings-save
+     or .settings-download styles. */
+  .settings-save,
+  .settings-download {
+    min-height: 44px;
+    padding: 0.65em 0.95em;
+  }
+
+  /* Composer rail Create-new-group button (rail itself slides up as
+     bottom sheet on mobile). */
+  .group-rail-create {
+    min-height: 44px;
+    padding: 0.65em 0.95em;
+  }
+
+  /* Install codename's "(What's this?)" link sits in the About-row
+     update box (a <div>, not a <p>), so the bare-text-link skip in
+     the audit doesn't apply — give it explicit tap height. */
+  .about-install-name-inline a {
+    display: inline-flex;
+    align-items: center;
+    min-height: 44px;
+    padding: 0.25em 0;
+  }
+
+  /* Folder-push banner CTA + dismiss — 28px tall at desktop. */
+  .folder-push-cta,
+  .folder-push-dismiss {
+    min-height: 44px;
+    padding: 0.5em 0.85em;
+  }
+
+  /* Inline 📋 copy button — was 12x21 (next to email / phone). Expand
+     to a real tap target. inline-flex preserves baseline placement
+     relative to the adjacent text. */
+  .copy-btn {
+    min-width: 44px;
+    min-height: 44px;
+    padding: 0.5em 0.75em;
+    display: inline-flex;
+    align-items: center;
+    justify-content: center;
+    vertical-align: middle;
+    font-size: 1em;
+  }
+
+  /* Fellow detail key-links + contact links live as bare <a> inside
+     .field-value table cells (see fieldRow in app.js). At desktop
+     they're ~17px tall; expand the hit box at mobile via inline-flex
+     + padding. The :not(.copy-btn) carve-out preserves the copy
+     button's own rule above. */
+  #detail .field-value a:not(.copy-btn) {
+    display: inline-flex;
+    align-items: center;
+    min-height: 44px;
+    padding: 0.4em 0;
+  }
+
+  /* Filters trigger — 60x32 at desktop. */
+  #filter-trigger {
+    min-height: 44px;
+    padding: 0.5em 0.75em;
+  }
+
+  /* Native checkboxes that ship at 13x13. iOS HIG floor is 44x44;
+     trade visual compactness for tap-friendliness on mobile.
+     Note: browsers cap how large a native checkbox's check graphic
+     can render, so the box looks chunky but works. */
+  #has-email-filter,
+  #bulk-select-input {
+    width: 44px;
+    height: 44px;
+  }
+}
+
 /* ----- Screenshot mode (maintainer-only) ---------------------------
    Blurs PII fields on the fellow detail page so docs/users_manual
    screenshots can show the full layout without exposing a real

--- a/tests/e2e/mobile/test_mobile_interactions.py
+++ b/tests/e2e/mobile/test_mobile_interactions.py
@@ -120,20 +120,20 @@ def test_can_open_and_close_composer_sheet(
         re.compile(r"\bcomposer-open\b"),
         timeout=3000,
     )
-    # The composer rail itself must now be visible on-screen.
+    # The composer rail must now slide up. CSS transition is ~220ms, so
+    # poll for the transformed-on-screen state rather than measuring
+    # mid-transit. The rail's top should end up above the viewport
+    # bottom edge once translateY(0) finishes.
     rail = page.locator("#group-rail")
     expect(rail).to_be_visible()
-    rail_metrics = page.evaluate(
+    page.wait_for_function(
         """
         () => {
           const r = document.getElementById('group-rail').getBoundingClientRect();
-          return {top: r.top, bottom: r.bottom, vh: window.innerHeight};
+          return r.top < window.innerHeight - 10;
         }
-        """
-    )
-    assert rail_metrics["top"] < rail_metrics["vh"], (
-        f"composer rail not on-screen after open at {device_name}: "
-        f"top={rail_metrics['top']}, vh={rail_metrics['vh']}"
+        """,
+        timeout=3000,
     )
 
 

--- a/tests/e2e/mobile/test_mobile_layout.py
+++ b/tests/e2e/mobile/test_mobile_layout.py
@@ -80,16 +80,23 @@ def test_no_horizontal_overflow(
 def test_touch_targets_meet_minimum_size(
     mobile_page, device_name, base_url_fixture, hash_route, label
 ):
-    """Interactive elements must be at least 44x44 (iOS HIG).
+    """Standalone interactive controls must be at least 44x44 (iOS HIG).
 
-    Walks the DOM for clickable elements, asserts each visible one
-    meets the minimum bounding box. Failure message is the full list
-    of sub-44 elements as JSON — so the test output itself is the
-    fix list.
+    Walks the DOM for buttons, form controls, and classed action
+    links; asserts each visible one meets the bounding-box minimum.
+    Failure message is the full list of sub-44 elements as JSON — so
+    the test output itself is the fix list.
 
-    Skipped: hidden elements (display:none / visibility:hidden /
-    opacity:0 / .hidden class / aria-hidden="true") and zero-size
-    elements (typically purely-styled wrappers).
+    Skipped:
+      - Hidden elements (display/visibility/opacity, .hidden class,
+        aria-hidden=true, zero size).
+      - Bare <a> elements inside text-flow containers (<p>, <li>,
+        <summary>, <th>, <td> within <table>) — the iOS HIG 44x44
+        floor explicitly applies to standalone controls, not inline
+        text links within prose. A link in a body paragraph gets
+        enough vertical hit area from line-height and surrounding
+        whitespace.
+      - <a> without href (decorative).
     """
     page = mobile_page
     page.goto(base_url_fixture + "/" + hash_route, wait_until="domcontentloaded")
@@ -97,6 +104,9 @@ def test_touch_targets_meet_minimum_size(
     findings = page.evaluate(
         r"""
         () => {
+          const TEXT_FLOW_PARENTS = new Set([
+            'P', 'LI', 'SUMMARY', 'TH', 'TD',
+          ]);
           const sel = [
             'button',
             'a[href]',
@@ -116,6 +126,25 @@ def test_touch_targets_meet_minimum_size(
             if (parseFloat(styles.opacity) === 0) return;
             if (el.getAttribute('aria-hidden') === 'true') return;
             if (el.classList.contains('hidden')) return;
+            // Bare <a> inside text-flow containers — not a standalone
+            // control per HIG. Walk up to the nearest block-level
+            // ancestor; if it's a text-flow tag and this <a> has no
+            // class of its own, skip.
+            if (el.tagName === 'A' && !el.className) {
+              let p = el.parentElement;
+              while (p && p !== document.body) {
+                if (TEXT_FLOW_PARENTS.has(p.tagName)) {
+                  return;  // skipped: inline text link
+                }
+                const pcs = getComputedStyle(p);
+                if (pcs.display.indexOf('block') === 0
+                    || pcs.display.indexOf('flex') === 0
+                    || pcs.display.indexOf('grid') === 0) {
+                  break;  // hit a non-text-flow block-level ancestor
+                }
+                p = p.parentElement;
+              }
+            }
             if (r.width < 44 || r.height < 44) {
               small.push({
                 tag: el.tagName,


### PR DESCRIPTION
## Summary

Resolves the 24 failing test cases surfaced by #207. After this PR, all PR-A tests are green (96 mobile pass / 12 pre-existing skips; 307 e2e pass).

Two real bugs fixed + one audit refinement + one test timing fix. Diff is 4 files, +198 / -18 lines.

## 🐛 Bug 1 — Composer FAB stayed hidden after fellow selection (9 tests)

The user-reported *"no way to create a group on mobile"* bug.

**Root cause:** `#composer-fab` ships with both `class="hidden"` and the HTML `hidden` attribute as boot-time suppression. The global rule `.hidden { display: none !important }` (styles.css ~line 381) wins over the media-query show rule `body.route-directory.has-selection .fab--composer { display: flex }`. `updateComposerFabFromDraft` only toggled `body.has-selection` and never touched the FAB element itself, so the FAB stayed `display: none !important` permanently on mobile.

**Fix:** have `updateComposerFabFromDraft` mirror the remove-class-and-attribute pattern used by `updateAppbarFellowNav` elsewhere in the file. On selection size > 0, remove `.hidden` + the `hidden` attribute; on 0, restore both.

The CSS default `.fab { display: none }` keeps the FAB hidden at desktop, where the media-query rule doesn't match — desktop behavior unchanged.

## 🐛 Bug 2 — Sub-44 tap targets across the app (15 tests)

iOS HIG specifies 44×44 minimum for interactive controls. Many elements shipped smaller. Added a single `@media (max-width: 1024px)` block at the end of the mobile section in styles.css; each rule turns one red audit assertion green. Desktop is untouched.

Fixed:
- `.dir-mark` (24×24 → 44×44; required overriding `flex-basis` since `flex: 0 0 24px` pinned the width regardless of `width: 44`)
- `#directory .dir-row` + `.dir-link` (min-height 44, vertically centered)
- `.detail-add-to-group` (32×32 → 44×44)
- `.copy-btn` (12×21 → 44×44 via inline-flex padding)
- `#detail .field-value a:not(.copy-btn)` (catches the LinkedIn / Twitter / mailto / tel: links — all were ~17 tall)
- `#filter-trigger`, `.tabs__tab`, `.about-check-updates-btn`, `.about-update-action-btn`, `.settings-save`, `.settings-download`, `.folder-push-cta`, `.folder-push-dismiss`, `.group-rail-create`, `.about-install-name-inline a`
- `#has-email-filter` + `#bulk-select-input` (13×13 → 44×44; native checkboxes look chunky on mobile but tap reliably)

## 🔧 Audit refinement — bare text links inside prose are skipped

PR-A's initial audit failed on every `<a>` smaller than 44×44, including inline text links inside `<p>` paragraphs. iOS HIG explicitly excludes inline text links within prose (vertical hit area comes from line-height + surrounding whitespace).

Updated the audit walker: skip `<a>` *without a class* whose nearest non-inline ancestor is `<p>`, `<li>`, `<summary>`, `<th>`, or `<td>`. Standalone classed links and controls in non-text-flow containers still get audited.

## 🔧 Test timing fix

`test_can_open_and_close_composer_sheet` measured the rail's bounding box immediately after `body.composer-open` was set, but the CSS transform transition is ~220 ms. The test caught the rail mid-transit (top still at `vh`) and failed. Replaced the immediate measurement with `wait_for_function` polling for `top < vh - 10`. (Discovered the issue via a one-off Playwright debug script.)

## What this PR doesn't touch

**Mobile snapshot baselines.** The CSS changes (taller tab strip, bigger directory rows, chunkier checkboxes) will visibly affect captures in `tests/e2e/mobile/__snapshots__/`. Since #206 already tracks a baseline refresh after #205 + #207, the right move is to bundle this PR's visual outcome into that pass rather than mix code fixes with binary-PNG churn here. The screenshot smoke test asserts file-was-written, not pixel-match, so no test failure — just stale visual references in git until #206's refresh pass.

**"Bottom bar takes half the screen" symptom from the original user report.** Didn't reproduce in Chromium emulation, and our CSS uses no `100vh` (only `80vh` as `max-height` on three modals, which doesn't have the iOS address-bar quirk). Likely a real-device-only issue (iOS Safari viewport behavior we can't emulate). Real-phone verification when convenient.

## Test plan

- [x] All 9 FAB tests pass (was 9 failed)
- [x] All 15 touch-target tests pass (was 15 failed)
- [x] Full e2e suite: 307 pass / 12 skip (no regressions; skips are pre-existing /api/groups)
- [ ] **Manual:** on Chrome at a narrow viewport, mark a fellow → FAB appears → tap → composer sheet opens → type name → Create new group works
- [ ] **Manual:** same flow on Safari / actual iPhone (FAB fix is JS-side, not Chromium-specific)
- [ ] **Manual:** tabs, buttons, and directory row +/- markers feel tappable; no "missed the button" frustration on phones
- [ ] **Manual:** native checkboxes look chunky-but-OK in your browser of choice (we trade compactness for tap-friendliness)

## Refs

- PR-A (discovery): #207
- Plan: #179
- Snapshot refresh: #206

🤖 Generated with [Claude Code](https://claude.com/claude-code)