### PR TITLE
fix(test): restore 12 mobile e2e tests dark since /api/groups was retired

### DIFF
--- a/tests/e2e/mobile/test_edit_mode_layout.py
+++ b/tests/e2e/mobile/test_edit_mode_layout.py
@@ -11,56 +11,40 @@ screenshot smoke test (`tests/e2e/mobile/test_routes.py`).
 """
 from __future__ import annotations
 
-import json
 import re
-import urllib.error
-import urllib.request
 
-import pytest
 from playwright.sync_api import expect
 
 
-@pytest.fixture
-def edit_target_group(base_url_fixture):
-    """Create a throwaway group; yield its id; delete after test."""
-    body = json.dumps(
-        {
-            "name": "Mobile edit-mode regression",
-            "note": "Created by tests/e2e/mobile/test_edit_mode_layout.py.",
-            "fellow_record_ids": [],
-        }
-    ).encode("utf-8")
-    req = urllib.request.Request(
-        base_url_fixture + "/api/groups",
-        data=body,
-        headers={"Content-Type": "application/json"},
-        method="POST",
-    )
-    try:
-        with urllib.request.urlopen(req, timeout=5) as r:
-            payload = json.loads(r.read().decode("utf-8"))
-    except urllib.error.URLError as exc:
-        pytest.skip(f"dev server unreachable for group creation: {exc}")
-    gid = int(payload["id"])
-    yield gid
-    try:
-        del_req = urllib.request.Request(
-            f"{base_url_fixture}/api/groups/{gid}", method="DELETE"
-        )
-        urllib.request.urlopen(del_req, timeout=5).read()
-    except urllib.error.URLError:
-        pass
-
-
 def test_edit_mode_keeps_rails_visible_on_mobile(
-    mobile_page, base_url_fixture, edit_target_group
+    mobile_page, base_url_fixture
 ):
     """On `#/edit/<id>` at mobile widths, the fellow-picker and editing rail
     must both be visible. Without them the page is blank and edit mode is
-    unusable (PR #75 regression)."""
+    unusable (PR #75 regression).
+
+    Test group is seeded via window.__dataProvider — Phase 1 of
+    plans/local_first_worker_architecture.md retired the dev server's
+    /api/groups route, so the HTTP-fixture approach this test originally
+    used now silently pytest.skips. OPFS is per-origin per-context, so
+    the group survives the second goto inside the same mobile_page
+    fixture."""
     page = mobile_page
+    page.goto(base_url_fixture + "/", wait_until="domcontentloaded")
+    page.wait_for_function(
+        "() => window.__dataProvider && window.__dataProvider.kind === 'worker'",
+        timeout=15000,
+    )
+    record = page.evaluate(
+        """() => window.__dataProvider.createGroup({
+            name: 'Mobile edit-mode regression',
+            note: 'Created by tests/e2e/mobile/test_edit_mode_layout.py.',
+            fellow_record_ids: [],
+        })"""
+    )
+    gid = int(record["id"])
     page.goto(
-        f"{base_url_fixture}/#/edit/{edit_target_group}",
+        f"{base_url_fixture}/#/edit/{gid}",
         wait_until="domcontentloaded",
     )
     page.locator("#loading").wait_for(state="hidden", timeout=10000)

--- a/tests/e2e/mobile/test_routes.py
+++ b/tests/e2e/mobile/test_routes.py
@@ -18,9 +18,6 @@ Run with ``just test-mobile``.
 """
 from __future__ import annotations
 
-import json
-import urllib.error
-import urllib.request
 from pathlib import Path
 
 import pytest
@@ -64,28 +61,26 @@ def _wait_for_app_boot(page, timeout: int = 10000) -> None:
     page.wait_for_timeout(400)
 
 
-@pytest.fixture(scope="session")
-def screenshot_group(base_url_fixture) -> int:
-    """Create a single test group via the API; reused across all group routes."""
-    body = json.dumps(
-        {
-            "name": "Mobile Screenshot Group",
-            "note": "Created by tests/e2e/mobile/test_routes.py — safe to delete.",
-            "fellow_record_ids": [],
-        }
-    ).encode("utf-8")
-    req = urllib.request.Request(
-        base_url_fixture + "/api/groups",
-        data=body,
-        headers={"Content-Type": "application/json"},
-        method="POST",
+def _create_screenshot_group_via_worker(page) -> int:
+    """Create a test group via the page's worker provider and return its id.
+
+    Phase 1 of plans/local_first_worker_architecture.md retired the dev
+    server's /api/groups route — relationships data lives in the
+    worker-owned OPFS relationships.db. Test setup goes through the
+    same window.__dataProvider RPC the real app uses. The previous
+    HTTP-based fixture silently skipped these tests after that cutover.
+
+    Caller must have navigated the page and waited for the worker
+    provider to be ready.
+    """
+    record = page.evaluate(
+        """() => window.__dataProvider.createGroup({
+            name: 'Mobile Screenshot Group',
+            note: 'Created by tests/e2e/mobile/test_routes.py.',
+            fellow_record_ids: [],
+        })"""
     )
-    try:
-        with urllib.request.urlopen(req, timeout=5) as r:
-            payload = json.loads(r.read().decode("utf-8"))
-    except urllib.error.URLError as exc:
-        pytest.skip(f"dev server unreachable for group creation: {exc}")
-    return int(payload["id"])
+    return int(record["id"])
 
 
 @pytest.mark.parametrize("hash_route,label", STATIC_ROUTES)
@@ -106,13 +101,24 @@ def test_screenshot_group_route(
     mobile_page,
     device_name,
     base_url_fixture,
-    screenshot_group,
     template,
     label,
 ):
-    """Snap each group-scoped route (uses the session-scoped test group)."""
+    """Snap each group-scoped route (creates a fresh group per test via
+    the worker; OPFS persists across the second goto inside the same
+    browser context, so the group is still there after navigation)."""
     page = mobile_page
-    hash_route = template.format(gid=screenshot_group)
+    # First navigate to / so the worker provider boots and we can
+    # seed a group via __dataProvider; then navigate to the target
+    # group-scoped route. OPFS is per-origin per-context; the group
+    # survives the second goto.
+    page.goto(base_url_fixture + "/", wait_until="domcontentloaded")
+    page.wait_for_function(
+        "() => window.__dataProvider && window.__dataProvider.kind === 'worker'",
+        timeout=15000,
+    )
+    gid = _create_screenshot_group_via_worker(page)
+    hash_route = template.format(gid=gid)
     page.goto(base_url_fixture + "/" + hash_route, wait_until="domcontentloaded")
     _wait_for_app_boot(page)
     out = OUT_DIR / f"{label}--{_device_slug(device_name)}.png"


### PR DESCRIPTION
## Summary

12 mobile tests have been silently `pytest.skip`-ping every `just test` run with the reason **"dev server unreachable for group creation"**:

- `tests/e2e/mobile/test_edit_mode_layout.py::test_edit_mode_keeps_rails_visible_on_mobile` × 3 devices
- `tests/e2e/mobile/test_routes.py::test_screenshot_group_route` × 3 group routes × 3 devices

This PR restores them.

## Root cause

Both test files seeded a test group by `POST /api/groups`. Phase 1 of `plans/local_first_worker_architecture.md` retired that route from the dev server — relationships data lives in the worker-owned OPFS `relationships.db` now, driven by `window.__dataProvider`. The POST 404'd, `urllib.urlopen` raised `URLError`, and both fixtures caught it and called `pytest.skip` with a message that read like a transient environment problem. Coverage went dark silently:

- PR #75's mobile-edit-mode regression guard (3 invocations) — pins `#directory` + `#group-rail` stay visible on `#/edit/<id>` at mobile widths
- 9 mobile visual-smoke screenshots for group routes (detail / visual directory / edit) across the device matrix

## Fix

Same pattern the rest of the e2e suite already follows (see comment in `tests/e2e/conftest.py:72-78`): drive setup through the worker via `window.__dataProvider.createGroup` inside the page. Removed the session-scoped HTTP fixture in `test_routes.py` and the per-test HTTP fixture in `test_edit_mode_layout.py`; inlined worker-RPC group seeding into the tests themselves. OPFS is per-origin per-context, so the seeded group survives the second `goto` to the target route inside the same `mobile_page` fixture.

## Test plan

- [x] `just test-e2e -- tests/e2e/mobile/test_routes.py tests/e2e/mobile/test_edit_mode_layout.py` — 27/27 passed (was 15 passed / 12 skipped).
- [ ] Maintainer: `just test` end-to-end to confirm zero skips with reason "dev server unreachable for group creation".

## Out of scope

Server-side `BrokenPipeError` / `ConnectionResetError` noise visible in the log lines around image fetches is real — `app/server.py:538` writes to an already-closed socket when Playwright tears down a page mid-response. Test-correctness-neutral, but clutters output. Addressed in a separate follow-up PR (Bucket C from the audit).

🤖 Generated with [Claude Code](https://claude.com/claude-code)