### PR TITLE
fix(test): folder-storage e2e isolation between folder-picking tests

### DIFF
--- a/tests/e2e/test_user_folder_storage.py
+++ b/tests/e2e/test_user_folder_storage.py
@@ -41,9 +41,41 @@ _STUB_DIRECTORY_PICKER = """
   };
   // Test affordance: nuke the stub folder so each test starts from a
   // clean slate. Called from the test via page.evaluate.
+  //
+  // Recursive removeEntry can fail when a child handle hasn't been
+  // fully released yet by the just-terminated worker — the original
+  // implementation swallowed that error and let Fellows/relationships.db
+  // linger into the next test, which would then hit the collision
+  // dialog instead of the clean-pick happy path. We now walk the tree
+  // explicitly (so removeEntry doesn't have to recurse over partially-
+  // released handles) and retry the outer remove a few times.
   window.__resetE2EUserFolder = async function () {
     var root = await navigator.storage.getDirectory();
-    try { await root.removeEntry(STUB_NAME, { recursive: true }); } catch (e) {}
+    async function purge(dir) {
+      for await (var entry of dir.values()) {
+        if (entry.kind === 'directory') {
+          try { await purge(entry); } catch (e) {}
+          try { await dir.removeEntry(entry.name, { recursive: true }); } catch (e) {}
+        } else {
+          try { await dir.removeEntry(entry.name); } catch (e) {}
+        }
+      }
+    }
+    try {
+      var stub = await root.getDirectoryHandle(STUB_NAME);
+      await purge(stub);
+    } catch (e) {
+      // Stub didn't exist — nothing to purge.
+    }
+    for (var attempt = 0; attempt < 3; attempt++) {
+      try {
+        await root.removeEntry(STUB_NAME, { recursive: true });
+        return;
+      } catch (e) {
+        if (attempt === 2) return;
+        await new Promise(function (r) { setTimeout(r, 50); });
+      }
+    }
   };
   // Test affordance: read back a probe of what landed in the stub
   // folder. Returns { hasFellows: bool, hasFellows2: bool,
@@ -169,9 +201,16 @@ def folder_page(standalone_page, base_url_fixture):
     kind = page.evaluate("() => window.__dataProvider.kind")
     if kind != "worker":
         pytest.skip(f"folder tests need the worker provider; got {kind!r}")
-    # Clean start: clear the IDB-stored handle and wipe any stub folder
-    # leftover from a previous run.
-    page.evaluate("() => window.__clearE2EFolderIdb()")
+    # Clean start: detach the worker's in-memory folder record AND
+    # delete the IDB-stored handle. Using _clearFolderHandle (rather
+    # than just __clearE2EFolderIdb) matters here: the worker keeps
+    # parentHandle/subfolderName in module-scope state, hydrated from
+    # IDB on init. If we only delete the IDB row, the next mutating
+    # RPC's post-commit hook still sees the stale in-memory handle
+    # and re-creates Fellows/relationships.db inside the just-purged
+    # stub folder — re-arming the collision dialog for whatever
+    # picks a folder next.
+    page.evaluate("() => window.__dataProvider._clearFolderHandle()")
     page.evaluate("() => window.__resetE2EUserFolder()")
     # Wipe relationships state so each test has a known baseline.
     page.evaluate("""
@@ -678,7 +717,13 @@ class TestPhase2WriteLock:
         # or the collision dialog opens (folder had prior content).
         dialog = folder_page.locator("#settings-folder-collision-dialog")
         try:
-            dialog.wait_for(state="visible", timeout=2000)
+            # 5s rather than 2s: under full-suite load the worker's
+            # setHandle('auto') probe (which surfaces requiresChoice
+            # and triggers the dialog) can run later than the snappy
+            # isolated case. A too-short wait drops into the except
+            # branch, leaving the modal undismissed for the 15s
+            # "Saved to" wait below.
+            dialog.wait_for(state="visible", timeout=5000)
             # Open existing — adopt the prior content; we'll overwrite
             # it with our test mutations anyway, and the badge flips
             # to Saved as soon as the open completes.


### PR DESCRIPTION
## Summary

Fixes the 6 e2e failures surfaced by `just test`:

- `TestUserFolderStorage::test_collision_dialog_offers_open_existing_or_create_new`
- `TestPhase2Pivot::test_snapshot_lands_in_folder_when_folder_mode_active`
- `TestPhase2Pivot::test_opfs_to_folder_backup_migration_on_folder_boot`
- `TestPhase2Pivot::test_path_detail_line_shows_after_folder_picked`
- `TestPhase2WriteLock::test_lock_held_during_write_surfaces_failure_then_recovers`
- `TestPhase2WriteLock::test_lock_held_by_second_page_blocks_first_page_write`

All 6 pass in isolation; only fail under `just test` after another folder-picking test in the same session leaves `__e2e_user_folder__/Fellows/relationships.db` behind. The next pick hit the collision dialog, no handler dismissed it, the badge stayed `"Browser-only — your data is not yet saved to a folder"`, and the `"Saved to"` assertion timed out.

Three-layer test-infra bug, fixed at all three layers. Test-only changes — no production code touched.

## What changed (one file, `tests/e2e/test_user_folder_storage.py`)

1. **Worker in-memory folder record stayed stale.** Fixture cleared the IDB row but the worker keeps `parentHandle` / `subfolderName` in module scope. The subsequent relationships-wipe fired post-commit folder writes that re-created `Fellows/relationships.db` *after* the stub-folder purge. Swapped `__clearE2EFolderIdb()` → `_clearFolderHandle()` (worker RPC that clears both).

2. **`__resetE2EUserFolder` swallowed recursive-remove failures.** The native `removeEntry({recursive:true})` raises when a child handle hasn't fully released. Now walks children explicitly first, then retries the outer remove 3× with a 50ms gap.

3. **Lock-helper dialog wait was too tight.** `_pick_folder_and_seed_group_a`'s `dialog.wait_for(timeout=2000)` lost the race under full-suite load (worker `setHandle` probe surfaces `requiresChoice` later than the snappy isolated case). Bumped to 5s.

## Test plan

- [x] `just test-e2e -- tests/e2e/test_user_folder_storage.py` — 14/14 (was 6 failed / 8 passed).
- [x] `just test-e2e -- tests/e2e/test_persist_storage.py tests/e2e/test_worker_rpc.py tests/e2e/test_reset_everything.py` — 22/22, no regressions in neighboring storage e2e.
- [ ] Maintainer: re-run `just test` end-to-end to confirm the prior 6 are the only delta.

🤖 Generated with [Claude Code](https://claude.com/claude-code)