### PR TITLE
Shrink the pre-ship manual test plan to its irreducible core

### DIFF
--- a/docs/debugging.md
+++ b/docs/debugging.md
@@ -61,3 +61,79 @@ just ship-fast          # if deploy/dist/ is already current, just re-push + smo
 Under the hood: `just drift` curls `https://fellows.globaldonut.com/build-meta.json` for prod's git SHA and `built_at`, then formats it next to `git log -1 HEAD` and `git log -1 origin/main`. All three lines have the same shape — `<sha> <iso-timestamp> <subject>` — so a glance tells you whether prod, your laptop, and the remote are in sync. Production has shipped with stale `deploy/dist/` before; if prod's SHA trails origin/main, run `just deploy` (or `./scripts/deploy_pwa.sh --ask-become-pass`).
 
 Other production debug entry points (service logs, Postmark send flow, Diagnostics panel) live in [`docs/email_system_management.md`](email_system_management.md) and [`docs/DevOps.md`](DevOps.md).
+
+## Pre-ship assist recipes (chrome-devtools-mcp)
+
+A handful of [`pre_ship_test_plan.md`](pre_ship_test_plan.md) steps can't be CI-gated
+under `just test` — they need a **real** Chrome with real service-worker / OPFS /
+installed-PWA state, or the real launcher. They stay manual, but you don't have to
+click through them by hand: attach Claude Code to a real Chrome (see *Attaching to your
+running Chrome* above) and hand off the matching recipe below. Each recipe is an
+attach-and-assert prompt — Claude drives the browser and reports pass/fail. None of
+them remove the **irreducible** part of the step (real inbox receipt, real device,
+the native Claude Desktop handshake); they automate the browser-observable part.
+
+Selectors/signals these lean on (all real, used by the e2e suite too): `#sw-update-banner`
+(the "New version available — Reload" banner), `#install-gate-private` (email gate),
+`window.__dataProvider.kind` (`'worker'` on the happy path), `window.__bootMarks`,
+`navigator.serviceWorker.controller`, `/api/auth/status`, `/build-meta.json`, and the
+`#/about` build badge. If served JS still contains the literal `__FELLOWS_UI_DIAG__`
+or `__CACHE_VERSION__`, the build-label substitution didn't run — that's a bug.
+
+### Recipe A — first-visit smoke on prod (Phase 2 §1, browser portion)
+
+Use **isolated mode** (throwaway profile) so it's a true first-time visitor.
+
+> *"Attach to a fresh isolated Chrome, open `https://fellows.globaldonut.com/`, and
+> report: (1) `GET /api/auth/status` returns `authEnabled:true, authenticated:false`;
+> (2) `#install-gate-private` is visible and `#directory` is not; (3) no console errors
+> and no failed network requests on load; (4) the served `app.js` contains neither
+> `__FELLOWS_UI_DIAG__` nor `__CACHE_VERSION__`. Do NOT submit an email — the real
+> inbox receipt (steps 1.2–1.6) is mine to do by hand."*
+
+Replaces the eyeball of 1.1; leaves the real Postmark round-trip (1.2–1.6) manual.
+
+### Recipe B — update banner on a real installed PWA (Phase 2 §5)
+
+Use **real-profile mode** (your normal `--user-data-dir`) so the actually-installed PWA
+and its registered SW are in scope. Re-read the **privacy caveat** above first — every
+tab in that Chrome is visible to Claude for the session.
+
+> *"Attach to my running Chrome (port 9222, my real profile). Open the installed Fellows
+> PWA (or `https://fellows.globaldonut.com/`). Report the current `#/about` build label
+> and `GET /build-meta.json` `git_sha`. Then wait for me to say 'deployed'; on that
+> signal, reload-poll for up to 60s and confirm: `#sw-update-banner` becomes visible,
+> then click its Reload control and confirm `navigator.serviceWorker.controller` changed
+> and the `#/about` build label now matches the new `/build-meta.json` `git_sha`."*
+
+Pinned in `just test` only as drift→banner *logic* (`test_update_check.py`); this recipe
+exercises the **real SW update** on a really-installed app.
+
+### Recipe C — real `serve-prod` launcher SW/precache pass (Phase 1 §1 caveat)
+
+The one gap the in-process `deploy_server` fixture can't cover: the real launcher's
+dist-build + SW-precache + build-label-stamp path. Run `just serve-prod` first.
+
+> *"Attach to a fresh isolated Chrome, open `http://127.0.0.1:8766/`, and report:
+> (1) the served `app.js` and `sw.js` contain neither `__FELLOWS_UI_DIAG__` nor
+> `__CACHE_VERSION__` (stamp ran); (2) `window.__dataProvider.kind === 'worker'` and
+> `window.__bootMarks.get_full_done` is set (clean boot); (3) the `#/about` build badge
+> shows my current `git rev-parse --short HEAD`. Then I'll run
+> `just serve-prod-reset && just serve-prod` to bump the build label — reload and confirm
+> `#sw-update-banner` appears (the SW noticed the new shell)."*
+
+### Recipe D — real Android Chrome over adb (Phase 2 §3, optional)
+
+For a tethered Android device with USB debugging on:
+
+```bash
+adb forward tcp:9222 localabstract:chrome_devtools_remote
+# then point chrome-devtools-mcp at --browser-url http://127.0.0.1:9222
+```
+
+> *"Attach to the Android Chrome on port 9222, open `https://fellows.globaldonut.com/`,
+> drive the magic-link round-trip (I'll paste the link), and confirm the directory loads,
+> a fellow detail opens, and selecting a fellow reveals the composer FAB."*
+
+The Add-to-Home-Screen install gesture itself stays manual (the OS install prompt is
+outside the page).

--- a/docs/pre_ship_test_plan.md
+++ b/docs/pre_ship_test_plan.md
@@ -70,7 +70,8 @@ visitor sees — gate appears because `authEnabled: true`, which is the prod pos
 > `test_install_landing.py`). This manual pass exists only to exercise the **real
 > `just serve-prod` launcher** end-to-end — the in-process test fixture can't catch
 > launcher-level SW/precache/build-stamp drift, and the e2e suite mocks
-> `/api/auth/status` rather than driving the real auth path.
+> `/api/auth/status` rather than driving the real auth path. The browser-observable
+> half can be driven with chrome-devtools-mcp ([`debugging.md`](debugging.md) § Recipe C).
 
 - [ ] **1.1** Email gate renders in the fresh incognito window (you're not auto-authed).
 - [ ] **1.2** Paste the test email → **Send link** → "Check your email…" appears.
@@ -166,8 +167,8 @@ just smoke                             # HTTPS health + manifest + diagnostics +
 ### 1. First-time-visitor smoke (real Postmark)
 
 > The browser-side gate→landing flow can be driven on real Chrome via
-> chrome-devtools-mcp ([`debugging.md`](debugging.md)). The **real inbox receipt**
-> below is irreducible.
+> chrome-devtools-mcp ([`debugging.md`](debugging.md) § Recipe A). The **real inbox
+> receipt** below is irreducible.
 
 - [ ] **1.1** New incognito window at `https://fellows.globaldonut.com/` → gate appears.
 - [ ] **1.2** Submit your real email (one Postmark can deliver to).
@@ -192,7 +193,7 @@ just smoke                             # HTTPS health + manifest + diagnostics +
 ### 3. Real Android Chrome install *(if you have an Android device)*
 
 > _(Optional assist: tether the device and drive it via chrome-devtools-mcp over
-> `adb forward` + `--browser-url` — see [`debugging.md`](debugging.md).)_
+> `adb forward` + `--browser-url` — see [`debugging.md`](debugging.md) § Recipe D.)_
 
 - [ ] **3.1** Same flow as iOS, but Chrome shows an "Add to Home Screen" prompt instead
       of Safari's share sheet.
@@ -208,7 +209,7 @@ just smoke                             # HTTPS health + manifest + diagnostics +
 
 > The drift→banner *logic* is covered by `just test` (`test_update_check.py`). What
 > stays manual: the **real SW update** on a **really-installed** PWA — drivable on
-> real Chrome via chrome-devtools-mcp ([`debugging.md`](debugging.md)).
+> real Chrome via chrome-devtools-mcp ([`debugging.md`](debugging.md) § Recipe B).
 
 - [ ] **5.1** Open your existing installed PWA (phone or laptop).
 - [ ] **5.2** Within ~30 s the "New version available — Reload" banner appears.

--- a/docs/pre_ship_test_plan.md
+++ b/docs/pre_ship_test_plan.md
@@ -1,24 +1,30 @@
 # Pre-ship test plan
 
-The maintainer's manual-QA checklist to run **before every deploy to prod**.
+The maintainer's **manual** QA checklist to run before every deploy to prod.
+
+**This plan holds only the tests that can't (yet) be automated.** Everything that
+*can* be automated is automated and runs under `just test` — and is therefore
+**not** repeated here. There is no third place: automated tests live in `just test`,
+manual tests live in this file. When an item here becomes automated, delete it from
+this plan in the same change that lands the test.
+
 Two phases:
 
 - **Phase 1** runs locally against `just serve-prod` (see
-  [`local_staging.md`](local_staging.md)). Covers everything the local
-  staging server can reach: auth flow, MCPB routes, folder mode, lock
-  behavior, cross-browser data silos.
-- **Phase 2** runs against `https://fellows.globaldonut.com/` **after**
-  the deploy lands. Covers only the irreducible real-device / real-network
-  tests that local staging can't replicate.
+  [`local_staging.md`](local_staging.md)). The irreducible local pass is the part
+  that exercises the **real `just serve-prod` launcher** end-to-end and the **real
+  OS gestures** (folder picker, file downloads) that the Playwright stubs can't reach.
+- **Phase 2** runs against `https://fellows.globaldonut.com/` **after** the deploy
+  lands — real devices, real Postmark, real Caddy, real Claude Desktop.
 
-If you find a regression in Phase 1, fix it before deploying. If you
-find one in Phase 2, fix-forward (ship a second deploy) or roll back.
-The point of the two-phase split is to keep Phase 2 small enough that
-a real-world regression is rare and localized.
+If you find a regression in Phase 1, fix it before deploying. If you find one in
+Phase 2, fix-forward (ship a second deploy) or roll back.
 
-This is a **living document** — the test items are tied to the current
-shipped feature set, not a snapshot of a specific batch. Past per-batch
-snapshots live in `plans/maintainer_test_plan_through_pr_*.md`.
+This is a **living document** — items are tied to the current shipped feature set.
+Past per-batch snapshots live in `plans/maintainer_test_plan_through_pr_*.md`.
+
+Each checkbox is numbered `<section>.<item>` so a regression report can say
+"step 4.2 failed" without restating the flow.
 
 ---
 
@@ -28,12 +34,17 @@ snapshots live in `plans/maintainer_test_plan_through_pr_*.md`.
 git checkout main && git pull         # confirm merges are local
 just doctor                            # .venv + DB + Playwright OK
 just build-mcpb                        # produces deploy/dist/mcpb/*.mcpb
-just test                              # full pytest + Playwright
+just test                              # full pytest + Playwright — MUST be green
 ```
 
-`just build-mcpb` only needs re-running when MCPB code changes (most ships
-don't touch it; safe to re-run anyway). If `just test` is red, fix or
-explicitly accept the flake and continue.
+`just test` is the gate. It already covers the auth decision-tree, MCPB Settings UI
+and auth-gated routes, folder-mode write/badge logic, mobile layout + interactions,
+the update-banner logic, and the app-basics regression set. If `just test` is red,
+fix it (or explicitly accept a known flake) before touching the manual steps below —
+a red suite means the thing you'd otherwise hand-test is already broken.
+
+`just build-mcpb` only needs re-running when MCPB code changes (most ships don't touch
+it; safe to re-run anyway).
 
 ## Per-session setup (each time you sit down to test)
 
@@ -41,91 +52,62 @@ explicitly accept the flake and continue.
 just serve-prod                        # foreground; Ctrl-C to stop
 ```
 
-The startup banner prints the test email (default
-`you@local-staging.example`) and the magic-link log path. Open a **new
-incognito / private window** at `http://127.0.0.1:8766/`.
+The startup banner prints the test email (default `you@local-staging.example`) and
+the magic-link log path. Open a **new incognito / private window** at
+`http://127.0.0.1:8766/`.
 
-Why incognito: nothing carries over from prior sessions. You see what a
-first-time visitor sees — gate appears because `authEnabled: true`,
-which is the prod posture.
+Why incognito: nothing carries over from prior sessions. You see what a first-time
+visitor sees — gate appears because `authEnabled: true`, which is the prod posture.
 
 ---
 
 ## Phase 1 — Local staging (`just serve-prod`)
 
-Every checkbox is numbered `<section>.<item>` so when you hit a regression
-you can tell the maintainer "step 4.2 failed" without restating the whole
-flow.
+### 1. Real-launcher magic-link round-trip
 
-The order below matches what the app itself recommends: pick a data
-folder before installing the Claude Desktop bundles (the MCPB preamble
-dialog calls this out). Section 3 (folder mode) used to be after MCPB;
-running it first matches what real users do and means the bundle
-install in §6 actually has somewhere durable to point at.
+> The auth **decision-tree branches** and the **verify-token round-trip** are covered
+> by `just test` (`test_email_gate.py`, `test_magic_link_standalone_unlock.py`,
+> `test_install_landing.py`). This manual pass exists only to exercise the **real
+> `just serve-prod` launcher** end-to-end — the in-process test fixture can't catch
+> launcher-level SW/precache/build-stamp drift, and the e2e suite mocks
+> `/api/auth/status` rather than driving the real auth path.
 
-### 1. Magic-link auth round-trip
+- [ ] **1.1** Email gate renders in the fresh incognito window (you're not auto-authed).
+- [ ] **1.2** Paste the test email → **Send link** → "Check your email…" appears.
+- [ ] **1.3** `just serve-prod-link` (second terminal) returns the unlock URL.
+- [ ] **1.4** Paste the URL → install landing appears → **Use the directory in this
+      tab** → directory loads.
+- [ ] **1.5** `#/about` build badge shows the current local `git HEAD` short SHA
+      (confirms the launcher's build-label substitution path; the literal
+      `__FELLOWS_UI_DIAG__` here is a bug).
+- [ ] **1.6** Submit a non-allowlisted email (e.g. `wrong@example.com`) → UI still
+      says "Check your email…" and `just serve-prod-link` shows **no** new entry
+      (anti-enumeration).
 
-- [ ] **1.1** Email gate renders (you're not auto-authed).
-- [ ] **1.2** Paste the test email shown on the launcher banner → click
-      **Send link** → UI shows "Check your email…" (anti-enum response).
-- [ ] **1.3** In a second terminal: `just serve-prod-link` returns the
-      unlock URL.
-- [ ] **1.4** Paste the URL into the same browser → install landing
-      appears (`authStatus.authenticated && installRecentlyAllowed`).
-- [ ] **1.5** **"Back to email gate"** link returns you to the gate;
-      cookie cleared.
-- [ ] **1.6** Re-submit gate, get a new link, paste → back at install
-      landing.
-- [ ] **1.7** Click **"Use the directory in this tab"** → directory loads.
-- [ ] **1.8** Navigate to `#/about` — the build badge there shows the
-      current local `git HEAD` short SHA. (By design the badge is not
-      surfaced on the directory route; About is the canonical place.)
+### 2. Folder mode — real OS picker
 
-### 2. Email-gate edge cases
+> Per-mutation badge/write logic runs under `just test` against a stubbed picker
+> (`test_user_folder_storage.py`). This manual pass covers what the stub deliberately
+> skips: the **real OS directory-picker gesture**, the **OS permission round-trip**,
+> and **Finder visibility** of the on-disk file.
 
-- [ ] **2.1** Append `?gate=1` to a logged-in tab's URL → gate UI overrides
-      (cookie still valid; just forces the gate view).
-- [ ] **2.2** Wait 30+ minutes after issuing a link, paste it → land at
-      `/?gate=1&reason=expired` with the "that link expired" banner.
-      (You can shortcut this by editing the token in the URL — wrong
-      token also triggers `reason=invalid`.)
-- [ ] **2.3** Submit a non-allowlisted email (e.g. `wrong@example.com`)
-      → UI still says "Check your email…" (anti-enum); `just
-      serve-prod-link` shows no new entry. (Server stderr is also quiet
-      here by design — the absence of a `magic_link_send` line is the
-      signal.)
+Settings → **Choose data folder…** → pick `~/Documents/local-staging/` (or any fresh folder).
 
-### 3. Folder mode (Phase 2 happy path)
+- [ ] **2.1** Badge flips to **Saved to local-staging / Fellows · just now**.
+- [ ] **2.2** In Finder, `Fellows/relationships.db` exists.
+- [ ] **2.3** Create / edit / delete a group → the on-disk file's size/timestamp
+      advances each time.
+- [ ] **2.4** Settings → **⬇ Download my private data** → a real `.db` blob lands in
+      `~/Downloads`.
 
-Settings → **Choose data folder…** → pick `~/Documents/local-staging/`
-(or any fresh folder).
+### 3. Folder Web Lock — manual verification
 
-- [ ] **3.1** Badge flips to **Saved to local-staging / Fellows · just
-      now**.
-- [ ] **3.2** Open the folder in Finder — `Fellows/relationships.db`
-      exists.
-- [ ] **3.3** Create a group "Test G1" with three fellows → badge
-      subtitle updates ("just now"). Folder file size increases.
-- [ ] **3.4** Edit the group → folder file timestamp advances.
-- [ ] **3.5** Delete the group → folder file timestamp advances.
-- [ ] **3.6** Settings → **⬇ Download my private data** → returns a
-      `.db` blob.
+> _(Automation candidate: the `window.__holdFolderLockForever()` /
+> `__releaseFolderLock()` seams already exist; a single-context e2e can assert the
+> badge flip. Delete this section when that test lands.)_
 
-### 4. Folder Web Lock — manual verification
-
-**Prerequisite:** Section 3 just completed. Settings → Private data folder
-badge currently reads **Saved to … / Fellows · …**. This test must run on
-the **same `127.0.0.1:8766` tab** as §3 — the dev server (`localhost:8765`)
-is a different origin with its own storage silo and doesn't reproduce
-this flow.
-
-**Where the badge lives.** The folder badge is in **Settings → Private
-data folder** (same pill you watched flip from "Browser-only" to "Saved
-to …" in §3). Step 4.2 is verifying that pill flips to a *third* state.
-Open `#/settings` in another browser tab before you run the snippet so
-you can switch back and forth.
-
-Open DevTools console:
+Must run on the **same `127.0.0.1:8766` tab** as §2. Open `#/settings` in a second tab
+so you can watch the badge. In DevTools console:
 
 ```js
 navigator.locks.request(
@@ -135,170 +117,102 @@ navigator.locks.request(
 );
 ```
 
-- [ ] **4.1** Create another group from the directory rail. The OPFS
-      commit succeeds (the group appears in-memory) but the post-commit
-      folder write hits the lock and fails fast.
-- [ ] **4.2** Switch to the `#/settings` tab → the Private data folder
-      badge has flipped from green "Saved to …" to **"Last save failed
-      — Change folder to re-pick"** within a second.
-- [ ] **4.3** Hover the badge or check the diagnostics panel — error
-      reason reads *"Another window has this folder open — close it,
-      then make any change to retry the save."*
-- [ ] **4.4** Reload the tab (releases the lock — Web Locks auto-release
-      on agent termination).
-- [ ] **4.5** Make a fresh mutation (rename a group, change a setting)
-      → badge returns to Saved. Folder file now contains the
-      previously-failed mutation too.
+- [ ] **3.1** Create another group from the directory rail. The OPFS commit succeeds
+      (group appears in-memory) but the post-commit folder write hits the lock and
+      fails fast.
+- [ ] **3.2** The Private data folder badge flips to **"Last save failed — Change
+      folder to re-pick"** within a second.
+- [ ] **3.3** Hover the badge / check diagnostics → reason reads *"Another window has
+      this folder open — close it, then make any change to retry the save."*
+- [ ] **3.4** Reload the tab (releases the lock — Web Locks auto-release on agent
+      termination).
+- [ ] **3.5** Make a fresh mutation → badge returns to Saved; the folder file now
+      contains the previously-failed mutation too.
 
-### 5. Honest mutation loss on tab close
+### 4. Honest mutation loss on tab close
 
-**Incognito session lifecycle matters here.** Chrome's incognito mode
-keeps OPFS, IndexedDB, cookies, and SW state alive across all tabs in
-the same incognito *session*, and only wipes them when **every
-incognito window of that session is closed**. Closing a single tab
-isn't enough — if you have any other incognito tab in the same session
-still open, the OPFS state survives, and §5.6 will fail spuriously
-("Lost" appears to still be there because it's in the surviving
-in-memory state, not because the folder write magically succeeded).
+> _(Automation candidate: the in-memory-lost-on-close logic is modelable with a fresh
+> Playwright context boundary against the deploy_server lane. The real
+> incognito-session OPFS lifecycle below is the residue that may stay manual.)_
 
-The crisp way to run §5 cleanly: **close every incognito window before
-§5.5**, then open a brand-new one. Confirm freshness by checking the
-About page — the **install codename** must differ from the §5.1–§5.4
-window's codename (the codename is generated on first launch and
-persists in OPFS, so a stale session shows the same codename).
+**Incognito session lifecycle matters.** Chrome keeps OPFS/IndexedDB/cookies/SW alive
+across all tabs in one incognito *session* and wipes them only when **every** incognito
+window of that session closes. Confirm freshness via the About page **install codename**
+(persisted in OPFS): a stale session shows the same codename.
 
-Every "sign in" below means a full magic-link round-trip: submit the
-test email, fetch the unlock URL with `just serve-prod-link`, paste it
-into the new window, land on the install landing → *Use the directory
-in this tab*. The session cookie is per-incognito-session, so this
-must be redone in every fresh window.
+Every "sign in" = a full magic-link round-trip (the session cookie is per-incognito-session).
 
-- [ ] **5.1** Open a new incognito window. Sign in (full magic-link
-      round-trip). Pick the same data folder (open-existing path).
-      Confirm group "Test G1" is visible.
-- [ ] **5.2** Create group "Doomed". Hold the lock in DevTools (same
-      snippet as §4).
-- [ ] **5.3** Create group "Lost". Badge says "Last save failed."
-- [ ] **5.4** **Close every incognito window of this session without
-      releasing the lock.** ("Close the tab" is not enough — any
-      sibling incognito tab keeps OPFS alive and turns this into a
-      false-pass test in §5.6.)
-- [ ] **5.5** Open a brand-new incognito window. Sign in. Pick the
-      same folder. **Sanity check:** About page shows a *different*
-      install codename than §5.1's; if it's the same codename, the
-      prior session is still alive — close everything and try again.
-- [ ] **5.6** Confirm "Test G1" and "Doomed" are visible; **"Lost" is
-      gone**. (This is the honest mutation loss the badge warned about
-      — verified end-to-end.)
+- [ ] **4.1** New incognito window. Sign in. Pick the same data folder (open-existing).
+      Confirm a prior group is visible.
+- [ ] **4.2** Create group "Doomed". Hold the lock (same snippet as §3).
+- [ ] **4.3** Create group "Lost". Badge says "Last save failed."
+- [ ] **4.4** **Close every incognito window of this session without releasing the
+      lock.** (Closing one tab is not enough — a sibling tab keeps OPFS alive and
+      false-passes §4.6.)
+- [ ] **4.5** Brand-new incognito window. Sign in. Pick the same folder. **Sanity:**
+      About shows a *different* install codename than §4.1; if it matches, the prior
+      session is still alive — close everything and retry.
+- [ ] **4.6** Confirm the saved groups + "Doomed" are visible; **"Lost" is gone** —
+      the honest mutation loss the badge warned about, verified end-to-end.
 
-### 6. MCPB Settings UI
+### 5. Claude Desktop end-to-end *(only with Claude Desktop on macOS)*
 
-Navigate to `#/settings`.
+> The MCPB **Settings UI** flow (preamble, three-bundle list, warning banner, cancel,
+> continue-dispatches-three-downloads, button relabel, localStorage persistence) and
+> the **auth-gated `/mcpb/*` routes** (403/200/404/suffix/traversal/content-type/log)
+> are covered by `just test` (`test_mcpb_settings.py`, `test_deploy_mcpb_routes.py`).
+> The MCP **server logic** is covered by `tests/test_*_data_ops.py`,
+> `test_comms.py`, `test_mcpb_parity.py`. What stays manual: the native Claude Desktop
+> install handshake and a live AI query — neither tool reaches Claude Desktop.
 
-- [ ] **6.1** **Claude Desktop integration (beta)** section renders
-      below Restore from backup.
-- [ ] **6.2** Click **Set up Claude Desktop integration** → preamble
-      dialog opens. Three numbered bundles listed with privacy
-      boundaries.
-- [ ] **6.3** Red install-warning preview banner is visible.
-- [ ] **6.4** **Cancel** → dialog closes; no downloads fired.
-- [ ] **6.5** Click **Set up** → **Continue** → three downloads arrive
-      in `~/Downloads` (~3-4 MB each — these are the real bundles,
-      unlike the dev server which 404s).
-- [ ] **6.6** Setup button relabels to "Re-download all extensions."
-- [ ] **6.7** Reload the page → state persists.
+- [ ] **5.1** Settings → **Set up Claude Desktop integration** → **Continue** → three
+      real `.mcpb` files (~3–4 MB each; needs `just build-mcpb`) land in `~/Downloads`.
+- [ ] **5.2** Drag each `.mcpb` into Claude Desktop → install dialog → **Install**
+      (approve the red banner).
+- [ ] **5.3** `private_data_ops.mcpb` asks for a file → navigate to
+      `<your-data-folder>/Fellows/relationships.db` (the folder picked in §2).
+- [ ] **5.4** **Quit Claude Desktop (⌘Q) and reopen.**
+- [ ] **5.5** Ask *"How many fellows are in the directory?"* → expect a number.
+- [ ] **5.6** Ask *"List my saved groups"* → expect the groups (or "none yet").
+- [ ] **5.7** Ask *"Draft an invite email to my [group] group, don't send"* → a
+      mail-compose window opens with To/Subject/Body pre-filled.
 
-### 7. MCPB auth-gated routes
+(The AI-query path is local-only — Claude Desktop ↔ local MCP subprocesses ↔ local
+SQLite. No server contact.)
 
-- [ ] **7.1** **Incognito window** (no session cookie):
-      `curl -s -o /dev/null -w "%{http_code}\n" http://127.0.0.1:8766/mcpb/comms.mcpb` → expect `403`.
-- [ ] **7.2** Authenticated browser: `/mcpb/comms.mcpb` downloads ~3.4 MB.
-- [ ] **7.3** Repeat for `/mcpb/shared_data_ops.mcpb` and
-      `/mcpb/private_data_ops.mcpb` (~4 MB each).
-- [ ] **7.4** `/mcpb/bogus.mcpb` → 404.
-- [ ] **7.5** `/mcpb/comms.txt` → 404 (must not serve under wrong
-      suffix).
-- [ ] **7.6** Launcher terminal shows a `mcpb_download` JSON line for
-      each hit.
+### 6. Cross-browser data silos
 
-### 8. Claude Desktop end-to-end (only if you have Claude Desktop on macOS)
+> _(Automation candidate: the silo concept + export/import migration are modelable
+> with two Playwright contexts. The **real Safari** install path below is the residue.)_
 
-- [ ] **8.1** After downloads from §6 land, drag each `.mcpb` into
-      Claude Desktop → install dialog → **Install** (approve the red
-      banner).
-- [ ] **8.2** `private_data_ops.mcpb` asks for a file → navigate to
-      `<your-data-folder>/Fellows/relationships.db` (the folder you
-      picked in §3).
-- [ ] **8.3** **Quit Claude Desktop (⌘Q) and reopen.**
-- [ ] **8.4** Ask: *"How many fellows are in the directory?"* → expect
-      a number.
-- [ ] **8.5** *"List my saved groups"* → expect Claude to list groups
-      (or "none yet").
-- [ ] **8.6** *"Draft an invite email to my [group] group, don't send"*
-      → mail-compose window opens with To/Subject/Body pre-filled.
+- [ ] **6.1** Open `http://127.0.0.1:8766/` in **Chrome** AND **Safari**; sign in to both.
+- [ ] **6.2** About page in each → different install codenames.
+- [ ] **6.3** Create a group in Chrome → open Safari → no groups (silo confirmed;
+      Safari uses OPFS-only fallback, no `showDirectoryPicker`).
+- [ ] **6.4** Migrate: Chrome → ⬇ Download my private data; Safari → ⬆ Restore from a
+      file → the Chrome group appears in Safari.
 
-(The AI-query path is local-only — Claude Desktop talks to local MCP
-subprocesses talking to local SQLite files. No server contact, real or
-staging.)
+*Note: Safari "Add to Dock" on localhost may refuse — the silo behavior still tests
+fine in a regular Safari window. Real Safari install is Phase 2.*
 
-### 9. Cross-browser data silos
+### 7. App-basics manual residue
 
-- [ ] **9.1** Open `http://127.0.0.1:8766/` in **Chrome** AND **Safari**,
-      sign in to both.
-- [ ] **9.2** About page in each → different install codenames.
-- [ ] **9.3** Create a group in Chrome. Open the Safari copy → no groups
-      (data silo confirmed). Safari install uses OPFS-only fallback (no
-      `showDirectoryPicker`).
-- [ ] **9.4** Migrate via the documented recipe:
-      - Chrome: Settings → ⬇ Download my private data → save to a file.
-      - Safari: Settings → ⬆ Restore from a file → pick the file.
-      - Group from Chrome appears in Safari.
+> _(Automation candidates pending Step-2 assertions: directory search results,
+> group edit/delete, group visual-directory portraits. Delete each when its test lands.)_
 
-*Note: Safari "Add to Dock" on localhost may refuse. If it does, the
-data-silo behavior still tests fine in a regular Safari window — you've
-just hit the limit of local staging. Real Safari install testing is
-Phase 2 (on prod).*
+- [ ] **7.1** Directory search returns results.
+- [ ] **7.2** Groups index → edit a group, delete a group.
+- [ ] **7.3** Visual directory route for a group renders portraits.
 
-### 10. Mobile layout (Chrome DevTools responsive mode)
-
-- [ ] **10.1** DevTools → toggle device toolbar → iPhone 13 / Pixel 5 /
-      360px wide.
-- [ ] **10.2** Directory route: rows have ≥ 44×44 tap targets; no
-      horizontal overflow.
-- [ ] **10.3** Select a fellow → composer FAB appears (the #179 fix —
-      without this, mobile users can't create groups).
-- [ ] **10.4** Open the composer FAB → composer sheet slides up → type
-      a name → Create new group works.
-- [ ] **10.5** Fellow detail: copy buttons, social links all clearly
-      tappable (≥ 44×44).
-- [ ] **10.6** Settings: all buttons tappable; kebab menu opens cleanly.
-
-### 11. App basics (regression guards)
-
-- [ ] **11.1** About page renders; install codename present; "Help from
-      the user manual" link works.
-- [ ] **11.2** Directory search returns results.
-- [ ] **11.3** Click a fellow → detail page; back arrow returns to
-      directory.
-- [ ] **11.4** Groups index → create, edit, delete group.
-- [ ] **11.5** Visual directory route for a group renders portraits.
-- [ ] **11.6** Settings: change "me" email, save → persists across
-      reload.
-- [ ] **11.7** Bug-report button (bottom-left) pre-fills install
-      codename + browser/OS + first-launch ISO.
-- [ ] **11.8** Update banner appears if you rebuild the dist
-      (`just serve-prod-reset` → `just serve-prod` again — bumps the
-      build label, SW notices on next visit).
-
-### 12. Shutdown
+### 8. Shutdown
 
 ```bash
-# Ctrl-C in serve-prod terminal, or:
+# Ctrl-C in the serve-prod terminal, or:
 just serve-prod-stop
 ```
 
-`tmp/prod-local/` persists across sessions (intentional — lets you
-resume). `just serve-prod-reset` for a clean slate next time.
+`tmp/prod-local/` persists across sessions (intentional — lets you resume).
+`just serve-prod-reset` for a clean slate.
 
 ---
 
@@ -310,76 +224,77 @@ Run only after the deploy has landed.
 just ship                              # build + test + deploy + smoke
 just whats-running                     # confirm prod git_sha matches HEAD
 just drift                             # SHA-aligned 3-line view (local / origin / prod)
-just smoke                             # HTTPS health + manifest probe
+just smoke                             # HTTPS health + manifest + diagnostics probe
 ```
 
-### 1. First-time-visitor smoke
+### 1. First-time-visitor smoke (real Postmark)
 
-- [ ] **New incognito window** at `https://fellows.globaldonut.com/` →
-      gate appears.
-- [ ] Submit your real email (the one Postmark can deliver to).
-- [ ] **Check the real inbox** — email arrives. Subject line is the
-      current expected copy. Body includes the unlock URL and the
-      "expires in 30 minutes" notice. Signing-key fingerprint section
-      present.
-- [ ] Click the link from the inbox (NOT a copy/paste — verify the
-      actual email flow). Land on install landing.
-- [ ] Install the PWA from the install landing.
-- [ ] App opens from the installed PWA window → directory loads.
-- [ ] About page shows the build label that matches `just drift` output.
+> The browser-side gate→landing flow can be driven on real Chrome via
+> chrome-devtools-mcp ([`debugging.md`](debugging.md)). The **real inbox receipt**
+> below is irreducible.
+
+- [ ] **1.1** New incognito window at `https://fellows.globaldonut.com/` → gate appears.
+- [ ] **1.2** Submit your real email (one Postmark can deliver to).
+- [ ] **1.3** **Check the real inbox** — email arrives; subject is current copy; body
+      has the unlock URL, the "expires in 30 minutes" notice, and the signing-key
+      fingerprint section.
+- [ ] **1.4** Click the link **from the inbox** (not copy/paste) → install landing.
+- [ ] **1.5** Install the PWA → it opens standalone → directory loads.
+- [ ] **1.6** About page build label matches `just drift`.
 
 ### 2. Real iOS Safari install (irreducible)
 
-- [ ] Open `https://fellows.globaldonut.com/` on a real iPhone.
-- [ ] Magic-link round-trip works (same email, same Postmark delivery).
-- [ ] **Add to Home Screen** from Safari's share sheet → app installs.
-- [ ] Open the installed PWA → directory loads.
-- [ ] **Tap a fellow** → detail loads. Back arrow returns.
-- [ ] **Select a fellow** → composer FAB appears. Tap → composer sheet
-      opens. Create a group.
-- [ ] **Check for the "bottom bar takes half the screen" symptom** that
-      didn't reproduce in Chromium emulation. If it appears, it's a real
-      iOS Safari viewport quirk we couldn't catch locally.
+- [ ] **2.1** Open `https://fellows.globaldonut.com/` on a real iPhone.
+- [ ] **2.2** Magic-link round-trip works (real email, real Postmark).
+- [ ] **2.3** **Add to Home Screen** from the share sheet → app installs.
+- [ ] **2.4** Open the installed PWA → directory loads.
+- [ ] **2.5** Tap a fellow → detail loads; back returns.
+- [ ] **2.6** Select a fellow → composer FAB appears → tap → sheet opens → create a group.
+- [ ] **2.7** Watch for the "bottom bar takes half the screen" symptom that Chromium
+      emulation can't reproduce.
 
-### 3. Real Android Chrome install (if you have an Android device)
+### 3. Real Android Chrome install *(if you have an Android device)*
 
-- [ ] Same flow as iOS, but Chrome shows an "Add to Home Screen" prompt
-      instead of Safari's share sheet.
+> _(Optional assist: tether the device and drive it via chrome-devtools-mcp over
+> `adb forward` + `--browser-url` — see [`debugging.md`](debugging.md).)_
+
+- [ ] **3.1** Same flow as iOS, but Chrome shows an "Add to Home Screen" prompt instead
+      of Safari's share sheet.
 
 ### 4. Caddy header preservation
 
-Inspect the response headers on a prod request — Caddy adds the headers
-the python server omits. Quick spot check:
+> Not covered by `just smoke` (it checks health/manifest/diagnostics, not these
+> headers). _(Automation candidate: add these greps to `scripts/smoke_prod.sh`, then
+> delete this section.)_
 
 ```bash
 curl -sI https://fellows.globaldonut.com/ | grep -iE "strict-transport|cross-origin"
 ```
 
-Expect:
-- `Strict-Transport-Security: max-age=31536000; includeSubDomains; preload`
-- `Cross-Origin-Opener-Policy: same-origin`
-- `Cross-Origin-Embedder-Policy: require-corp`
+- [ ] **4.1** `Strict-Transport-Security: max-age=31536000; includeSubDomains; preload`
+- [ ] **4.2** `Cross-Origin-Opener-Policy: same-origin`
+- [ ] **4.3** `Cross-Origin-Embedder-Policy: require-corp`
 
-If any are missing, Caddy config drifted. See `docs/DevOps.md` § Architecture-at-a-glance for the COOP/COEP gotcha.
+If any are missing, Caddy config drifted — see [`DevOps.md`](DevOps.md) § Architecture.
 
-### 5. Real MCPB install (if you tested it in Phase 1)
+### 5. Real MCPB install *(if you tested it in Phase 1)*
 
-- [ ] On prod, download a `.mcpb` from Settings → MCPB.
-- [ ] Confirm it installs into Claude Desktop just like Phase 1.
-- [ ] Quick query: "How many fellows are in the directory?" — confirm
-      the count matches the build's `fellows.db`.
+- [ ] **5.1** On prod, download a `.mcpb` from Settings → Claude Desktop integration.
+- [ ] **5.2** Confirm it installs into Claude Desktop as in Phase 1 §5.
+- [ ] **5.3** Quick query: "How many fellows are in the directory?" — count matches the
+      build's `fellows.db`.
 
-### 6. Update flow
+### 6. Update flow on a real install
 
-- [ ] **Existing installed PWA** (your phone or laptop) — open it.
-- [ ] Within ~30 seconds the "New version available — Reload" banner
-      should appear (SW noticed the new build).
-- [ ] Click Reload → fresh shell loads. About page shows the new
-      build label.
+> The drift→banner *logic* is covered by `just test` (`test_update_check.py`). What
+> stays manual: the **real SW update** on a **really-installed** PWA — drivable on
+> real Chrome via chrome-devtools-mcp ([`debugging.md`](debugging.md)).
+
+- [ ] **6.1** Open your existing installed PWA (phone or laptop).
+- [ ] **6.2** Within ~30 s the "New version available — Reload" banner appears.
+- [ ] **6.3** Click Reload → fresh shell loads → About shows the new build label.
 
 ### 7. Worst-case rollback (don't run unless needed)
-
-If a Phase 2 finding is bad enough to need rollback:
 
 ```bash
 git revert <bad-merge-commit>          # or git revert --no-commit <range>
@@ -389,34 +304,26 @@ just smoke
 
 ---
 
-## What this doesn't cover (irreducible gaps)
+## What this plan doesn't cover (irreducible gaps)
 
-Even with Phase 1 + Phase 2 both green, the following are still
-operating on trust and not direct verification:
+Even with `just test` green and both phases passed, these operate on trust:
 
 | Gap | Why | Mitigation |
 |---|---|---|
-| **External-process folder concurrency** | Web Locks are per-origin per-browser-profile. Dropbox / iCloud / Syncthing replicating the folder bytes, or a second browser pointed at the same synced folder, can corrupt the file. | Documented as out of scope in `plans/user_folder_storage.md` § Risks. Tell users not to use synced folders for `relationships.db`. |
-| **Cross-device sync** | Intentionally not supported. The `relationships.db` is per-device. | Export / Import recipe in `docs/users_manual.md` § Migrating from another browser. |
-| **Real Postmark deliverability across all email providers** | Gmail, ProtonMail, Outlook, etc. each apply their own spam scoring. | Ship-and-watch: `just prod-stats` reports send/verify counts; if verify rate is anomalously low after a deploy, investigate Postmark dashboard. |
+| **External-process folder concurrency** | Web Locks are per-origin per-browser-profile. Dropbox / iCloud / Syncthing replicating the folder, or a second browser on the same synced folder, can corrupt the file. | Out of scope in `plans/user_folder_storage.md` § Risks. Tell users not to sync `relationships.db`. |
+| **Cross-device sync** | Intentionally unsupported; `relationships.db` is per-device. | Export / Import recipe in `docs/users_manual.md` § Migrating from another browser. |
+| **Real Postmark deliverability across providers** | Gmail / Proton / Outlook each spam-score differently. | Ship-and-watch: `just prod-stats` send/verify counts; investigate Postmark if verify rate drops. |
 | **Older Claude Desktop versions** | `.mcpb` format may not be recognized. | Surface the version-incompatibility error per `plans/easy_mcp_install.md` § Risks. |
-| **Multi-tab worker takeover** | `plans/multi_tab_ownership_takeover.md` is unimplemented. Two tabs both attempting to open `relationships.db` will fail the second with a generic panel. | Cheap-fix landed earlier shows "another tab is open"; full takeover is post-MVP. |
-| **The signing-key fingerprint TOFU window** | First-time install trust is anchored on the `sw.js`-embedded `PROD_PUBLIC_KEY_HEX`. | Magic-link email body includes the fingerprint for out-of-band cross-check (`docs/DevOps.md` § Out-of-band fingerprint publication). |
-
-If any of these surface as recurring real-world issues, they're candidates
-for a future sprint — but they're explicitly accepted gaps, not test-plan
-oversights.
+| **Multi-tab worker takeover** | `plans/multi_tab_ownership_takeover.md` unimplemented; the 2nd tab fails with a generic panel. | Cheap "another tab is open" panel shipped; full takeover is post-MVP. |
+| **Signing-key fingerprint TOFU window** | First-install trust anchors on the `sw.js`-embedded `PROD_PUBLIC_KEY_HEX`. | Magic-link email body carries the fingerprint for out-of-band cross-check (`docs/DevOps.md`). |
 
 ---
 
 ## Related
 
 - [`local_staging.md`](local_staging.md) — how to run `just serve-prod`.
-- [`DevOps.md`](DevOps.md) — what `just ship` / `just deploy` / `just smoke`
-  do under the hood.
-- [`email_gate.md`](email_gate.md) — the magic-link decision tree this plan
-  exercises.
-- [`persistence_and_upgrades.md`](persistence_and_upgrades.md) — the
-  storage-layer matrix this plan's folder/OPFS tests touch.
-- `plans/maintainer_test_plan_through_pr_200.md` — snapshot example of
-  per-batch test plans (now superseded by this living doc).
+- [`debugging.md`](debugging.md) — attaching Claude Code to your real Chrome via chrome-devtools-mcp (assist for the Phase-2 manual steps).
+- [`DevOps.md`](DevOps.md) — what `just ship` / `just deploy` / `just smoke` do.
+- [`email_gate.md`](email_gate.md) — the magic-link decision tree.
+- [`persistence_and_upgrades.md`](persistence_and_upgrades.md) — the storage-layer matrix.
+- `plans/maintainer_test_plan_through_pr_200.md` — superseded per-batch snapshot example.

--- a/docs/pre_ship_test_plan.md
+++ b/docs/pre_ship_test_plan.md
@@ -100,62 +100,7 @@ Settings → **Choose data folder…** → pick `~/Documents/local-staging/` (or
 - [ ] **2.4** Settings → **⬇ Download my private data** → a real `.db` blob lands in
       `~/Downloads`.
 
-### 3. Folder Web Lock — manual verification
-
-> _(Automation candidate: the `window.__holdFolderLockForever()` /
-> `__releaseFolderLock()` seams already exist; a single-context e2e can assert the
-> badge flip. Delete this section when that test lands.)_
-
-Must run on the **same `127.0.0.1:8766` tab** as §2. Open `#/settings` in a second tab
-so you can watch the badge. In DevTools console:
-
-```js
-navigator.locks.request(
-  'fellows-relationships-folder-write',
-  { mode: 'exclusive' },
-  () => new Promise(() => {})   // holds forever
-);
-```
-
-- [ ] **3.1** Create another group from the directory rail. The OPFS commit succeeds
-      (group appears in-memory) but the post-commit folder write hits the lock and
-      fails fast.
-- [ ] **3.2** The Private data folder badge flips to **"Last save failed — Change
-      folder to re-pick"** within a second.
-- [ ] **3.3** Hover the badge / check diagnostics → reason reads *"Another window has
-      this folder open — close it, then make any change to retry the save."*
-- [ ] **3.4** Reload the tab (releases the lock — Web Locks auto-release on agent
-      termination).
-- [ ] **3.5** Make a fresh mutation → badge returns to Saved; the folder file now
-      contains the previously-failed mutation too.
-
-### 4. Honest mutation loss on tab close
-
-> _(Automation candidate: the in-memory-lost-on-close logic is modelable with a fresh
-> Playwright context boundary against the deploy_server lane. The real
-> incognito-session OPFS lifecycle below is the residue that may stay manual.)_
-
-**Incognito session lifecycle matters.** Chrome keeps OPFS/IndexedDB/cookies/SW alive
-across all tabs in one incognito *session* and wipes them only when **every** incognito
-window of that session closes. Confirm freshness via the About page **install codename**
-(persisted in OPFS): a stale session shows the same codename.
-
-Every "sign in" = a full magic-link round-trip (the session cookie is per-incognito-session).
-
-- [ ] **4.1** New incognito window. Sign in. Pick the same data folder (open-existing).
-      Confirm a prior group is visible.
-- [ ] **4.2** Create group "Doomed". Hold the lock (same snippet as §3).
-- [ ] **4.3** Create group "Lost". Badge says "Last save failed."
-- [ ] **4.4** **Close every incognito window of this session without releasing the
-      lock.** (Closing one tab is not enough — a sibling tab keeps OPFS alive and
-      false-passes §4.6.)
-- [ ] **4.5** Brand-new incognito window. Sign in. Pick the same folder. **Sanity:**
-      About shows a *different* install codename than §4.1; if it matches, the prior
-      session is still alive — close everything and retry.
-- [ ] **4.6** Confirm the saved groups + "Doomed" are visible; **"Lost" is gone** —
-      the honest mutation loss the badge warned about, verified end-to-end.
-
-### 5. Claude Desktop end-to-end *(only with Claude Desktop on macOS)*
+### 3. Claude Desktop end-to-end *(only with Claude Desktop on macOS)*
 
 > The MCPB **Settings UI** flow (preamble, three-bundle list, warning banner, cancel,
 > continue-dispatches-three-downloads, button relabel, localStorage persistence) and
@@ -165,46 +110,37 @@ Every "sign in" = a full magic-link round-trip (the session cookie is per-incogn
 > `test_comms.py`, `test_mcpb_parity.py`. What stays manual: the native Claude Desktop
 > install handshake and a live AI query — neither tool reaches Claude Desktop.
 
-- [ ] **5.1** Settings → **Set up Claude Desktop integration** → **Continue** → three
+- [ ] **3.1** Settings → **Set up Claude Desktop integration** → **Continue** → three
       real `.mcpb` files (~3–4 MB each; needs `just build-mcpb`) land in `~/Downloads`.
-- [ ] **5.2** Drag each `.mcpb` into Claude Desktop → install dialog → **Install**
+- [ ] **3.2** Drag each `.mcpb` into Claude Desktop → install dialog → **Install**
       (approve the red banner).
-- [ ] **5.3** `private_data_ops.mcpb` asks for a file → navigate to
+- [ ] **3.3** `private_data_ops.mcpb` asks for a file → navigate to
       `<your-data-folder>/Fellows/relationships.db` (the folder picked in §2).
-- [ ] **5.4** **Quit Claude Desktop (⌘Q) and reopen.**
-- [ ] **5.5** Ask *"How many fellows are in the directory?"* → expect a number.
-- [ ] **5.6** Ask *"List my saved groups"* → expect the groups (or "none yet").
-- [ ] **5.7** Ask *"Draft an invite email to my [group] group, don't send"* → a
+- [ ] **3.4** **Quit Claude Desktop (⌘Q) and reopen.**
+- [ ] **3.5** Ask *"How many fellows are in the directory?"* → expect a number.
+- [ ] **3.6** Ask *"List my saved groups"* → expect the groups (or "none yet").
+- [ ] **3.7** Ask *"Draft an invite email to my [group] group, don't send"* → a
       mail-compose window opens with To/Subject/Body pre-filled.
 
 (The AI-query path is local-only — Claude Desktop ↔ local MCP subprocesses ↔ local
 SQLite. No server contact.)
 
-### 6. Cross-browser data silos
+### 4. Cross-browser data silos
 
 > _(Automation candidate: the silo concept + export/import migration are modelable
 > with two Playwright contexts. The **real Safari** install path below is the residue.)_
 
-- [ ] **6.1** Open `http://127.0.0.1:8766/` in **Chrome** AND **Safari**; sign in to both.
-- [ ] **6.2** About page in each → different install codenames.
-- [ ] **6.3** Create a group in Chrome → open Safari → no groups (silo confirmed;
+- [ ] **4.1** Open `http://127.0.0.1:8766/` in **Chrome** AND **Safari**; sign in to both.
+- [ ] **4.2** About page in each → different install codenames.
+- [ ] **4.3** Create a group in Chrome → open Safari → no groups (silo confirmed;
       Safari uses OPFS-only fallback, no `showDirectoryPicker`).
-- [ ] **6.4** Migrate: Chrome → ⬇ Download my private data; Safari → ⬆ Restore from a
+- [ ] **4.4** Migrate: Chrome → ⬇ Download my private data; Safari → ⬆ Restore from a
       file → the Chrome group appears in Safari.
 
 *Note: Safari "Add to Dock" on localhost may refuse — the silo behavior still tests
 fine in a regular Safari window. Real Safari install is Phase 2.*
 
-### 7. App-basics manual residue
-
-> _(Automation candidates pending Step-2 assertions: directory search results,
-> group edit/delete, group visual-directory portraits. Delete each when its test lands.)_
-
-- [ ] **7.1** Directory search returns results.
-- [ ] **7.2** Groups index → edit a group, delete a group.
-- [ ] **7.3** Visual directory route for a group renders portraits.
-
-### 8. Shutdown
+### 5. Shutdown
 
 ```bash
 # Ctrl-C in the serve-prod terminal, or:
@@ -280,7 +216,7 @@ If any are missing, Caddy config drifted — see [`DevOps.md`](DevOps.md) § Arc
 ### 5. Real MCPB install *(if you tested it in Phase 1)*
 
 - [ ] **5.1** On prod, download a `.mcpb` from Settings → Claude Desktop integration.
-- [ ] **5.2** Confirm it installs into Claude Desktop as in Phase 1 §5.
+- [ ] **5.2** Confirm it installs into Claude Desktop as in Phase 1 §3.
 - [ ] **5.3** Quick query: "How many fellows are in the directory?" — count matches the
       build's `fellows.db`.
 

--- a/docs/pre_ship_test_plan.md
+++ b/docs/pre_ship_test_plan.md
@@ -160,7 +160,7 @@ Run only after the deploy has landed.
 just ship                              # build + test + deploy + smoke
 just whats-running                     # confirm prod git_sha matches HEAD
 just drift                             # SHA-aligned 3-line view (local / origin / prod)
-just smoke                             # HTTPS health + manifest + diagnostics probe
+just smoke                             # HTTPS health + manifest + diagnostics + COOP/COEP/HSTS headers
 ```
 
 ### 1. First-time-visitor smoke (real Postmark)
@@ -197,40 +197,24 @@ just smoke                             # HTTPS health + manifest + diagnostics p
 - [ ] **3.1** Same flow as iOS, but Chrome shows an "Add to Home Screen" prompt instead
       of Safari's share sheet.
 
-### 4. Caddy header preservation
+### 4. Real MCPB install *(if you tested it in Phase 1)*
 
-> Not covered by `just smoke` (it checks health/manifest/diagnostics, not these
-> headers). _(Automation candidate: add these greps to `scripts/smoke_prod.sh`, then
-> delete this section.)_
-
-```bash
-curl -sI https://fellows.globaldonut.com/ | grep -iE "strict-transport|cross-origin"
-```
-
-- [ ] **4.1** `Strict-Transport-Security: max-age=31536000; includeSubDomains; preload`
-- [ ] **4.2** `Cross-Origin-Opener-Policy: same-origin`
-- [ ] **4.3** `Cross-Origin-Embedder-Policy: require-corp`
-
-If any are missing, Caddy config drifted — see [`DevOps.md`](DevOps.md) § Architecture.
-
-### 5. Real MCPB install *(if you tested it in Phase 1)*
-
-- [ ] **5.1** On prod, download a `.mcpb` from Settings → Claude Desktop integration.
-- [ ] **5.2** Confirm it installs into Claude Desktop as in Phase 1 §3.
-- [ ] **5.3** Quick query: "How many fellows are in the directory?" — count matches the
+- [ ] **4.1** On prod, download a `.mcpb` from Settings → Claude Desktop integration.
+- [ ] **4.2** Confirm it installs into Claude Desktop as in Phase 1 §3.
+- [ ] **4.3** Quick query: "How many fellows are in the directory?" — count matches the
       build's `fellows.db`.
 
-### 6. Update flow on a real install
+### 5. Update flow on a real install
 
 > The drift→banner *logic* is covered by `just test` (`test_update_check.py`). What
 > stays manual: the **real SW update** on a **really-installed** PWA — drivable on
 > real Chrome via chrome-devtools-mcp ([`debugging.md`](debugging.md)).
 
-- [ ] **6.1** Open your existing installed PWA (phone or laptop).
-- [ ] **6.2** Within ~30 s the "New version available — Reload" banner appears.
-- [ ] **6.3** Click Reload → fresh shell loads → About shows the new build label.
+- [ ] **5.1** Open your existing installed PWA (phone or laptop).
+- [ ] **5.2** Within ~30 s the "New version available — Reload" banner appears.
+- [ ] **5.3** Click Reload → fresh shell loads → About shows the new build label.
 
-### 7. Worst-case rollback (don't run unless needed)
+### 6. Worst-case rollback (don't run unless needed)
 
 ```bash
 git revert <bad-merge-commit>          # or git revert --no-commit <range>

--- a/scripts/smoke_prod.sh
+++ b/scripts/smoke_prod.sh
@@ -61,3 +61,30 @@ print("diagnostics OK (authActive=%s)" % d.get("authActive"))
   exit 1
 fi
 rm -f /tmp/fellows_smoke_diag.txt
+
+# Security headers the edge MUST preserve. COOP/COEP are load-bearing:
+# the OPFS-SAH-Pool VFS that holds relationships.db + fellows.db refuses
+# to install without crossOriginIsolated=true, and a reverse-proxy that
+# strips them is a silent "Settings has no backup/restore" failure
+# (docs/DevOps.md § Architecture). HSTS is part of the prod TLS contract
+# (Caddy sets it; the Python server does not) — only asserted for https
+# targets so this stays valid against the plain-http local-staging server.
+# Use GET with header dump (-D -) rather than HEAD: the stdlib server
+# implements do_GET, not do_HEAD.
+echo "GET ${BASE}/ (security headers)"
+hdrs=$(curl -sS -D - -o /dev/null "${BASE}/" || true)
+missing=""
+echo "$hdrs" | grep -qiE '^cross-origin-opener-policy:[[:space:]]*same-origin' \
+  || missing="${missing} Cross-Origin-Opener-Policy"
+echo "$hdrs" | grep -qiE '^cross-origin-embedder-policy:[[:space:]]*require-corp' \
+  || missing="${missing} Cross-Origin-Embedder-Policy"
+if [[ "$BASE" == https://* ]]; then
+  echo "$hdrs" | grep -qiE '^strict-transport-security:.*max-age=' \
+    || missing="${missing} Strict-Transport-Security"
+fi
+if [[ -n "$missing" ]]; then
+  echo "FAIL: missing/unexpected security headers:${missing}"
+  echo "$hdrs" | grep -iE 'strict-transport|cross-origin' || echo "(none present)"
+  exit 1
+fi
+echo "OK security headers (COOP + COEP$([[ "$BASE" == https://* ]] && echo ' + HSTS'))"

--- a/tests/e2e/test_user_folder_storage.py
+++ b/tests/e2e/test_user_folder_storage.py
@@ -775,6 +775,11 @@ class TestPhase2WriteLock:
         re-attempts the folder write; this time the lock is free,
         the write succeeds with all the in-memory state including B,
         lastError clears and lastSavedAt advances.
+
+        Also pins the user-facing Settings badge: "Last save failed"
+        + the "Another window…" detail line while blocked, and back to
+        "Saved to …" after recovery — the surface the pre-ship checklist
+        used to verify by hand.
         """
         gid_a, baseline_saved_at, baseline_rel_size = (
             self._pick_folder_and_seed_group_a(folder_page, base_url_fixture)
@@ -812,6 +817,23 @@ class TestPhase2WriteLock:
             f"lock-held lastError should carry the actionable copy; "
             f"got {state_after_b['lastError']['reason']!r}"
         )
+        # The blocked write surfaces in the Settings folder badge — the
+        # user-facing signal the pre-ship checklist used to verify by hand.
+        # Re-render the settings route IN-PAGE (hash bounce, NOT a reload:
+        # a reload would re-boot the worker and drop the in-memory
+        # lastError) so renderFolderSection repaints from the failed state.
+        folder_page.evaluate("() => { location.hash = '#/'; }")
+        folder_page.evaluate("() => { location.hash = '#/settings'; }")
+        folder_page.locator("#settings-folder-section").wait_for(
+            state="visible", timeout=5000
+        )
+        badge_text = folder_page.locator(
+            "#settings-folder-badge .settings-folder-badge-text"
+        )
+        expect(badge_text).to_contain_text("Last save failed", timeout=5000)
+        expect(
+            folder_page.locator("#settings-folder-detail")
+        ).to_contain_text("Another window")
         # lastSavedAt did NOT advance — folder is still at A only.
         assert state_after_b["lastSavedAt"] == baseline_saved_at, (
             f"lastSavedAt should NOT advance when the write was blocked; "
@@ -854,6 +876,18 @@ class TestPhase2WriteLock:
             f"lastSavedAt should advance on retry; "
             f"baseline={baseline_saved_at!r} after_retry={state_after_retry['lastSavedAt']!r}"
         )
+        # Badge UI recovers to Saved after the successful retry (the other
+        # half of the pre-ship badge check). Same in-page re-render trick.
+        folder_page.evaluate("() => { location.hash = '#/'; }")
+        folder_page.evaluate("() => { location.hash = '#/settings'; }")
+        folder_page.locator("#settings-folder-section").wait_for(
+            state="visible", timeout=5000
+        )
+        expect(
+            folder_page.locator(
+                "#settings-folder-badge .settings-folder-badge-text"
+            )
+        ).to_contain_text("Saved to", timeout=5000)
 
     def test_tab_close_with_pending_write_failure_preserves_folder_state(
         self, folder_page, base_url_fixture, context


### PR DESCRIPTION
## What & why

The pre-ship manual QA checklist (`docs/pre_ship_test_plan.md`) was re-verifying by hand a large fraction of what `just test` already proves. This collapses it to only the **irreducible-manual** tests and establishes a two-category rule: automatable tests live in `just test`; manual tests live in the plan; when something is automated it's deleted from the plan. No third artifact.

**Manual checkboxes: 86 → 41. Phase 1 hand-checks: 65 → 21.**

Every deletion was gated by reading the cited test (not its name) to confirm it actually asserts the behavior.

## Commits (one per step)

1. **`docs(pre-ship)`** — prune items already covered by `just test`: removed the MCPB-UI, MCPB-routes, mobile, and 5/8 app-basics sections; collapsed granular auth/folder steps into the real-launcher + real-OS-gesture passes.
2. **`test(e2e)+docs`** — the Web Lock, mutation-loss, and app-basics sections were already covered (`TestPhase2WriteLock`, groups/directory tests). Closed the one real gap — the **"Last save failed" badge UI** — by extending the lock test (in-page hash re-render so the worker's `lastError` survives), then deleted §3/§4/§7.
3. **`feat(smoke)+docs`** — added COOP/COEP/HSTS assertions to `smoke_prod.sh` (the last cheaply-automatable manual item), deleted manual Phase 2 §4.
4. **`docs(debugging)`** — 4 chrome-devtools-mcp attach-and-assert recipes for the real-browser residue, cross-linked from each matching manual step.

## Scope note (honest)

Step 3 was planned to add a `deploy_server` Playwright e2e lane to automate the auth-on/folder flows — but Steps 1–2 found those **already covered**, so the lane would have been unused infrastructure. Dropped it; did the one thing that actually shrank the plan (the header check).

## What stays manual (irreducible)

Real Postmark inbox receipt · real iOS Safari install · real Android install · native Claude Desktop `.mcpb` handshake + AI query · real folder-picker OS gesture · one real-launcher SW/precache pass · rollback runbook. Several now carry a chrome-devtools-mcp recipe.

## Test results

`just test`: **615 passed, 3 skipped, 1 failed**. The one failure is `test_edit_mode_keeps_rails_visible_on_mobile` — a **pre-existing flake** (boot race: page boots to `#/groups` instead of `#/edit/<id>`). It passes intermittently on **both `main` and this branch** (verified: passes 1/3 isolated runs on each; different viewports fail each run), and this branch's diff imports into none of that code. Per the plan's own policy ("accept the flake and continue").

## Maintainer QA

- `just smoke` against prod now prints `OK security headers (COOP + COEP + HSTS)` — **already verified green** against `https://fellows.globaldonut.com/` during this work.
- Extended folder-lock test: `just test-e2e "test_lock_held_during_write_surfaces_failure_then_recovers"` → passes; full `test_user_folder_storage.py` → 14 passed.

🤖 Generated with [Claude Code](https://claude.com/claude-code)