### PR TITLE
fix(test): stabilize mcpb settings e2e against late boot-driven re-renders

### DIFF
--- a/tests/e2e/test_mcpb_settings.py
+++ b/tests/e2e/test_mcpb_settings.py
@@ -23,13 +23,26 @@ EXPECTED_BUNDLES = ["shared_data_ops", "private_data_ops", "comms"]
 
 
 def _boot_to_settings(page, base_url: str) -> None:
-    """Boot to the directory, wait for the worker, then navigate to
-    Settings via hash. Mirrors the pattern used in the other Settings
-    E2Es — initial boot from the directory route avoids a race where
-    settings renders before the worker is ready."""
+    """Boot to the directory, wait for the two-phase load to *complete*,
+    then navigate to Settings via hash. Waiting only for the worker
+    provider isn't enough: the boot's getList and getFull completions
+    each call route() (app.js lines ~10640 and ~10671), and the late
+    getFull-triggered route() re-renders the settings page if we've
+    navigated there in the meantime. That re-render tears down the
+    preamble <dialog> DOM mid-test and surfaces as flaky
+    "element was detached from the DOM" / "element is not visible"
+    errors on whichever dialog control the test was about to click.
+    """
     page.goto(base_url + "/", wait_until="domcontentloaded")
     page.wait_for_function(
         "() => window.__dataProvider && window.__dataProvider.kind === 'worker'",
+        timeout=15000,
+    )
+    # Boot phase mark `get_full_done` is set after the phase-2 route()
+    # call fires; once it's present we know no further boot-driven
+    # re-render will land on the settings page we're about to open.
+    page.wait_for_function(
+        "() => window.__bootMarks && window.__bootMarks.get_full_done != null",
         timeout=15000,
     )
     page.evaluate("location.hash = '#/settings'")


### PR DESCRIPTION
## Summary

Fixes intermittent flake in `tests/e2e/test_mcpb_settings.py`. Across the past few `just test` runs, different tests in this file failed each time — all with variants of "element was detached from the DOM, retrying" / "element is not visible" on dialog controls.

## Root cause

The boot path calls `route()` twice after the worker provider lands:

- After `getList` completes (`app/static/app.js:10640`)
- After `getFull` completes (`app/static/app.js:10671`)

The old `_boot_to_settings` waited only for `window.__dataProvider`, not for the two-phase load to finish. If the test navigated to `#/settings` between those two `route()` calls, the late one re-ran `renderSettingsPage`, whose `innerHTML` replacement tore down the open preamble `<dialog>` the test had just opened. `getFull` is ~50KB of JSON, so whether it landed during the test's pre-click window or after the final assertion depended on network timing — hence the flake.

Test-only race in practice. The same window exists in production but is not user-observable: clicking through the five-step Settings → MCPB Setup flow inside the ~1s cold-boot window isn't realistic.

## Fix

In `_boot_to_settings`, wait for `window.__bootMarks.get_full_done` before navigating to `#/settings`. Both boot-driven `route()` calls fire before the test interacts with the dialog, so the DOM stays stable.

`window.__bootMarks` is the documented e2e test seam from `docs/Architecture.md § Boot orchestration` — same seam already used by other suites; no new test scaffolding.

## Test plan

- [x] `just test-e2e -- tests/e2e/test_mcpb_settings.py` × 5 consecutive runs — 11/11 each.
- [x] `just test-e2e` (full e2e suite) — 310 passed, 12 skipped. Zero regressions.
- [ ] Maintainer: re-run `just test` end-to-end to confirm the mcpb failures are gone.

🤖 Generated with [Claude Code](https://claude.com/claude-code)