### PR TITLE
feat(testing): local staging server with auth + MCPB routes

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -37,6 +37,10 @@ ansible/inventory/hosts.ini
 # Production build output (rsync / Ansible target)
 deploy/dist/
 
+# Local staging server scratch (scripts/serve_prod_local.py output).
+# Contains a tmp dist, signed manifest, magic-link log, test email marker.
+tmp/
+
 # Ansible Galaxy collections (see ansible/collections/requirements.yml)
 ansible/collections/ansible_collections/
 

--- a/docs/local_staging.md
+++ b/docs/local_staging.md
@@ -1,0 +1,139 @@
+# Local staging server
+
+A local-only server that runs `deploy/server.py` (the production server) on
+`http://127.0.0.1:8766` with auth on and Postmark stubbed to a file. Bridges
+the gap between the dev server (no auth, no MCPB routes, returns
+`authEnabled: false`) and prod (requires a deploy to test).
+
+Use this when you need to verify:
+
+- The magic-link round-trip (gate → email → unlock → session → install landing).
+- Auth-gated routes (`/mcpb/<name>.mcpb`, the session-checked `/fellows.db` path, etc.).
+- Any UI branch that gates on `authStatus.authEnabled === true`.
+- The MCPB Settings UI's "Continue" path, which 404s against the dev server.
+- Folder mode (Phase 2) under real session-cookie behavior.
+
+Do **not** use this as a production server. It uses committed test-only
+secrets, signs the bundle manifest with the committed dev signing key (which
+prod's service-worker origin check rejects), and allows insecure cookies so
+the session works over plain HTTP.
+
+## Prereqs
+
+```bash
+just doctor               # confirms .venv, fellows.db, Playwright
+just build-mcpb           # one-time; only needed for § 6 / § 7 of the test plan
+```
+
+Without `just build-mcpb`, the `/mcpb/*` routes will 404. Everything else
+works.
+
+## Quick start
+
+```bash
+just serve-prod
+```
+
+You'll see a banner with the test email (default `you@local-staging.example`)
+and the magic-link log path.
+
+Open a **new private window** at `http://127.0.0.1:8766/`. You land at the
+email gate — different from `just serve`, which skips the gate entirely.
+
+## Magic-link auth flow
+
+1. Submit the gate form with the test email shown on the startup banner.
+2. The fake Postmark stub writes the link to `tmp/prod-local/magic_links.log`
+   and prints it to the launcher's stderr.
+3. Get the link:
+   ```bash
+   just serve-prod-link
+   ```
+4. Paste it into the same browser. The session cookie sets, the install
+   landing renders.
+
+The session is a real HMAC-signed v3 cookie. All session-gated routes
+behave as they do in prod.
+
+## When to reset
+
+`tmp/prod-local/` is reused across runs by default so you can resume a
+session. Reset when:
+
+- You change anything in `app/static/` (the SW would otherwise serve the
+  cached old shell from the precache the maintainer-test session installed).
+- You rebuild `app/fellows.db` (`just db-rebuild`).
+- The launcher complains the manifest is stale.
+
+```bash
+just serve-prod-reset      # wipe tmp/prod-local/
+just serve-prod            # rebuilds dist on next start
+```
+
+## What's different from real prod
+
+| What | Local staging | Prod |
+|---|---|---|
+| Hostname | `127.0.0.1:8766` (HTTP) | `fellows.globaldonut.com` (HTTPS via Caddy) |
+| Session cookie | HMAC-signed, `Secure` flag off | HMAC-signed, `Secure` on |
+| Magic-link sender | File + stderr | Real Postmark to real inbox |
+| Bundle signing key | Committed dev key | Operator-held prod key (origin-checked in sw.js) |
+| CAA / HSTS preload | None | Per `docs/DevOps.md` § Signing keys |
+| `fellows.db` | Your local rebuild | Whatever was last deployed |
+| `.mcpb` bundles | From `deploy/dist/mcpb/` (run `just build-mcpb` first) | Same path, served from the deployed dist |
+
+The launcher's Handler subclass adds `Cross-Origin-Opener-Policy: same-origin`
+and `Cross-Origin-Embedder-Policy: require-corp` — Caddy adds these in prod
+and `deploy/server.py` omits them intentionally
+(`deploy/server.py:_security_headers` → see comment block). Without them
+OPFS-SAH-Pool refuses to install in the browser, and folder mode can't be
+tested.
+
+## Troubleshooting
+
+**Port 8766 stuck.** Previous run didn't shut down cleanly.
+```bash
+just serve-prod-stop
+just serve-prod
+```
+
+**OPFS panel says "browser not supported".** Either your browser genuinely
+doesn't support OPFS-SAH-Pool, or COOP/COEP isn't reaching it. Check
+DevTools → Network → response headers for the index page; both
+`Cross-Origin-Opener-Policy` and `Cross-Origin-Embedder-Policy` should be
+present. If not, the Handler subclass isn't taking effect — file a bug.
+
+**Magic-link form says "Could not send."** The fake-Postmark stub raised
+something. Check the launcher's stderr; the most common cause is the
+test email not in the dist's `fellows.db` (run `just serve-prod-reset`).
+
+**Settings → MCPB → Continue downloads three empty files.** You haven't
+run `just build-mcpb`. Bundles live at `deploy/dist/mcpb/*.mcpb`; the
+launcher copies them into the staging dist at startup.
+
+**Browser says "your connection is not private."** You're hitting `https://`
+by accident — local staging is plain `http://127.0.0.1:8766/`.
+
+## What this doesn't cover
+
+- iOS Safari + Android Chrome real-device installs (need HTTPS + reachable
+  hostname — that's a future Option 2 improvement, not here).
+- Real Postmark deliverability (spam scoring, DMARC).
+- Caddy header preservation regressions (the python server sets CSP /
+  Permissions-Policy / CORP itself; the Caddy-added COOP / COEP / HSTS
+  layer is only validated on prod).
+- Real Let's Encrypt / CAA / HSTS preload.
+
+For those, fall back to the existing prod smoke after deploy
+(`just smoke`, `just drift`, manual phone test).
+
+## Related
+
+- `tests/conftest.py:deploy_server` — the in-process pytest fixture this
+  launcher mirrors. Keep both consistent.
+- `plans/maintainer_test_plan_through_pr_200.md` — items marked `(S)` Ship
+  are the ones this launcher moves to `(L)` Local.
+- `docs/DevOps.md` § Signing keys — prod signing flow this launcher
+  short-circuits with the dev key.
+- `docs/email_gate.md` — the magic-link decision tree this launcher
+  exercises.

--- a/justfile
+++ b/justfile
@@ -133,6 +133,36 @@ serve-lan:
     ./run.sh start
 
 
+# ---- local staging (deploy/server.py + auth + stubbed Postmark) ----------
+# See docs/local_staging.md. Foreground on http://127.0.0.1:8766.
+
+# Start local staging server. Ctrl-C to stop. Pass --reset to rebuild dist.
+[group('staging')]
+serve-prod *args:
+    {{python}} scripts/serve_prod_local.py {{args}}
+
+# Print the most recent magic-link URL captured by the fake Postmark stub.
+[group('staging')]
+serve-prod-link:
+    @if [ -f tmp/prod-local/magic_links.log ]; then \
+        grep -E '^Link:' tmp/prod-local/magic_links.log | tail -1 | sed 's/^Link: //'; \
+    else \
+        echo "No magic links yet. Submit the gate form at http://127.0.0.1:8766/ first."; \
+    fi
+
+# Wipe tmp/prod-local/ so next serve-prod rebuilds from current sources.
+[group('staging')]
+serve-prod-reset:
+    rm -rf tmp/prod-local
+    @echo "Reset. Run 'just serve-prod' to rebuild."
+
+# Free port 8766 (e.g. previous run didn't shut down cleanly).
+[group('staging')]
+serve-prod-stop:
+    @lsof -ti:8766 | xargs -r kill -9 2>/dev/null || true
+    @echo "Port 8766 freed."
+
+
 # ---- db / data -----------------------------------------------------------
 
 # Canonical rebuild from Knack dump (auto-backup first).

--- a/scripts/serve_prod_local.py
+++ b/scripts/serve_prod_local.py
@@ -1,0 +1,273 @@
+#!/usr/bin/env python3
+"""Local staging server — runs deploy/server.py with auth on, Postmark stubbed.
+
+Bridges the gap between the dev server (`app/server.py`, no auth, no MCPB
+routes) and prod (`deploy/server.py` on https://fellows.globaldonut.com,
+which requires a real deploy to test). Use this to verify the magic-link
+flow, the `/mcpb/<name>.mcpb` auth-gated routes, and any UI branch gated
+on `authStatus.authEnabled === true` without pushing to prod.
+
+NOT for production. Uses committed test-only secrets, signs with the
+committed dev signing key (which the SW's origin check rejects on prod),
+and allows insecure cookies so the session works over plain HTTP.
+
+Mirrors the in-process setup in tests/conftest.py:deploy_server so the
+two stay consistent. If a Phase-2 user-folder-storage test depends on a
+behavior the launcher doesn't reproduce, that's a bug in one of them.
+
+See docs/local_staging.md for the maintainer workflow.
+
+Usage:
+    python scripts/serve_prod_local.py            # foreground; Ctrl-C to stop
+    python scripts/serve_prod_local.py --reset    # wipe tmp dist + rebuild
+    python scripts/serve_prod_local.py --email me@example.com
+"""
+
+from __future__ import annotations
+
+import argparse
+import base64
+import os
+import shutil
+import sqlite3
+import sys
+from datetime import datetime
+from functools import partial
+from pathlib import Path
+
+REPO_ROOT = Path(__file__).resolve().parent.parent
+TMP_DIR = REPO_ROOT / "tmp" / "prod-local"
+DIST_DIR = TMP_DIR / "dist"
+MAGIC_LINK_LOG = TMP_DIR / "magic_links.log"
+TEST_EMAIL_FILE = TMP_DIR / "test_email.txt"
+SRC_DB = REPO_ROOT / "app" / "fellows.db"
+DEV_SIGNING_KEY = REPO_ROOT / "tests" / "fixtures" / "dev_signing_key.pem"
+MCPB_SOURCE_DIR = REPO_ROOT / "deploy" / "dist" / "mcpb"
+
+PORT = 8766
+DEFAULT_TEST_EMAIL = "you@local-staging.example"
+# Test-only secrets. The string literals are intentional — readers
+# grepping a real prod env file for these values will know they hit a
+# local-staging artifact, not a prod leak.
+TEST_SESSION_SECRET = "local-staging-secret-DO-NOT-USE-IN-PROD"
+TEST_HMAC_KEY = "local-staging-hmac-DO-NOT-USE-IN-PROD"
+
+
+def _build_dist(force: bool) -> None:
+    """Materialize tmp/prod-local/dist/ — a deploy-shaped static root.
+
+    Mirrors tests/conftest.py:deploy_server fixture's setup:
+    1. Copy app/static + app/fellows.db.
+    2. Stamp build label + SRI hashes.
+    3. Write build-meta.json + bundle manifest.
+    4. Sign manifest with the committed dev key.
+    5. Symlink (or copy) the .mcpb bundles from deploy/dist/mcpb/
+       if they exist, so /mcpb/<name>.mcpb routes serve real bytes.
+    """
+    if DIST_DIR.is_dir() and (DIST_DIR / "fellows.db").is_file() and not force:
+        print(f"  Reusing existing dist at {DIST_DIR.relative_to(REPO_ROOT)}")
+        print(f"  (use --reset to rebuild from current sources)")
+        return
+
+    if not SRC_DB.is_file():
+        sys.exit(
+            f"DB not found at {SRC_DB.relative_to(REPO_ROOT)}.\n"
+            f"Run: python build/restore_from_knack_scrapefile.py"
+        )
+
+    TMP_DIR.mkdir(parents=True, exist_ok=True)
+    if DIST_DIR.is_dir():
+        shutil.rmtree(DIST_DIR)
+    shutil.copytree(REPO_ROOT / "app" / "static", DIST_DIR)
+    shutil.copy2(SRC_DB, DIST_DIR / "fellows.db")
+
+    sys.path.insert(0, str(REPO_ROOT / "build"))
+    import build_pwa  # noqa: E402
+
+    label = build_pwa.compute_build_label(REPO_ROOT)
+    build_pwa.stamp_static_assets(DIST_DIR, label)
+    build_pwa.stamp_sri_attributes(DIST_DIR)
+    build_pwa.write_build_meta(
+        DIST_DIR / "build-meta.json",
+        label,
+        db_path=DIST_DIR / "fellows.db",
+        sw_js_path=DIST_DIR / "sw.js",
+    )
+    build_pwa.write_bundle_manifest(DIST_DIR, label)
+
+    # Sign the manifest with the dev key. Same key tests/conftest.py uses;
+    # the SW verify path runs in full but the origin check renders this
+    # key inert on the real prod hostname, so leaking it doesn't matter.
+    from cryptography.hazmat.primitives import hashes, serialization
+    from cryptography.hazmat.primitives.asymmetric import ec
+    from cryptography.hazmat.primitives.asymmetric.utils import (
+        decode_dss_signature,
+    )
+
+    dev_key = serialization.load_pem_private_key(
+        DEV_SIGNING_KEY.read_bytes(), password=None
+    )
+    manifest_bytes = (DIST_DIR / "manifest.json").read_bytes()
+    der = dev_key.sign(manifest_bytes, ec.ECDSA(hashes.SHA256()))
+    r, s = decode_dss_signature(der)
+    raw_sig = r.to_bytes(32, "big") + s.to_bytes(32, "big")
+    (DIST_DIR / "manifest.sig").write_text(
+        base64.b64encode(raw_sig).decode("ascii") + "\n",
+        encoding="utf-8",
+    )
+
+    # Wire the .mcpb bundles if a previous `just build-mcpb` produced them.
+    # Without this, § 6/§ 7 of the maintainer test plan can't run locally.
+    if MCPB_SOURCE_DIR.is_dir():
+        bundles = sorted(MCPB_SOURCE_DIR.glob("*.mcpb"))
+        if bundles:
+            target = DIST_DIR / "mcpb"
+            target.mkdir(exist_ok=True)
+            for b in bundles:
+                shutil.copy2(b, target / b.name)
+            print(f"  Wired {len(bundles)} .mcpb bundle(s) from deploy/dist/mcpb/")
+    else:
+        print(
+            "  No .mcpb bundles found at deploy/dist/mcpb/ — run "
+            "`just build-mcpb` first if you want § 6/§ 7 tests."
+        )
+
+    print(f"  Built dist at {DIST_DIR.relative_to(REPO_ROOT)} (label: {label})")
+
+
+def _allowlist_test_email(email: str) -> None:
+    """Insert the test email into the dist's fellows.db so init_auth()
+    derives an HMAC for it and the allowlist accepts it."""
+    db = DIST_DIR / "fellows.db"
+    conn = sqlite3.connect(str(db))
+    try:
+        conn.execute(
+            "INSERT OR REPLACE INTO fellows "
+            "(record_id, slug, name, contact_email) VALUES (?, ?, ?, ?)",
+            (
+                "local-staging-tester",
+                "local-staging-tester",
+                "Local Staging Tester",
+                email,
+            ),
+        )
+        conn.commit()
+    finally:
+        conn.close()
+    TEST_EMAIL_FILE.write_text(email + "\n")
+
+
+def _start_server(email: str) -> None:
+    """Configure env, import deploy/server.py, monkey-patch Postmark,
+    subclass Handler to add COOP/COEP, run foreground."""
+    os.environ["FELLOWS_DIST_ROOT"] = str(DIST_DIR)
+    os.environ["FELLOWS_SESSION_SECRET"] = TEST_SESSION_SECRET
+    os.environ["FELLOWS_ALLOWLIST_HMAC_KEY"] = TEST_HMAC_KEY
+    os.environ["FELLOWS_COOKIE_INSECURE"] = "1"
+    os.environ["PORT"] = str(PORT)
+    # Never send real email from a local-staging run, even if the dev
+    # shell has a real token in it.
+    os.environ.pop("FELLOWS_POSTMARK_TOKEN", None)
+
+    sys.path.insert(0, str(REPO_ROOT / "deploy"))
+    # Force re-import so module-level globals (DIST_DIR, PORT) honor
+    # our env. Safe to do at startup of a fresh process.
+    for mod in ("server", "magic_link_auth", "sqlite_api_support"):
+        sys.modules.pop(mod, None)
+    import server as deploy_srv  # noqa: E402
+    import magic_link_auth as ml  # noqa: E402
+
+    # Replace the Postmark sender with a file-writer + stderr printer.
+    # Maintainer reads the link from `just serve-prod-link` (latest) or
+    # `tail -F tmp/prod-local/magic_links.log` (live stream).
+    def fake_send(to_email, magic_url, pubkey_fingerprint=None):
+        with MAGIC_LINK_LOG.open("a", encoding="utf-8") as f:
+            f.write(f"Time: {datetime.now().isoformat()}\n")
+            f.write(f"To:   {to_email}\n")
+            f.write(f"Link: {magic_url}\n")
+            f.write("---\n")
+        print(f"\n[fake-postmark] {magic_url}", file=sys.stderr, flush=True)
+        return {
+            "status": 200,
+            "message_id": "stub-local-staging",
+            "error_code": 0,
+            "message": "OK (local staging stub)",
+            "to": to_email,
+            "submitted_at": None,
+            "raw": {},
+        }
+
+    ml.send_postmark_magic_link = fake_send
+
+    deploy_srv.init_auth()
+    # Diagnostics blob has a build_meta field the prod server populates
+    # from a separate code path; tests set it to {}, we do the same.
+    deploy_srv.BUILD_META = {}
+
+    # deploy/server.py omits COOP / COEP intentionally — they're set by
+    # Caddy at the edge in prod (see deploy/server.py:210-216 and
+    # ansible/roles/caddy/templates/Caddyfile.j2). Without them OPFS-
+    # SAH-Pool refuses to install in the browser and folder mode can't
+    # be tested. Add them at the local-staging layer so the in-browser
+    # experience matches prod behavior.
+    _OrigHandler = deploy_srv.Handler
+
+    class LocalStagingHandler(_OrigHandler):
+        def _security_headers(self) -> None:  # type: ignore[override]
+            super()._security_headers()
+            self.send_header("Cross-Origin-Opener-Policy", "same-origin")
+            self.send_header("Cross-Origin-Embedder-Policy", "require-corp")
+
+    handler_factory = partial(LocalStagingHandler, directory=str(DIST_DIR))
+    httpd = deploy_srv.ThreadingHTTPServer(("127.0.0.1", PORT), handler_factory)
+
+    sys.stderr.write(
+        "\n"
+        "╭──────────────────────────────────────────────────────╮\n"
+        "│ Local staging server                                  │\n"
+        f"│ http://127.0.0.1:{PORT}/                                │\n"
+        f"│ Test email:  {email:<40s}│\n"
+        "│ Magic links: just serve-prod-link (latest)            │\n"
+        "│               tail -F tmp/prod-local/magic_links.log  │\n"
+        "│ Stop:        Ctrl-C                                   │\n"
+        "╰──────────────────────────────────────────────────────╯\n"
+        "\n"
+    )
+    sys.stderr.flush()
+
+    try:
+        httpd.serve_forever()
+    except KeyboardInterrupt:
+        sys.stderr.write("\nShutting down…\n")
+        httpd.shutdown()
+
+
+def main() -> int:
+    parser = argparse.ArgumentParser(
+        description="Local staging server (deploy/server.py + auth + stubbed Postmark)."
+    )
+    parser.add_argument(
+        "--reset",
+        action="store_true",
+        help="Wipe tmp/prod-local/ and rebuild the dist from current sources.",
+    )
+    parser.add_argument(
+        "--email",
+        default=DEFAULT_TEST_EMAIL,
+        help=f"Email to allowlist (default: {DEFAULT_TEST_EMAIL}).",
+    )
+    args = parser.parse_args()
+
+    if args.reset and TMP_DIR.is_dir():
+        shutil.rmtree(TMP_DIR)
+        print(f"  Reset {TMP_DIR.relative_to(REPO_ROOT)}")
+
+    TMP_DIR.mkdir(parents=True, exist_ok=True)
+    _build_dist(force=args.reset)
+    _allowlist_test_email(args.email)
+    _start_server(args.email)
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())


### PR DESCRIPTION
## Summary

Adds `just serve-prod` — a foreground launcher that runs `deploy/server.py` on `http://127.0.0.1:8766` with auth on and Postmark stubbed to a file. Bridges the gap between the dev server (no auth, no MCPB routes, `authEnabled:false`) and prod (which requires a real deploy to test).

After this PR, the maintainer can verify the magic-link flow, `/mcpb/*` routes, and every UI branch gated on `authStatus.authEnabled === true` entirely locally — no prod deploy required for those.

## Why now

The current shipping cadence is "deploy to prod, test, find regressions" because most of the (S) Ship-to-test items in `plans/maintainer_test_plan_through_pr_200.md` aren't reachable against the dev server. This PR moves the largest chunk of that list to (L) Local-test:

- § 4d (MCPB Continue flow — was "404s from dev server, that's expected")
- § 6 (MCPB prod routes — was entirely (S))
- Download half of § 7 (Claude Desktop install bundles)

Real-device tests (iOS Safari install, real Postmark deliverability, Caddy header preservation) still need prod and aren't unlockable by any local-only infrastructure. Those four gaps are documented in `docs/local_staging.md` § "What this doesn't cover."

Cycle-time savings: ~30 min of manual prod verification per release; pays back from cycle 2.

## What ships

- **`scripts/serve_prod_local.py`** (~230 lines). Mirrors the in-process setup in `tests/conftest.py:deploy_server` so the launcher and the test fixture stay consistent — if a Phase-2 test depends on a behavior the launcher doesn't reproduce, that's a bug in one of them.
- **`justfile` recipes**: `serve-prod` / `serve-prod-link` / `serve-prod-reset` / `serve-prod-stop`. Grouped under `[staging]`.
- **`docs/local_staging.md`** — maintainer-facing README covering quickstart, magic-link auth walkthrough, what's different from prod, and troubleshooting.
- **`.gitignore`** — adds `tmp/`.

Zero application code touched.

## Important: COOP / COEP

`deploy/server.py` omits `Cross-Origin-Opener-Policy` and `Cross-Origin-Embedder-Policy` because Caddy adds them at the edge in prod (see `deploy/server.py:_security_headers:210-216` and `ansible/roles/caddy/templates/Caddyfile.j2`). Without those headers OPFS-SAH-Pool refuses to install in the browser and folder mode falls back to `api+idb`. The launcher's `LocalStagingHandler` subclass adds them locally so the in-browser experience matches prod behavior.

This means local staging does **not** validate "Caddy strips a header it shouldn't" regressions — that gap still needs a separate prod smoke check. Reasonable follow-up: extend `scripts/smoke_prod.sh` to assert on the five edge-set headers. Out of scope here.

## Smoke test (passed locally end-to-end)

```
GET / → 200
COOP/COEP headers present ✓
GET /mcpb/comms.mcpb without session → 403
POST /api/send-unlock → {"sent": true} + link captured to tmp/prod-local/magic_links.log
POST /api/verify-token → {"ok": true} + session cookie set
GET /api/auth/status with cookie → {authEnabled:true, authenticated:true, installRecentlyAllowed:true}
GET /mcpb/comms.mcpb with session → 200, 3.4 MB, application/octet-stream
GET /mcpb/bogus.mcpb → 404
```

`--reset` and `--email <addr>` flags verified.

## Test plan

- [x] `just serve-prod` starts on port 8766 with the expected banner
- [x] `just serve-prod-link` returns the most recent captured magic link
- [x] `just serve-prod-reset` wipes `tmp/prod-local/`
- [x] `just serve-prod-stop` frees port 8766
- [x] COOP/COEP headers present on all responses
- [x] Magic-link round-trip end-to-end (gate → file capture → unlock → session cookie)
- [x] Auth-gated `/mcpb/*` routes (403 without session, 200 with)
- [x] `--reset` and `--email <addr>` CLI flags
- [x] Full `just test`: 599 pass / 15 skip / 2 flake-pattern failures
  - `test_post_commit_auto_writes_advance_last_saved_at` and `test_directory_route_has_visible_content[iPhone 13-chromium]` both passed in isolation
  - Same flake pattern as observed during PR #209 development (full-suite state accumulation)
  - This PR touches zero application code and zero test code — no causal mechanism
- [ ] Real-use validation: walk § 4d / § 6 / § 7 of `maintainer_test_plan_through_pr_200.md` against the launcher (deferred to first real maintainer use)

## What this doesn't cover

| Gap | Workaround |
|---|---|
| iOS Safari / Android Chrome real-device install | Future Option 2 (mkcert + HTTPS) or prod smoke after deploy |
| Real Postmark deliverability (spam scoring, DMARC) | Manual prod check post-deploy |
| Caddy header preservation regressions | Extend `scripts/smoke_prod.sh` (separate 10-min fix) |
| Real Let's Encrypt / CAA / HSTS preload | Not testable except on prod |

## Refs

- `tests/conftest.py:deploy_server` — the in-process fixture this launcher mirrors. Keep both consistent.
- `plans/maintainer_test_plan_through_pr_200.md` — the (S) items that become (L) after this.
- `docs/DevOps.md` § Signing keys — the prod signing flow this launcher short-circuits with the committed dev key.
- `docs/email_gate.md` — the magic-link decision tree this launcher exercises.

🤖 Generated with [Claude Code](https://claude.com/claude-code)