### PR TITLE
docs(pre-ship): number every step, reorder folder before MCPB, clarify §4

### DIFF
--- a/docs/pre_ship_test_plan.md
+++ b/docs/pre_ship_test_plan.md
@@ -152,14 +152,41 @@ navigator.locks.request(
 
 ### 5. Honest mutation loss on tab close
 
-- [ ] **5.1** Open a new incognito window. Sign in. Pick the same data
-      folder (open-existing path). Confirm group "Test G1" is visible.
+**Incognito session lifecycle matters here.** Chrome's incognito mode
+keeps OPFS, IndexedDB, cookies, and SW state alive across all tabs in
+the same incognito *session*, and only wipes them when **every
+incognito window of that session is closed**. Closing a single tab
+isn't enough — if you have any other incognito tab in the same session
+still open, the OPFS state survives, and §5.6 will fail spuriously
+("Lost" appears to still be there because it's in the surviving
+in-memory state, not because the folder write magically succeeded).
+
+The crisp way to run §5 cleanly: **close every incognito window before
+§5.5**, then open a brand-new one. Confirm freshness by checking the
+About page — the **install codename** must differ from the §5.1–§5.4
+window's codename (the codename is generated on first launch and
+persists in OPFS, so a stale session shows the same codename).
+
+Every "sign in" below means a full magic-link round-trip: submit the
+test email, fetch the unlock URL with `just serve-prod-link`, paste it
+into the new window, land on the install landing → *Use the directory
+in this tab*. The session cookie is per-incognito-session, so this
+must be redone in every fresh window.
+
+- [ ] **5.1** Open a new incognito window. Sign in (full magic-link
+      round-trip). Pick the same data folder (open-existing path).
+      Confirm group "Test G1" is visible.
 - [ ] **5.2** Create group "Doomed". Hold the lock in DevTools (same
       snippet as §4).
 - [ ] **5.3** Create group "Lost". Badge says "Last save failed."
-- [ ] **5.4** **Close the window without releasing the lock.**
-- [ ] **5.5** Open a fresh incognito window. Sign in. Pick the same
-      folder.
+- [ ] **5.4** **Close every incognito window of this session without
+      releasing the lock.** ("Close the tab" is not enough — any
+      sibling incognito tab keeps OPFS alive and turns this into a
+      false-pass test in §5.6.)
+- [ ] **5.5** Open a brand-new incognito window. Sign in. Pick the
+      same folder. **Sanity check:** About page shows a *different*
+      install codename than §5.1's; if it's the same codename, the
+      prior session is still alive — close everything and try again.
 - [ ] **5.6** Confirm "Test G1" and "Doomed" are visible; **"Lost" is
       gone**. (This is the honest mutation loss the badge warned about
       — verified end-to-end.)

--- a/docs/pre_ship_test_plan.md
+++ b/docs/pre_ship_test_plan.md
@@ -53,88 +53,77 @@ which is the prod posture.
 
 ## Phase 1 — Local staging (`just serve-prod`)
 
+Every checkbox is numbered `<section>.<item>` so when you hit a regression
+you can tell the maintainer "step 4.2 failed" without restating the whole
+flow.
+
+The order below matches what the app itself recommends: pick a data
+folder before installing the Claude Desktop bundles (the MCPB preamble
+dialog calls this out). Section 3 (folder mode) used to be after MCPB;
+running it first matches what real users do and means the bundle
+install in §6 actually has somewhere durable to point at.
+
 ### 1. Magic-link auth round-trip
 
-- [ ] Email gate renders (you're not auto-authed).
-- [ ] Paste the test email shown on the launcher banner → click **Send
-      link** → UI shows "Check your email…" (anti-enum response).
-- [ ] In a second terminal: `just serve-prod-link` returns the unlock URL.
-- [ ] Paste the URL into the same browser → install landing appears
-      (`authStatus.authenticated && installRecentlyAllowed`).
-- [ ] **"Back to email gate"** link returns you to the gate; cookie cleared.
-- [ ] Re-submit gate, get a new link, paste → back at install landing.
-- [ ] Click **"Use the directory in this tab"** → directory loads.
-- [ ] Build badge in lower-right shows the current local `git HEAD` short SHA.
+- [ ] **1.1** Email gate renders (you're not auto-authed).
+- [ ] **1.2** Paste the test email shown on the launcher banner → click
+      **Send link** → UI shows "Check your email…" (anti-enum response).
+- [ ] **1.3** In a second terminal: `just serve-prod-link` returns the
+      unlock URL.
+- [ ] **1.4** Paste the URL into the same browser → install landing
+      appears (`authStatus.authenticated && installRecentlyAllowed`).
+- [ ] **1.5** **"Back to email gate"** link returns you to the gate;
+      cookie cleared.
+- [ ] **1.6** Re-submit gate, get a new link, paste → back at install
+      landing.
+- [ ] **1.7** Click **"Use the directory in this tab"** → directory loads.
+- [ ] **1.8** Navigate to `#/about` — the build badge there shows the
+      current local `git HEAD` short SHA. (By design the badge is not
+      surfaced on the directory route; About is the canonical place.)
 
 ### 2. Email-gate edge cases
 
-- [ ] Append `?gate=1` to a logged-in tab's URL → gate UI overrides
+- [ ] **2.1** Append `?gate=1` to a logged-in tab's URL → gate UI overrides
       (cookie still valid; just forces the gate view).
-- [ ] Wait 30+ minutes after issuing a link, paste it → land at
+- [ ] **2.2** Wait 30+ minutes after issuing a link, paste it → land at
       `/?gate=1&reason=expired` with the "that link expired" banner.
       (You can shortcut this by editing the token in the URL — wrong
       token also triggers `reason=invalid`.)
-- [ ] Submit a non-allowlisted email (e.g. `wrong@example.com`) → UI
-      still says "Check your email…" (anti-enum); `just serve-prod-link`
-      shows no new entry.
+- [ ] **2.3** Submit a non-allowlisted email (e.g. `wrong@example.com`)
+      → UI still says "Check your email…" (anti-enum); `just
+      serve-prod-link` shows no new entry. (Server stderr is also quiet
+      here by design — the absence of a `magic_link_send` line is the
+      signal.)
 
-### 3. MCPB Settings UI (was § 4 of the per-batch plan)
-
-Navigate to `#/settings`.
-
-- [ ] **Claude Desktop integration (beta)** section renders below Restore
-      from backup.
-- [ ] Click **Set up Claude Desktop integration** → preamble dialog
-      opens. Three numbered bundles listed with privacy boundaries.
-- [ ] Red install-warning preview banner is visible.
-- [ ] **Cancel** → dialog closes; no downloads fired.
-- [ ] Click **Set up** → **Continue** → three downloads arrive in
-      `~/Downloads` (~3-4 MB each — these are the real bundles, unlike
-      the dev server which 404s).
-- [ ] Setup button relabels to "Re-download all extensions."
-- [ ] Reload the page → state persists.
-
-### 4. MCPB auth-gated routes (was § 6 of the per-batch plan)
-
-- [ ] **Incognito window** (no session cookie):
-      `curl -s -o /dev/null -w "%{http_code}\n" http://127.0.0.1:8766/mcpb/comms.mcpb` → expect `403`.
-- [ ] Authenticated browser: `/mcpb/comms.mcpb` downloads ~3.4 MB.
-- [ ] Repeat for `/mcpb/shared_data_ops.mcpb` and `/mcpb/private_data_ops.mcpb` (~4 MB each).
-- [ ] `/mcpb/bogus.mcpb` → 404.
-- [ ] `/mcpb/comms.txt` → 404 (must not serve under wrong suffix).
-- [ ] Launcher terminal shows a `mcpb_download` JSON line for each hit.
-
-### 5. Claude Desktop end-to-end (only if you have Claude Desktop on macOS)
-
-- [ ] After downloads from step 3 land, drag each `.mcpb` into Claude
-      Desktop → install dialog → **Install** (approve the red banner).
-- [ ] `private_data_ops.mcpb` asks for a file → navigate to
-      `<your-data-folder>/Fellows/relationships.db`.
-- [ ] **Quit Claude Desktop (⌘Q) and reopen.**
-- [ ] Ask: *"How many fellows are in the directory?"* → expect a number.
-- [ ] *"List my saved groups"* → expect Claude to list groups (or "none
-      yet").
-- [ ] *"Draft an invite email to my [group] group, don't send"* →
-      mail-compose window opens with To/Subject/Body pre-filled.
-
-(The AI-query path is local-only — Claude Desktop talks to local MCP
-subprocesses talking to local SQLite files. No server contact, real or
-staging.)
-
-### 6. Folder mode (Phase 2 happy path)
+### 3. Folder mode (Phase 2 happy path)
 
 Settings → **Choose data folder…** → pick `~/Documents/local-staging/`
 (or any fresh folder).
 
-- [ ] Badge flips to **Saved to local-staging / Fellows · just now**.
-- [ ] Open the folder in Finder — `Fellows/relationships.db` exists.
-- [ ] Create a group "Test G1" with three fellows → badge subtitle
-      updates ("just now"). Folder file size increases.
-- [ ] Edit the group → folder file timestamp advances.
-- [ ] Delete the group → folder file timestamp advances.
-- [ ] Settings → **⬇ Download my private data** → returns a `.db` blob.
+- [ ] **3.1** Badge flips to **Saved to local-staging / Fellows · just
+      now**.
+- [ ] **3.2** Open the folder in Finder — `Fellows/relationships.db`
+      exists.
+- [ ] **3.3** Create a group "Test G1" with three fellows → badge
+      subtitle updates ("just now"). Folder file size increases.
+- [ ] **3.4** Edit the group → folder file timestamp advances.
+- [ ] **3.5** Delete the group → folder file timestamp advances.
+- [ ] **3.6** Settings → **⬇ Download my private data** → returns a
+      `.db` blob.
 
-### 7. Folder Web Lock — manual verification
+### 4. Folder Web Lock — manual verification
+
+**Prerequisite:** Section 3 just completed. Settings → Private data folder
+badge currently reads **Saved to … / Fellows · …**. This test must run on
+the **same `127.0.0.1:8766` tab** as §3 — the dev server (`localhost:8765`)
+is a different origin with its own storage silo and doesn't reproduce
+this flow.
+
+**Where the badge lives.** The folder badge is in **Settings → Private
+data folder** (same pill you watched flip from "Browser-only" to "Saved
+to …" in §3). Step 4.2 is verifying that pill flips to a *third* state.
+Open `#/settings` in another browser tab before you run the snippet so
+you can switch back and forth.
 
 Open DevTools console:
 
@@ -146,38 +135,94 @@ navigator.locks.request(
 );
 ```
 
-- [ ] Create another group → badge flips to **"Last save failed — Change
-      folder to re-pick"** within a second.
-- [ ] Hover the badge or check the diagnostics panel — error reason
-      reads *"Another window has this folder open — close it, then make
-      any change to retry the save."*
-- [ ] Reload the tab (releases the lock).
-- [ ] Make a fresh mutation (rename a group, change a setting) → badge
-      returns to Saved. Folder file now contains the previously-failed
-      mutation too.
+- [ ] **4.1** Create another group from the directory rail. The OPFS
+      commit succeeds (the group appears in-memory) but the post-commit
+      folder write hits the lock and fails fast.
+- [ ] **4.2** Switch to the `#/settings` tab → the Private data folder
+      badge has flipped from green "Saved to …" to **"Last save failed
+      — Change folder to re-pick"** within a second.
+- [ ] **4.3** Hover the badge or check the diagnostics panel — error
+      reason reads *"Another window has this folder open — close it,
+      then make any change to retry the save."*
+- [ ] **4.4** Reload the tab (releases the lock — Web Locks auto-release
+      on agent termination).
+- [ ] **4.5** Make a fresh mutation (rename a group, change a setting)
+      → badge returns to Saved. Folder file now contains the
+      previously-failed mutation too.
 
-### 8. Honest mutation loss on tab close
+### 5. Honest mutation loss on tab close
 
-- [ ] Open a new incognito window. Sign in. Pick the same data folder
-      (open-existing path). Confirm group "Test G1" is visible.
-- [ ] Create group "Doomed". Hold the lock in DevTools (same snippet
-      as step 7).
-- [ ] Create group "Lost". Badge says "Last save failed."
-- [ ] **Close the window without releasing the lock.**
-- [ ] Open a fresh incognito window. Sign in. Pick the same folder.
-- [ ] Confirm "Test G1" and "Doomed" are visible; **"Lost" is gone**.
-      (This is the honest mutation loss the badge warned about —
-      verified end-to-end.)
+- [ ] **5.1** Open a new incognito window. Sign in. Pick the same data
+      folder (open-existing path). Confirm group "Test G1" is visible.
+- [ ] **5.2** Create group "Doomed". Hold the lock in DevTools (same
+      snippet as §4).
+- [ ] **5.3** Create group "Lost". Badge says "Last save failed."
+- [ ] **5.4** **Close the window without releasing the lock.**
+- [ ] **5.5** Open a fresh incognito window. Sign in. Pick the same
+      folder.
+- [ ] **5.6** Confirm "Test G1" and "Doomed" are visible; **"Lost" is
+      gone**. (This is the honest mutation loss the badge warned about
+      — verified end-to-end.)
 
-### 9. Cross-browser data silos (was § 8 of the per-batch plan)
+### 6. MCPB Settings UI
 
-- [ ] Open `http://127.0.0.1:8766/` in **Chrome** AND **Safari**, sign
-      in to both.
-- [ ] About page in each → different install codenames.
-- [ ] Create a group in Chrome. Open the Safari copy → no groups (data
-      silo confirmed). Safari install uses OPFS-only fallback (no
+Navigate to `#/settings`.
+
+- [ ] **6.1** **Claude Desktop integration (beta)** section renders
+      below Restore from backup.
+- [ ] **6.2** Click **Set up Claude Desktop integration** → preamble
+      dialog opens. Three numbered bundles listed with privacy
+      boundaries.
+- [ ] **6.3** Red install-warning preview banner is visible.
+- [ ] **6.4** **Cancel** → dialog closes; no downloads fired.
+- [ ] **6.5** Click **Set up** → **Continue** → three downloads arrive
+      in `~/Downloads` (~3-4 MB each — these are the real bundles,
+      unlike the dev server which 404s).
+- [ ] **6.6** Setup button relabels to "Re-download all extensions."
+- [ ] **6.7** Reload the page → state persists.
+
+### 7. MCPB auth-gated routes
+
+- [ ] **7.1** **Incognito window** (no session cookie):
+      `curl -s -o /dev/null -w "%{http_code}\n" http://127.0.0.1:8766/mcpb/comms.mcpb` → expect `403`.
+- [ ] **7.2** Authenticated browser: `/mcpb/comms.mcpb` downloads ~3.4 MB.
+- [ ] **7.3** Repeat for `/mcpb/shared_data_ops.mcpb` and
+      `/mcpb/private_data_ops.mcpb` (~4 MB each).
+- [ ] **7.4** `/mcpb/bogus.mcpb` → 404.
+- [ ] **7.5** `/mcpb/comms.txt` → 404 (must not serve under wrong
+      suffix).
+- [ ] **7.6** Launcher terminal shows a `mcpb_download` JSON line for
+      each hit.
+
+### 8. Claude Desktop end-to-end (only if you have Claude Desktop on macOS)
+
+- [ ] **8.1** After downloads from §6 land, drag each `.mcpb` into
+      Claude Desktop → install dialog → **Install** (approve the red
+      banner).
+- [ ] **8.2** `private_data_ops.mcpb` asks for a file → navigate to
+      `<your-data-folder>/Fellows/relationships.db` (the folder you
+      picked in §3).
+- [ ] **8.3** **Quit Claude Desktop (⌘Q) and reopen.**
+- [ ] **8.4** Ask: *"How many fellows are in the directory?"* → expect
+      a number.
+- [ ] **8.5** *"List my saved groups"* → expect Claude to list groups
+      (or "none yet").
+- [ ] **8.6** *"Draft an invite email to my [group] group, don't send"*
+      → mail-compose window opens with To/Subject/Body pre-filled.
+
+(The AI-query path is local-only — Claude Desktop talks to local MCP
+subprocesses talking to local SQLite files. No server contact, real or
+staging.)
+
+### 9. Cross-browser data silos
+
+- [ ] **9.1** Open `http://127.0.0.1:8766/` in **Chrome** AND **Safari**,
+      sign in to both.
+- [ ] **9.2** About page in each → different install codenames.
+- [ ] **9.3** Create a group in Chrome. Open the Safari copy → no groups
+      (data silo confirmed). Safari install uses OPFS-only fallback (no
       `showDirectoryPicker`).
-- [ ] Migrate via the documented recipe:
+- [ ] **9.4** Migrate via the documented recipe:
       - Chrome: Settings → ⬇ Download my private data → save to a file.
       - Safari: Settings → ⬆ Restore from a file → pick the file.
       - Group from Chrome appears in Safari.
@@ -189,31 +234,34 @@ Phase 2 (on prod).*
 
 ### 10. Mobile layout (Chrome DevTools responsive mode)
 
-- [ ] DevTools → toggle device toolbar → iPhone 13 / Pixel 5 / 360px wide.
-- [ ] Directory route: rows have ≥ 44×44 tap targets; no horizontal
-      overflow.
-- [ ] Select a fellow → composer FAB appears (the #179 fix — without
-      this, mobile users can't create groups).
-- [ ] Open the composer FAB → composer sheet slides up → type a name →
-      Create new group works.
-- [ ] Fellow detail: copy buttons, social links all clearly tappable
-      (≥ 44×44).
-- [ ] Settings: all buttons tappable; kebab menu opens cleanly.
+- [ ] **10.1** DevTools → toggle device toolbar → iPhone 13 / Pixel 5 /
+      360px wide.
+- [ ] **10.2** Directory route: rows have ≥ 44×44 tap targets; no
+      horizontal overflow.
+- [ ] **10.3** Select a fellow → composer FAB appears (the #179 fix —
+      without this, mobile users can't create groups).
+- [ ] **10.4** Open the composer FAB → composer sheet slides up → type
+      a name → Create new group works.
+- [ ] **10.5** Fellow detail: copy buttons, social links all clearly
+      tappable (≥ 44×44).
+- [ ] **10.6** Settings: all buttons tappable; kebab menu opens cleanly.
 
 ### 11. App basics (regression guards)
 
-- [ ] About page renders; install codename present; "Help from the
-      user manual" link works.
-- [ ] Directory search returns results.
-- [ ] Click a fellow → detail page; back arrow returns to directory.
-- [ ] Groups index → create, edit, delete group.
-- [ ] Visual directory route for a group renders portraits.
-- [ ] Settings: change "me" email, save → persists across reload.
-- [ ] Bug-report button (bottom-left) pre-fills install codename +
-      browser/OS + first-launch ISO.
-- [ ] Update banner appears if you rebuild the dist (`just serve-prod-reset`
-      → `just serve-prod` again — bumps the build label, SW notices on
-      next visit).
+- [ ] **11.1** About page renders; install codename present; "Help from
+      the user manual" link works.
+- [ ] **11.2** Directory search returns results.
+- [ ] **11.3** Click a fellow → detail page; back arrow returns to
+      directory.
+- [ ] **11.4** Groups index → create, edit, delete group.
+- [ ] **11.5** Visual directory route for a group renders portraits.
+- [ ] **11.6** Settings: change "me" email, save → persists across
+      reload.
+- [ ] **11.7** Bug-report button (bottom-left) pre-fills install
+      codename + browser/OS + first-launch ISO.
+- [ ] **11.8** Update banner appears if you rebuild the dist
+      (`just serve-prod-reset` → `just serve-prod` again — bumps the
+      build label, SW notices on next visit).
 
 ### 12. Shutdown
 


### PR DESCRIPTION
## Summary

Three improvements to `docs/pre_ship_test_plan.md` Phase 1, all surfaced by a real walk-through:

1. **Numbering.** Every checkbox now reads `**N.M**` (1.1, 1.2, … 8.6) so a failure can be reported as "step 4.2" without restating the whole flow.

2. **Reorder: folder mode before MCPB.** The MCPB preamble dialog itself tells users to set up the folder first. Section ordering now matches the actual user flow:

   | Old | New | Section |
   |---|---|---|
   | §3 | §6 | MCPB Settings UI |
   | §4 | §7 | MCPB auth-gated routes |
   | §5 | §8 | Claude Desktop end-to-end |
   | §6 | §3 | Folder mode |
   | §7 | §4 | Folder Web Lock |
   | §8 | §5 | Honest mutation loss |

   Bonus: `docs/local_staging.md:25` already claimed `just build-mcpb` was needed for "§ 6 / § 7" — that cross-reference was wrong before (pointing at folder sections) and is now correct.

3. **§4 (Folder Web Lock) clarification.** Previous wording asked you to run a JS snippet and observe a badge flip without naming WHERE the badge lives or that you must be in folder mode first. Added:
   - Explicit `Prerequisite` block: section 3 just completed, badge currently reads "Saved to …"
   - "Where the badge lives" callout: Settings → Private data folder
   - Port reminder: must run on `127.0.0.1:8766`, not the dev server's `localhost:8765` (separate origin, separate storage silo, doesn't reproduce the flow)

Minor: §1.8 build-badge line now names About as the canonical surface (badge is by-design absent from the directory route). §2.3 notes that quiet server stderr is the expected signal on a non-allowlisted submission.

## Test plan

- [x] Markdown renders cleanly; numbering reads naturally.
- [x] All cross-references inside the doc (§3, §4, §6) point at the new section numbers.
- [x] `docs/local_staging.md`'s "§ 6 / § 7" cross-reference now correctly points at the two MCPB sections.

## Out of scope (filed separately)

Walk-through also surfaced two real UX bugs not addressed by this doc PR:

- **Folder-push banner shows on install landing.** The "Save your fellows data to disk … Set up data folder" banner renders on the install landing screen, before the user has even installed the PWA. Will file as an issue.
- **"No install prompt yet. Two ways forward:" copy is too technical.** End users don't know what an "install prompt" is. Will file as an issue with a copy proposal.

🤖 Generated with [Claude Code](https://claude.com/claude-code)