### PR TITLE
feat(pna): cloud-LLM consent gate + non-PNA mode / EX-CLOUD-LLM exception

### DIFF
--- a/app/static/app.js
+++ b/app/static/app.js
@@ -110,6 +110,8 @@
   var backToGateLinkEl = document.getElementById('back-to-gate-link');
   var swUpdateBannerEl = document.getElementById('sw-update-banner');
   var swUpdateReloadEl = document.getElementById('sw-update-reload');
+  var notAPnaBannerEl = document.getElementById('not-a-pna-banner');
+  var notAPnaDismissEl = document.getElementById('not-a-pna-dismiss');
   var siteHeaderEl = document.getElementById('site-header');
   // Mobile shell (≤1024px): appbar + tab strip + kebab sheet. Hidden on
   // desktop via CSS, hidden during install/boot via the same .hidden
@@ -469,6 +471,96 @@
     var state = getMcpbSetupState() || {};
     if (!state.consentAt) state.consentAt = new Date().toISOString();
     persistMcpbSetupState(state);
+    // Recording consent RAISES the EX-CLOUD-LLM exception → the app
+    // enters non-PNA mode. Surface the banner immediately.
+    syncNotAPnaBanner();
+  }
+
+  // ── PNA exceptions / non-PNA mode ───────────────────────────────────
+  // An "exception" (modeled on a software exception) is a stable-ID'd
+  // condition under which this app deliberately leaves PNA mode — the
+  // PNA spec's local-only / never-SaaS guarantee. Today there is exactly
+  // one: EX-CLOUD-LLM, raised when the user consents to wiring the
+  // directory to a cloud LLM (Claude Desktop MCP). Raising it == recording
+  // consent (recordMcpbConsent); the handler is the consent gate
+  // (pre-raise) + the "Going rogue — not a PNA" banner + the
+  // #/exception/<id> explainer + the return-to-PNA control below. The ID
+  // is the single greppable marker tying gate ↔ banner ↔ route ↔ state,
+  // and is what a conformance check / the PNT spec linter catches.
+  // See plans/pna_toolkit_exceptions_contribution.md.
+  var PNA_EXCEPTION_CLOUD_LLM = 'EX-CLOUD-LLM';
+  // Canonical, app-independent definition the in-app explainer links out
+  // to. Points at the toolkit repo today; becomes the
+  // exceptions.md#ex-cloud-llm anchor once the contribution in plans/
+  // lands upstream.
+  var PNA_EXCEPTION_CANONICAL_URL = 'https://github.com/richbodo/personal_network_toolkit';
+
+  // The app is in non-PNA mode while any exception is active. Today that
+  // is exactly: the cloud-LLM consent has been recorded and not since
+  // cleared by "return to PNA mode". Reversibility lives in
+  // returnToPnaMode().
+  function isPnaExceptionActive() {
+    var state = getMcpbSetupState();
+    return !!(state && state.consentAt);
+  }
+
+  function activePnaExceptions() {
+    return isPnaExceptionActive() ? [PNA_EXCEPTION_CLOUD_LLM] : [];
+  }
+
+  // Reversibility — EX-CLOUD-LLM declares Reversible: yes (MODE only).
+  // Clearing the exception returns the app to PNA mode. This stops FUTURE
+  // sharing; it does NOT recall data already sent to the cloud provider
+  // (the explainer says so explicitly). Clearing consentAt also re-arms
+  // the full consent gate, so re-enabling is a fresh, deliberate raise.
+  function returnToPnaMode() {
+    var state = getMcpbSetupState();
+    if (!state) return;
+    delete state.consentAt;
+    delete state.pnaBannerDismissedAt;
+    persistMcpbSetupState(state);
+    syncNotAPnaBanner();
+  }
+
+  function dismissNotAPnaBanner() {
+    var state = getMcpbSetupState();
+    if (!state) return;
+    // Dismissal acknowledges; it MUST NOT clear the exception (the app is
+    // still in non-PNA mode). We just stop showing the banner.
+    if (!state.pnaBannerDismissedAt) {
+      state.pnaBannerDismissedAt = new Date().toISOString();
+      persistMcpbSetupState(state);
+    }
+    syncNotAPnaBanner();
+  }
+
+  // Show/hide the banner and stamp machine-readable markers on <body>
+  // (data-pna-mode + data-pna-exceptions) so the runtime state is
+  // greppable for tests and a future conformance check. Banner is visible
+  // iff an exception is active AND not yet dismissed.
+  function syncNotAPnaBanner() {
+    var active = isPnaExceptionActive();
+    var exceptions = activePnaExceptions();
+    if (document.body) {
+      document.body.setAttribute('data-pna-mode', active ? 'non-pna' : 'pna');
+      if (exceptions.length) {
+        document.body.setAttribute('data-pna-exceptions', exceptions.join(','));
+      } else {
+        document.body.removeAttribute('data-pna-exceptions');
+      }
+    }
+    if (!notAPnaBannerEl) return;
+    var state = getMcpbSetupState();
+    var dismissed = !!(state && state.pnaBannerDismissedAt);
+    if (active && !dismissed) notAPnaBannerEl.classList.remove('hidden');
+    else notAPnaBannerEl.classList.add('hidden');
+  }
+
+  function initNotAPnaBanner() {
+    if (notAPnaDismissEl) {
+      notAPnaDismissEl.addEventListener('click', dismissNotAPnaBanner);
+    }
+    syncNotAPnaBanner();
   }
 
   function initBuildBadge() {
@@ -6931,12 +7023,105 @@
       });
   }
 
+  // ===== PNA exception explainer pages ===================================
+  // The in-app surface an active exception's banner (and the consent gate)
+  // links to. Per the exceptions handler contract, the app — not a static
+  // GitHub page — must explain the CURRENTLY-ACTIVE exception set, because
+  // combinations are installation-specific. Each page links out to the
+  // canonical (app-independent) definition in the toolkit.
+  function renderExceptionsIndex() {
+    if (!detailEl) return;
+    var active = activePnaExceptions();
+    var html = '<div class="exception-page">';
+    html += '<h2 class="exception-title">PNA mode</h2>';
+    if (!active.length) {
+      html += '<p class="exception-status exception-status--ok">' +
+        'This app is in <strong>PNA mode</strong> — it runs local-only and talks to no ' +
+        'SaaS server beyond delivering the app and directory data. No exceptions are active.</p>';
+    } else {
+      html += '<p class="exception-status exception-status--warn">' +
+        'This app is <strong>not in PNA mode</strong>. ' + active.length + ' exception' +
+        (active.length === 1 ? '' : 's') + ' active:</p>';
+      html += '<ul class="exception-list">';
+      active.forEach(function (id) {
+        html += '<li><a href="#/exception/' + encodeURIComponent(id) + '">' +
+          escapeHtml(id) + '</a></li>';
+      });
+      html += '</ul>';
+    }
+    html += '<p class="exception-back"><a href="#/">← Back to the directory</a></p>';
+    html += '</div>';
+    detailEl.innerHTML = html;
+    detailEl.scrollIntoView({ behavior: 'smooth', block: 'nearest' });
+  }
+
+  function renderExceptionPage(id) {
+    if (!detailEl) return;
+    if (id !== PNA_EXCEPTION_CLOUD_LLM) {
+      detailEl.innerHTML = '<div class="exception-page">' +
+        '<h2 class="exception-title">Unknown exception</h2>' +
+        '<p>No exception is registered under <code>' + escapeHtml(id) + '</code>.</p>' +
+        '<p class="exception-back"><a href="#/exceptions">← All exceptions</a></p>' +
+        '</div>';
+      return;
+    }
+    var active = isPnaExceptionActive();
+    var statusHtml = active
+      ? '<p class="exception-status exception-status--warn">' +
+          '<strong>Active now.</strong> This app is currently <strong>not a PNA</strong> — ' +
+          'you enabled cloud-AI integration.</p>'
+      : '<p class="exception-status exception-status--ok">' +
+          '<strong>Not currently active.</strong> This is what would happen if you enable ' +
+          'cloud-AI integration. The app is in PNA mode right now.</p>';
+    var html = '<div class="exception-page" data-pna-exception="' + escapeHtml(id) + '">';
+    html += '<h2 class="exception-title">Cloud AI integration — ' + escapeHtml(id) + '</h2>';
+    html += statusHtml;
+    html += '<h3>What this exception is</h3>';
+    html += '<p>A personal-network app (PNA) runs <strong>local-only</strong> and never sends ' +
+      'your data to a SaaS server. Connecting Claude Desktop (a cloud AI) to this directory ' +
+      'deliberately breaks that promise — so it is treated as a named <em>exception</em> ' +
+      '(<code>' + escapeHtml(id) + '</code>) that takes the app out of PNA mode.</p>';
+    html += '<h3>What it relaxes</h3>';
+    html += '<p>The PNA definition (local-only / never-SaaS) and <code>AC-MCP-A</code> ' +
+      '(cloud-AI access to private data). It stresses Goal 1 — private-data sovereignty.</p>';
+    html += '<h3>What data is affected</h3>';
+    html += '<p>Whatever the AI reads flows to its provider (Anthropic): the fellows directory, ' +
+      'and — if you install the private extension — your saved groups and notes.</p>';
+    html += '<h3>Is it reversible?</h3>';
+    html += '<p><strong>Yes — the mode is reversible.</strong> You can return to PNA mode at ' +
+      'any time (below, or from Settings → Claude Desktop integration). ' +
+      '<strong>But returning to PNA mode does not recall data already sent to the cloud ' +
+      'provider</strong> — it only stops further sharing.</p>';
+    if (active) {
+      html += '<p class="exception-actions"><button type="button" id="exception-return-pna" ' +
+        'class="exception-return-pna">Return to PNA mode</button></p>';
+    } else {
+      html += '<p class="exception-actions"><a href="#/settings">Set up cloud-AI integration in Settings →</a></p>';
+    }
+    html += '<p class="exception-canonical">Canonical definition: ' +
+      '<a href="' + PNA_EXCEPTION_CANONICAL_URL + '" target="_blank" rel="noopener">Personal Network Toolkit</a>.</p>';
+    html += '<p class="exception-back"><a href="#/">← Back to the directory</a> · ' +
+      '<a href="#/exceptions">All exceptions</a></p>';
+    html += '</div>';
+    detailEl.innerHTML = html;
+    detailEl.scrollIntoView({ behavior: 'smooth', block: 'nearest' });
+    var retBtn = document.getElementById('exception-return-pna');
+    if (retBtn) {
+      retBtn.addEventListener('click', function () {
+        returnToPnaMode();
+        renderExceptionPage(id); // re-render to reflect the now-PNA mode
+      });
+    }
+  }
+
   function route() {
     var hash = window.location.hash || '';
     var editMatch = hash.match(/^#\/edit\/(\d+)$/);
     var nextEditId = editMatch ? parseInt(editMatch[1], 10) : null;
     var directoryMatch = hash.match(/^#\/groups\/(\d+)\/directory$/);
     var groupMatch = !directoryMatch ? hash.match(/^#\/groups\/(\d+)$/) : null;
+    var exceptionMatch = hash.match(/^#\/exception\/([A-Za-z0-9_-]+)$/);
+    var exceptionsIndex = hash === '#/exceptions';
 
     // Tag <body> with the current focus mode so CSS can collapse the
     // global directory + composer rails (and, in edit mode, the central
@@ -6946,7 +7131,8 @@
     body.classList.remove(
       'route-groups-list', 'route-group-detail',
       'route-group-edit', 'route-group-directory',
-      'route-directory', 'route-about', 'route-settings', 'route-fellow'
+      'route-directory', 'route-about', 'route-settings', 'route-fellow',
+      'route-exception'
     );
     if (directoryMatch) body.classList.add('route-group-directory');
     else if (groupMatch) body.classList.add('route-group-detail');
@@ -6954,6 +7140,7 @@
     else if (hash === '#/groups') body.classList.add('route-groups-list');
     else if (hash === '#/about') body.classList.add('route-about');
     else if (hash === '#/settings') body.classList.add('route-settings');
+    else if (exceptionMatch || exceptionsIndex) body.classList.add('route-exception');
     else if (hash.indexOf('#/fellow/') === 0) body.classList.add('route-fellow');
     else body.classList.add('route-directory');
 
@@ -7003,6 +7190,7 @@
     // know a richer title (group name, fellow name) can overwrite by
     // calling setShellChrome again after their data resolves.
     if (hash === '#/about') setShellChrome('about', 'About');
+    else if (exceptionMatch || exceptionsIndex) setShellChrome('about', 'PNA mode');
     else if (hash === '#/settings') setShellChrome('settings', 'Settings');
     else if (hash === '#/groups') setShellChrome('groups', 'Groups');
     else if (groupMatch || directoryMatch || editMatch) setShellChrome('groups', 'Group');
@@ -7017,6 +7205,14 @@
     }
     if (hash === '#/about') {
       renderAboutPage();
+      return;
+    }
+    if (exceptionsIndex) {
+      renderExceptionsIndex();
+      return;
+    }
+    if (exceptionMatch) {
+      renderExceptionPage(exceptionMatch[1]);
       return;
     }
     if (hash === '#/settings') {
@@ -8789,6 +8985,18 @@
         '</div>' +
         '<p id="settings-mcpb-setup-meta" class="settings-hint settings-mcpb-meta" hidden></p>' +
         '<span id="settings-mcpb-status" class="settings-status" aria-live="polite"></span>' +
+        // Non-PNA-mode status + reversibility control. Shown only while the
+        // EX-CLOUD-LLM exception is active (wireMcpbSection toggles it).
+        '<div id="settings-mcpb-pna-mode" class="settings-mcpb-pna-mode" hidden>' +
+          '<p class="settings-mcpb-pna-mode-line">' +
+            '<strong>Not in PNA mode.</strong> Cloud-AI integration (<code>EX-CLOUD-LLM</code>) is ' +
+            'active. <a href="#/exception/EX-CLOUD-LLM">What this means</a>.' +
+          '</p>' +
+          '<button type="button" id="settings-mcpb-return-pna" class="settings-download">' +
+            'Return to PNA mode' +
+          '</button>' +
+          '<span id="settings-mcpb-return-pna-status" class="settings-status" aria-live="polite"></span>' +
+        '</div>' +
         '<div id="settings-mcpb-post-install" class="settings-mcpb-post-install" hidden>' +
           '<h4 class="settings-section-subtitle">After the downloads finish</h4>' +
           '<ol class="settings-mcpb-next-steps">' +
@@ -8866,6 +9074,12 @@
                 'and the extensions themselves only read the two fellows files.' +
               '</p>' +
             '</div>' +
+            '<p class="settings-mcpb-agreement-exception">' +
+              'Accepting raises the <code>EX-CLOUD-LLM</code> exception and takes this app ' +
+              'out of PNA (local-only) mode. ' +
+              '<a href="#/exception/EX-CLOUD-LLM" id="settings-mcpb-exception-link">Read the full explanation</a> ' +
+              '(opens the explainer and closes this dialog). It is reversible — you can return to PNA mode later.' +
+            '</p>' +
             '<label class="settings-mcpb-consent-accept">' +
               '<input type="checkbox" id="settings-mcpb-consent-checkbox" disabled>' +
               '<span>I understand and accept these risks.</span>' +
@@ -9311,10 +9525,21 @@
     var consentReminder = document.getElementById('settings-mcpb-consent-reminder');
     var consentReminderWhen = document.getElementById('settings-mcpb-consent-reminder-when');
     var consentReminderTerms = document.getElementById('settings-mcpb-consent-reminder-terms');
+    var exceptionLink = document.getElementById('settings-mcpb-exception-link');
     // Tracks the mode the currently-open dialog is in so the close
     // handler knows whether to record consent before downloading.
     var preambleMode = 'gate';
     if (!setupBtn || !dialog) return;
+
+    // The "Read the full explanation" link navigates to the in-app
+    // exception explainer. Close the dialog first (returnValue stays
+    // empty → the close handler records no consent and starts no
+    // download) so the user lands cleanly on #/exception/EX-CLOUD-LLM.
+    if (exceptionLink) {
+      exceptionLink.addEventListener('click', function () {
+        try { if (dialog.open) dialog.close(); } catch (e) {}
+      });
+    }
 
     function setStatus(text) {
       if (statusEl) statusEl.textContent = text || '';
@@ -9356,6 +9581,10 @@
         }
         if (postInstall) postInstall.hidden = true;
       }
+      // Non-PNA-mode row + reversibility control: visible iff the
+      // EX-CLOUD-LLM exception is active.
+      var pnaModeEl = document.getElementById('settings-mcpb-pna-mode');
+      if (pnaModeEl) pnaModeEl.hidden = !isPnaExceptionActive();
       // Directory-data-update affordance moved to the About page in
       // PR #205 — all "your stuff needs refreshing" signals consolidate
       // there alongside the app + directory-data version rows.
@@ -9525,6 +9754,18 @@
     }
 
     setupBtn.addEventListener('click', openPreamble);
+    // "Return to PNA mode" — reversibility for the EX-CLOUD-LLM exception.
+    // Clears the exception (stops future sharing; does not recall data
+    // already sent), hides the banner, and re-arms the full consent gate.
+    var returnPnaBtn = document.getElementById('settings-mcpb-return-pna');
+    if (returnPnaBtn) {
+      returnPnaBtn.addEventListener('click', function () {
+        returnToPnaMode();
+        var st = document.getElementById('settings-mcpb-return-pna-status');
+        if (st) st.textContent = 'Back in PNA mode. Re-enabling will ask for consent again.';
+        refreshUiFromState();
+      });
+    }
     // Scroll within the agreement region unlocks the accept checkbox.
     if (agreementEl) {
       agreementEl.addEventListener('scroll', syncConsentScrollState);
@@ -10723,6 +10964,7 @@
   }
 
   initSwReloadButton();
+  initNotAPnaBanner();
   initClearCacheButton();
   initResetEverythingButton();
   initDiagnosticsPanel();

--- a/app/static/app.js
+++ b/app/static/app.js
@@ -9396,6 +9396,16 @@
       continueBtn.disabled = !(consentCheckbox && consentCheckbox.checked);
     }
 
+    // Re-evaluate the (non-)scrollable a11y fallback on resize/zoom — a
+    // wider viewport may make the agreement fit without scrolling. This
+    // is the one listener bound to `window` (which persists across
+    // Settings re-renders), so it's added on dialog open and removed on
+    // close rather than once per wireMcpbSection() call — otherwise a
+    // stale closure would accumulate on every visit to Settings.
+    function onWindowResize() {
+      if (dialog && dialog.open) syncConsentScrollState();
+    }
+
     function openPreamble() {
       if (!dialog) return;
       // FULL GATE vs REMINDER: a recorded `consentAt` means the user has
@@ -9452,6 +9462,7 @@
         // unlocked immediately) on first paint.
         syncConsentScrollState();
         syncContinueEnabled();
+        window.addEventListener('resize', onWindowResize);
       }
       catch (e) {
         // Fallback for browsers without <dialog> support — surface as
@@ -9518,17 +9529,15 @@
     if (agreementEl) {
       agreementEl.addEventListener('scroll', syncConsentScrollState);
     }
-    // Re-evaluate the (non-)scrollable a11y fallback on resize/zoom —
-    // a wider viewport may make the agreement fit without scrolling.
-    window.addEventListener('resize', function () {
-      if (dialog && dialog.open) syncConsentScrollState();
-    });
     // Checking the accept box is what enables Continue.
     if (consentCheckbox) {
       consentCheckbox.addEventListener('change', syncContinueEnabled);
     }
     if (dialog) {
       dialog.addEventListener('close', function () {
+        // Tear down the open-scoped resize listener (see onWindowResize)
+        // on every close, regardless of how the dialog was dismissed.
+        window.removeEventListener('resize', onWindowResize);
         // <dialog>'s close event fires for any submit (including the
         // primary "Continue" button). returnValue carries the button's
         // value attribute — "continue" / "cancel" / empty (Esc).

--- a/app/static/app.js
+++ b/app/static/app.js
@@ -455,6 +455,22 @@
     persistMcpbSetupState(state);
   }
 
+  // One-time informed-consent gate for wiring the directory to a cloud
+  // LLM (Claude Desktop). Connecting the MCP servers sends fellows data
+  // — potentially including private groups/notes — to a SaaS vendor,
+  // which breaks the app's never-SaaS commitment. We record consent
+  // ONCE (a `consentAt` ISO timestamp on the existing
+  // fellows_mcpb_setup state) so the first setup shows the full
+  // scroll-then-accept agreement and later re-downloads show only a
+  // one-line reminder. Consent is recorded the moment the user accepts
+  // (before downloads start) so a user who accepts but cancels the
+  // browser download prompt still won't re-see the full gate.
+  function recordMcpbConsent() {
+    var state = getMcpbSetupState() || {};
+    if (!state.consentAt) state.consentAt = new Date().toISOString();
+    persistMcpbSetupState(state);
+  }
+
   function initBuildBadge() {
     var clientEl = document.getElementById('build-badge-client');
     if (clientEl) clientEl.textContent = 'app: ' + FELLOWS_UI_DIAG;
@@ -8803,9 +8819,65 @@
             '<strong>Your browser:</strong> the easy install works on Chrome, Edge, Brave, and Arc. ' +
             'Safari and Firefox need the manual setup linked above.' +
           '</p>' +
+          // REMINDER mode (shown only when consent was already recorded):
+          // one-line reminder + a "Review full terms" toggle that
+          // re-reveals the full agreement. Hidden by default; shown by
+          // openPreamble() when state.consentAt exists.
+          '<div id="settings-mcpb-consent-reminder" class="settings-mcpb-consent-reminder" hidden>' +
+            '<p class="settings-mcpb-consent-reminder-line">' +
+              'Connecting Claude Desktop routes your fellows data to a cloud LLM (Anthropic). ' +
+              '<span id="settings-mcpb-consent-reminder-when"></span>' +
+            '</p>' +
+            '<details class="settings-mcpb-bundle-details">' +
+              '<summary>Review full terms</summary>' +
+              '<div id="settings-mcpb-consent-reminder-terms"></div>' +
+            '</details>' +
+          '</div>' +
+          // FULL-GATE mode: the two-point agreement in a scrollable
+          // region. The user must scroll to the bottom (or the region
+          // must be short enough to not scroll) to enable the accept
+          // checkbox, which in turn enables Continue.
+          '<div id="settings-mcpb-consent-gate">' +
+            '<h5 class="settings-mcpb-section-title">Before you connect a cloud AI — please read</h5>' +
+            '<div id="settings-mcpb-agreement" class="settings-mcpb-agreement" tabindex="0">' +
+              '<ol class="settings-mcpb-agreement-points">' +
+                '<li>' +
+                  '<strong>You’re leaving the local-only model.</strong> ' +
+                  'Local AI is hard for most people to run, and Claude Desktop is the option nearly everyone actually wants. ' +
+                  'But connecting it sends your fellows data — potentially including your private groups and notes — ' +
+                  'to a SaaS vendor (Anthropic). No one can guarantee what a SaaS vendor will or won’t do with data you send it. ' +
+                  'This breaks the central promise of a personal-network app: that it never talks to a SaaS server. ' +
+                  'You have to be OK with that to continue.' +
+                '</li>' +
+                '<li>' +
+                  '<strong>MCP and LLMs are new, and can misbehave.</strong> ' +
+                  'MCP integrations are very new. We wrote these extensions to do only benign, read-only things, and the code is auditable — ' +
+                  'but an LLM driving them can still make mistakes or hit bugs. You accept the risk that something could go wrong with your fellows database. ' +
+                  'The good news: these extensions only touch two files, and both are recoverable. ' +
+                  'You can always re-download the shared directory, and you can restore your private data (groups, notes) from a backup or export. ' +
+                  'So the worst case is recoverable — but this still isn’t the spirit of a local-only app, and you have to accept that risk.' +
+                '</li>' +
+              '</ol>' +
+              '<p class="settings-mcpb-agreement-foot">' +
+                'When you open each extension, <strong>Claude Desktop will show its own scary, vague warning</strong> ' +
+                'that the extension “can access everything on your computer.” That message is Claude Desktop’s, not ours, ' +
+                'and it’s far broader than what actually happens. <strong>The accurate description is the one above:</strong> ' +
+                'the real tradeoff is your data crossing to a cloud LLM plus the newness of LLM-driven tools — ' +
+                'and the extensions themselves only read the two fellows files.' +
+              '</p>' +
+            '</div>' +
+            '<label class="settings-mcpb-consent-accept">' +
+              '<input type="checkbox" id="settings-mcpb-consent-checkbox" disabled>' +
+              '<span>I understand and accept these risks.</span>' +
+            '</label>' +
+            '<p id="settings-mcpb-consent-scroll-hint" class="settings-mcpb-consent-scroll-hint">' +
+              'Scroll to the end of the text above to enable the checkbox.' +
+            '</p>' +
+          '</div>' +
           '<div class="settings-mcpb-warning settings-mcpb-warning--banner">' +
             '<strong>Installing will grant this extension access to everything on your computer.</strong> ' +
-            'Nothing is wrong. The extensions only read fellows data. Click <strong>Install</strong> to proceed.' +
+            'That is Claude Desktop’s generic warning, not a description of what these extensions do — they only read fellows data. ' +
+            'Click <strong>Install</strong> to proceed.' +
           '</div>' +
           '<h5 class="settings-mcpb-section-title">What happens next</h5>' +
           '<ol class="settings-mcpb-steps">' +
@@ -8817,7 +8889,7 @@
             '<li>Test by asking Claude: <em>"How many fellows are in the directory?"</em></li>' +
           '</ol>' +
           '<menu class="settings-folder-dialog-actions">' +
-            '<button type="submit" value="continue" class="settings-folder-dialog-primary" id="settings-mcpb-preamble-continue">Continue — start downloads</button>' +
+            '<button type="submit" value="continue" class="settings-folder-dialog-primary" id="settings-mcpb-preamble-continue" disabled>Continue — start downloads</button>' +
             '<button type="submit" value="cancel" class="settings-folder-dialog-cancel">Cancel</button>' +
           '</menu>' +
           '<details class="settings-mcpb-bundle-details">' +
@@ -9232,6 +9304,16 @@
     var folderWarning = document.getElementById('settings-mcpb-preamble-folder-warning');
     var browserWarning = document.getElementById('settings-mcpb-preamble-browser-warning');
     var continueBtn = document.getElementById('settings-mcpb-preamble-continue');
+    var consentGate = document.getElementById('settings-mcpb-consent-gate');
+    var agreementEl = document.getElementById('settings-mcpb-agreement');
+    var consentCheckbox = document.getElementById('settings-mcpb-consent-checkbox');
+    var scrollHint = document.getElementById('settings-mcpb-consent-scroll-hint');
+    var consentReminder = document.getElementById('settings-mcpb-consent-reminder');
+    var consentReminderWhen = document.getElementById('settings-mcpb-consent-reminder-when');
+    var consentReminderTerms = document.getElementById('settings-mcpb-consent-reminder-terms');
+    // Tracks the mode the currently-open dialog is in so the close
+    // handler knows whether to record consent before downloading.
+    var preambleMode = 'gate';
     if (!setupBtn || !dialog) return;
 
     function setStatus(text) {
@@ -9279,8 +9361,67 @@
       // there alongside the app + directory-data version rows.
     }
 
+    // --- Consent gate (full-gate mode) helpers ----------------------
+    // The accept checkbox is locked until the agreement is scrolled to
+    // the bottom. ACCESSIBILITY FALLBACK: if the agreement region isn't
+    // actually scrollable (content fits, short viewport, zoom), treat
+    // the scroll condition as already satisfied so the checkbox is
+    // never permanently locked. Checked on render + on resize + on
+    // scroll.
+    function agreementScrolledToEnd() {
+      if (!agreementEl) return true;
+      // Not scrollable → nothing to scroll → condition satisfied.
+      if (agreementEl.scrollHeight <= agreementEl.clientHeight + 1) return true;
+      // Within a few px of the bottom counts as "read to the end" —
+      // sub-pixel rounding and momentum scrolling rarely land exactly.
+      return (agreementEl.scrollTop + agreementEl.clientHeight) >=
+        (agreementEl.scrollHeight - 4);
+    }
+
+    function syncConsentScrollState() {
+      if (preambleMode !== 'gate') return;
+      var atEnd = agreementScrolledToEnd();
+      if (consentCheckbox) consentCheckbox.disabled = !atEnd;
+      if (scrollHint) scrollHint.hidden = atEnd;
+    }
+
+    function syncContinueEnabled() {
+      if (!continueBtn) return;
+      if (preambleMode === 'reminder') {
+        continueBtn.disabled = false;
+        return;
+      }
+      // Full-gate mode: Continue requires the accept checkbox checked
+      // (which itself requires the agreement scrolled to the end).
+      continueBtn.disabled = !(consentCheckbox && consentCheckbox.checked);
+    }
+
     function openPreamble() {
       if (!dialog) return;
+      // FULL GATE vs REMINDER: a recorded `consentAt` means the user has
+      // already accepted the cloud-LLM tradeoff once; we don't re-gate
+      // them, just remind. No `consentAt` → full scroll-then-accept gate.
+      var state = getMcpbSetupState();
+      var hasConsent = !!(state && state.consentAt);
+      preambleMode = hasConsent ? 'reminder' : 'gate';
+      if (consentGate) consentGate.hidden = hasConsent;
+      if (consentReminder) consentReminder.hidden = !hasConsent;
+      if (hasConsent) {
+        if (consentReminderWhen) {
+          consentReminderWhen.textContent =
+            'You accepted this ' + formatRelativeTime(state.consentAt) + '.';
+        }
+        // Lift the full agreement copy into the "Review full terms"
+        // toggle so reminder-mode users can re-read it without losing
+        // the gate markup. Clone keeps a single source of truth.
+        if (consentReminderTerms && agreementEl) {
+          consentReminderTerms.innerHTML = agreementEl.innerHTML;
+        }
+      } else {
+        // Reset gate controls for a fresh first-time render.
+        if (consentCheckbox) consentCheckbox.checked = false;
+        if (agreementEl) agreementEl.scrollTop = 0;
+      }
       // Decide which warnings to surface BEFORE opening so first
       // render is correct. The folder check is async (worker RPC); the
       // browser check is sync.
@@ -9303,12 +9444,23 @@
           }, function () {});
         }
       } catch (e) {}
-      try { dialog.showModal(); }
+      try {
+        dialog.showModal();
+        // scrollHeight/clientHeight are only meaningful once the dialog
+        // is laid out, so sync the gate after showModal(). This applies
+        // the a11y fallback (short/unscrollable agreement → checkbox
+        // unlocked immediately) on first paint.
+        syncConsentScrollState();
+        syncContinueEnabled();
+      }
       catch (e) {
         // Fallback for browsers without <dialog> support — surface as
         // a confirm() so the user can at least proceed past the
-        // preamble. The actual download trigger still works.
-        if (window.confirm('Set up Claude Desktop integration — three .mcpb files will download. Proceed?')) {
+        // preamble. We still honor the consent record: in full-gate
+        // mode, accepting the confirm() counts as consent and is
+        // recorded before downloads start.
+        if (window.confirm('Connecting Claude Desktop sends your fellows data — potentially including private groups and notes — to a cloud LLM (Anthropic). This leaves the local-only model. Three .mcpb files will download. Proceed?')) {
+          if (preambleMode === 'gate') recordMcpbConsent();
           runMcpbDownloads();
         }
       }
@@ -9362,12 +9514,30 @@
     }
 
     setupBtn.addEventListener('click', openPreamble);
+    // Scroll within the agreement region unlocks the accept checkbox.
+    if (agreementEl) {
+      agreementEl.addEventListener('scroll', syncConsentScrollState);
+    }
+    // Re-evaluate the (non-)scrollable a11y fallback on resize/zoom —
+    // a wider viewport may make the agreement fit without scrolling.
+    window.addEventListener('resize', function () {
+      if (dialog && dialog.open) syncConsentScrollState();
+    });
+    // Checking the accept box is what enables Continue.
+    if (consentCheckbox) {
+      consentCheckbox.addEventListener('change', syncContinueEnabled);
+    }
     if (dialog) {
       dialog.addEventListener('close', function () {
         // <dialog>'s close event fires for any submit (including the
         // primary "Continue" button). returnValue carries the button's
         // value attribute — "continue" / "cancel" / empty (Esc).
         if (dialog.returnValue === 'continue') {
+          // Record consent BEFORE downloads start, and only when we
+          // showed the full gate. A user who accepts here but then
+          // cancels the browser's download prompt still won't re-see
+          // the full gate. Cancel/Esc records nothing.
+          if (preambleMode === 'gate') recordMcpbConsent();
           runMcpbDownloads();
         }
       });

--- a/app/static/index.html
+++ b/app/static/index.html
@@ -127,6 +127,25 @@
     </span>
   </div>
 
+  <!--
+    "Going rogue — not a PNA" banner — the catch-and-handle surface for an
+    active PNA exception (see PNA_EXCEPTION_CLOUD_LLM in app.js and
+    plans/pna_toolkit_exceptions_contribution.md). Shown whenever the app
+    is in non-PNA mode and the notice hasn't been dismissed. The
+    data-pna-exception attribute is the machine-readable marker a
+    conformance check / the PNT linter can catch.
+  -->
+  <div id="not-a-pna-banner" class="not-a-pna-banner hidden" role="status" aria-live="polite" data-pna-exception="EX-CLOUD-LLM">
+    <span class="not-a-pna-banner-text">
+      <strong class="not-a-pna-banner-lead">Going rogue — not a PNA.</strong>
+      <span class="not-a-pna-banner-detail">You enabled a cloud-AI exception, so this app has left local-only mode.</span>
+    </span>
+    <span class="not-a-pna-banner-actions">
+      <a href="#/exception/EX-CLOUD-LLM" class="not-a-pna-banner-link" id="not-a-pna-banner-link">What this means</a>
+      <button type="button" id="not-a-pna-dismiss" class="not-a-pna-dismiss" aria-label="Dismiss this notice">Dismiss</button>
+    </span>
+  </div>
+
   <div id="install-gate-private" class="install-landing install-gate-private hidden" aria-label="Request access">
     <div class="install-landing-inner">
       <div class="install-brand" aria-hidden="true">EHF</div>

--- a/app/static/styles.css
+++ b/app/static/styles.css
@@ -3576,6 +3576,99 @@ a.group-action-btn--primary {
   padding-left: 1.25rem;
 }
 
+/* --- Cloud-LLM informed-consent gate (issue #156) ------------------
+   One-time scroll-then-accept agreement shown before the first
+   Claude Desktop setup. The scrollable region forces the user past
+   the two risk points; the accept checkbox + Continue button stay
+   disabled until they've engaged with it. Later re-downloads show
+   the one-line reminder instead. */
+.settings-mcpb-agreement {
+  max-height: 40vh;
+  overflow-y: auto;
+  border: 1px solid #cbd5e1;
+  border-radius: 6px;
+  padding: 0.75rem 1rem;
+  margin: 0 0 0.75rem;
+  background: #fff;
+  font-size: 0.9rem;
+  line-height: 1.5;
+  color: #334155;
+}
+
+.settings-mcpb-agreement ol.settings-mcpb-agreement-points {
+  margin: 0;
+  padding-left: 1.25rem;
+}
+
+.settings-mcpb-agreement ol.settings-mcpb-agreement-points li {
+  margin-bottom: 0.85rem;
+}
+
+.settings-mcpb-agreement ol.settings-mcpb-agreement-points li:last-child {
+  margin-bottom: 0;
+}
+
+.settings-mcpb-agreement-foot {
+  margin: 0.85rem 0 0;
+  padding-top: 0.75rem;
+  border-top: 1px dashed #cbd5e1;
+  color: #475569;
+}
+
+.settings-mcpb-consent-accept {
+  display: flex;
+  align-items: flex-start;
+  gap: 0.5rem;
+  margin: 0 0 0.4rem;
+  font-size: 0.92rem;
+  font-weight: 600;
+  color: var(--text-strong, #0f172a);
+  cursor: pointer;
+}
+
+.settings-mcpb-consent-accept input[type="checkbox"] {
+  margin-top: 0.15rem;
+  flex: 0 0 auto;
+}
+
+.settings-mcpb-consent-accept input[type="checkbox"]:disabled {
+  cursor: not-allowed;
+}
+
+.settings-mcpb-consent-scroll-hint {
+  margin: 0 0 1rem;
+  font-size: 0.82rem;
+  color: #64748b;
+}
+
+.settings-mcpb-consent-reminder {
+  margin: 0 0 1rem;
+  padding: 0.6rem 0.85rem;
+  border: 1px solid #d8d2e8;
+  border-radius: 6px;
+  background: #faf9fc;
+}
+
+.settings-mcpb-consent-reminder-line {
+  margin: 0 0 0.4rem;
+  font-size: 0.9rem;
+  line-height: 1.45;
+  color: #334155;
+}
+
+.settings-mcpb-consent-reminder .settings-mcpb-bundle-details {
+  margin-top: 0;
+}
+
+/* Disabled Continue button — make the locked state visually obvious
+   so it doesn't read as a dead button. */
+.settings-folder-dialog-primary:disabled,
+.settings-folder-dialog-primary:disabled:hover {
+  opacity: 0.5;
+  cursor: not-allowed;
+  filter: none;
+}
+
 .settings-restore-migrate-hint {
   font-size: 0.85rem;
   margin-top: 0.5rem;

--- a/app/static/styles.css
+++ b/app/static/styles.css
@@ -1580,6 +1580,112 @@ h1 {
   background: #8a1c1c;
 }
 
+/* "Going rogue — not a PNA" banner — the catch-and-handle surface for an
+   active PNA exception (EX-CLOUD-LLM). Loud red palette by design: leaving
+   PNA mode should feel conspicuous, not routine. Dismissable, but dismissal
+   only hides the banner; it does not clear the exception. */
+.not-a-pna-banner {
+  margin: 0 0 0.75rem;
+  padding: 0.5rem 0.75rem;
+  font-size: 0.9rem;
+  background: #fdecea;
+  color: #8a1c1c;
+  border: 1px solid #e0a3a3;
+  border-left: 4px solid #8a1c1c;
+  border-radius: 6px;
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+  gap: 0.75rem;
+  flex-wrap: wrap;
+}
+
+.not-a-pna-banner.hidden { display: none; }
+
+.not-a-pna-banner-text { flex: 1 1 280px; min-width: 0; }
+.not-a-pna-banner-lead { font-weight: 700; margin-right: 0.35rem; }
+.not-a-pna-banner-detail { font-weight: 400; }
+
+.not-a-pna-banner-actions {
+  display: flex;
+  gap: 0.5rem;
+  flex-wrap: wrap;
+  align-items: center;
+}
+
+.not-a-pna-banner-link {
+  color: #8a1c1c;
+  font-weight: 600;
+  text-decoration: underline;
+  white-space: nowrap;
+}
+
+.not-a-pna-dismiss {
+  padding: 0.35rem 0.75rem;
+  font-size: 0.85rem;
+  border-radius: 4px;
+  border: 1px solid #c27a7a;
+  background: transparent;
+  color: #8a1c1c;
+  cursor: pointer;
+}
+
+/* In-app exception explainer pages (#/exception/<id>, #/exceptions). */
+.exception-page {
+  max-width: 640px;
+  margin: 0 auto;
+  padding: 1rem 0.5rem 2rem;
+  line-height: 1.5;
+}
+
+.exception-title { margin: 0 0 0.75rem; }
+.exception-page h3 { margin: 1.25rem 0 0.35rem; font-size: 1rem; }
+
+.exception-status {
+  padding: 0.6rem 0.85rem;
+  border-radius: 6px;
+  margin: 0 0 0.5rem;
+}
+
+.exception-status--warn {
+  background: #fdecea;
+  color: #8a1c1c;
+  border: 1px solid #e0a3a3;
+}
+
+.exception-status--ok {
+  background: #e8f5e9;
+  color: #1b5e20;
+  border: 1px solid #a5d6a7;
+}
+
+.exception-actions { margin: 1rem 0; }
+
+.exception-return-pna {
+  padding: 0.5rem 1rem;
+  font-size: 0.9rem;
+  border-radius: 4px;
+  border: 1px solid #1b5e20;
+  background: #1b5e20;
+  color: #fff;
+  cursor: pointer;
+}
+
+.exception-canonical,
+.exception-back { font-size: 0.85rem; color: #555; margin-top: 1rem; }
+
+/* Settings → non-PNA-mode status + reversibility control. */
+.settings-mcpb-pna-mode {
+  margin: 0.5rem 0;
+  padding: 0.6rem 0.85rem;
+  background: #fdecea;
+  border: 1px solid #e0a3a3;
+  border-radius: 6px;
+}
+
+.settings-mcpb-pna-mode[hidden] { display: none; }
+.settings-mcpb-pna-mode-line { margin: 0 0 0.5rem; color: #8a1c1c; }
+
 .about-support {
   margin-top: 1rem;
   font-size: 0.95rem;

--- a/docs/Architecture.md
+++ b/docs/Architecture.md
@@ -337,6 +337,7 @@ Architecture-adjacent docs that specialize one part of the spec or operator surf
 | [`./persistence_and_upgrades.md`](./persistence_and_upgrades.md) | Storage slot — state-survival matrix across Clear App Cache / Reset Everything / app update; auto-backup; restore. |
 | [`./browser_support.md`](./browser_support.md) | Storage slot — capability detection inside the worker, required versions, unsupported-browser surfacing (AC-12). |
 | [`./data_provenance.md`](./data_provenance.md) | Ingestion slot — column-by-column source mapping; backup/restore workflow; recovery paths. |
+| [`./architectural_findings.md`](./architectural_findings.md) | Findings that feed back into the spec — e.g. the cloud-LLM "exception" / non-PNA-mode concept (`EX-CLOUD-LLM`). |
 
 ---
 

--- a/docs/ac_decisions_log.md
+++ b/docs/ac_decisions_log.md
@@ -18,6 +18,41 @@ link to the newer entry. Newest first.
 
 ---
 
+## 2026-05-30 — Cloud-LLM integration is allowed but treated as a named, reversible "exception" that exits PNA mode, not forbidden and not silent
+
+**Why this is worth recording.** The PNA definition is "local-only,
+never as SaaS," and AC-MCP-A wants cloud-AI access to private data gated.
+A future contributor seeing the Claude Desktop integration ship will
+reasonably ask: *"doesn't wiring a cloud LLM to the directory just
+violate the whole premise?"* It does — deliberately. Our ~500-fellow
+user base wants Claude Desktop on the hosted model, and local AI isn't
+realistic for them (see [`architectural_findings.md`](architectural_findings.md)).
+Rather than forbid the feature or allow it silently, we model the
+violation as a first-class **exception** (`EX-CLOUD-LLM`): accepting the
+consent gate **raises** it and takes the app out of *PNA mode*; the
+handler is the persistent "Going rogue — not a PNA" banner, the in-app
+`#/exception/<id>` explainer, and a **reversible** "Return to PNA mode"
+control.
+
+**The constraint that shaped the code.** Conformance is reframed from
+"never deviates" to "catches and handles every deviation honestly." So
+the code does *not* hide the state: it stamps `data-pna-mode` /
+`data-pna-exceptions` on `<body>` (a greppable marker a conformance check
+can catch), surfaces the banner unmissably, and makes the exit path real.
+Reversibility is **mode-only** — returning to PNA mode stops future
+sharing but does not recall data already sent; the UI says so rather than
+implying an undo. Without the exception framing, the natural default
+would have been a buried README caveat (the prior state — see
+`mcp_servers/README.md`) and an app that quietly stopped being a PNA.
+
+**Upstream.** This is staged as a Personal Network Toolkit contribution
+(a new `spec/exceptions.md`, a `lint-spec-ids.py` extension for `EX-*` /
+`Relaxes:` / `Reversible:`, and the validation-not-certification framing)
+in [`../plans/pna_toolkit_exceptions_contribution.md`](../plans/pna_toolkit_exceptions_contribution.md);
+fellows_local_db is the demonstrating reference design. Not yet filed.
+
+---
+
 ## 2026-05-22 — MCP easy install is Chromium-desktop-first; Safari / Firefox get a documented secondary path; cross-browser-on-one-device data silos are accepted, not engineered around
 
 **Why this is worth recording.** A future contributor reading

--- a/docs/architectural_findings.md
+++ b/docs/architectural_findings.md
@@ -1,0 +1,101 @@
+# Architectural Findings
+
+Discoveries about *this application* that reshaped how we think about the
+PNA architecture it conforms to. Where [`ac_decisions_log.md`](ac_decisions_log.md)
+records individual decisions made *under* the architecture, this file
+records the rarer moments where building and operating the app taught us
+something the architecture itself didn't yet account for — findings worth
+feeding back into the [PNA Spec / Personal Network Toolkit](https://github.com/richbodo/personal_network_toolkit).
+
+Newest first.
+
+---
+
+## 2026-05-30 — Users want a cloud LLM; "exceptions" let a PNA stay honest instead of forbidding it
+
+### The finding
+
+The PNA architecture's core promise is in its own definition: a personal
+network application *"runs local-only, never as SaaS."* Goal 1 is
+private-data sovereignty. Taken literally, that forbids wiring the
+directory to a cloud LLM — connecting Claude Desktop (a cloud-hosted
+model) to the MCP servers sends fellows data, and potentially a user's
+private groups and notes, to a SaaS vendor.
+
+But when we shipped the MCP servers and watched our ~500-fellow user base
+actually use them, **every test user wanted Claude Desktop**, on the
+hosted model. Local AI — a locally-served model behind Ollama or similar
+— is the architecturally "green" path, but it is well beyond the hardware
+and the patience of essentially all of these users. There is, today, no
+realistic local option for them. Cloud LLM integration is simultaneously
+**the thing everyone wants** and **a direct violation of the app's
+defining constraint**.
+
+That is the finding: for a real PNA with real users, the local-only
+guarantee will be deliberately broken, by users, on purpose, because the
+SaaS option is the only usable one. A spec that only says "don't" leaves
+the app with three bad choices — forbid the feature users need, allow it
+silently (dishonest), or quietly stop being a PNA.
+
+### The resolution: exceptions
+
+We model the violation as a first-class, named **exception** — borrowing
+the software-exception metaphor. An exception (`EX-*`) is a stable-ID'd
+condition under which the app deliberately departs from a baseline
+guarantee. Like a software exception it is **raised** (by a specific
+user action), must be **caught** (never silent), and is **handled** by a
+defined solution. Raising one **exits PNA mode**; the app is "in PNA
+mode" when no exceptions are active.
+
+The first (and so far only) exception is **`EX-CLOUD-LLM`**: raised when
+the user consents to wiring the directory to a cloud LLM. Its handler, as
+implemented here, is:
+
+- A pre-raise **informed-consent gate** (scroll-then-accept) that names
+  the exception and links to its explanation.
+- A persistent, dismissable **"Going rogue — not a PNA" banner** while
+  the exception is active — onerous enough that nobody wants it
+  permanently, which is itself a gentle disincentive against casual SaaS
+  coupling. Dismissal *acknowledges*; it does not resolve.
+- An in-app **explainer** (`#/exception/EX-CLOUD-LLM`) describing the
+  currently-active exception set — in-app rather than on GitHub because
+  exception *combinations* are installation-specific and can't be
+  enumerated statically.
+- A **reversible** path back to PNA mode (Settings + the explainer).
+  Reversibility is **mode-only**: returning to PNA mode stops future
+  sharing but does not recall data already sent to the provider. We say
+  so explicitly rather than implying an "undo."
+
+The key reframing: **conformance stops being "never deviates" and becomes
+"catches and handles every deviation honestly."** An app stays a
+conformant PNA — even while *not in PNA mode* — if and only if every
+active exception is handled to contract. A user can take the app out of
+PNA mode and put it back; the architecture's job is to make sure they
+always *know which mode they're in*.
+
+### A second-order finding: validation, not certification
+
+Working this through surfaced something the toolkit under-states today:
+**PNT validates behaviors against Goals; it does not certify.** There is
+no pass/fail badge. The right posture for reversibility, for instance, is
+not "every exception MUST be reversible" but "an exception *declares*
+whether it is reversible, and the validation system *detects and verifies*
+that claim against the code/UX." The exceptions work is the natural place
+to make the validation-not-certification framing explicit.
+
+### What this feeds back into the toolkit
+
+The plan to contribute this upstream — a new `spec/exceptions.md` (the
+normative handler contract + the `EX-CLOUD-LLM` registry entry), a
+`lint-spec-ids.py` extension that traces `EX-*` / `Relaxes:` /
+`Reversible:` the way it already traces `AC-*` / `Realizes:`, the
+validation-not-certification framing, and fellows_local_db as the
+demonstrating reference design — lives in
+[`../plans/pna_toolkit_exceptions_contribution.md`](../plans/pna_toolkit_exceptions_contribution.md).
+Per the toolkit's reference-driven model, the spec change rides along
+with the working design that demonstrates it; this app is that design.
+
+The in-app realization (the banner, the explainer route, the
+reversibility control, the `EX-CLOUD-LLM` marker) is documented for
+users in [`users_manual.md`](users_manual.md) and recorded as a decision
+in [`ac_decisions_log.md`](ac_decisions_log.md).

--- a/docs/use_with_claude_desktop.md
+++ b/docs/use_with_claude_desktop.md
@@ -75,9 +75,41 @@ the warning banner Claude Desktop will show during install (see
 *[About that red warning banner](#about-that-red-warning-banner)*
 below).
 
-### Step 2 — Read the preamble dialog, click Continue
+### Step 2 — Accept the cloud-AI consent agreement, then Continue
 
-The dialog explains that you will install three extensions to claude code - you probably want all three.
+**The first time only**, the dialog shows a short agreement you have to
+read and accept. This exists because the rest of the Fellows app is
+**local-only** — it never talks to a server — and connecting Claude
+Desktop deliberately breaks that:
+
+- **You're leaving the local-only model.** Claude Desktop is a cloud
+  product. Connecting it sends your fellows data — potentially including
+  your private groups and notes — to a SaaS vendor (Anthropic). No one
+  can guarantee what a SaaS vendor will or won't do with data you send
+  it. You have to be OK with that to continue.
+- **MCP and LLMs are new, and can misbehave.** The extensions are
+  written to do only benign, read-only things and the code is auditable,
+  but an LLM driving them can still make mistakes. The good news: they
+  only touch two files, both recoverable — you can re-download the shared
+  directory and restore your private data (groups, notes) from a backup
+  or export, so the worst case is recoverable.
+
+To proceed: scroll the agreement to the end, tick **I understand and
+accept these risks**, then click **Continue — start downloads**. Until
+you've scrolled and ticked the box, Continue stays greyed out. (If the
+text already fits on your screen without scrolling, the checkbox is
+enabled right away.)
+
+The app records your consent **once**. The next time you click
+**Re-download all extensions**, you won't see the full agreement again —
+just a one-line reminder with a **Review full terms** link, and Continue
+works immediately.
+
+This consent agreement is *not* the same as Claude Desktop's own install
+warning (the red "can access everything on your computer" banner). That
+one is Claude Desktop's, and it's far broader than what actually happens
+— see *[About that red warning banner](#about-that-red-warning-banner)*.
+The agreement above is the accurate description of the real tradeoff.
 
 When you click **Continue**, three files download
 into your Downloads folder - you need to find these files:

--- a/docs/use_with_claude_desktop.md
+++ b/docs/use_with_claude_desktop.md
@@ -105,6 +105,13 @@ The app records your consent **once**. The next time you click
 just a one-line reminder with a **Review full terms** link, and Continue
 works immediately.
 
+The agreement also names what you're turning on: the **EX-CLOUD-LLM
+exception**, a named exception to the app's local-only promise. The
+agreement links to an in-app explainer page (route
+`#/exception/EX-CLOUD-LLM`) that describes exactly what the exception
+relaxes, what data is affected, and how to reverse it. You don't need to
+read it to continue, but it's there if you want the full picture.
+
 This consent agreement is *not* the same as Claude Desktop's own install
 warning (the red "can access everything on your computer" banner). That
 one is Claude Desktop's, and it's far broader than what actually happens
@@ -117,6 +124,28 @@ into your Downloads folder - you need to find these files:
 - `shared_data_ops.mcpb`
 - `private_data_ops.mcpb`
 - `comms.mcpb`
+
+#### After you accept: the "Going rogue — not a PNA" banner
+
+The moment you accept the agreement, the app leaves **PNA mode** (its
+normal local-only state) by raising the **EX-CLOUD-LLM exception**. From
+then on a persistent **red banner** sits at the top of the app:
+
+> **Going rogue — not a PNA.**
+
+That's expected, not an error — it's how the app reminds you it's now
+wired to a cloud AI. The banner's **What this means** link opens the
+explainer page (route `#/exception/EX-CLOUD-LLM`). You can **Dismiss** the
+banner to hide it; dismissing is just an acknowledgement, so it stays
+gone across reloads but does *not* disconnect Claude Desktop.
+
+**This is reversible.** While the exception is active, a **Return to PNA
+mode** control appears both on the explainer page and in **Settings →
+Claude Desktop integration**. Clicking it removes the banner, puts the app
+back in local-only mode, and re-arms the consent agreement (so re-enabling
+the integration asks for consent again). The one caveat: returning to PNA
+mode stops future sharing but **cannot recall data already sent** to
+Anthropic.
 
 ### Step 3 — Open each .mcpb, approve in Claude Desktop, restart
 

--- a/docs/users_manual.md
+++ b/docs/users_manual.md
@@ -698,6 +698,50 @@ and it's far broader than what actually happens — the extensions only
 read the two fellows files. The accurate description of the real tradeoff
 is the agreement above.
 
+### PNA mode and the "not a PNA" banner
+
+Most of the time the Fellows app runs in **PNA mode**. PNA stands for
+*personal-network app*: the app lives entirely on your device and never
+talks to a SaaS server. That's the normal, safe state.
+
+Accepting the consent agreement and connecting Claude Desktop is a
+deliberate choice to **leave PNA mode**. Internally the app calls this
+the **EX-CLOUD-LLM exception** — a named exception to the local-only
+promise. While it's active, a persistent **red banner** sits at the top
+of the app:
+
+> **Going rogue — not a PNA.**
+
+The banner is how the app tells you which mode you're in, so you're never
+in cloud-AI mode without knowing it. It has two controls:
+
+- **What this means** opens an in-app explainer page (route
+  `#/exception/EX-CLOUD-LLM`; there's also an index at `#/exceptions`).
+  The explainer spells out what the exception relaxes — the
+  local-only / never-SaaS promise — what data is affected (the shared
+  directory, plus your private groups and notes if the private extension
+  is installed), and confirms that it's reversible.
+- **Dismiss** hides the banner. Dismissing is an **acknowledgement, not a
+  fix**: it does *not* return the app to PNA mode, and the dismissal
+  persists across reloads. You're still connected to the cloud AI — you've
+  just told the app you've seen the notice.
+
+### Returning to PNA mode
+
+Leaving PNA mode is reversible. You'll find a **Return to PNA mode**
+control in two places, shown only while the exception is active:
+
+- On the **What this means** explainer page, and
+- In **Settings → Claude Desktop integration**.
+
+Clicking it returns the app to PNA mode, removes the red banner, and
+**re-arms the consent gate** — so the next time you connect Claude
+Desktop, the app asks you to read and accept the agreement again.
+
+One honest caveat: returning to PNA mode stops *future* sharing, but it
+**cannot recall data already sent** to the cloud provider. It changes
+what happens from here on, not what's already left your device.
+
 ---
 
 ## Updates

--- a/docs/users_manual.md
+++ b/docs/users_manual.md
@@ -664,6 +664,40 @@ See [Use with Claude Desktop](use_with_claude_desktop.md) for the
 step-by-step setup walkthrough. Optional — the Fellows app itself
 doesn't need any of this.
 
+### One-time consent before you connect a cloud AI
+
+The first time you set this up, the app shows a short agreement you have
+to read and accept. This is deliberate. The rest of the Fellows app is
+**local-only** — it never sends your data to anyone's server. Connecting
+Claude Desktop changes that:
+
+- **You're leaving the local-only model.** Claude Desktop is a cloud
+  product. When it answers questions about your fellows, your data —
+  potentially including your private groups and notes — is sent to a SaaS
+  vendor (Anthropic). No one can guarantee what a SaaS vendor will or
+  won't do with data you send it. You have to be OK with that to
+  continue.
+- **MCP and LLMs are new, and can misbehave.** The extensions are written
+  to do only benign, read-only things, and the code is auditable — but an
+  LLM driving them can still make mistakes or hit bugs. The good news:
+  the extensions only touch two files, and both are recoverable. You can
+  re-download the shared directory at any time, and you can restore your
+  private data (groups, notes) from a backup or export. So the worst case
+  is recoverable.
+
+To proceed you scroll the agreement to the end, tick **I understand and
+accept these risks**, then click **Continue — start downloads**. The app
+records your consent once. On later **Re-download all extensions**, it
+shows only a one-line reminder (with a *Review full terms* link) and lets
+you continue right away.
+
+Separately, when you open each downloaded extension, **Claude Desktop
+shows its own scary, vague warning** that the extension "can access
+everything on your computer." That message is Claude Desktop's, not ours,
+and it's far broader than what actually happens — the extensions only
+read the two fellows files. The accurate description of the real tradeoff
+is the agreement above.
+
 ---
 
 ## Updates

--- a/plans/pna_toolkit_exceptions_contribution.md
+++ b/plans/pna_toolkit_exceptions_contribution.md
@@ -1,0 +1,586 @@
+# Plan — Contributing the **Exceptions** concept to the Personal Network Toolkit (PNT)
+
+> **Status: PLAN ONLY.** This document stages a future contribution to the
+> [`personal_network_toolkit`](https://github.com/richbodo/personal_network_toolkit) (PNT) repo.
+> It is **not** the contribution itself, and nothing here has been executed. No issues or PRs are
+> to be filed into PNT until the maintainer explicitly says so. This file lives in the
+> `fellows_local_db` repo (`plans/`) as a design record the maintainer reviews first.
+>
+> Local paths referenced below:
+> - PNT repo: `/Users/richbodo/src/personal_network_toolkit`
+> - Demonstrating design (this repo): `/Users/richbodo/src/fellows_local_db-mcp-consent`
+
+---
+
+## 1. Summary + motivation
+
+### The discovery
+
+`fellows_local_db` ships three MCP servers (`mcp_servers/shared_data_ops.py`,
+`mcp_servers/private_data_ops.py`, `mcp_servers/comms.py`) so an AI client can drive the directory
+and a user's saved relationships. The flagship UX is a Claude Desktop user asking the model to
+find a group, look up emails, and stage a `mailto:` — exactly the cooperation pattern the PNA Spec's
+§ Vision describes.
+
+The honest operational reality, captured today in `mcp_servers/README.md` § *Cloud LLM caveat*:
+
+> "For v1, none of the three servers detects or gates cloud clients. … Today's position is:
+> **document the boundary, trust the user's choice**. Wire the servers up to a local model … for
+> the green-path posture."
+
+A roughly **500-user base** (EHF fellows) wants the cloud-LLM integration. For almost all of them,
+running a capable local model (the AC-MCP-A "green path") is impractical — wrong hardware, no
+appetite to operate Ollama, and the hosted Claude Desktop model is simply what they already have.
+So the realistic choice is binary and uncomfortable:
+
+1. **Forbid it** — refuse cloud MCP clients on the Private Data Ops server. Conforms to AC-MCP-A,
+   but denies the feature the users actually asked for, and pushes them toward worse, un-audited
+   tools.
+2. **Allow it silently** — what v1 does today: the data crosses the network to the provider and the
+   only safeguard is a caveat buried in a README. This is dishonest about the app's posture at the
+   moment a user is actually pointing a cloud model at their Private DB.
+
+Neither is satisfying, and the tension is **structural**, not a fellows-specific wart. The PNA
+definition is *"runs local-only, never as SaaS"* (`spec/PNA_Spec.md` § Vocabulary, `vocab-pna`),
+and AC-MCP-A makes cloud Private-DB access opt-in. But there is no first-class way for a PNA to say
+*"the user knowingly turned this guarantee off, here is how we caught it and how we handle it."*
+The spec models conformance as **never deviating**; real deployments need a way to **deviate
+honestly**.
+
+### The resolution
+
+Introduce a new first-class PNT concept — **Exceptions** — modeled on software exceptions. An
+Exception is a stable-ID'd (`EX-*`) condition under which a PNA *deliberately departs* from a
+baseline guarantee (a named AC, or the core PNA definition). Like a software exception, it is
+**raised** by a specific user action, must be **caught** (never silent), and must be **handled** by
+a defined **solution**. Raising any exception **exits PNA mode**.
+
+The cloud-LLM tension then resolves into a third option:
+
+3. **Allow it as a caught, handled Exception** — `EX-CLOUD-LLM`. Consent gate before raising,
+   persistent "not a PNA right now" signal while active, in-app explainer of the active exception
+   set, and a declared return-to-PNA-mode path. The app is honest, conformant *in non-PNA mode*,
+   and the user gets the feature they asked for with eyes open.
+
+This is the same ship-and-iterate bias the project already runs on: rather than block the feature
+until local models are practical for 500 people, ship the honest non-PNA mode and refine the
+handler from real use.
+
+### Why this belongs upstream, not just in fellows
+
+Per `pna-build-eval-contrib/SKILL.md` § Contribute → Preflight, three patterns justify a submission.
+This is the most valuable one: a **new architectural concept the spec doesn't yet name**, with a
+demonstrating reference design (`fellows_local_db`). The spec change rides along with working code,
+exactly as `CONTRIBUTING.md` requires ("Spec changes without a demonstrating design are not
+accepted").
+
+---
+
+## 2. The Exceptions concept
+
+### Software-exception metaphor
+
+| Software exception | PNA Exception |
+|---|---|
+| A condition that interrupts normal control flow | A condition under which a PNA departs from a baseline guarantee |
+| `raise` / `throw` | **Raised** by a specific user action (e.g. connecting a cloud MCP client) |
+| Uncaught exception crashes / leaks | A *silent* deviation is the failure mode — exceptions MUST be **caught** |
+| `try/except` handler | A defined **solution** (consent gate + signal + explainer + reversal path) |
+| Stack trace identifies the exception | Every exception has a stable `EX-*` ID and a canonical definition |
+
+### Raise / catch / handle
+
+- **Raise** — a specific, named user action turns the exception on. There is no implicit or
+  background raise. For `EX-CLOUD-LLM`, the raise event is "user connects a cloud-hosted MCP client
+  to a Private-DB-returning server."
+- **Catch** — the app detects the raise and surfaces it. A deviation the app fails to catch is a
+  conformance failure regardless of intent. "Caught" means consent was obtained *before* the raise
+  and a persistent signal is shown *while active*.
+- **Handle** — the app runs the exception's **solution**: the consent surface, the persistent
+  signal, the active-exception explainer, and the declared reversibility path.
+
+### PNA mode vs non-PNA mode
+
+> **An app is in PNA mode when no exceptions are active.** Raising any exception exits PNA mode.
+
+A PNA stays **spec-conformant in non-PNA mode iff every active exception is handled to contract**
+(the normative handler contract in § 3a). This reframes conformance:
+
+- **Old framing:** conformant = *never deviates from any AC or the PNA definition.*
+- **New framing:** conformant = *in PNA mode, honors every applicable AC; in non-PNA mode, catches
+  and handles every active deviation honestly.*
+
+This makes the spec describe reality. A tool that lets a user point a hosted model at their Private
+DB is not "non-conformant garbage" and is not "secretly fine" — it is **a conformant PNA operating
+in a declared non-PNA mode**, and the validation surface can say exactly that, by `EX-*` ID.
+
+### Validation, not certification (the framing the maintainer wants surfaced)
+
+PNT already states this in scattered places — `CONTRIBUTING.md` § "Acceptance is not certification"
+and `SKILL.md` § Principles ("Conformance is checked, not awarded"). The Exceptions concept makes it
+load-bearing and the maintainer wants it **promoted to a first-class framing statement**:
+
+> **PNT validates behaviors against Goals; it does not certify.** There is no pass/fail badge and no
+> certifying body. The evaluate flow *detects* exceptions and *verifies how they are handled*,
+> reporting by `EX-*` ID. "This app raises `EX-CLOUD-LLM` and handles it to contract" is a finding,
+> not a grade.
+
+Exceptions are what make this framing actionable: the evaluate flow now has concrete, ID'd things to
+detect and verify the *handling* of, rather than a binary conform/not-conform verdict.
+
+### Terminology note (settled, recorded for the PR)
+
+The concept was considered under the names *extensions*, *deviations*, and *exceptions*. The
+maintainer chose **Exceptions** — the software metaphor (raise/catch/handle) carries the contract
+intuition for free, and "extension" is already taken (`vocab-plugin` defines "Plugin / extension").
+See § 5 for the residual terminology questions.
+
+---
+
+## 3. Proposed PNT artifacts
+
+Each sub-plan below is concrete enough to be mechanical to execute, with DRAFT text where it helps.
+None of it is to be applied to PNT yet.
+
+### 3a. NEW file: `spec/exceptions.md`
+
+A new spec file (sibling to `spec/axes.md` and `spec/use_cases.md`). It carries three things: the
+normative handler contract, the header conventions (`Relaxes:` / `Reversible:`), and the exception
+registry (first entry `EX-CLOUD-LLM`).
+
+#### DRAFT — front matter + concept
+
+```markdown
+# PNA Exceptions
+
+> **Spec-Version:** tracks the PNA Spec version in spec/PNA_Spec.md.
+>
+> This file defines **Exceptions**: stable-ID'd conditions (`EX-*`) under which a PNA deliberately
+> departs from a baseline guarantee — a named AC, or the core PNA definition ("runs local-only,
+> never as SaaS"; see PNA_Spec.md § Vocabulary, `vocab-pna`).
+
+## Concept
+
+An Exception is modeled on a software exception. It is **raised** by a specific user action, must
+be **caught** (never raised silently), and must be **handled** by a defined **solution**.
+
+**An app is in PNA mode when no exceptions are active.** Raising any exception exits PNA mode. A PNA
+is spec-conformant in non-PNA mode **iff** every active exception is handled to the contract below.
+
+PNT validates behaviors against the Goals; it does not certify. The evaluate flow detects
+exceptions and verifies how each is handled, reporting by `EX-*` ID.
+```
+
+#### DRAFT — normative handler contract (RFC 2119; refined from the maintainer's brief)
+
+```markdown
+## Handler contract
+
+Normative language uses RFC 2119 / RFC 8174 keywords (MUST, MUST NOT, SHOULD, MAY) only when
+capitalized, consistent with PNA_Spec.md § Universal architectural commitments.
+
+For each exception it can raise, a conforming PNA:
+
+- **EX-H1 — Stable identity.** MUST define and reference the exception by its stable `EX-*` ID.
+- **EX-H2 — Consent before raise.** MUST obtain explicit informed consent BEFORE raising the
+  exception (no silent raise). The consent surface MUST link to an explanation of that specific
+  exception.
+- **EX-H3 — Persistent non-PNA-mode signal.** While the exception is active, MUST present a
+  persistent user-facing signal that the app is not in PNA mode. The signal MUST name the active
+  exception and MUST link to an explanation of the active exception set. The signal MAY be
+  dismissable, but dismissal MUST NOT clear the exception (dismissal acknowledges; it does not
+  resolve).
+- **EX-H4 — Active-set explainer.** MUST provide a user-reachable explanation of the
+  CURRENTLY-ACTIVE exception set. Because active combinations are installation-specific and cannot
+  be enumerated in a static doc, this explainer MUST be generated at runtime from the active set and
+  MUST link out to each active exception's canonical definition in this file.
+- **EX-H5 — Declared reversibility.** MUST declare whether returning to PNA mode is supported
+  (reversible) or not (irreversible). If it declares reversible, it MUST provide a practical,
+  user-reachable path back to PNA mode that the validation flow can confirm from code/UX.
+  Reversibility refers to **MODE ONLY**: a handler MUST NOT imply that returning to PNA mode undoes
+  consequences already incurred (e.g. data already disclosed to a third party).
+- **EX-H6 — Recommended solution.** SHOULD name a recommended solution in its registry entry,
+  demonstrated by a reference design.
+```
+
+> **Sub-contract IDs.** `EX-H1..EX-H6` follow PNT's existing sub-contract convention
+> (`<prefix>-<integer>`, monotonic, never renumbered — see `PNA_Spec.md` § Sub-contracts per slot).
+> Using `EX-H*` keeps them distinct from the `EX-*` exception-registry IDs while staying in the
+> same family namespace. **Open question for the maintainer (§ 5): are sub-contract IDs wanted here,
+> or should the handler clauses stay prose-only?** They make the evaluate flow citable
+> ("`EX-CLOUD-LLM` fails EX-H3 — no persistent signal") so the plan recommends keeping them.
+
+#### DRAFT — header conventions (the inverse of `Realizes:`)
+
+```markdown
+## Header conventions
+
+These mirror the existing `Realizes: AC-...` header that contract files in `contracts/` carry
+(see tools/lint-spec-ids.py). They appear in an exception's registry entry and in any reference
+design's handler declaration.
+
+- **`Relaxes:`** — names the baseline guarantee(s) the exception departs from. The inverse of
+  `Realizes:`. Each token is either an `AC-*` ID or the literal `PNA-DEFINITION` (for departures
+  from "local-only, never SaaS"). Multiple tokens are comma-separated.
+  Example: `Relaxes: PNA-DEFINITION, AC-MCP-A`
+- **`Reversible:`** — declares whether returning to PNA mode is supported. Value is `yes` or `no`.
+  If `yes`, a `Reversal:` field MUST follow naming the mechanism (a route, a control, or a code
+  reference the validation flow can confirm). See EX-H5.
+  Example: `Reversible: yes` / `Reversal: in-app "Return to PNA mode" control disconnects the
+  cloud MCP client; see <design>'s Architecture.md.`
+- **`Stresses:`** *(optional, non-normative)* — names a Goal the exception puts under pressure
+  without strictly relaxing a single AC. Example: `Stresses: Goal 1`.
+```
+
+> **`PNA-DEFINITION` as a relaxable token.** The PNA definition lives in prose (`vocab-pna`), not in
+> the `| AC-X |` table, so it has no AC ID. The plan introduces the literal sentinel `PNA-DEFINITION`
+> so `Relaxes:` can reference it and the lint can resolve it (see § 3c). **Open question (§ 5):
+> alternatively, mint an `AC-0`/`AC-PNA` for the definition so the existing `AC_RE` machinery covers
+> it with no special case.**
+
+#### DRAFT — exception registry (first entry)
+
+```markdown
+## Exception registry
+
+| EX | Name | Relaxes | Stresses | Reversible | Recommended solution |
+|---|---|---|---|---|---|
+| EX-CLOUD-LLM | Cloud-hosted AI over PNA data | PNA-DEFINITION, AC-MCP-A | Goal 1 | yes (mode only) | pre-raise consent gate + persistent dismissable "not a PNA" banner + in-app active-exception explainer + return-to-PNA-mode — demonstrated by fellows_local_db |
+
+### EX-CLOUD-LLM — Cloud-hosted AI over PNA data
+
+**Relaxes:** PNA-DEFINITION, AC-MCP-A
+**Stresses:** Goal 1
+**Reversible:** yes
+**Reversal:** mode only — the user can disconnect the cloud MCP client and return to PNA mode.
+Returning to PNA mode does NOT undo any disclosure already made to the cloud provider (EX-H5).
+
+**Raised when:** the user connects a cloud-hosted MCP client (e.g. Claude Desktop on a hosted
+model, ChatGPT desktop) to a PNA's MCP servers that can return Private DB rows. The canonical
+trigger is the Private Data Ops server (see PNA_Spec.md § Vocabulary, MCP server).
+
+**Recommended solution:** pre-raise consent gate (EX-H2) + persistent dismissable "not a PNA right
+now" banner naming EX-CLOUD-LLM (EX-H3) + in-app active-exception explainer (EX-H4) +
+return-to-PNA-mode control (EX-H5). Demonstrated by `fellows_local_db`
+(reference_designs/fellows_local_db/).
+```
+
+> **Table format and the lint.** Each registry row begins `| EX-... |`, mirroring the `| AC-X |`
+> rows the lint already scans. § 3c adds an `EX_RE` that mirrors `AC_RE` exactly.
+
+#### Note on what `EX-CLOUD-LLM` does and does not relax
+
+It relaxes the *delivery* guarantee (data leaves the device to a cloud model) and AC-MCP-A's
+per-call-consent posture. It does **not** relax AC-MCP-B (the workspace still launches transports),
+AC-1, or any other AC. Keeping the `Relaxes:` set tight is part of honest handling — an exception
+should name the *minimum* set of guarantees it actually departs from.
+
+### 3b. ONE-LINE pointer from `spec/PNA_Spec.md`
+
+The lightest possible touch that keeps the AC-ID lint green. The lint (`tools/lint-spec-ids.py`)
+only reads `spec/PNA_Spec.md` and `spec/axes.md` for AC IDs and does not parse free text, so a prose
+pointer is safe — it adds no `| AC-X |` rows and changes no existing ones.
+
+**Proposed insertion** — one bullet at the end of `PNA_Spec.md` § Scope and versioning's deferred
+list is the *wrong* place (it's not deferred — it's a new sibling concept). Two viable spots:
+
+- **Preferred:** a one-line pointer in the § Vocabulary entry for the PNA definition (`vocab-pna`),
+  since exceptions are precisely departures from that definition. DRAFT:
+
+  ```markdown
+  > A PNA may deliberately and temporarily depart from this definition or from a named AC by
+  > **raising an Exception** — see [`exceptions.md`](exceptions.md). Raising any exception exits
+  > "PNA mode"; the PNA stays conformant only while every active exception is handled to the
+  > exceptions.md handler contract.
+  ```
+
+- **Alternative:** a one-line entry in § Axes / a new short § "Exceptions" heading with a single
+  sentence + link. Heavier; only do this if the maintainer wants exceptions visible in the spec's
+  table of contents rather than tucked into vocabulary.
+
+**Lint-safety check (do this when executing):** after editing, run
+`python tools/lint-spec-ids.py` from the PNT repo root and confirm it still prints `OK` and the same
+AC count. The pointer text must not contain a line starting with `| AC-` (it won't).
+
+### 3c. Extend `tools/lint-spec-ids.py`
+
+The current linter (95 lines) does three checks (file header docstring): collects AC IDs from the
+two spec files, collects `Realizes:` headers from `contracts/`, and verifies each realized AC
+resolves. The extension mirrors that machinery for exceptions. **Design-level, not final code:**
+
+**New regexes (mirror `AC_RE` / `REALIZES_RE`):**
+
+```python
+# Mirrors AC_RE (line 22). Collects EX-* IDs from registry rows in spec/exceptions.md.
+EX_RE = re.compile(r"^\| (EX-[A-Z0-9-]+?)(?=\s|\*|\|)", re.MULTILINE)
+
+# Mirrors REALIZES_RE (line 23). Tokens may be AC-*, EX-*, or the PNA-DEFINITION sentinel.
+RELAXES_RE = re.compile(
+    r"Relaxes:\s*((?:(?:AC-[A-Z0-9-]+|EX-[A-Z0-9-]+|PNA-DEFINITION)(?:\s*,\s*)?)+)",
+    re.IGNORECASE,
+)
+
+# Reversible: yes|no. When 'yes', a Reversal: field must be present (checked separately, not by
+# this regex).
+REVERSIBLE_RE = re.compile(r"Reversible:\s*(yes|no)\b", re.IGNORECASE)
+```
+
+**New collection functions (mirror `collect_spec_ac_ids` / `collect_contract_realizes`):**
+
+1. `collect_exception_ids()` — read `spec/exceptions.md`, `EX_RE.findall(text)`, return the set of
+   `EX-*` IDs. Same shape as `collect_spec_ac_ids()` (lines 26–35). If the file is absent, this is a
+   no-op returning an empty set (so the lint stays green on repos that haven't adopted exceptions).
+
+2. `collect_relaxes()` — scan each registry entry (and, later, each reference-design handler
+   declaration if PNT decides to lint those) for a `Relaxes:` header. Return `{source: [tokens]}`,
+   same shape as `collect_contract_realizes()` (lines 38–52).
+
+**New checks in `main()` (mirror the loop at lines 69–76):**
+
+- For every token in every `Relaxes:` header: it MUST resolve to a known `AC-*` ID
+  (`spec_ids`), a known `EX-*` ID (`exception_ids`), or the literal `PNA-DEFINITION`. Otherwise
+  append a failure: `f"{src}: Relaxes names {tok}, which is not a known AC, EX, or PNA-DEFINITION."`
+  This is the exact inverse of the existing "claims to realize {ac}, but {ac} is not defined"
+  check.
+- For every registry entry / handler declaration that carries a `Reversible:` field: the value
+  MUST match `REVERSIBLE_RE` (well-formed `yes|no`). If `yes`, a `Reversal:` field MUST be present
+  in the same entry. The lint validates the **declaration's well-formedness and presence**, NOT
+  whether the reversal path actually works — that's the LLM layer's job (§ 3d / § 3e). Failure:
+  `f"{src}: Reversible: declared but malformed, or 'yes' without a Reversal: field."`
+
+**What the lint deliberately does NOT do:** it does not assert that an exception is genuinely
+caught/handled at runtime, and it does not verify a reversal path exists in code. It validates the
+*shape of the declaration* (presence + traceability), exactly as the existing tool validates that
+`Realizes:` headers name real ACs without checking the realization is correct. This keeps the
+80/20 "description-and-process over a Python conformance runner" principle (`SKILL.md` § Principles).
+
+**Output additions:** extend the success summary (lines 87–89) with
+`spec defines N exception IDs` and `M Relaxes header(s) resolved`.
+
+**Docstring update:** add checks 4–6 to the module docstring (lines 1–12) describing the EX/Relaxes/
+Reversible invariants.
+
+### 3d. Strengthen the "validation, not certification" framing
+
+Two surfaces, both small additions:
+
+1. **`spec/PNA_Spec.md`** — there is no single framing sentence today; the closest is § Vision's
+   "conformance evaluation" paragraph and § Building a PNA. Add one sentence to § Building a PNA (or
+   a short callout near the AC table intro). DRAFT:
+
+   ```markdown
+   > **Validation, not certification.** PNT validates behaviors against the Goals; it does not
+   > certify. There is no pass/fail badge and no certifying body. Where a PNA deliberately departs
+   > from a guarantee, it raises an Exception (exceptions.md); the evaluate flow detects each
+   > exception and verifies how it is handled, reporting by `EX-*` ID rather than by a grade.
+   ```
+
+   This complements, and should cross-link, the existing `CONTRIBUTING.md` § "Acceptance is not
+   certification" and `SKILL.md` § Principles ("Conformance is checked, not awarded").
+
+2. **`pna-build-eval-contrib/SKILL.md` § Evaluate flow** — see § 3e; the reversibility step and the
+   "report by EX-* ID, don't grade" framing land together there.
+
+### 3e. Add a reversibility-detection step to the SKILL Evaluate flow
+
+The Evaluate flow today (`SKILL.md` lines 30–49) loops over ACs and produces a report keyed by AC
+ID. Add an exceptions pass. **Proposed wording**, inserted as a new step after the current step 3
+(typed-contract checks) and before step 4 (structured report):
+
+```markdown
+3b. **Detect and verify exceptions.** For each Exception the candidate can raise (declared in its
+    Architecture document's exception/handler table, or inferred from the source where undeclared):
+    - **Caught & handled?** Confirm consent is obtained before the raise (EX-H2), a persistent
+      non-PNA-mode signal is shown while active (EX-H3), and a runtime active-set explainer exists
+      (EX-H4). Cite the code/UX for each.
+    - **Reversibility claimed?** Read the `Reversible:` declaration. If `yes`, trace the declared
+      `Reversal:` mechanism and decide whether the code/UX actually delivers a practical,
+      user-reachable path back to PNA mode. Cite the control or route. Reversibility is MODE only —
+      do not credit a handler that implies returning to PNA mode undoes prior disclosure.
+    - **Undeclared deviations.** You are the backstop: if the candidate departs from an AC or the
+      PNA definition WITHOUT declaring an exception, that is a silent (uncaught) deviation — a
+      conformance failure. Flag it and propose the `EX-*` it should have raised.
+    Report each finding by `EX-*` ID (and "undeclared" for silent deviations).
+```
+
+Also update step 4's report-keying note and the § Principles list so the "report by ID, do not
+grade" framing is explicit:
+
+```markdown
+- **Validation, not certification.** Report findings — conformant/non-conformant/exception-handled
+  — by AC or EX ID. There is no overall pass/fail grade and no badge.
+```
+
+The three-layer split the maintainer wants is then complete and explicit:
+- **Lint (mechanical):** `Reversible:` well-formed + `Relaxes:`/`EX-*` traceability (§ 3c).
+- **Evaluate (LLM):** does the reversal path actually work; catch undeclared deviations (this step).
+- **Human:** final judgment at PR time (`CONTRIBUTING.md` § Acceptance process — unchanged).
+
+### 3f. `fellows_local_db` as the demonstrating reference design
+
+The contribution must ride along with a reference design that demonstrates `EX-CLOUD-LLM` handling
+(`CONTRIBUTING.md`: "spec changes must ride along with a demonstrating reference design"). Three
+artifacts, per `SKILL.md` § PR authoring and `CONTRIBUTING.md` § PR contents required:
+
+**(i) Design record — `reference_designs/fellows_local_db/README.md`**
+Already exists as a placeholder (read it; First-accepted date and SWHID are `pending`). Add a
+*Contributions to the spec* subsection for this PR. DRAFT bullet:
+
+```markdown
+### PNA Spec v<next> — Exceptions concept + EX-CLOUD-LLM (PR #<n>)
+
+- Introduces the Exceptions concept (spec/exceptions.md), the Relaxes:/Reversible: header
+  conventions, the lint extension, and the EX-CLOUD-LLM registry entry.
+- Demonstrated by fellows_local_db's cloud-MCP consent handler: pre-raise consent gate, persistent
+  "not a PNA right now" banner, runtime active-exception explainer, and a return-to-PNA-mode
+  control. See this design's Architecture.md § Exceptions.
+- Reference design version: commit `<sha>` (TBD when the handler ships).
+```
+
+**(ii) Architecture.md copy — `reference_designs/fellows_local_db/Architecture.md`**
+PNT keeps its own copy at acceptance (`SKILL.md` step 4). This is a copy of fellows'
+`docs/Architecture.md` *with* the new Exceptions content (see the gap analysis below — the upstream
+doc needs the additions first).
+
+**(iii) AC/Exception attestation row for `EX-CLOUD-LLM`**
+A new attestation block in fellows' `docs/Architecture.md`, copied into the PNT Architecture.md.
+DRAFT row (Verification column is mandatory — see gap analysis):
+
+```markdown
+## Exception attestation
+
+| EX | Handled? | Realization | Reversible | Verification | Status |
+|---|---|---|---|---|---|
+| EX-CLOUD-LLM | yes | Consent gate before a cloud MCP client can reach Private Data Ops; persistent dismissable "not a PNA right now" banner naming EX-CLOUD-LLM; in-app active-exception explainer route; "Return to PNA mode" control that disconnects the cloud client. Code: `mcp_servers/private_data_ops.py` (consent gate), `app/static/app.js` (banner + explainer route + return control). | yes (mode only) | LLM rubric: "trace the cloud-MCP code path; confirm consent precedes any Private-DB row return (EX-H2), a persistent signal naming EX-CLOUD-LLM is shown while active (EX-H3), the explainer route exists and lists the active set (EX-H4), and the return-to-PNA control disconnects the client (EX-H5)." Plus a deterministic test asserting the consent gate refuses Private-DB tools until consent is recorded. | conformant (once handler ships) / planned |
+| | | | | | |
+```
+
+> **Honesty flag for the maintainer:** the handler (consent gate + banner + explainer + return
+> control) is **not yet implemented** in this repo — today's state is the README caveat only
+> (`mcp_servers/README.md` § Cloud LLM caveat: "none of the three servers detects or gates cloud
+> clients"). The attestation above is the *target*. The reference-design PR cannot honestly attest
+> `EX-CLOUD-LLM` as `conformant` until that handler ships. **Sequencing depends on building the
+> handler first** (§ 4). The `-mcp-consent` worktree name suggests this is the active line of work.
+
+#### Gap analysis — what in fellows' current `docs/Architecture.md` would fail the SKILL preflight
+
+The SKILL preflight (`SKILL.md` § Preflight, step 1 + step 3) requires the Architecture document's
+**AC attestation table to have a Verification column on every row**, per
+`reference_designs/templates/ARCHITECTURE_TEMPLATE.md` ("A row missing the Verification field … is
+grounds for PR rejection") and `CONTRIBUTING.md` § What we don't accept.
+
+Reading fellows' `docs/Architecture.md` (the version in this worktree) against that requirement:
+
+1. **No AC attestation table with Realization/Verification/Status columns at all.** § "Universal
+   ACs" (lines 25–27) is a *list* of AC IDs ("AC-1, AC-4, AC-6, …") with no per-AC Realization,
+   **no Verification column**, and no Status. The § "Flavor-derived ACs" table (lines 33–41) has
+   *Realization* ("Fellows's realization") but **no Verification column and no Status column**. The
+   MCP-AC bullets (lines 43–46) and the "vacuous ACs" note (lines 48–50) likewise carry no
+   Verification.
+   **→ This is the single biggest preflight blocker.** Every universal AC and every triggered
+   flavor-derived AC needs a row with a concrete Verification reference (a test file, an LLM rubric,
+   or a human-review note) before the PR is acceptable. The doc is rich on *Realization* but was
+   written as a specialization narrative, not as the template's attestation table.
+
+2. **No Exceptions section.** There is no § Exceptions, no exception attestation table, and no
+   mention of PNA-mode vs non-PNA-mode. Expected — the concept doesn't exist yet — but it must be
+   added for this contribution.
+
+3. **`EX-CLOUD-LLM` handler not implemented**, so even once an Exceptions section is added, its
+   Status is `planned`, not `conformant` (see honesty flag above). Preflight will (correctly) flag
+   the Verification side as not-yet-passing until the handler and its test land.
+
+4. **The PNT-side design record placeholder** (`reference_designs/fellows_local_db/README.md`) still
+   has `First accepted: PNA Spec v0.1, <YYYY-MM-DD pending>` and a pending SWHID, and its own copy
+   of `Architecture.md` is described as "Pending Phase 5 … with the AC attestation table
+   backfilled." So the attestation table is *known-missing on both sides* (upstream design record
+   and this repo's source doc). This contribution is a natural moment to backfill it.
+
+**Net:** the Exceptions spec work (§ 3a–3e) is mechanically clean, but the *reference-design half*
+(§ 3f) has real prerequisite work in fellows' own `docs/Architecture.md`: build the full AC
+attestation table with a Verification column, then add the Exceptions section + attestation. Both
+must precede the PNT PR. Neither is part of *this* plan's output (this plan only writes itself) —
+they are sequenced in § 4.
+
+---
+
+## 4. Sequencing + how this is driven through the SKILL Contribute flow
+
+This stays a **PLAN in the fellows repo** until the maintainer approves. The sequence, when
+approved:
+
+1. **Build the `EX-CLOUD-LLM` handler in fellows first** (separate feature work, not in PNT):
+   consent gate on the cloud-MCP path, persistent "not a PNA right now" banner, runtime
+   active-exception explainer route, return-to-PNA-mode control. This is the demonstrating code the
+   spec change rides along with. UI/UX changes also land in `docs/users_manual.md` per this repo's
+   CLAUDE.md convention. *Without this, the reference design cannot honestly attest the exception.*
+2. **Backfill fellows' `docs/Architecture.md` AC attestation table** with the Verification column on
+   every applicable AC (fixes gap #1), then add the § Exceptions + exception attestation
+   (fixes gaps #2–#3). This is the preflight-blocking work.
+3. **Run the SKILL preflight** (`SKILL.md` § Contribute → Preflight) against fellows: validate the
+   Architecture doc against the code, confirm every AC row (and the EX row) has a working
+   Verification reference, iterate until the report is clean.
+4. **Author the PNT changes on a branch in a PNT checkout** (still no PR): `spec/exceptions.md`
+   (§ 3a), the one-line `PNA_Spec.md` pointer (§ 3b), the `tools/lint-spec-ids.py` extension
+   (§ 3c), the framing additions (§ 3d), the SKILL Evaluate-flow step (§ 3e), and the reference
+   design record + Architecture.md copy + attestation (§ 3f). Run `python tools/lint-spec-ids.py`
+   and confirm green.
+5. **Only on the maintainer's explicit go-ahead:** open the PNT PR per `SKILL.md` § PR authoring /
+   `CONTRIBUTING.md` § PR contents — spec diff, design record, Architecture.md copy, canonical repo
+   URL + commit SHA. Version bump is **Minor** per `CONTRIBUTING.md` § Versioning (additive: a new
+   spec file, a new concept, new sub-contracts, a new lint check — no existing AC semantically
+   altered, no pick removed).
+6. **Post-merge** (maintainer): Software Heritage archival of fellows at the accepted commit; record
+   the SWHID in the design record; final clean preflight run.
+
+**Explicit decision recorded here:** no issues or PRs are filed into PNT (or anywhere) from this
+plan. This document is the artifact the maintainer reviews; everything downstream waits on approval.
+
+---
+
+## 5. Open questions / terminology notes
+
+1. **Naming — settled but worth a sentence in the PR.** "Exceptions" was chosen over "extensions"
+   (collides with `vocab-plugin` "Plugin / extension") and "deviations." Confirm the software
+   metaphor (raise/catch/handle) is the framing the PR leads with.
+
+2. **MUST vs SHOULD on the reversal-path requirement (EX-H5).** Current draft: *if* an exception
+   declares `Reversible: yes`, it **MUST** provide a confirmable path. The conditional MUST is
+   right — but should declaring reversibility itself be encouraged (SHOULD prefer reversible where
+   feasible) or stay neutral? `EX-CLOUD-LLM` is reversible (mode only); an irreversible exception
+   (e.g. a hypothetical one-way data export) would legitimately declare `Reversible: no`. Recommend
+   staying neutral: the spec validates the *honesty* of the declaration, not the *choice*.
+
+3. **One-line pointer vs standalone referenced doc (§ 3b).** Is a single vocabulary-section pointer
+   into `exceptions.md` acceptable, or does the maintainer want exceptions surfaced as a top-level
+   `PNA_Spec.md` section (heavier, more visible)? The plan recommends the light pointer + standalone
+   `exceptions.md` (parallels how `axes.md`/`use_cases.md` are standalone and pointed-to), but flags
+   it as the maintainer's call.
+
+4. **`PNA-DEFINITION` sentinel vs minting `AC-PNA` (§ 3a/§ 3c).** The PNA definition is prose, not a
+   `| AC-X |` row, so `Relaxes:` needs either the `PNA-DEFINITION` literal (lint special-case) or a
+   new AC ID for the definition. Minting `AC-PNA` would let the existing `AC_RE` resolve it with
+   zero special-casing — cleaner lint, but it puts the foundational definition into the AC table,
+   which may be conceptually heavier than wanted. Maintainer's call.
+
+5. **Handler clause IDs `EX-H1..EX-H6` (§ 3a).** Keep them as citable sub-contracts (recommended —
+   the evaluate flow can cite "fails EX-H3") or leave the handler contract prose-only? If kept,
+   confirm the `EX-H*` namespace doesn't collide with the `EX-*` registry namespace in the lint
+   (the regexes in § 3c anchor registry IDs to `| EX-...` table rows, so `EX-H*` clauses in prose
+   are not collected as registry exceptions — no collision, but worth a confirming read).
+
+6. **Should the lint also collect `Relaxes:`/`Reversible:` from reference-design Architecture docs,
+   or only from `spec/exceptions.md`?** § 3c is written to support both but the first cut can lint
+   only the spec registry (PNT holds the canonical copy of accepted designs' Architecture.md, so the
+   tokens are local to the repo either way). Recommend: lint the spec registry first; extend to
+   design-doc handler declarations if/when a second exception lands.
+
+7. **Where does the active-set explainer (EX-H4) live across an MCP boundary?** For `EX-CLOUD-LLM`
+   the *workspace* (the PWA) is the natural home of the persistent signal and explainer, but the
+   raise happens at the *MCP server* (a separate process the workspace doesn't directly observe).
+   This is a real design wrinkle for fellows' handler (§ 4 step 1) and may surface a general
+   sub-question for the spec: how does a persistent non-PNA-mode signal work when the exception is
+   raised in a headless server the user isn't looking at? Worth flagging in the PR as a known
+   limitation of the first handler even if fellows solves it pragmatically (e.g. the workspace polls
+   or the MCP consent is recorded in a place the workspace reads).
+```

--- a/tests/e2e/test_mcpb_settings.py
+++ b/tests/e2e/test_mcpb_settings.py
@@ -85,6 +85,26 @@ def _captured_clicks(page) -> list[str]:
     return page.evaluate("window.__capturedMcpbClicks || []")
 
 
+def _satisfy_consent_gate(page) -> None:
+    """First-setup helper: scroll the consent agreement to the bottom
+    (unlocks the accept checkbox) and check it (enables Continue). The
+    agreement scrolls inside its own region; jump scrollTop to the end
+    and dispatch a scroll event so the JS sync handler fires. Safe to
+    call even when the region isn't scrollable — the a11y fallback has
+    already unlocked the checkbox in that case.
+    """
+    page.evaluate(
+        """() => {
+          const a = document.getElementById('settings-mcpb-agreement');
+          if (a) {
+            a.scrollTop = a.scrollHeight;
+            a.dispatchEvent(new Event('scroll'));
+          }
+        }"""
+    )
+    page.check("#settings-mcpb-consent-checkbox")
+
+
 class TestMcpbSection:
     def test_section_renders_with_intro_and_setup_button(self, standalone_page, base_url_fixture):
         page = standalone_page
@@ -206,6 +226,7 @@ class TestPreambleActions:
         _install_anchor_intercept(page)
         _boot_to_settings(page, base_url_fixture)
         page.click("#settings-mcpb-setup")
+        _satisfy_consent_gate(page)
         page.click("#settings-mcpb-preamble-continue")
 
         # downloadFromUrl uses a 250ms inter-anchor delay; three downloads
@@ -232,6 +253,7 @@ class TestPostSetupState:
         _install_anchor_intercept(page)
         _boot_to_settings(page, base_url_fixture)
         page.click("#settings-mcpb-setup")
+        _satisfy_consent_gate(page)
         page.click("#settings-mcpb-preamble-continue")
         page.wait_for_function(
             """() => {
@@ -251,6 +273,7 @@ class TestPostSetupState:
         _install_anchor_intercept(page)
         _boot_to_settings(page, base_url_fixture)
         page.click("#settings-mcpb-setup")
+        _satisfy_consent_gate(page)
         page.click("#settings-mcpb-preamble-continue")
         page.wait_for_function(
             """() => {
@@ -272,3 +295,120 @@ class TestPostSetupState:
     # section to the About page (paintDataRow surfaces it inline with
     # the directory-data check result). New coverage lives in
     # test_directory_data_update_flow.py.
+
+
+class TestCloudConsentGate:
+    """Issue #156 — one-time informed-consent gate before wiring the
+    directory to a cloud LLM (Claude Desktop). First setup shows a
+    scroll-then-accept agreement; later re-downloads show a one-line
+    reminder and skip the gate.
+    """
+
+    def test_first_setup_continue_disabled_until_scrolled_and_checked(
+        self, standalone_page, base_url_fixture
+    ):
+        page = standalone_page
+        _install_anchor_intercept(page)
+        _boot_to_settings(page, base_url_fixture)
+        page.click("#settings-mcpb-setup")
+        # Full-gate mode: agreement region + checkbox visible, reminder
+        # hidden.
+        expect(page.locator("#settings-mcpb-consent-gate")).to_be_visible()
+        expect(page.locator("#settings-mcpb-consent-reminder")).to_be_hidden()
+        continue_btn = page.locator("#settings-mcpb-preamble-continue")
+        checkbox = page.locator("#settings-mcpb-consent-checkbox")
+        # Continue starts disabled.
+        expect(continue_btn).to_be_disabled()
+        # Scroll the agreement to the end → checkbox becomes enabled.
+        page.evaluate(
+            """() => {
+              const a = document.getElementById('settings-mcpb-agreement');
+              a.scrollTop = a.scrollHeight;
+              a.dispatchEvent(new Event('scroll'));
+            }"""
+        )
+        expect(checkbox).to_be_enabled()
+        # Checkbox still unchecked → Continue still disabled.
+        expect(continue_btn).to_be_disabled()
+        # Check it → Continue enabled.
+        checkbox.check()
+        expect(continue_btn).to_be_enabled()
+
+    def test_cancel_records_no_consent_and_regates(
+        self, standalone_page, base_url_fixture
+    ):
+        page = standalone_page
+        _install_anchor_intercept(page)
+        _boot_to_settings(page, base_url_fixture)
+        page.click("#settings-mcpb-setup")
+        _satisfy_consent_gate(page)
+        # Cancel instead of Continue.
+        page.locator(
+            "#settings-mcpb-preamble-dialog .settings-folder-dialog-cancel"
+        ).click()
+        expect(page.locator("#settings-mcpb-preamble-dialog")).not_to_be_visible()
+        # No consent recorded.
+        raw = page.evaluate("localStorage.getItem('fellows_mcpb_setup')")
+        if raw:
+            import json as _json
+
+            assert _json.loads(raw).get("consentAt") is None
+        # Re-opening still shows the FULL gate, not the reminder.
+        page.click("#settings-mcpb-setup")
+        expect(page.locator("#settings-mcpb-consent-gate")).to_be_visible()
+        expect(page.locator("#settings-mcpb-consent-reminder")).to_be_hidden()
+        # And Continue is disabled again (checkbox reset).
+        expect(
+            page.locator("#settings-mcpb-preamble-continue")
+        ).to_be_disabled()
+
+    def test_consent_recorded_on_accept_before_downloads(
+        self, standalone_page, base_url_fixture
+    ):
+        page = standalone_page
+        _install_anchor_intercept(page)
+        _boot_to_settings(page, base_url_fixture)
+        page.click("#settings-mcpb-setup")
+        _satisfy_consent_gate(page)
+        page.click("#settings-mcpb-preamble-continue")
+        page.wait_for_function(
+            """() => {
+              const s = document.getElementById('settings-mcpb-status');
+              return s && /Downloads triggered/.test(s.textContent || '');
+            }""",
+            timeout=5000,
+        )
+        raw = page.evaluate("localStorage.getItem('fellows_mcpb_setup')")
+        assert raw is not None
+        import json as _json
+
+        assert _json.loads(raw).get("consentAt"), "consentAt should be recorded"
+
+    def test_after_accept_reopen_shows_reminder_and_continue_enabled(
+        self, standalone_page, base_url_fixture
+    ):
+        page = standalone_page
+        _install_anchor_intercept(page)
+        _boot_to_settings(page, base_url_fixture)
+        page.click("#settings-mcpb-setup")
+        _satisfy_consent_gate(page)
+        page.click("#settings-mcpb-preamble-continue")
+        page.wait_for_function(
+            """() => {
+              const s = document.getElementById('settings-mcpb-status');
+              return s && /Downloads triggered/.test(s.textContent || '');
+            }""",
+            timeout=5000,
+        )
+        # Re-open: REMINDER mode — gate hidden, reminder shown, Continue
+        # enabled immediately with no scroll required.
+        page.click("#settings-mcpb-setup")
+        expect(page.locator("#settings-mcpb-preamble-dialog")).to_be_visible()
+        expect(page.locator("#settings-mcpb-consent-reminder")).to_be_visible()
+        expect(page.locator("#settings-mcpb-consent-gate")).to_be_hidden()
+        expect(
+            page.locator("#settings-mcpb-preamble-continue")
+        ).to_be_enabled()
+        # The "Review full terms" toggle re-reveals the agreement copy.
+        terms = page.locator("#settings-mcpb-consent-reminder-terms")
+        expect(terms).to_contain_text("leaving the local-only model")

--- a/tests/e2e/test_pna_exception_mode.py
+++ b/tests/e2e/test_pna_exception_mode.py
@@ -1,0 +1,181 @@
+"""E2E for the PNA "exception" / non-PNA-mode handler.
+
+Wiring the directory to a cloud LLM (Claude Desktop) is modeled as a
+named, stable-ID'd *exception* (``EX-CLOUD-LLM``) that takes the app out
+of PNA (local-only) mode. Accepting the consent gate RAISES the
+exception; the handler is the persistent "Going rogue — not a PNA"
+banner, the in-app ``#/exception/<id>`` explainer, and a reversible
+"Return to PNA mode" control.
+
+Runtime state is mirrored onto ``<body>`` as ``data-pna-mode`` /
+``data-pna-exceptions`` (the machine-readable marker a conformance check
+can catch) and persisted on ``localStorage[fellows_mcpb_setup]``.
+
+See plans/pna_toolkit_exceptions_contribution.md.
+"""
+from __future__ import annotations
+
+from playwright.sync_api import expect
+
+
+def _boot_to_settings(page, base_url: str) -> None:
+    page.goto(base_url + "/", wait_until="domcontentloaded")
+    page.wait_for_function(
+        "() => window.__dataProvider && window.__dataProvider.kind === 'worker'",
+        timeout=15000,
+    )
+    page.wait_for_function(
+        "() => window.__bootMarks && window.__bootMarks.get_full_done != null",
+        timeout=15000,
+    )
+    page.evaluate("location.hash = '#/settings'")
+    page.wait_for_selector("#settings-mcpb-section", timeout=10000)
+
+
+_MCPB_CLICK_INTERCEPT = """
+window.__capturedMcpbClicks = [];
+(function () {
+  const origClick = HTMLAnchorElement.prototype.click;
+  HTMLAnchorElement.prototype.click = function () {
+    const href = this.getAttribute('href') || '';
+    if (href.indexOf('/mcpb/') !== -1) {
+      window.__capturedMcpbClicks.push(href);
+      return;
+    }
+    return origClick.call(this);
+  };
+})();
+"""
+
+
+def _enter_non_pna_mode(page, base_url: str) -> None:
+    """Boot to Settings, run the integration setup, scroll+accept the
+    consent gate, and Continue — which records consent and raises the
+    EX-CLOUD-LLM exception. Downloads are swallowed by the anchor
+    intercept; we only care about the resulting mode state.
+    """
+    page.add_init_script(_MCPB_CLICK_INTERCEPT)
+    _boot_to_settings(page, base_url)
+    page.click("#settings-mcpb-setup")
+    page.evaluate(
+        """() => {
+          const a = document.getElementById('settings-mcpb-agreement');
+          if (a) { a.scrollTop = a.scrollHeight; a.dispatchEvent(new Event('scroll')); }
+        }"""
+    )
+    page.check("#settings-mcpb-consent-checkbox")
+    page.click("#settings-mcpb-preamble-continue")
+    page.wait_for_function(
+        "() => document.body.getAttribute('data-pna-mode') === 'non-pna'",
+        timeout=5000,
+    )
+
+
+class TestPnaExceptionMode:
+    def test_accepting_consent_enters_non_pna_mode_and_shows_banner(
+        self, standalone_page, base_url_fixture
+    ):
+        page = standalone_page
+        _enter_non_pna_mode(page, base_url_fixture)
+        # Body carries the machine-readable markers.
+        assert page.evaluate("document.body.getAttribute('data-pna-mode')") == "non-pna"
+        assert "EX-CLOUD-LLM" in (
+            page.evaluate("document.body.getAttribute('data-pna-exceptions')") or ""
+        )
+        # The banner is visible and names/links the exception.
+        expect(page.locator("#not-a-pna-banner")).to_be_visible()
+        expect(page.locator("#not-a-pna-banner")).to_contain_text("not a PNA")
+        assert (
+            page.get_attribute("#not-a-pna-banner-link", "href")
+            == "#/exception/EX-CLOUD-LLM"
+        )
+
+    def test_dismiss_hides_banner_but_stays_non_pna(
+        self, standalone_page, base_url_fixture
+    ):
+        page = standalone_page
+        _enter_non_pna_mode(page, base_url_fixture)
+        page.click("#not-a-pna-dismiss")
+        expect(page.locator("#not-a-pna-banner")).to_be_hidden()
+        # Dismissal acknowledges; it MUST NOT clear the exception.
+        assert page.evaluate("document.body.getAttribute('data-pna-mode')") == "non-pna"
+        import json as _json
+
+        raw = page.evaluate("localStorage.getItem('fellows_mcpb_setup')")
+        assert _json.loads(raw).get("consentAt"), "exception still active"
+        # Banner stays hidden across a reload (dismissal persists).
+        page.reload(wait_until="domcontentloaded")
+        page.wait_for_selector("#not-a-pna-banner", state="attached", timeout=10000)
+        expect(page.locator("#not-a-pna-banner")).to_be_hidden()
+
+    def test_banner_links_to_active_explainer(self, standalone_page, base_url_fixture):
+        page = standalone_page
+        _enter_non_pna_mode(page, base_url_fixture)
+        page.click("#not-a-pna-banner-link")
+        page.wait_for_function(
+            "() => location.hash === '#/exception/EX-CLOUD-LLM'", timeout=5000
+        )
+        explainer = page.locator(".exception-page")
+        expect(explainer).to_be_visible()
+        expect(explainer).to_contain_text("Active now")
+        expect(explainer).to_contain_text("reversible")
+        # The honesty guard: returning to PNA mode does not recall sent data.
+        expect(explainer).to_contain_text("does not recall data already sent")
+
+    def test_return_to_pna_mode_from_explainer_clears_exception(
+        self, standalone_page, base_url_fixture
+    ):
+        page = standalone_page
+        _enter_non_pna_mode(page, base_url_fixture)
+        page.evaluate("location.hash = '#/exception/EX-CLOUD-LLM'")
+        page.wait_for_selector("#exception-return-pna", timeout=5000)
+        page.click("#exception-return-pna")
+        page.wait_for_function(
+            "() => document.body.getAttribute('data-pna-mode') === 'pna'", timeout=5000
+        )
+        # Banner gone, exception cleared from storage.
+        expect(page.locator("#not-a-pna-banner")).to_be_hidden()
+        assert not page.evaluate("document.body.getAttribute('data-pna-exceptions')")
+        import json as _json
+
+        raw = page.evaluate("localStorage.getItem('fellows_mcpb_setup')")
+        assert _json.loads(raw).get("consentAt") is None, "consent cleared"
+        # The page re-renders to the inactive state.
+        expect(page.locator(".exception-page")).to_contain_text("Not currently active")
+
+    def test_return_to_pna_mode_from_settings(self, standalone_page, base_url_fixture):
+        page = standalone_page
+        _enter_non_pna_mode(page, base_url_fixture)
+        # The Settings non-PNA row is visible while the exception is active.
+        expect(page.locator("#settings-mcpb-pna-mode")).to_be_visible()
+        page.click("#settings-mcpb-return-pna")
+        page.wait_for_function(
+            "() => document.body.getAttribute('data-pna-mode') === 'pna'", timeout=5000
+        )
+        expect(page.locator("#settings-mcpb-pna-mode")).to_be_hidden()
+        expect(page.locator("#not-a-pna-banner")).to_be_hidden()
+
+    def test_explainer_route_when_inactive(self, standalone_page, base_url_fixture):
+        page = standalone_page
+        page.goto(base_url_fixture + "/", wait_until="domcontentloaded")
+        page.wait_for_function(
+            "() => window.__bootMarks && window.__bootMarks.get_full_done != null",
+            timeout=15000,
+        )
+        page.evaluate("location.hash = '#/exception/EX-CLOUD-LLM'")
+        page.wait_for_selector(".exception-page", timeout=5000)
+        expect(page.locator(".exception-page")).to_contain_text("Not currently active")
+        # No exception active → no banner, body in PNA mode.
+        assert page.evaluate("document.body.getAttribute('data-pna-mode')") == "pna"
+        expect(page.locator("#not-a-pna-banner")).to_be_hidden()
+
+    def test_unknown_exception_route(self, standalone_page, base_url_fixture):
+        page = standalone_page
+        page.goto(base_url_fixture + "/", wait_until="domcontentloaded")
+        page.wait_for_function(
+            "() => window.__bootMarks && window.__bootMarks.get_full_done != null",
+            timeout=15000,
+        )
+        page.evaluate("location.hash = '#/exception/EX-BOGUS'")
+        page.wait_for_selector(".exception-page", timeout=5000)
+        expect(page.locator(".exception-page")).to_contain_text("Unknown exception")


### PR DESCRIPTION
## What

Wiring the directory to a cloud LLM (Claude Desktop, via the MCP extensions) is now treated as a named, reversible **exception** — `EX-CLOUD-LLM` — that takes the app out of **PNA mode** (personal-network app = local-only, never-SaaS), instead of being forbidden or buried in a README caveat.

Builds on the one-time consent gate already on this branch. Closes the cloud-LLM-consent direction of #156 (issue body rewritten to match).

## Why

Our ~500-fellow user base wants Claude Desktop on the hosted model; local AI isn't realistic for them. The PNA definition forbids cloud-SaaS data flow — so the honest move is to *catch and handle* the deviation, not pretend it away. Conformance reframes from "never deviates" to "catches and handles every deviation honestly." See `docs/architectural_findings.md`.

## What's in it

- **`EX-CLOUD-LLM` exception** — accepting the consent gate *raises* it → app enters non-PNA mode.
- **"Going rogue — not a PNA" banner** — persistent red top banner; names + links the exception; **dismissable** (acknowledges, does not clear; persists across reloads).
- **In-app explainer** `#/exception/<id>` (+ `#/exceptions` index) — what it relaxes, data affected, reversibility, and the honest "does not recall already-sent data" caveat. Handles active / inactive / unknown-id.
- **Reversible "Return to PNA mode"** — explainer + Settings; clears the exception, re-arms the consent gate.
- **Catchable marker** — `<body data-pna-mode / data-pna-exceptions>` for a conformance check / the PNT linter.
- **Docs** — users_manual, use_with_claude_desktop, ac_decisions_log, new architectural_findings.md.
- **Upstream plan** — `plans/pna_toolkit_exceptions_contribution.md` stages a PNT contribution (new `spec/exceptions.md`, a `lint-spec-ids.py` extension, validation-not-certification framing, fellows as reference design). **Not yet filed.**

## Tests

- New `tests/e2e/test_pna_exception_mode.py` (7) — raise/dismiss/persist, explainer active+inactive+unknown, return-to-PNA from both surfaces.
- `tests/e2e/test_mcpb_settings.py` (15, incl. the consent gate) still green.
- Full e2e suite + `test_api.py` green.

## Manual QA for the maintainer

1. Settings → Claude Desktop integration → **Set up…** → scroll + tick accept → **Continue**. Expect: red **"Going rogue — not a PNA"** banner at the top.
2. Click the banner's **What this means** → lands on `#/exception/EX-CLOUD-LLM`, status **Active now**, reversibility + "doesn't recall sent data" copy present.
3. **Dismiss** the banner → it hides; reload → still hidden, and Settings still shows the non-PNA row (you're still connected).
4. **Return to PNA mode** (Settings *or* the explainer) → banner gone, `#/exception/EX-CLOUD-LLM` now reads **Not currently active**, and re-opening setup shows the *full* consent gate again (not the reminder).
5. Visit `#/exception/EX-BOGUS` → "Unknown exception"; visit `#/exceptions` → index reflects PNA / non-PNA state.

> Note: this branch overlaps `docs/users_manual.md` with the in-flight security-review branch; expect a trivial merge there.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
