### PR TITLE
fix(dev-server): suppress client-disconnect tracebacks during test runs

### DIFF
--- a/app/server.py
+++ b/app/server.py
@@ -236,6 +236,22 @@ class Handler(BaseHTTPRequestHandler):
     def log_message(self, format, *args):
         pass  # quiet by default; override to log
 
+    def handle_one_request(self):
+        # When Playwright tears down a page or the browser cancels an
+        # in-flight asset fetch (common for the per-fellow image
+        # requests this server fires off), the socket closes mid-
+        # response and any subsequent `wfile.write(...)` raises
+        # BrokenPipeError / ConnectionResetError. socketserver's
+        # default `handle_error` then prints a full traceback to
+        # stderr — which clutters every `just test` run and obscures
+        # real failures. Caddy absorbs the same noise upstream in
+        # production. Catch it here, mark the connection as closed
+        # (the underlying socket is already gone) and return cleanly.
+        try:
+            super().handle_one_request()
+        except (BrokenPipeError, ConnectionResetError):
+            self.close_connection = True
+
     def end_headers(self):
         # Cross-origin isolation. sqlite3-wasm's OPFS-SAH-Pool VFS gates
         # SharedArrayBuffer / Atomics on this; without crossOriginIsolated


### PR DESCRIPTION
## Summary

Every `just test` run prints several stderr tracebacks like:

\`\`\`
Exception occurred during processing of request from ('127.0.0.1', N)
Traceback (most recent call last):
  ...
  File \"app/server.py\", line 538, in do_GET
    self.wfile.write(data)
  File \"...socketserver.py\", line 826, in write
    self._sock.sendall(b)
BrokenPipeError: [Errno 32] Broken pipe
\`\`\`

(also `ConnectionResetError [Errno 54]`). All originate from Playwright tearing down a page — or the browser cancelling an in-flight asset fetch during the per-fellow image fetch storm — while the dev server is mid-response. The bytes were already abandoned by the client; the exception is purely a stderr nuisance.

Production sees the same condition every day; Caddy absorbs the upstream noise so it never reaches operator logs. Locally there's no proxy in front, so every `just test` run gets cluttered and real failures are harder to spot.

## Fix

Override `Handler.handle_one_request` to catch `(BrokenPipeError, ConnectionResetError)`, mark the connection closed, and return cleanly. 16 lines, dev server only.

## Test plan

- [x] `just test-e2e -- tests/e2e/mobile/test_routes.py tests/e2e/mobile/test_edit_mode_layout.py` — 27/27 passed; **zero** \"Traceback\" / \"BrokenPipeError\" / \"ConnectionResetError\" / \"Exception occurred during processing of request\" lines in the output (was multiple per run pre-fix).
- [ ] Maintainer: re-run `just test` end-to-end to confirm a clean stderr stream.

## Note on PR ordering

This is independent of #214 (mobile e2e fixture restoration). #214 produced fewer disconnect events because it stopped doing HTTP-fixture setup that triggered some of them, but doesn't address the wider class of disconnects from image fetches and page teardown. Both PRs are worth landing.

🤖 Generated with [Claude Code](https://claude.com/claude-code)