### PR TITLE
security: 2026-05-30 audit pass — PII-in-logs, infra hardening, audit docs

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -57,8 +57,3 @@ backup/*.zip
 
 # Ansible become-password temp files — never commit
 BECOME_PASS*
-
-# Security analyses, notes, and threat-model write-ups. Local-only by
-# default — these can name fields, hash schemes, and other internal
-# detail we don't want indexed publicly.
-security_review/

--- a/SECURITY.md
+++ b/SECURITY.md
@@ -50,7 +50,7 @@ The trade-off this locks in:
 
 ### 2. "Strip sensitive fields, serve on-demand" — considered and rejected
 
-The original threat analysis (`security_review/2026-05-08_local_vs_saas_risk.md`, kept locally, gitignored) proposed stripping `contact_email` and `mobile_number` from the bundle and serving them via a new authenticated `GET /api/fellow-private/<slug>` endpoint. A device compromise would then leak the directory roster but not the contact-book.
+The original threat analysis (now published as [`docs/local_vs_saas_risk.md`](docs/local_vs_saas_risk.md)) proposed stripping `contact_email` and `mobile_number` from the bundle and serving them via a new authenticated `GET /api/fellow-private/<slug>` endpoint. A device compromise would then leak the directory roster but not the contact-book.
 
 Cut, for four reasons that compound:
 
@@ -94,7 +94,7 @@ Currently in flight or queued:
 - **Optional "lock my user data" toggle.** User-driven encryption-at-rest for `relationships.db` and its OPFS backups, surfaced as a "lock on quit?" prompt with an off-toggle. Not forced — peace-of-mind for paranoid moments (airport, lending the laptop, retiring a device).
 - **Operational hardening.** Maintainer workstation hardening doc, user-guide hygiene section ("your device is now the directory"), HSTS preload submission status check.
 
-These are tracked in `security_review/2026-05-08_local_vs_saas_risk.md` (kept locally; gitignored because it names concrete file paths and threat-model details that don't belong in the public-search index).
+The live recommendations checklist (done / outstanding / deliberately-not-done) is [`docs/securityaudit.md`](docs/securityaudit.md).
 
 ---
 
@@ -108,4 +108,4 @@ The threat model assumes:
 - Compromise of the maintainer's deploy pipeline is the worst plausible breach event by **impact** (poisoned bundle reaches all users); signed bundles are the partial answer.
 - Once distribution shuts down, "server compromise" stops being a category at all — the only remaining attack surface is the per-device installed app.
 
-For the full analysis with quantified estimates and a comparison to the SaaS alternative, see `security_review/2026-05-08_local_vs_saas_risk.md` (gitignored; ask the maintainer for a copy if you're doing security review work on this codebase).
+For the full analysis with quantified estimates and a comparison to the SaaS alternative, see [`docs/local_vs_saas_risk.md`](docs/local_vs_saas_risk.md).

--- a/ansible/roles/caddy/handlers/main.yml
+++ b/ansible/roles/caddy/handlers/main.yml
@@ -1,5 +1,9 @@
 ---
+# Full restart, not reload: `admin off` in the Caddyfile disables the admin
+# API that `caddy reload` (systemctl reload → ExecReload) drives, so a reload
+# would fail. A restart re-reads the file directly. Brief connection blip on
+# config change; acceptable for this low-traffic distribution server.
 - name: Reload caddy
   ansible.builtin.service:
     name: caddy
-    state: reloaded
+    state: restarted

--- a/ansible/roles/caddy/templates/Caddyfile.j2
+++ b/ansible/roles/caddy/templates/Caddyfile.j2
@@ -5,6 +5,16 @@
 #   - www.{{ globaldonut_domain }}    → 301 to apex
 {
 	email {{ caddy_admin_email }}
+	# Disable the Caddy admin API (default: localhost:2019, unauthenticated).
+	# Our config is fully static and applied by Ansible, so we never need the
+	# live admin/config API. Leaving it on gives any local process (e.g. an
+	# RCE'd app running as the `fellows` user) an unauthenticated control plane
+	# that can extract TLS private keys or rewrite routing post-foothold.
+	# Trade-off: `caddy reload` (graceful, API-driven) no longer works, so the
+	# caddy role's handler does a full `systemctl restart` instead (a brief
+	# connection blip on config change — negligible for this low-traffic,
+	# soon-to-be-retired distribution server).
+	admin off
 }
 
 {{ fellows_domain }} {

--- a/ansible/roles/common/handlers/main.yml
+++ b/ansible/roles/common/handlers/main.yml
@@ -3,3 +3,8 @@
   ansible.builtin.service:
     name: ssh
     state: restarted
+
+- name: Restart fail2ban
+  ansible.builtin.service:
+    name: fail2ban
+    state: restarted

--- a/ansible/roles/common/tasks/main.yml
+++ b/ansible/roles/common/tasks/main.yml
@@ -6,6 +6,7 @@
       - python3-venv
       - curl
       - ufw
+      - fail2ban
       - ca-certificates
       - gnupg
       - rsync
@@ -108,3 +109,35 @@
     group: root
     mode: "0644"
   notify: Restart sshd
+
+# Defence-in-depth on the SSH key (the operator key is the highest-value
+# credential — it can read fellows.db, the secrets env file, and push the
+# bundle to all users). Password auth is already off, so brute force can't
+# succeed; fail2ban's job here is to ban scanners/credential-stuffers early
+# and keep the auth log clean. backend=systemd because Ubuntu 24.04 has no
+# /var/log/auth.log by default — the sshd jail reads the journal. port binds
+# the jail to the non-standard SSH port from the inventory.
+- name: Configure fail2ban sshd jail
+  ansible.builtin.copy:
+    dest: /etc/fail2ban/jail.local
+    owner: root
+    group: root
+    mode: "0644"
+    content: |
+      # Managed by Ansible (roles/common). Do not edit by hand.
+      [DEFAULT]
+      backend = systemd
+      bantime = 1h
+      findtime = 10m
+      maxretry = 5
+
+      [sshd]
+      enabled = true
+      port = {{ ssh_listen_port }}
+  notify: Restart fail2ban
+
+- name: Ensure fail2ban is enabled and started
+  ansible.builtin.service:
+    name: fail2ban
+    state: started
+    enabled: true

--- a/ansible/roles/fellows_app/templates/fellows-pwa.service.j2
+++ b/ansible/roles/fellows_app/templates/fellows-pwa.service.j2
@@ -17,6 +17,11 @@ RestartSec=3
 # reads server.py + helpers + fellows.db + static files. It never writes to
 # its own code tree. dist/ is listed in ReadWritePaths only as a safety net
 # for sqlite3 journal files; the server's query path is read-only in practice.
+# Files the service creates (sqlite WAL/journal under dist/) default to
+# world-readable without this — the one finding that drops
+# `systemd-analyze security fellows-pwa` below an otherwise-clean score.
+# 0077 makes new files owner-only.
+UMask=0077
 NoNewPrivileges=yes
 ProtectSystem=strict
 ProtectHome=yes

--- a/app/server.py
+++ b/app/server.py
@@ -485,15 +485,17 @@ class Handler(BaseHTTPRequestHandler):
         # so the panel renders cleanly in dev instead of showing a
         # network error. Mirrors the prod shape in `deploy/server.py`.
         if path == "/api/debug/diagnostics":
+            # Field set mirrors deploy/server.py's diagnostics body (dev/prod
+            # parity): config-presence booleans only, no exact allowlist size
+            # and no internal filesystem path.
             self.send_json(
                 {
                     "authActive": False,
-                    "allowlistHashCount": 0,
+                    "allowlistConfigured": False,
                     "sessionSecretConfigured": False,
                     "postmarkTokenConfigured": False,
                     "fellowsDbPresent": DB_PATH.is_file(),
                     "build": BUILD_META,
-                    "distRoot": str(APP_DIR),
                 }
             )
             return

--- a/deploy/server.py
+++ b/deploy/server.py
@@ -317,19 +317,26 @@ class Handler(SimpleHTTPRequestHandler):
             return
 
         if path == "/api/debug/diagnostics":
+            # Unauthenticated by design: scripts/smoke_prod.sh probes this
+            # to catch a silently-broken send path (authActive but a secret
+            # unconfigured). Because it's public, the body is kept to
+            # config-presence booleans only — no exact roster size
+            # (allowlist count) and no internal filesystem path (distRoot),
+            # which are pure reconnaissance for an attacker and read by no
+            # tooling. `allowlistConfigured` is a boolean so the smoke check
+            # and operators can still tell auth is wired without disclosing N.
             sec = ml.session_secret_bytes()
             hkey = ml.allowlist_hmac_key()
             postmark = bool(os.environ.get("FELLOWS_POSTMARK_TOKEN", "").strip())
             self.send_json(
                 {
                     "authActive": AUTH_ACTIVE,
-                    "allowlistHashCount": len(ALLOWLIST),
+                    "allowlistConfigured": bool(ALLOWLIST),
                     "sessionSecretConfigured": bool(sec),
                     "allowlistHmacKeyConfigured": bool(hkey),
                     "postmarkTokenConfigured": postmark,
                     "fellowsDbPresent": DB_PATH.is_file(),
                     "build": BUILD_META,
-                    "distRoot": str(DIST_DIR),
                 }
             )
             return
@@ -541,7 +548,28 @@ class Handler(SimpleHTTPRequestHandler):
                         "result": "sent",
                         "email_hash_prefix": h[:12],
                         "token_prefix": token[:12],
-                        "postmark": meta,
+                        # `meta` carries the full Postmark response, which
+                        # includes the raw recipient address (meta["to"] and
+                        # meta["raw"]["To"]). journald is the only persistence
+                        # for this event and is readable by every operator /
+                        # adm / systemd-journal member — logging the raw email
+                        # would build a plaintext list of everyone who ever
+                        # requested a link, defeating the email_hash_prefix
+                        # scheme used everywhere else. Log a PII-free subset;
+                        # the recipient stays recoverable out-of-band from
+                        # email_hash_prefix + fellows.db (`prod_stats
+                        # --include-emails`) or the Postmark API
+                        # (`just email-debug --postmark`) when triage needs it.
+                        "postmark": {
+                            k: meta.get(k)
+                            for k in (
+                                "status",
+                                "message_id",
+                                "error_code",
+                                "message",
+                                "submitted_at",
+                            )
+                        },
                     }
                 ),
                 file=sys.stderr,

--- a/docs/local_vs_saas_risk.md
+++ b/docs/local_vs_saas_risk.md
@@ -1,0 +1,199 @@
+# The Risk of Decentralising a Directory: Local-First vs. SaaS
+
+**Audience:** the fellows, and anyone who was part of — or wants to understand —
+the decision to turn a shared, centrally-hosted directory into a local-first
+app that every member carries a full copy of. The decision is already made
+(the central directory is being retired). This document exists so the reasoning
+is on the record for posterity, and so the next community facing the same choice
+has an honest analysis to start from rather than a slogan.
+
+It is **not** a backlog of things to fix — that's
+[`docs/securityaudit.md`](./securityaudit.md). This is an analysis of a risk we
+**chose to take**, why it's defensible, and where it would *not* be.
+
+---
+
+## The question
+
+When a central directory is wound down, the data doesn't have to die with it.
+You can hand every member a full local copy and let the directory live on their
+devices — offline, indefinitely, owned by no one. That's what this app does.
+
+But "decentralise it so it survives" is a trade, not a free win. The honest
+question is: **what risk do you take on when you replace one well-defended
+central copy with N≈500 copies spread across members' laptops and phones, and
+turn off the central infrastructure that used to mediate access?**
+
+The intuitive answer — "SaaS is one big target; spreading it across 500 devices
+is safer" — is misleading here. In *both* models, any authenticated member can
+see the entire directory. Per-account blast radius is the full N in both. The
+real differences live elsewhere: in *who* can be compromised, in *how long* a
+leak persists, and in *what happens when the lights go out*.
+
+---
+
+## The two models, side by side
+
+| Dimension | Centralised SaaS (e.g. the retired directory) | Local-first (this app) |
+|---|---|---|
+| Server-side full-DB exfil | Provider's security sets the floor | Smaller surface: no per-user state, just an allowlist + a mail token + a session secret |
+| Per-account / per-device takeover | Full N exposed during the session window | Full N exposed (whatever is on disk) |
+| Persistence of a leak | Session-bound; revocable by resetting the account | **Indefinite**; the copy on a stolen device can't be revoked |
+| Ex-member retention | Revoke the account → their future access ends | Past data lives forever on departed members' devices |
+| Provider insider / subpoena / breach | A real, central risk | None — there is no provider |
+| Provider shutdown | **Catastrophic** — the directory disappears for everyone | None — the directory survives on every device |
+| Update / supply chain | The provider's deploy pipeline | **One maintainer + one VPS** is the entire supply chain |
+| Audit / detection | Central logs; mass exfil is at least *detectable* | None — a leak is invisible to the maintainer |
+| Patching cadence | One server, patched fast | N devices, long-tailed; old copies never patch |
+
+Read the table as a *reshaping* of risk, not a reduction of it. Decentralisation
+**removes the peak risks** (no provider to breach, no insider, no subpoena, no
+single shutdown that ends the directory) and **adds tail risks** (copies that
+can't be revoked, a one-person supply chain, no central detection).
+
+---
+
+## Rough quantification
+
+Order-of-magnitude, 5-year horizon, ~500 members. The point isn't the exact
+numbers — it's that the two models land in the same ballpark, and *where* they
+differ.
+
+- **p(server full-DB compromise / year):** ≈ 2% for a well-run SaaS; ≈ 1–3% for
+  a single hardened droplet. Comparable. (And for the local-first model this
+  term **goes to zero** once distribution shuts down — there's no longer a
+  server to compromise.)
+- **p(per-member device/account compromise / year):** ≈ 3% baseline (phishing +
+  malware), independent across members. So **E[compromise events/year] ≈ 0.03 ×
+  500 ≈ 15** — and this dominates the breach count, *in both models roughly
+  equally.* Most breaches are a member's own device or inbox, not the server.
+
+The interesting term is the **conditional cost** of each event:
+
+- **SaaS account takeover:** attacker has a bounded window; ~1× full-N exposure,
+  then the account can be reset.
+- **Local device compromise:** attacker reads the on-disk copy at leisure —
+  including the highest-value fields (mobile numbers, citizenship, free-text) —
+  and **the data persists** even after the session, the device owner's
+  awareness, or the maintainer are gone.
+
+With ~5%/year membership turnover, over a decade **~250 ex-members hold full,
+unrevocable copies**. SaaS revokes departed members; local-first cannot. That
+cumulative, unrevocable retention is the **structural risk premium** of going
+local-first. It is the price of the thing that makes local-first worth doing.
+
+**Net:** comparable expected exposure in any single year; **lower peak risk**
+(no provider/insider/subpoena/shutdown event is even possible) bought with
+**higher tail risk over time** (retention compounds; the update channel is a
+single point of failure). Local-first here is *defensible* — not *unambiguously
+safer.*
+
+---
+
+## What decentralisation buys
+
+1. **It survives the shutdown.** The whole reason this exists. When the central
+   directory is retired, a SaaS directory would simply be *gone*. The local-first
+   directory keeps working on every device that installed it — offline, forever,
+   even after the maintainer, the org, or the server are no longer around. Its
+   single most useful function (composing email to a saved group) works with no
+   server at all.
+2. **No provider to breach, subpoena, or sell.** There is no central honeypot,
+   no insider with standing access, no third party whose terms can change. The
+   peak-severity events of the SaaS world are removed from the board.
+3. **The data lives at the level it was always shared.** For *this* directory,
+   the fields involved (email, mobile) were already shared among all members by
+   the directory's social contract. Persisting them on each member's device is
+   the deal members accepted — not a new exposure.
+
+## What it costs
+
+1. **Unrevocable retention.** You cannot un-give the data. A departed member, or
+   a stolen device, keeps the directory indefinitely. There is no "disable
+   account."
+2. **A one-person supply chain.** One maintainer and one VPS sign and serve the
+   bundle. A compromise there is the worst plausible event *by impact* — a
+   poisoned update could reach every device. (This app mitigates it with
+   out-of-band **signed bundles** the service worker verifies, and a public-key
+   fingerprint delivered through a separate channel — see `SECURITY.md` — but the
+   maintainer's keys remain the crown jewels.)
+3. **No central detection.** In the SaaS model a mass exfil at least leaves a log.
+   Here, a leak from a member's device is simply invisible. You trade
+   detectability for the absence of a thing to detect.
+
+---
+
+## "But could we just keep the SaaS alive on donations?"
+
+A fair counter-question, and worth answering honestly rather than dismissing.
+Keeping an unmaintained (or barely-maintained) central directory alive — funded
+by member donations or goodwill — carries its *own* risks, and they are not
+obviously smaller:
+
+- **An unmaintained app is a decaying app.** A live server running
+  rarely-patched application code is a *growing* attack surface over time. The
+  local-first bundle, by contrast, exposes no server-side application logic once
+  distribution ends.
+- **The funding cliff is a shutdown waiting to happen.** Donation-funded infra
+  survives only as long as the donations and a willing operator do. The day
+  either lapses, you get the *catastrophic* SaaS-shutdown event anyway — except
+  now with no decentralised copies to fall back on. You'd have paid the running
+  cost *and* still lost the directory.
+- **It re-centralises the high-severity risks** decentralisation removed:
+  provider insider access, subpoena exposure, one breach = everyone, and a
+  single operator whose account compromise is total.
+- **It doesn't actually lower the dominant risk.** Recall the math: ~15 of the
+  ~15 expected yearly breaches come from *members' own* devices and inboxes.
+  Keeping the server alive doesn't touch that term. It mostly buys back
+  *revocability* and *central detection* — real but secondary — at the cost of
+  re-introducing every peak risk plus an ongoing maintenance burden.
+
+The defensible reading: a donation-funded SaaS makes sense **only** if the
+community both (a) genuinely needs revocability/detection enough to pay for it,
+and (b) can guarantee a *maintained* — not merely *alive* — application
+indefinitely. Absent (b), "keep it alive on donations" tends to be the worst of
+both worlds: SaaS-level peak risk, plus the eventual shutdown, plus a steady
+maintenance bill. For this directory, with the central option already retired
+and a trusted-ish membership, decentralising and stepping back was the better
+trade.
+
+---
+
+## When this pattern fits — and when it doesn't
+
+**This recurs whenever an organisation wants to decentralise an archival
+directory before winding down its central infrastructure.** If you're applying
+the same playbook to another community, the decision turns on a few questions:
+
+- **Is the data "public among the members" already?** If the fields are what
+  every member shares *with every other member* by the group's own social
+  contract (names, emails, "what I'm working on"), local-first persistence is
+  just formalising the existing deal. ✅ Good fit.
+- **Is some of the data sensitive *between* members?** Health records, current
+  physical location, employer disputes — data members would *not* hand each
+  other freely. Then unrevocable, full-copy-on-every-device is the wrong shape.
+  ✗ Wrong fit; that data wants an app with different contracts (server-mediated,
+  per-record reads, revocable access) — a *different* app, not a tweak to this
+  one.
+- **Is the central option actually surviving?** If a maintained central service
+  is genuinely on the table and funded, the revocability + detection it buys may
+  be worth keeping. If it's being retired regardless (as here), local-first is
+  about *survival*, and the comparison is moot.
+- **Can you make the supply chain trustworthy?** A one-maintainer local-first
+  channel is only as safe as its update path. Signed bundles + an out-of-band
+  key are the minimum bar; without them, the supply-chain tail risk dominates.
+
+---
+
+## Conclusion
+
+For a moderate-sensitivity directory, with a trusted-ish membership, and no
+surviving central option, **local-first is defensible — it trades concentration
+risk for tail risk, not "more secure" in the simple sense.** It removes the
+peak-severity events (provider breach, insider, subpoena, catastrophic
+shutdown) at the cost of unrevocable retention and a single-maintainer supply
+chain. The mitigations that matter most are therefore the ones aimed at the tail:
+hardening the maintainer's keys and update channel (see
+[`docs/securityaudit.md`](./securityaudit.md) B2), signing every bundle, and
+raising members' own device hygiene — because in both models, the member's own
+device is where most breaches actually begin.

--- a/docs/securityaudit.md
+++ b/docs/securityaudit.md
@@ -42,7 +42,7 @@ sensitive asset class (`fellows.db`) and three secrets; there is no
 **not the app** — it's whoever holds the operator SSH key (see B2). The auth
 gate, header regime, and secret-handling all verified correct in production.
 
-### Fixed in this pass (2026-05-30 hardening PR)
+### Fixed in this pass (2026-05-30 hardening — PR #224)
 
 - ✅ **C1 — Raw recipient email removed from journald.** The `send_unlock_email`
   event logged the full Postmark response, including the raw recipient address

--- a/docs/securityaudit.md
+++ b/docs/securityaudit.md
@@ -1,0 +1,159 @@
+# Security Audit — recommendations checklist
+
+This is the **living checklist of security-audit recommendations** for the
+Fellows directory: what's been done, what's outstanding, and what's been
+deliberately *not* done. It supersedes the tracking that used to live in the
+gitignored `security_review/` folder.
+
+Two companion docs carry the parts that don't belong here:
+
+- [`SECURITY.md`](../SECURITY.md) — the public-facing, stable statement of the
+  project's architectural security decisions and reporting path. Doesn't track
+  in-flight work.
+- [`docs/local_vs_saas_risk.md`](./local_vs_saas_risk.md) — the analysis of the
+  *accepted* risk of decentralising a directory into a local-first app vs. a
+  centralised SaaS. Those are decisions already made, not items to fix; this
+  checklist points at them so an auditor doesn't re-litigate them as bugs.
+
+**Scope reminder (read before filing anything as a vuln):** the production
+server is a *delivery channel, not a service*. It authenticates a magic-link
+request, hands over the bundle + `fellows.db`, and steps back; the maintainer
+plans to shut it down once dissemination is complete. Several "weaknesses" are
+load-bearing trade-offs of that model — see `local_vs_saas_risk.md` and
+`SECURITY.md` § Architectural security decisions before classifying them.
+
+Legend: ✅ done · ☐ outstanding · ✗ deliberately not done (needs a different app)
+
+---
+
+## Latest audit pass — 2026-05-30
+
+A high-level audit focused on **logical risks from the intentional design** and
+**risks to PII held on the production server**. Method: review of the prod
+server / auth helpers / Caddy + systemd + Ansible hardening, plus live
+non-destructive probing of the droplet (listening sockets, file permissions on
+`fellows.db` and the secrets env file, journald contents, the auth gate, public
+endpoint reachability, edge headers, `systemd-analyze security`, brute-force
+protections, on-disk backup sweep).
+
+**Headline:** the design holds up well. The server persists exactly one
+sensitive asset class (`fellows.db`) and three secrets; there is no
+`relationships.db` and no DB backups on the box. The dominant threat to PII is
+**not the app** — it's whoever holds the operator SSH key (see B2). The auth
+gate, header regime, and secret-handling all verified correct in production.
+
+### Fixed in this pass (2026-05-30 hardening PR)
+
+- ✅ **C1 — Raw recipient email removed from journald.** The `send_unlock_email`
+  event logged the full Postmark response, including the raw recipient address
+  (`meta["to"]` / `meta["raw"]["To"]`), accumulating a plaintext roster of
+  everyone who ever requested a link — contradicting the `email_hash_prefix`
+  scheme used everywhere else. Now logs a PII-free subset. **No capability
+  lost:** `just prod-stats-long` and `just installed-versions` reconstruct the
+  plaintext recipient by joining the 12-hex `email_hash_prefix` against
+  `fellows.db`, not from the log; `just email-debug --postmark` resolves
+  recipients via the Postmark API. (`deploy/server.py`)
+- ✅ **B3 — Caddy admin API disabled (`admin off`).** The unauthenticated admin
+  control plane on `127.0.0.1:2019` let any local process (e.g. an RCE'd app
+  running as the `fellows` user) extract TLS keys or rewrite routing
+  post-foothold. Config is fully static, so the API isn't needed; the caddy
+  reload handler switched to a full restart to match.
+  (`ansible/roles/caddy/`)
+- ✅ **B4 — `UMask=0077` on the service unit.** Was the only finding dropping
+  `systemd-analyze security fellows-pwa` below an otherwise-clean score (files
+  the service creates — sqlite WAL/journal — defaulted world-readable).
+  (`ansible/roles/fellows_app/templates/fellows-pwa.service.j2`)
+- ✅ **B5 — Public diagnostics endpoint trimmed.** `/api/debug/diagnostics` is
+  unauthenticated by design (the smoke check probes it to catch a
+  silently-broken send path). It disclosed the exact roster size
+  (`allowlistHashCount`) and an internal filesystem path (`distRoot`) — pure
+  recon, read by no tooling. Now emits config-presence booleans only
+  (`allowlistConfigured`). Mirrored in the dev server for parity.
+  (`deploy/server.py`, `app/server.py`)
+- ✅ **B1 — fail2ban for SSH.** Defence-in-depth on the operator key. Password
+  auth is already off so brute force can't succeed; fail2ban bans
+  scanners/credential-stuffers early and keeps the auth log clean
+  (`backend=systemd`, jail bound to the non-standard SSH port).
+  (`ansible/roles/common/`)
+
+### Outstanding — ranked
+
+- ☐ **B2 — Operator SSH key / maintainer workstation hardening (highest
+  leverage).** The operator key is the single most powerful credential in the
+  system: it can read `fellows.db` (full PII), read the secrets env file (both
+  via the `fellows` group), become root (sudo), and push a new bundle to all
+  users. There is no second factor. The maintainer workstation that holds the
+  key + the signing key is effectively inside the trust boundary. Recommended:
+  hardware-backed FIDO2/`sk-` SSH key; signed commits; the secrets env file
+  never on the laptop in plaintext; a documented recovery path if the laptop
+  holding the (encrypted) signing key is lost. *(Was Tier-3 in the prior
+  tracking; promoted here because live probing confirmed it is threat #1.)*
+- ☐ **CAA DNS records** for `fellows.globaldonut.com` (`issue
+  "letsencrypt.org"`, `issuewild ";"`, `iodef "mailto:richbodo@gmail.com"`).
+  ~10 min operator task; documented in `docs/DevOps.md` § Signing keys.
+- ☐ **HSTS preload submission** at <https://hstspreload.org/?domain=fellows.globaldonut.com>.
+  The header already advertises `preload`; the registry submission is the
+  remaining step (~5 min; inclusion lags weeks).
+- ☐ **CT-log monitoring** via crt.sh alerts for the domain — early warning on a
+  mis-issued certificate. Optional, ~5 min.
+- ☐ **User-guide hygiene section** in `docs/users_manual.md`: "your device is
+  now the directory" — full-disk encryption, screen lock, retiring a device
+  (Reset Everything → factory reset). The user-facing complement to
+  `SECURITY.md` § 1; raises endpoint baseline at zero technical cost.
+- ☐ **Fix `scripts/debug_email_delivery.py --dump-allowlist`** — broken since
+  the HMAC/DB-derived allowlist landed (PR #139); the old plaintext-file
+  assumption no longer holds.
+- ☐ **`scripts/sign_bundle.py` polish** — catch `KeyboardInterrupt` for a clean
+  "Aborted." exit; have the wrong-passphrase path mention Ctrl-C.
+- ☐ **App-layer encryption of `relationships.db`** ("lock my user data"
+  toggle) — user-driven lock-on-quit with an off switch, covering OPFS backups.
+  This is a *device-side* control, not server-side; tracked here for
+  completeness. Honest threat-model copy required (file-level theft yes, live
+  malware no).
+
+### Deliberately not done — would need a different app
+
+These deliver real wins but only under contracts this app doesn't hold. They
+belong in a sibling/successor app for higher-sensitivity data, not here. Full
+reasoning in `SECURITY.md` § 2–3 and `local_vs_saas_risk.md`.
+
+- ✗ **Strip sensitive fields from the bundle; serve on-demand.** Adds a
+  per-fellow authenticated read endpoint — the bright line `README.md` § Design
+  Stance forbids. Also breaks offline `mailto:` group export.
+- ✗ **Server-side revocation list / freshness re-auth (N-day TTL).** Introduce
+  per-user server state and/or break "install once, works forever"; both stop
+  working once distribution shuts down anyway.
+
+---
+
+## Accepted risks (decided — do not file as bugs)
+
+These are the load-bearing trade-offs of the local-first / Never-SaaS model.
+The full analysis is in [`local_vs_saas_risk.md`](./local_vs_saas_risk.md);
+the short list:
+
+- **The system is only as secure as each fellow's email account.** A
+  compromised inbox → magic link → full `fellows.db`. Structural ceiling of
+  magic-link delivery; nothing server-side raises it.
+- **Every installed device holds the full directory, forever, unrevocably.**
+  Device compromise = full-directory leak. The offline-forever payoff.
+- **The operator is fully trusted with both PII and secrets.** The `fellows`
+  group read access to `fellows.db` and the env file is the deploy model. B2
+  hardens the *credential*; it doesn't change the trust model.
+- **`contact_email` / `mobile_number` ship in the bundle.** They're the social
+  contract every fellow accepted on joining the directory; persistence is the
+  deal, not the flaw.
+
+---
+
+## Previously shipped (2026-05, Tier 1–2)
+
+Context for auditors so already-closed items aren't re-reported: strict CSP on
+both servers; Permissions-Policy / CORP / Referrer-Policy / nosniff on every
+response; COOP/COEP at the edge + both servers; removed `allowed_emails.json`
+(allowlist now HMAC'd in memory from `fellows.db`); v3 session cookies bound to
+a server-side `session_id` registry (a leaked session secret alone can't mint
+cookies); SRI on `index.html` scripts; out-of-band **signed bundles** with SW
+signature verification + public-key fingerprint in the magic-link email; systemd
+hardening (`ProtectSystem=strict`, `ProtectHome`, `MemoryDenyWriteExecute`,
+etc.). See `SECURITY.md` § Defensive controls for the current table.


### PR DESCRIPTION
Implements the actionable findings from the 2026-05-30 security audit (focus: logical/design risks + PII held on the prod server), and publishes the audit + risk docs.

## What changed

| ID | Fix | Files |
|---|---|---|
| **C1** | Stop logging the raw recipient email to journald (the `send_unlock_email` event echoed the full Postmark response incl. `To`, building a plaintext roster of every link requester). Logs a PII-free subset now. | `deploy/server.py` |
| **B5** | Trim the unauthenticated `/api/debug/diagnostics` body — drop exact roster size (`allowlistHashCount`) + internal path (`distRoot`); emit `allowlistConfigured` boolean. | `deploy/server.py`, `app/server.py` |
| **B3** | `admin off` for Caddy (the `:2019` admin API was an unauthenticated local control plane); reload handler → restart. | `ansible/roles/caddy/` |
| **B4** | `UMask=0077` on the service unit. | `ansible/roles/fellows_app/…` |
| **B1** | fail2ban for SSH (defence-in-depth on the operator key). | `ansible/roles/common/` |
| docs | Split the gitignored `security_review/` doc into committed `docs/securityaudit.md` (checklist) + `docs/local_vs_saas_risk.md` (posterity risk analysis); repoint `SECURITY.md`. | `docs/`, `.gitignore`, `SECURITY.md` |

**No capability lost from C1:** `just prod-stats-long` and `just installed-versions` reconstruct recipient emails from `email_hash_prefix` + `fellows.db`, not from the log; `just email-debug --postmark` resolves via the Postmark API.

## Tests
`just test-fast` green (DB + API + prod-stats + installed-versions). Targeted suites green: deploy auth round-trip, deploy client errors, magic-link auth, debug-email-delivery, prod-stats, installed-versions (163 passed). No test pins the diagnostics body shape; `app.js` / the e2e diag panel don't read the trimmed fields.

## Maintainer QA — manual steps after merge

Most of this lands on the next deploy/bootstrap. **B3 + B1 require `just bootstrap`** (the caddy + common roles); B4 + C1 + B5 ship on a normal `just ship`.

1. **Ship app-layer (C1, B5, B4):**
   ```
   git checkout main && git pull
   just ship          # build → test → deploy → smoke
   just smoke         # should still pass — diagnostics still 200, fields trimmed
   ```
   - Verify `/api/debug/diagnostics` no longer contains `distRoot` / `allowlistHashCount`:
     `curl -s https://fellows.globaldonut.com/api/debug/diagnostics | python3 -m json.tool`
   - Trigger one magic-link send to yourself, then confirm journald no longer logs the raw recipient:
     `just prod-logs` → the `send_unlock_email` line should show `email_hash_prefix` + a `postmark` block **without** a `to`/`raw` field.
   - Confirm the feature still works: `just prod-stats-long` still lists plaintext recipients; `just installed-versions` still resolves emails.

2. **Apply infra-layer (B3, B1) via bootstrap:**
   ```
   just bootstrap     # runs common (fail2ban, UMask via fellows_app) + caddy (admin off)
   ```
   - **B3:** confirm the admin port is gone — on the droplet, `ss -tlnH | grep 2019` returns nothing; `curl -s -o /dev/null -w '%{http_code}' http://127.0.0.1:2019/config/` is now a connection failure.
   - Confirm Caddy is healthy after the restart-based reload: `just prod-status`, then `just smoke`.
   - **B1:** `systemctl is-active fail2ban` → `active`; `sudo fail2ban-client status sshd` shows the jail on port 52221.
   - **B4:** `systemd-analyze security fellows-pwa` no longer flags `UMask=` (overall score improves from 5.4).

## Follow-up
Remaining audit items (B2 operator-key/workstation hardening, CAA records, HSTS preload submission, CT-log alerts, user-guide hygiene) are tracked in `docs/securityaudit.md` and will be a separate pass after this merges.

🤖 Generated with [Claude Code](https://claude.com/claude-code)