### PR TITLE
security: audit follow-ups — dump-allowlist fix, CT/CAA tooling, device hygiene, sign-bundle polish

### DIFF
--- a/docs/DevOps.md
+++ b/docs/DevOps.md
@@ -370,7 +370,9 @@ All three should match. Mismatch on any pair = stop installing and report.
 
 ### Supporting DNS: CAA records
 
-Add to your DNS provider (Cloudflare for `globaldonut.com`):
+CAA is **hierarchical**: the most-specific CAA record set found walking up from a name is authoritative, and it does *not* merge with ancestor records. That matters here — the `globaldonut.com` zone is **not** Let's-Encrypt-only. Other subdomains legitimately use other CAs (e.g. `pitch.globaldonut.com` → Google Trust Services), and the apex itself has appeared with a Sectigo cert. So a Let's-Encrypt-only CAA on the **apex** would forbid those CAs and break their renewals.
+
+**Scope the records to `fellows.globaldonut.com`**, not the apex. A record at the subdomain overrides the (absent or different) apex policy for that name only, protecting the app's cert without touching the rest of the zone. In Cloudflare (DNS for `globaldonut.com`), add three CAA records on **name `fellows`**:
 
 ```
 fellows.globaldonut.com.  CAA  0 issue "letsencrypt.org"
@@ -378,30 +380,42 @@ fellows.globaldonut.com.  CAA  0 issuewild ";"
 fellows.globaldonut.com.  CAA  0 iodef "mailto:richbodo@gmail.com"
 ```
 
-Tells every CA: "Only Let's Encrypt may issue certificates for this name. Wildcard certs are forbidden. Report attempted misissuance to this mailbox." A rogue CA (or one tricked by a phishing-style domain-validation attack) is required by RFC 8659 to refuse — this raises the bar substantially against a fraudulent-cert MITM at first install.
+In the Cloudflare dashboard each is: Type **CAA**, Name `fellows`, Tag (`issue` / `issuewild` / `iodef`), and the value (`letsencrypt.org` / `;` / `mailto:richbodo@gmail.com`).
 
-Verify after publication:
+Tells every CA: "Only Let's Encrypt may issue certificates for `fellows.globaldonut.com`. Wildcard certs are forbidden. Report attempted misissuance to this mailbox." A rogue CA (or one tricked by a phishing-style domain-validation attack) is required by RFC 8659 to refuse — this raises the bar substantially against a fraudulent-cert MITM at first install.
+
+> **Cloudflare proxy caveat.** `fellows.globaldonut.com` is **DNS-only** today (grey cloud) — browsers get Caddy's Let's Encrypt cert from the droplet directly, so `issue "letsencrypt.org"` is correct. If you ever enable the orange-cloud **proxy** on the `fellows` record, Cloudflare terminates TLS at its edge with *its own* CA — you must then **also** add a CAA `issue` record for Cloudflare's issuer (e.g. `issue "pki.goog"` for Google Trust Services, whichever Cloudflare currently uses) or proxied TLS will break.
+
+> **Apex-wide alternative (only if you want it).** If you later want a single zone-wide policy, put CAA on the apex but enumerate **every** CA actually in use across the zone (`letsencrypt.org` + Google Trust's `pki.goog` + whatever issues the apex), not Let's Encrypt alone — otherwise you break `pitch.globaldonut.com` and the apex. Run `just ct-check` first to see the full issuer list before doing this.
+
+Verify after publication (`just check-env` also runs this check and warns if it's missing):
 
 ```bash
-dig +short CAA fellows.globaldonut.com
-# Expect three lines, matching the above.
+dig +short CAA fellows.globaldonut.com   # expect the three lines above
 ```
 
 ### HSTS preload submission
 
-Caddy already sets `Strict-Transport-Security: max-age=31536000; includeSubDomains; preload`. The `preload` directive is necessary but not sufficient — Chrome/Firefox/Safari only honor it for sites on their **preload list**. Submit at:
+Caddy already sets `Strict-Transport-Security: max-age=31536000; includeSubDomains; preload` on both `fellows.globaldonut.com` and the `globaldonut.com` apex. The `preload` directive is necessary but not sufficient — Chrome/Firefox/Safari only honor it for sites on their **preload list**.
+
+**Submit `fellows.globaldonut.com`, not the apex:**
 
 <https://hstspreload.org/?domain=fellows.globaldonut.com>
 
-The form runs a series of checks (HSTS header present, redirect from HTTP to HTTPS, no expired certs); pass them, click submit. Inclusion lags by one major browser release (~6–10 weeks). Once on the list, every browser refuses HTTP for `fellows.globaldonut.com` from the very first visit, closing the "first HTTP request gets MITM'd before HSTS takes effect" window entirely.
+The form runs a series of checks (HSTS header with `includeSubDomains`+`preload`, redirect from HTTP to HTTPS, no expired certs); pass them, click submit. Inclusion lags by one major browser release (~6–10 weeks). Once on the list, every browser refuses HTTP for `fellows.globaldonut.com` from the very first visit, closing the "first HTTP request gets MITM'd before HSTS takes effect" window entirely.
+
+> **Why the subdomain and not the apex.** Preloading the apex with `includeSubDomains` forces **every** current and future `*.globaldonut.com` subdomain to HTTPS-only in browsers that ship the list, and removal takes months to propagate. The zone is *not* just the Caddy sites — `just ct-check` shows third-party-hosted subdomains (e.g. `pitch.globaldonut.com`) and non–Let's-Encrypt issuers in the apex. Preloading the whole apex would bet that all of those — and anything you add later — stay HTTPS-only forever. Scoping the preload to `fellows.globaldonut.com` gets the full first-visit protection for the app while leaving the rest of the zone alone. Only preload the apex if you've confirmed every `globaldonut.com` subdomain is, and will remain, HTTPS-only.
 
 This is opt-in but free; do it once.
 
 ### Certificate Transparency monitoring (optional but recommended)
 
-Subscribe to crt.sh notifications for `fellows.globaldonut.com`. Any new cert issuance — by Let's Encrypt or anyone else — generates an email. If a cert appears that you didn't trigger (e.g. an attacker tricked a CA into issuing one despite the CAA records), you find out the same day rather than after a user reports.
+Two complementary checks:
 
-Free signup: <https://crt.sh/?domain=fellows.globaldonut.com> → click the email-monitor link.
+- **On-demand:** `just ct-check` (`scripts/check_ct_log.py`) queries crt.sh for every logged certificate covering the domain and flags any issuer that isn't Let's Encrypt. Run it any time, or wire it into a periodic job. Read-only, stdlib only.
+- **Push alerts:** subscribe to crt.sh notifications so any *new* cert issuance — by Let's Encrypt or anyone else — generates an email the same day, rather than waiting for the next `just ct-check`. Free signup: <https://crt.sh/?domain=globaldonut.com> → click the email-monitor link.
+
+If a cert appears that you didn't trigger (e.g. an attacker tricked a CA into issuing one despite the CAA records), either path surfaces it.
 
 ### What gets signed and what doesn't
 

--- a/docs/securityaudit.md
+++ b/docs/securityaudit.md
@@ -76,6 +76,29 @@ gate, header regime, and secret-handling all verified correct in production.
   (`backend=systemd`, jail bound to the non-standard SSH port).
   (`ansible/roles/common/`)
 
+### Fixed in the follow-up pass (2026-05-30 — PR #225)
+
+In-repo completion of the remaining checklist (operator console actions for
+CAA / HSTS / crt.sh tracked below):
+
+- ✅ **User-guide hygiene section** — "Your device is now the directory" added to
+  `docs/users_manual.md` (full-disk encryption, screen lock, browser updates,
+  retiring/lending a device, no-remote-wipe). Ships to users via the About-page
+  link.
+- ✅ **`--dump-allowlist` rewritten** for the HMAC/DB-derived model
+  (`scripts/debug_email_delivery.py`). No more `allowed_emails.json` assumption;
+  reports distinct-email count (= allowlist), fellows with no contact_email,
+  duplicate emails, and a "fellows.db newer than the running server" staleness
+  warning (the only drift that can still exist). The `--email` HIT/MISS check
+  now resolves membership against the DB email set (no HMAC key needed).
+- ✅ **`scripts/check_ct_log.py` + `just ct-check`** — on-demand Certificate
+  Transparency check via crt.sh; flags any issuer that isn't Let's Encrypt.
+- ✅ **CAA guardrail** — `just check-env` (`scripts/check_deploy_env.sh`) now
+  warns when no CAA record is effective for the host or when it doesn't
+  authorize Let's Encrypt; DevOps.md CAA/HSTS sections corrected (see finding).
+- ✅ **`sign_bundle.py` polish** — clean `Aborted.` on Ctrl-C; wrong-passphrase
+  prompt mentions Ctrl-C.
+
 ### Outstanding — ranked
 
 - ☐ **B2 — Operator SSH key / maintainer workstation hardening (highest
@@ -88,28 +111,34 @@ gate, header regime, and secret-handling all verified correct in production.
   never on the laptop in plaintext; a documented recovery path if the laptop
   holding the (encrypted) signing key is lost. *(Was Tier-3 in the prior
   tracking; promoted here because live probing confirmed it is threat #1.)*
-- ☐ **CAA DNS records** for `fellows.globaldonut.com` (`issue
-  "letsencrypt.org"`, `issuewild ";"`, `iodef "mailto:richbodo@gmail.com"`).
-  ~10 min operator task; documented in `docs/DevOps.md` § Signing keys.
-- ☐ **HSTS preload submission** at <https://hstspreload.org/?domain=fellows.globaldonut.com>.
-  The header already advertises `preload`; the registry submission is the
-  remaining step (~5 min; inclusion lags weeks).
-- ☐ **CT-log monitoring** via crt.sh alerts for the domain — early warning on a
-  mis-issued certificate. Optional, ~5 min.
-- ☐ **User-guide hygiene section** in `docs/users_manual.md`: "your device is
-  now the directory" — full-disk encryption, screen lock, retiring a device
-  (Reset Everything → factory reset). The user-facing complement to
-  `SECURITY.md` § 1; raises endpoint baseline at zero technical cost.
-- ☐ **Fix `scripts/debug_email_delivery.py --dump-allowlist`** — broken since
-  the HMAC/DB-derived allowlist landed (PR #139); the old plaintext-file
-  assumption no longer holds.
-- ☐ **`scripts/sign_bundle.py` polish** — catch `KeyboardInterrupt` for a clean
-  "Aborted." exit; have the wrong-passphrase path mention Ctrl-C.
-- ☐ **App-layer encryption of `relationships.db`** ("lock my user data"
-  toggle) — user-driven lock-on-quit with an off switch, covering OPFS backups.
-  This is a *device-side* control, not server-side; tracked here for
-  completeness. Honest threat-model copy required (file-level theft yes, live
-  malware no).
+- ☐ **CAA DNS records for `fellows.globaldonut.com`** (operator console).
+  Tooling + docs done — `just check-env` warns when CAA is missing, and
+  `docs/DevOps.md` § Supporting DNS has the exact three records. Remaining: paste
+  them into Cloudflare. **Scope to the `fellows` subdomain, not the apex** — see
+  the zone finding below.
+- ☐ **HSTS preload submission for `fellows.globaldonut.com`** (operator console)
+  at <https://hstspreload.org/?domain=fellows.globaldonut.com>. The header
+  already advertises `preload`; submit the **subdomain, not the apex** (see
+  finding). ~5 min; inclusion lags weeks.
+- ☐ **crt.sh email-alert signup** (operator console). The in-repo half is done
+  (`just ct-check`); remaining is the push-alert subscription for same-day
+  notice of any new issuance.
+- ☐ **App-layer encryption of `relationships.db`** — *owner-scheduled, deferred.*
+  Device-side "lock my user data" toggle (lock-on-quit + off switch, covers OPFS
+  backups). Honest threat-model copy required (file theft yes, live malware no).
+- ☐ **Risk-doc rewrite** — *owner-scheduled, deferred.* Evolve
+  [`local_vs_saas_risk.md`](./local_vs_saas_risk.md) into a forward-looking
+  stakeholder decision record: the accepted-risk statement weighed against the
+  cost and appetite of keeping a donation-funded SaaS directory alive.
+
+> **Zone finding (`just ct-check`, 2026-05-30):** the `globaldonut.com` zone is
+> **not** Let's-Encrypt-only — `pitch.globaldonut.com` uses Google Trust
+> Services and the apex has appeared with a Sectigo cert. Consequences (now
+> reflected in `docs/DevOps.md`): **(a)** CAA must be scoped to
+> `fellows.globaldonut.com` — an apex Let's-Encrypt-only record would break those
+> other CAs' renewals; **(b)** HSTS preload should target the `fellows` subdomain,
+> not the apex — apex + `includeSubDomains` would force every zone subdomain
+> HTTPS-only, permanently. Re-run `just ct-check` periodically.
 
 ### Deliberately not done — would need a different app
 

--- a/docs/users_manual.md
+++ b/docs/users_manual.md
@@ -856,6 +856,39 @@ update iOS itself (iPhone 8 and newer support 16.4+).
 
 ---
 
+## Your device is now the directory
+
+Because the app is local-first, the full directory — every fellow's
+email and phone number — lives on **your** device after you install,
+and keeps working with no server. That's the point: it survives even
+after the distribution server is shut down. The flip side is that your
+device is now where the directory needs protecting. There is **no
+remote wipe** — if a device is lost, the copy on it can't be revoked.
+
+A few minutes of basic hygiene covers almost all of the real risk:
+
+- **Turn on full-disk encryption.** FileVault (Mac), BitLocker
+  (Windows), or the on-by-default encryption on a modern iPhone /
+  Android. This is the single biggest protection: a lost or stolen
+  device is then just a brick, not a copy of the directory.
+- **Use a screen lock** with a passcode/biometric and a short
+  auto-lock timeout.
+- **Keep your browser and OS updated.** The app's security depends on
+  the browser; updates are how that stays true over time.
+- **Retiring or selling a device?** Open the app and use **Settings →
+  Reset Everything** (see *Clearing app data* above) to wipe your
+  groups, notes, and the cached directory, then do a full factory
+  reset of the device.
+- **Lending your laptop to someone?** Lock the screen, or use a
+  separate OS user account — the installed app is visible to anyone
+  who can use your logged-in session.
+
+None of this is unusual — it's the same care any contact list on your
+phone deserves. It just matters a little more here, because this list
+belongs to the whole fellowship.
+
+---
+
 ## Privacy
 
 This app ships fellows' contact info and free-text responses. It is

--- a/justfile
+++ b/justfile
@@ -519,6 +519,12 @@ smoke url="":
 check-env:
     ./scripts/check_deploy_env.sh
 
+# Certificate Transparency check — list logged certs for DOMAIN (and
+# subdomains) via crt.sh, flag any issuer that isn't Let's Encrypt.
+[group('prod')]
+ct-check domain="globaldonut.com":
+    {{python}} scripts/check_ct_log.py --domain {{domain}}
+
 # Show local HEAD, the build label that the next 'just build' would
 # stamp into the bundle, prod's build-meta, and a refresh cheat-sheet
 # for the SW shell-cache gotcha.

--- a/scripts/check_ct_log.py
+++ b/scripts/check_ct_log.py
@@ -1,0 +1,161 @@
+#!/usr/bin/env python3
+"""Certificate Transparency spot-check for a domain via crt.sh.
+
+Lists every logged certificate covering ``<domain>`` and its subdomains and
+flags any issued by a CA other than the expected one (Let's Encrypt). A cert
+you didn't trigger — e.g. one a rogue CA issued despite the CAA records — shows
+up here the same day it's logged, rather than after a user reports a problem.
+
+Read-only. Python stdlib only. Complements the crt.sh *email* alerts documented
+in docs/DevOps.md § Certificate Transparency monitoring: this is the on-demand
+half (`just ct-check`); the email subscription is the push half.
+
+Usage:
+    scripts/check_ct_log.py                          # default domain globaldonut.com
+    scripts/check_ct_log.py --domain example.com
+    scripts/check_ct_log.py --allow-issuer "Let's Encrypt" --allow-issuer "Google Trust"
+    scripts/check_ct_log.py --json
+
+Exit status: 0 if every cert is from an allowed issuer (or the lookup couldn't
+run), 1 if any cert is from an unexpected issuer.
+"""
+
+from __future__ import annotations
+
+import argparse
+import json
+import sys
+import urllib.error
+import urllib.parse
+import urllib.request
+
+CRT_SH = "https://crt.sh/"
+DEFAULT_DOMAIN = "globaldonut.com"
+DEFAULT_ALLOWED = ["Let's Encrypt"]
+DISPLAY_LIMIT = 25
+
+
+def fetch_crtsh(query: str, timeout: int = 30) -> list[dict]:
+    """GET crt.sh JSON for one identity query. Returns [] on any failure
+    (with a stderr note) so the caller can degrade gracefully rather than
+    crash on a slow/rate-limited crt.sh."""
+    url = CRT_SH + "?" + urllib.parse.urlencode({"q": query, "output": "json"})
+    req = urllib.request.Request(url, headers={"User-Agent": "fellows-ct-check/1"})
+    try:
+        with urllib.request.urlopen(req, timeout=timeout) as resp:
+            body = resp.read().decode("utf-8")
+    except (urllib.error.URLError, OSError) as e:
+        sys.stderr.write(f"crt.sh query failed for {query!r}: {e}\n")
+        return []
+    if not body.strip():
+        return []
+    try:
+        data = json.loads(body)
+    except json.JSONDecodeError:
+        # crt.sh occasionally returns an HTML error/rate-limit page with a 200.
+        sys.stderr.write(f"crt.sh returned non-JSON for {query!r} (rate-limited?).\n")
+        return []
+    return data if isinstance(data, list) else []
+
+
+def collect_certs(domain: str) -> list[dict]:
+    """Fetch certs for the apex and its subdomains, de-duplicated by crt.sh id.
+
+    crt.sh identity matching is exact, so we query both the bare domain (apex
+    certs) and the ``%.`` wildcard form (subdomain certs, including the fellows
+    host) and merge.
+    """
+    merged: dict = {}
+    for q in (domain, "%." + domain):
+        for row in fetch_crtsh(q):
+            cid = row.get("id")
+            key = cid if cid is not None else json.dumps(row, sort_keys=True)
+            merged[key] = row
+    rows = list(merged.values())
+    # Newest first by not_before (string ISO sorts chronologically).
+    rows.sort(key=lambda r: r.get("not_before") or "", reverse=True)
+    return rows
+
+
+def issuer_allowed(issuer_name: str, allowed: list[str]) -> bool:
+    n = (issuer_name or "").lower()
+    return any(a.lower() in n for a in allowed)
+
+
+def analyze(rows: list[dict], allowed: list[str]) -> dict:
+    unexpected = [r for r in rows if not issuer_allowed(r.get("issuer_name", ""), allowed)]
+    return {
+        "total": len(rows),
+        "unexpected_count": len(unexpected),
+        "unexpected": unexpected,
+        "rows": rows,
+    }
+
+
+def _issuer_short(issuer_name: str) -> str:
+    # issuer_name is an RFC4514-ish DN, e.g. "C=US, O=Let's Encrypt, CN=R11".
+    parts = dict(
+        p.split("=", 1) for p in issuer_name.split(", ") if "=" in p
+    ) if issuer_name else {}
+    return parts.get("O") or issuer_name or "(unknown)"
+
+
+def print_human(domain: str, result: dict, allowed: list[str]) -> None:
+    rows = result["rows"]
+    print(f"== Certificate Transparency check · {domain} (and subdomains) ==")
+    print(f"Allowed issuer(s): {', '.join(allowed)}")
+    print(f"Certificates logged: {result['total']}")
+    if not rows:
+        print("  (no certs found — crt.sh may be unreachable, or the domain is new)")
+        return
+    shown = rows[:DISPLAY_LIMIT]
+    print(f"\nMost recent {len(shown)} (newest first):")
+    for r in shown:
+        flag = "" if issuer_allowed(r.get("issuer_name", ""), allowed) else "  ⚠ UNEXPECTED ISSUER"
+        name = (r.get("common_name") or (r.get("name_value") or "").splitlines()[0] or "?")
+        print(
+            f"  {r.get('not_before','?')[:10]} → {r.get('not_after','?')[:10]}  "
+            f"{name:38.38s}  [{_issuer_short(r.get('issuer_name',''))}]{flag}"
+        )
+    if len(rows) > DISPLAY_LIMIT:
+        print(f"  … {len(rows) - DISPLAY_LIMIT} older not shown")
+    print("")
+    if result["unexpected_count"]:
+        print(
+            f"✗ {result['unexpected_count']} certificate(s) from an unexpected issuer. "
+            "If you did not request these, a CA may have mis-issued — investigate now."
+        )
+    else:
+        print("✓ Every logged certificate is from an allowed issuer.")
+
+
+def main(argv: list[str] | None = None) -> int:
+    ap = argparse.ArgumentParser(description=__doc__)
+    ap.add_argument("--domain", default=DEFAULT_DOMAIN, help=f"Domain to check (default: {DEFAULT_DOMAIN}).")
+    ap.add_argument(
+        "--allow-issuer",
+        action="append",
+        default=None,
+        help="Issuer-name substring to treat as expected (repeatable). "
+        "Default: \"Let's Encrypt\".",
+    )
+    ap.add_argument("--json", action="store_true", help="Emit raw JSON instead of the formatted report.")
+    args = ap.parse_args(argv)
+    allowed = args.allow_issuer or DEFAULT_ALLOWED
+
+    rows = collect_certs(args.domain)
+    result = analyze(rows, allowed)
+
+    if args.json:
+        print(json.dumps(
+            {"domain": args.domain, "allowed_issuers": allowed, **result},
+            indent=2, default=str,
+        ))
+    else:
+        print_human(args.domain, result, allowed)
+
+    return 1 if result["unexpected_count"] else 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/scripts/check_deploy_env.sh
+++ b/scripts/check_deploy_env.sh
@@ -17,5 +17,38 @@ curl -fsSI "https://${HOST}/" 2>/dev/null | head -20 || {
 }
 
 echo ""
+echo "== CAA records (authorize only Let's Encrypt for ${HOST}) =="
+# CAA resolution walks UP from the queried name and the FIRST record set found
+# is authoritative (it does not merge with ancestors). We scope CAA to the host
+# itself rather than the apex, because the apex zone may legitimately use other
+# CAs for other subdomains — see docs/DevOps.md § Supporting DNS: CAA records.
+# Check the host first; if it has no records, report that it inherits the apex.
+APEX="$(echo "${HOST}" | rev | cut -d. -f1,2 | rev)"
+host_caa="$(dig +short CAA "${HOST}" || true)"
+if [ -n "${host_caa}" ]; then
+  level="${HOST}"; caa="${host_caa}"
+else
+  level="${APEX} (inherited — ${HOST} has no CAA of its own)"
+  caa="$(dig +short CAA "${APEX}" || true)"
+fi
+if [ -z "${caa}" ]; then
+  echo "WARNING: no CAA records effective for ${HOST} — ANY CA may issue its cert."
+  echo "  Fix: add the records in docs/DevOps.md § Supporting DNS: CAA records (scope: ${HOST})."
+else
+  echo "effective at: ${level}"
+  echo "${caa}"
+  if echo "${caa}" | grep -q 'issue "letsencrypt.org"'; then
+    echo "OK: Let's Encrypt is authorized."
+  else
+    echo "WARNING: CAA present but does NOT authorize letsencrypt.org — Caddy renewals may fail."
+  fi
+  others="$(echo "${caa}" | grep -E 'issue(wild)? ' | grep -vE 'letsencrypt.org|issue(wild)? ";"' || true)"
+  if [ -n "${others}" ]; then
+    echo "NOTE: another CA is also authorized to issue for this name:"
+    echo "${others}"
+  fi
+fi
+
+echo ""
 echo "== /healthz =="
 curl -fsS "https://${HOST}/healthz" && echo ""

--- a/scripts/debug_email_delivery.py
+++ b/scripts/debug_email_delivery.py
@@ -246,45 +246,24 @@ def filter_events(
 
 
 DEFAULT_ENV_FILE = "/etc/fellows/fellows-pwa.env"
-DEFAULT_ALLOWLIST_PATH = "/opt/fellows/deploy/dist/allowed_emails.json"
 
 
-def fetch_allowlist_from_prod(
-    host: str,
-    port: str,
-    user: str,
-    allowlist_path: str = DEFAULT_ALLOWLIST_PATH,
-) -> set[str]:
-    """SSH + plain `cat` the allowlist JSON; no sudo needed.
+def check_allowlist(email: str, db_emails: set[str]) -> dict:
+    """Return {email, normalized, hit, allowlist_size} for the given email.
 
-    ``/opt/fellows/deploy/dist/`` is mode 2775 owned by ``fellows:fellows``,
-    and the operator (``rsb``) is in the ``fellows`` group, so we can read it
-    directly. Returns a set of hex SHA-256 hashes.
+    Membership model (post-PR #139): there is no ``allowed_emails.json`` file
+    any more. The server builds its allowlist in memory at startup by HMAC-ing
+    every distinct, non-empty ``contact_email`` in ``fellows.db`` — so the
+    *set* of allowed addresses is exactly those emails. An email is allowed iff
+    its normalized (lower/trim) form is a contact_email in the DB; checking that
+    needs only the DB email set, not the HMAC key.
     """
-    remote_cmd = f"cat {shlex.quote(allowlist_path)}"
-    cmd = ["ssh", "-o", "BatchMode=yes", "-p", str(port), f"{user}@{host}", remote_cmd]
-    r = subprocess.run(cmd, capture_output=True, text=True, timeout=30, check=False)
-    if r.returncode != 0:
-        raise RuntimeError(
-            f"ssh/cat allowlist failed (exit {r.returncode}): "
-            + (r.stderr.strip() or "no stderr")
-        )
-    try:
-        data = json.loads(r.stdout)
-    except json.JSONDecodeError as e:
-        raise RuntimeError(f"allowlist JSON parse failed: {e}")
-    hashes = data.get("hashes") or []
-    return {str(h).lower() for h in hashes if h}
-
-
-def check_allowlist(email: str, allowlist: set[str]) -> dict:
-    """Return {email, hash, hit, allowlist_size} for the given email."""
-    h = hash_email(email)
+    normalized = email.strip().lower()
     return {
         "email": email,
-        "hash": h,
-        "hit": h in allowlist,
-        "allowlist_size": len(allowlist),
+        "normalized": normalized,
+        "hit": normalized in db_emails,
+        "allowlist_size": len(db_emails),
     }
 
 
@@ -303,18 +282,20 @@ def fetch_fellow_emails_from_prod(
     always available. The ``sqlite3`` CLI binary is NOT installed (it's not a
     fellows-pwa dep) so we use Python directly — one-liner, JSON out.
 
-    Same path as the allowlist (group-readable, no sudo needed). Returns a list
-    of ``{"record_id", "name", "email"}`` dicts with email lowercased+trimmed,
-    matching the build_pwa hashing recipe.
+    Group-readable, no sudo needed. Returns a list of
+    ``{"record_id", "name", "email"}`` dicts for **all** fellows, with email
+    lowercased+trimmed (``""`` when the fellow has no contact_email). The caller
+    splits with-email from without-email; the with-email set is exactly the
+    server's allowlist after a restart.
     """
     py_code = (
         "import json, sqlite3; "
         f"c = sqlite3.connect({db_path!r}); "
         "c.row_factory = sqlite3.Row; "
         "rows = c.execute("
-        "\"SELECT record_id, name, lower(trim(contact_email)) AS email "
-        "FROM fellows WHERE contact_email IS NOT NULL "
-        "AND trim(contact_email) != ''\""
+        "\"SELECT record_id, name, "
+        "lower(trim(coalesce(contact_email, ''))) AS email "
+        "FROM fellows\""
         ").fetchall(); "
         "print(json.dumps([dict(r) for r in rows]))"
     )
@@ -335,82 +316,142 @@ def fetch_fellow_emails_from_prod(
     return data if isinstance(data, list) else []
 
 
-def dump_allowlist_report(host: str, port: str, user: str) -> dict:
-    """Cross-reference allowlist hashes against the fellows DB.
+def _safe_int(s: str) -> int:
+    try:
+        return int((s or "").strip())
+    except (ValueError, TypeError):
+        return 0
 
-    Returns a structured summary and writes a human-readable report to stdout.
-    Flags two invariants:
-      - every fellow with a contact_email should have their hash on the allowlist
-      - every hash on the allowlist should map back to at least one fellow email
-    Both should be true whenever build_pwa.py runs over the same DB. Drift
-    means the allowlist and DB were built from different sources.
+
+def fetch_db_meta_from_prod(
+    host: str,
+    port: str,
+    user: str,
+    db_path: str = DEFAULT_FELLOWS_DB,
+    unit: str = UNIT,
+) -> dict:
+    """Best-effort: fellows.db mtime vs the fellows-pwa start time (epochs).
+
+    Detects the one drift that can still exist post-PR #139: the in-memory
+    allowlist is derived from fellows.db at startup, so if the DB on disk
+    changed *after* the server started, the running allowlist is stale and a
+    restart is needed. Returns ``{"db_mtime", "service_start"}`` epochs; zeros
+    on any failure, so staleness reports as "unknown" rather than a false alarm.
+    Read-only; ``systemctl show`` and ``stat`` both work without sudo.
     """
-    allow = fetch_allowlist_from_prod(host, port, user)
-    fellows = fetch_fellow_emails_from_prod(host, port, user)
+    remote = (
+        f"echo DB_MTIME=$(stat -c %Y {shlex.quote(db_path)} 2>/dev/null || echo 0); "
+        "echo SVC_START=$(date -d "
+        f"\"$(systemctl show -p ActiveEnterTimestamp --value {shlex.quote(unit)} 2>/dev/null)\" "
+        "+%s 2>/dev/null || echo 0)"
+    )
+    cmd = ["ssh", "-o", "BatchMode=yes", "-p", str(port), f"{user}@{host}", remote]
+    out = {"db_mtime": 0, "service_start": 0}
+    try:
+        r = subprocess.run(cmd, capture_output=True, text=True, timeout=30, check=False)
+    except (OSError, subprocess.SubprocessError):
+        return out
+    if r.returncode != 0:
+        return out
+    for line in r.stdout.splitlines():
+        line = line.strip()
+        if line.startswith("DB_MTIME="):
+            out["db_mtime"] = _safe_int(line.split("=", 1)[1])
+        elif line.startswith("SVC_START="):
+            out["service_start"] = _safe_int(line.split("=", 1)[1])
+    return out
 
-    fellow_hash_to_fellow: dict[str, dict] = {}
+
+def dump_allowlist_report(host: str, port: str, user: str) -> dict:
+    """Report the allowlist's source-of-truth (fellows.db) and its health.
+
+    Post-PR #139 the allowlist is not a separate artifact — the server derives
+    it from fellows.db at startup, so the old "allowlist vs DB drift" check is
+    structurally impossible (they're the same set by construction). The
+    meaningful checks now are:
+      - how many distinct emails the allowlist covers (= addresses that can
+        receive a magic link),
+      - which fellows have NO contact_email (they can never get a link),
+      - which emails are shared by multiple fellows (collapse to one entry),
+      - whether fellows.db changed after the server started (stale in-memory
+        allowlist → restart needed).
+    """
+    fellows = fetch_fellow_emails_from_prod(host, port, user)
+    meta = fetch_db_meta_from_prod(host, port, user)
+
+    with_email: list[dict] = []
+    without_email: list[dict] = []
+    email_to_names: dict[str, list[str]] = {}
     for f in fellows:
         email = (f.get("email") or "").strip().lower()
-        if not email:
-            continue
-        fellow_hash_to_fellow.setdefault(hash_email(email), f)
+        if email:
+            with_email.append(f)
+            email_to_names.setdefault(email, []).append(f.get("name") or "?")
+        else:
+            without_email.append(
+                {"record_id": f.get("record_id"), "name": f.get("name") or "?"}
+            )
 
-    fellow_hashes = set(fellow_hash_to_fellow.keys())
+    duplicate_emails = {e: names for e, names in email_to_names.items() if len(names) > 1}
 
-    missing_from_allowlist = [
-        fellow_hash_to_fellow[h] for h in fellow_hashes if h not in allow
-    ]
-    orphans_in_allowlist = sorted(allow - fellow_hashes)
+    db_mtime = meta.get("db_mtime", 0)
+    svc_start = meta.get("service_start", 0)
+    staleness_known = bool(db_mtime and svc_start)
+    stale = bool(staleness_known and db_mtime > svc_start)
 
-    summary = {
-        "allowlist_size": len(allow),
-        "fellows_with_email": len(fellows),
-        "fellow_distinct_email_hashes": len(fellow_hashes),
-        "missing_from_allowlist": missing_from_allowlist,
-        "orphans_in_allowlist": orphans_in_allowlist,
-        "in_sync": not missing_from_allowlist and not orphans_in_allowlist,
+    return {
+        "allowlist_size": len(email_to_names),  # distinct emails = allowlist after restart
+        "fellows_total": len(fellows),
+        "fellows_with_email": len(with_email),
+        "fellows_without_email": without_email,
+        "duplicate_emails": duplicate_emails,
+        "db_mtime": db_mtime,
+        "service_start": svc_start,
+        "staleness_known": staleness_known,
+        "stale": stale,
+        "in_sync": not stale,
     }
-    return summary
 
 
 def format_dump_report(host: str, summary: dict) -> str:
     lines = [f"Allowlist state on {host}:"]
-    lines.append(f"  Allowlist hashes:             {summary['allowlist_size']}")
-    lines.append(f"  Fellows with contact_email:   {summary['fellows_with_email']}")
-    lines.append(
-        f"  Distinct email hashes from DB: {summary['fellow_distinct_email_hashes']}"
-    )
-    if summary["in_sync"]:
-        lines.append("  ✓ In sync — every email hash is on the allowlist and vice versa.")
-        return "\n".join(lines) + "\n"
+    lines.append(f"  Distinct emails (allowlist after restart): {summary['allowlist_size']}")
+    lines.append(f"  Fellows total:                             {summary['fellows_total']}")
+    lines.append(f"  Fellows with a contact_email:              {summary['fellows_with_email']}")
 
-    lines.append("  ✗ Drift detected.")
-    missing = summary["missing_from_allowlist"]
-    orphans = summary["orphans_in_allowlist"]
-    if missing:
+    without = summary.get("fellows_without_email") or []
+    if without:
         lines.append("")
         lines.append(
-            f"  Fellows with email NOT on allowlist ({len(missing)}) — they can't get magic links:"
+            f"  Fellows with NO contact_email ({len(without)}) — they can't receive a magic link:"
         )
-        for f in missing[:50]:
-            lines.append(f"    {f.get('name', '?')}  <{f.get('email', '?')}>")
-        if len(missing) > 50:
-            lines.append(f"    … {len(missing) - 50} more")
-    if orphans:
+        for f in without[:50]:
+            lines.append(f"    {f.get('name', '?')}")
+        if len(without) > 50:
+            lines.append(f"    … {len(without) - 50} more")
+
+    dups = summary.get("duplicate_emails") or {}
+    if dups:
         lines.append("")
         lines.append(
-            f"  Hashes on allowlist with no matching fellow email ({len(orphans)}):"
+            f"  Emails shared by multiple fellows ({len(dups)}) — one allowlist entry each:"
         )
-        for h in orphans[:20]:
-            lines.append(f"    {h[:16]}…")
-        if len(orphans) > 20:
-            lines.append(f"    … {len(orphans) - 20} more")
+        for email, names in list(dups.items())[:20]:
+            lines.append(f"    {email}  ←  {', '.join(names)}")
+        if len(dups) > 20:
+            lines.append(f"    … {len(dups) - 20} more")
+
     lines.append("")
-    lines.append(
-        "  Drift usually means allowed_emails.json and fellows.db were "
-        "generated from different sources. Rebuild both together via "
-        "`python build/build_pwa.py` and redeploy."
-    )
+    if not summary.get("staleness_known"):
+        lines.append(
+            "  Staleness: unknown (couldn't read fellows.db mtime / service start time)."
+        )
+    elif summary.get("stale"):
+        lines.append("  ✗ STALE: fellows.db changed AFTER the server started — the running")
+        lines.append("    in-memory allowlist is behind the DB on disk. Restart to pick it up:")
+        lines.append("      sudo systemctl restart fellows-pwa")
+    else:
+        lines.append("  ✓ In sync: the running allowlist matches the fellows.db on disk.")
     return "\n".join(lines) + "\n"
 
 
@@ -512,14 +553,13 @@ def fetch_postmark_message(message_id: str, token: str) -> dict:
 def _format_allowlist_status(chk: dict) -> list[str]:
     """Render the allowlist check block for the human-readable report."""
     out = ["Allowlist status:"]
-    hp = chk["hash"][:16]
     if chk["hit"]:
         out.append(
-            f"  HIT — {chk['email']} (hash {hp}…) is in the {chk['allowlist_size']}-entry allowlist."
+            f"  HIT — {chk['email']} is in the {chk['allowlist_size']}-entry allowlist."
         )
     else:
         out.append(
-            f"  MISS — {chk['email']} (hash {hp}…) is NOT in the {chk['allowlist_size']}-entry allowlist."
+            f"  MISS — {chk['email']} is NOT in the {chk['allowlist_size']}-entry allowlist."
         )
         out.append(
             "  The server silently returns {sent: true} for non-allowlisted emails"
@@ -722,11 +762,11 @@ def build_arg_parser() -> argparse.ArgumentParser:
     ap.add_argument(
         "--dump-allowlist",
         action="store_true",
-        help="Dump the allowlist and cross-reference against the fellows DB on "
-        "prod. Doesn't fetch journal events; doesn't need --sudo. Flags drift "
-        "(fellow emails missing from allowlist, or allowlist hashes without a "
-        "matching fellow email) — both are invariants that should never hold "
-        "if allowed_emails.json and fellows.db were built from the same DB.",
+        help="Report the allowlist source-of-truth (fellows.db) on prod: how "
+        "many distinct emails it covers, fellows with no contact_email (can't "
+        "get a link), duplicate emails, and whether fellows.db changed after "
+        "the server started (stale in-memory allowlist). Doesn't fetch journal "
+        "events; doesn't need --sudo.",
     )
     ap.add_argument(
         "--json",
@@ -793,8 +833,10 @@ def main(argv: list[str] | None = None) -> int:
     allowlist_check: dict | None = None
     if args.email:
         try:
-            allow = fetch_allowlist_from_prod(args.host, args.port, args.user)
-            allowlist_check = check_allowlist(args.email, allow)
+            fellows = fetch_fellow_emails_from_prod(args.host, args.port, args.user)
+            db_emails = {(f.get("email") or "").strip().lower() for f in fellows}
+            db_emails.discard("")
+            allowlist_check = check_allowlist(args.email, db_emails)
         except RuntimeError as e:
             sys.stderr.write(f"(allowlist check skipped: {e})\n")
 

--- a/scripts/sign_bundle.py
+++ b/scripts/sign_bundle.py
@@ -76,7 +76,7 @@ def load_private_key(key_path: Path, passphrase_env: str | None) -> ec.EllipticC
                     key = serialization.load_pem_private_key(raw, password=pw)
                     break
                 except (ValueError, InvalidKey):
-                    print("Wrong passphrase. Try again.", file=sys.stderr)
+                    print("Wrong passphrase. Try again. (Ctrl-C to abort)", file=sys.stderr)
             else:
                 raise SystemExit("Too many failed passphrase attempts.")
 
@@ -132,4 +132,11 @@ def main(argv: list[str] | None = None) -> int:
 
 
 if __name__ == "__main__":
-    raise SystemExit(main())
+    try:
+        raise SystemExit(main())
+    except KeyboardInterrupt:
+        # Clean exit on Ctrl-C (e.g. abandoning the passphrase prompt) —
+        # no Python traceback. 130 is the conventional shell code for
+        # SIGINT.
+        print("\nAborted.", file=sys.stderr)
+        raise SystemExit(130)

--- a/tests/test_debug_email_delivery.py
+++ b/tests/test_debug_email_delivery.py
@@ -490,62 +490,15 @@ def test_sudo_no_sudo_flag_opts_out():
     assert args.sudo is False
 
 
-def test_fetch_allowlist_from_prod_parses_and_normalises(monkeypatch):
-    class _R:
-        returncode = 0
-        stdout = '{"hashes": ["AABBCC", "ddEEff", "1234"]}'
-        stderr = ""
-
-    captured = {}
-
-    def fake_run(cmd, **kw):
-        captured["cmd"] = cmd
-        return _R()
-
-    monkeypatch.setattr(ded.subprocess, "run", fake_run)
-    allow = ded.fetch_allowlist_from_prod("h", "22", "u")
-    # lowercased for consistent comparison with sha256().hexdigest()
-    assert allow == {"aabbcc", "ddeeff", "1234"}
-    # No sudo involved — must use BatchMode=yes to fail fast on auth prompts.
-    assert "BatchMode=yes" in " ".join(captured["cmd"])
-    # And we didn't smuggle sudo into the remote command.
-    assert "sudo" not in captured["cmd"][-1]
-
-
-def test_fetch_allowlist_from_prod_raises_on_ssh_failure(monkeypatch):
-    class _R:
-        returncode = 255
-        stdout = ""
-        stderr = "Permission denied"
-
-    monkeypatch.setattr(ded.subprocess, "run", lambda *a, **kw: _R())
-    import pytest
-    with pytest.raises(RuntimeError, match="exit 255"):
-        ded.fetch_allowlist_from_prod("h", "22", "u")
-
-
-def test_fetch_allowlist_from_prod_raises_on_bad_json(monkeypatch):
-    class _R:
-        returncode = 0
-        stdout = "not json {"
-        stderr = ""
-
-    monkeypatch.setattr(ded.subprocess, "run", lambda *a, **kw: _R())
-    import pytest
-    with pytest.raises(RuntimeError, match="parse failed"):
-        ded.fetch_allowlist_from_prod("h", "22", "u")
-
-
 def test_check_allowlist_hit_and_miss():
-    allow = {
-        ded.hash_email("a@example.com"),
-        ded.hash_email("b@example.com"),
-    }
-    hit = ded.check_allowlist("a@example.com", allow)
+    # Membership is now "is this normalized email a contact_email in fellows.db?"
+    # (the server derives the allowlist from those emails) — no hash file.
+    db_emails = {"a@example.com", "b@example.com"}
+    hit = ded.check_allowlist("A@Example.com ", db_emails)  # normalize on the way in
     assert hit["hit"] is True
     assert hit["allowlist_size"] == 2
-    assert hit["hash"] == ded.hash_email("a@example.com")
-    miss = ded.check_allowlist("c@example.com", allow)
+    assert hit["normalized"] == "a@example.com"
+    miss = ded.check_allowlist("c@example.com", db_emails)
     assert miss["hit"] is False
 
 
@@ -626,59 +579,74 @@ def test_fetch_fellow_emails_from_prod_handles_empty_result(monkeypatch):
     assert ded.fetch_fellow_emails_from_prod("h", "22", "u") == []
 
 
-def test_dump_allowlist_in_sync_when_fellows_hashes_match_allowlist(monkeypatch):
+def _fresh_meta(*a, **kw):
+    # fellows.db older than the running service → in-memory allowlist is current.
+    return {"db_mtime": 1000, "service_start": 2000}
+
+
+def test_dump_allowlist_counts_distinct_emails_and_lists_missing(monkeypatch):
     fellows = [
         {"record_id": "r1", "name": "Alice", "email": "alice@example.com"},
         {"record_id": "r2", "name": "Bob", "email": "bob@example.com"},
+        {"record_id": "r3", "name": "No Email", "email": ""},
     ]
-    allow = {ded.hash_email(f["email"]) for f in fellows}
-
-    monkeypatch.setattr(ded, "fetch_allowlist_from_prod", lambda *a, **kw: allow)
     monkeypatch.setattr(ded, "fetch_fellow_emails_from_prod", lambda *a, **kw: fellows)
+    monkeypatch.setattr(ded, "fetch_db_meta_from_prod", _fresh_meta)
     summary = ded.dump_allowlist_report("h", "22", "u")
-    assert summary["in_sync"] is True
-    assert summary["allowlist_size"] == 2
+    assert summary["allowlist_size"] == 2  # distinct non-empty emails = allowlist
+    assert summary["fellows_total"] == 3
     assert summary["fellows_with_email"] == 2
-    assert summary["missing_from_allowlist"] == []
-    assert summary["orphans_in_allowlist"] == []
+    assert [f["name"] for f in summary["fellows_without_email"]] == ["No Email"]
+    assert summary["in_sync"] is True
+    report = ded.format_dump_report("fellows.example", summary)
+    assert "No Email" in report
+    assert "NO contact_email" in report
+    assert "In sync" in report
 
 
-def test_dump_allowlist_surfaces_fellow_missing_from_allowlist(monkeypatch):
-    """The exact failure mode that broke Rich's testing on Apr 20."""
+def test_dump_allowlist_flags_duplicate_emails(monkeypatch):
     fellows = [
-        {"record_id": "r1", "name": "Richard Bodo", "email": "richbodo@gmail.com"},
-        {"record_id": "r2", "name": "Bob", "email": "bob@example.com"},
+        {"record_id": "r1", "name": "Alice", "email": "shared@example.com"},
+        {"record_id": "r2", "name": "Al Ias", "email": "Shared@example.com"},  # same after normalize
     ]
-    # Only Bob's hash on the allowlist — Rich's missing.
-    allow = {ded.hash_email("bob@example.com")}
-
-    monkeypatch.setattr(ded, "fetch_allowlist_from_prod", lambda *a, **kw: allow)
     monkeypatch.setattr(ded, "fetch_fellow_emails_from_prod", lambda *a, **kw: fellows)
+    monkeypatch.setattr(ded, "fetch_db_meta_from_prod", _fresh_meta)
     summary = ded.dump_allowlist_report("h", "22", "u")
-    assert summary["in_sync"] is False
-    assert len(summary["missing_from_allowlist"]) == 1
-    assert summary["missing_from_allowlist"][0]["name"] == "Richard Bodo"
+    assert summary["allowlist_size"] == 1  # collapses to a single allowlist entry
+    assert "shared@example.com" in summary["duplicate_emails"]
+    assert sorted(summary["duplicate_emails"]["shared@example.com"]) == ["Al Ias", "Alice"]
     report = ded.format_dump_report("fellows.example", summary)
-    assert "Drift detected" in report
-    assert "Richard Bodo" in report
-    assert "richbodo@gmail.com" in report
+    assert "shared by multiple fellows" in report
 
 
-def test_dump_allowlist_surfaces_orphan_hashes(monkeypatch):
-    """Hashes on the allowlist that don't correspond to any fellow's email."""
+def test_dump_allowlist_flags_stale_db(monkeypatch):
     fellows = [{"record_id": "r1", "name": "Alice", "email": "alice@example.com"}]
-    allow = {
-        ded.hash_email("alice@example.com"),
-        ded.hash_email("stale@example.com"),  # no fellow with this email
-    }
-
-    monkeypatch.setattr(ded, "fetch_allowlist_from_prod", lambda *a, **kw: allow)
     monkeypatch.setattr(ded, "fetch_fellow_emails_from_prod", lambda *a, **kw: fellows)
+    # fellows.db newer than the running service → stale in-memory allowlist.
+    monkeypatch.setattr(
+        ded, "fetch_db_meta_from_prod",
+        lambda *a, **kw: {"db_mtime": 5000, "service_start": 1000},
+    )
     summary = ded.dump_allowlist_report("h", "22", "u")
+    assert summary["stale"] is True
     assert summary["in_sync"] is False
-    assert len(summary["orphans_in_allowlist"]) == 1
     report = ded.format_dump_report("fellows.example", summary)
-    assert "no matching fellow email (1)" in report
+    assert "STALE" in report
+    assert "restart fellows-pwa" in report
+
+
+def test_dump_allowlist_staleness_unknown_when_timestamps_missing(monkeypatch):
+    fellows = [{"record_id": "r1", "name": "Alice", "email": "alice@example.com"}]
+    monkeypatch.setattr(ded, "fetch_fellow_emails_from_prod", lambda *a, **kw: fellows)
+    monkeypatch.setattr(
+        ded, "fetch_db_meta_from_prod", lambda *a, **kw: {"db_mtime": 0, "service_start": 0}
+    )
+    summary = ded.dump_allowlist_report("h", "22", "u")
+    assert summary["staleness_known"] is False
+    assert summary["stale"] is False
+    assert summary["in_sync"] is True  # unknown is not the same as stale
+    report = ded.format_dump_report("fellows.example", summary)
+    assert "unknown" in report
 
 
 def test_fetch_postmark_token_from_prod_raises_on_ssh_failure(monkeypatch):


### PR DESCRIPTION
Completes the remaining `docs/securityaudit.md` checklist items (except the owner-deferred B2 workstation hardening, app-layer encryption, and risk-doc rewrite). Follows #224.

## What changed

| Item | Change | Files |
|---|---|---|
| **--dump-allowlist fix** | Rewrote for the HMAC/DB-derived allowlist (broken since #139 removed `allowed_emails.json`). Reports distinct-email count, fellows with no email, duplicates, and a "fellows.db newer than the running server" staleness warning. `--email` HIT/MISS now resolves against the DB email set. | `scripts/debug_email_delivery.py` + tests |
| **CT monitoring** | `scripts/check_ct_log.py` + `just ct-check` — crt.sh query, flags non-Let's-Encrypt issuers. | `scripts/check_ct_log.py`, `justfile` |
| **CAA guardrail** | `just check-env` warns when no CAA is effective for the host / doesn't authorize LE. | `scripts/check_deploy_env.sh` |
| **CAA/HSTS scope correction** | See finding below. | `docs/DevOps.md` |
| **Device hygiene** | "Your device is now the directory" user-guide section. | `docs/users_manual.md` |
| **sign-bundle polish** | Clean `Aborted.` on Ctrl-C. | `scripts/sign_bundle.py` |
| **Checklist refresh** | Tick completions; track remaining operator actions + deferred items. | `docs/securityaudit.md` |

## ⚠️ Finding from running `just ct-check` (changes the CAA/HSTS plan)

The CT check immediately surfaced that the **`globaldonut.com` zone is not Let's-Encrypt-only**:
- `pitch.globaldonut.com` → **Google Trust Services**
- `globaldonut.com` apex → a **Sectigo** cert (alongside the Caddy/LE ones)

So the originally-planned **apex-wide** CAA and HSTS preload would over-reach:
- An apex `issue "letsencrypt.org"` CAA would **break cert renewal** for `pitch.globaldonut.com` and any Sectigo apex issuance.
- Apex HSTS preload (`includeSubDomains`) would force **every** `globaldonut.com` subdomain HTTPS-only, permanently.

**Both are now scoped to `fellows.globaldonut.com`** in the docs/guardrail — full protection for the app, no collateral on the rest of the zone. The apex-wide option is documented as available only after enumerating every in-use CA / confirming every subdomain is HTTPS-forever.

## Tests
`just test-fast` green (93). `tests/test_debug_email_delivery.py` + `tests/test_sign_bundle.py` green (48). `just ct-check` and `just check-env` verified live (read-only).

## Maintainer console actions still open (not code — your hands)
These are the irreducible external steps; the in-repo tooling/docs for each are done:

1. **CAA** — in Cloudflare, add 3 records on name **`fellows`** (not apex): `issue "letsencrypt.org"`, `issuewild ";"`, `iodef "mailto:richbodo@gmail.com"`. Verify: `just check-env`.
2. **HSTS preload** — submit **`fellows.globaldonut.com`** (not apex) at <https://hstspreload.org/?domain=fellows.globaldonut.com>.
3. **crt.sh alerts** — subscribe at <https://crt.sh/?domain=globaldonut.com> → email-monitor link. (On-demand: `just ct-check`.)

## Deferred (owner-scheduled, still tracked in securityaudit.md)
B2 operator-key/workstation hardening · app-layer `relationships.db` encryption · risk-doc rewrite.

🤖 Generated with [Claude Code](https://claude.com/claude-code)