### PR TITLE
fix(staging): copy profile images into local-staging + test-fixture dist

### DIFF
--- a/build/build_pwa.py
+++ b/build/build_pwa.py
@@ -317,6 +317,38 @@ def write_bundle_manifest(dist_dir: Path, build_label: str) -> Path:
     return out
 
 
+def copy_images_to_dist(dist_dir: Path) -> int:
+    """Copy profile images into `<dist_dir>/images/`.
+
+    Prefers `app/fellow_profile_images_by_name/` and falls back to
+    `final_fellows_set/fellow_profile_images_by_name/`. Returns the
+    count of files copied (0 if neither source dir exists).
+
+    Shared by main() (production build), scripts/serve_prod_local.py
+    (manual staging launcher), and tests/conftest.py:deploy_server
+    (e2e fixture) so all three paths produce a dist with working
+    `/images/<slug>.{jpg,png}` routes. The launcher and the test
+    fixture were silently skipping this step until 2026-05; missing
+    images surfaced as ~1000 console 404s on the maintainer's About
+    page during a Phase 1 walk-through.
+    """
+    img_src = (
+        IMAGES_SRC
+        if IMAGES_SRC.is_dir()
+        else (IMAGES_FALLBACK if IMAGES_FALLBACK.is_dir() else None)
+    )
+    if not img_src:
+        return 0
+    dest = dist_dir / "images"
+    dest.mkdir(parents=True, exist_ok=True)
+    n = 0
+    for p in img_src.iterdir():
+        if p.is_file() and p.suffix.lower() in (".jpg", ".jpeg", ".png", ".gif", ".webp"):
+            shutil.copy2(p, dest / p.name)
+            n += 1
+    return n
+
+
 def main() -> int:
     if not STATIC_DIR.is_dir():
         print(f"Missing static directory: {STATIC_DIR}", file=sys.stderr)
@@ -339,13 +371,7 @@ def main() -> int:
         shutil.copy2(DB_SRC, DIST_DIR / "fellows.db")
     else:
         print(f"Warning: no database at {DB_SRC} — run build/restore_from_knack_scrapefile.py", file=sys.stderr)
-    img_src = IMAGES_SRC if IMAGES_SRC.is_dir() else (IMAGES_FALLBACK if IMAGES_FALLBACK.is_dir() else None)
-    if img_src:
-        dest = DIST_DIR / "images"
-        dest.mkdir(parents=True, exist_ok=True)
-        for p in img_src.iterdir():
-            if p.is_file() and p.suffix.lower() in (".jpg", ".jpeg", ".png", ".gif", ".webp"):
-                shutil.copy2(p, dest / p.name)
+    copy_images_to_dist(DIST_DIR)
     nfiles = sum(1 for p in DIST_DIR.rglob("*") if p.is_file())
     print(f"Wrote {DIST_DIR} ({nfiles} files)  build_label={label}")
     return 0

--- a/scripts/serve_prod_local.py
+++ b/scripts/serve_prod_local.py
@@ -95,6 +95,12 @@ def _build_dist(force: bool) -> None:
     )
     build_pwa.write_bundle_manifest(DIST_DIR, label)
 
+    # Mirror build_pwa.main()'s image copy so /images/<slug>.{jpg,png}
+    # work on the staging server. Without this every fellow detail /
+    # visual directory render fires ~1000 console 404s, which makes
+    # staging look broken even though the app shell is fine.
+    build_pwa.copy_images_to_dist(DIST_DIR)
+
     # Sign the manifest with the dev key. Same key tests/conftest.py uses;
     # the SW verify path runs in full but the origin check renders this
     # key inert on the real prod hostname, so leaking it doesn't matter.

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -167,6 +167,15 @@ def deploy_server(tmp_path_factory):
     )
     _build_pwa.write_bundle_manifest(dist_dir, label)
 
+    # Mirror build_pwa.main()'s image copy so /images/<slug>.{jpg,png}
+    # work in e2e tests that hit the deploy server. No test currently
+    # asserts on image bytes, but keeping the fixture's dist symmetric
+    # with `scripts/serve_prod_local.py` (the manual staging launcher
+    # that copy-pastes this recipe) means a future image-related e2e
+    # doesn't have to track down "why does staging behave differently
+    # from the test fixture."
+    _build_pwa.copy_images_to_dist(dist_dir)
+
     # Sign the manifest with the committed dev test key (same key the
     # dev server uses on the fly). The SW's verify path will run in
     # full against e2e tests; an SRI / manifest / signing bug surfaces


### PR DESCRIPTION
## Summary

`just serve-prod` and the e2e `deploy_server` fixture both build a deploy-shaped static root at `tmp/prod-local/dist/` (and a `tmp_path` equivalent), but neither copy-pasted the image-copy step from `build/build_pwa.py:main()`. Result: every `/images/<slug>.{jpg,png}` returned 404 on the staging server. A single About-page render fires ~1020 console 404s; any fellow-detail or visual-directory route on staging looks broken even though the app shell is fine.

Surfaced during a Phase 1 pre-ship walk-through (`docs/pre_ship_test_plan.md`).

## Why both paths had the gap

The launcher's docstring says *"Mirrors `tests/conftest.py:deploy_server` fixture's setup"* and `docs/local_staging.md` says *"Keep both consistent."* They were — both copy-pasted an incomplete recipe. No e2e test currently asserts on image bytes, so the bug stayed quiet until manual QA hit it.

## Fix

Extract a shared helper `copy_images_to_dist(dist_dir)` in `build_pwa.py` (preserves the exact behavior of the old inline block: prefers `app/fellow_profile_images_by_name/`, falls back to `final_fellows_set/...`, accepts `.jpg/.jpeg/.png/.gif/.webp`). Call it from all three sites:

- `build_pwa.py:main()` — was inline, now calls the helper. No behavior change.
- `scripts/serve_prod_local.py:_build_dist()` — new call after the `fellows.db` copy. Fixes the manual-QA path.
- `tests/conftest.py:deploy_server` — new call in the same place. Keeps the twin symmetric; no current test depends on it, but a future image-related e2e shouldn't have to discover that staging and the test fixture diverged.

## Test plan

- [x] `rm -rf tmp/prod-local && python -c '… _build_dist(force=True)'` → produces **515** images in `tmp/prod-local/dist/images/` (was 0).
- [x] `just test-e2e -- tests/test_deploy_auth_round_trip.py tests/test_deploy_mcpb_routes.py tests/test_deploy_client_errors.py` → 38/38 pass (the entire set of `deploy_server` fixture consumers).
- [ ] Maintainer: hit `http://127.0.0.1:8766/#/about` on a fresh `just serve-prod-reset && just serve-prod` and confirm zero `/images/*.jpg|.png` 404s in DevTools console.

🤖 Generated with [Claude Code](https://claude.com/claude-code)