### PR TITLE
security: pin Caddy to Let's Encrypt; record CAA done + HSTS preload declined

### DIFF
--- a/ansible/roles/caddy/templates/Caddyfile.j2
+++ b/ansible/roles/caddy/templates/Caddyfile.j2
@@ -15,6 +15,15 @@
 	# connection blip on config change — negligible for this low-traffic,
 	# soon-to-be-retired distribution server).
 	admin off
+	# Pin ACME to Let's Encrypt. Caddy's default is LE *plus a ZeroSSL
+	# fallback*, and ZeroSSL certs are issued by Sectigo — which the
+	# fellows.globaldonut.com CAA record (`issue "letsencrypt.org"`) forbids.
+	# So the fallback could never actually issue; pinning here makes Caddy's
+	# behaviour match the CAA, keeps issuance LE-only across every site in
+	# this file, and avoids confusing ZeroSSL-CAA-rejection log lines if LE
+	# ever has a transient hiccup. (90-day certs + ~30-day renewal runway mean
+	# a brief LE outage is not an availability risk.)
+	acme_ca https://acme-v02.api.letsencrypt.org/directory
 }
 
 {{ fellows_domain }} {

--- a/docs/DevOps.md
+++ b/docs/DevOps.md
@@ -402,19 +402,20 @@ Verify after publication (`just check-env` also runs this check and warns if it'
 dig +short CAA fellows.globaldonut.com   # expect the three lines above
 ```
 
-### HSTS preload submission
+### HSTS preload submission — considered and declined
 
-Caddy already sets `Strict-Transport-Security: max-age=31536000; includeSubDomains; preload` on both `fellows.globaldonut.com` and the `globaldonut.com` apex. The `preload` directive is necessary but not sufficient — Chrome/Firefox/Safari only honor it for sites on their **preload list**.
+Caddy already sets `Strict-Transport-Security: max-age=31536000; includeSubDomains; preload` on both `fellows.globaldonut.com` and the `globaldonut.com` apex. The header alone protects every **returning** visitor (the browser enforces HTTPS for a year after any one HTTPS visit). The `preload` directive additionally closes the **first-visit** window — but only for sites baked into the browsers' preload list, which requires a submission at <https://hstspreload.org/>.
 
-**Submit `fellows.globaldonut.com`, not the apex:**
+**Decision (2026-05-31): do not submit to the preload list. Keep the header.**
 
-<https://hstspreload.org/?domain=fellows.globaldonut.com>
+The reasoning:
 
-The form runs a series of checks (HSTS header with `includeSubDomains`+`preload`, redirect from HTTP to HTTPS, no expired certs); pass them, click submit. Inclusion lags by one major browser release (~6–10 weeks). Once on the list, every browser refuses HTTP for `fellows.globaldonut.com` from the very first visit, closing the "first HTTP request gets MITM'd before HSTS takes effect" window entirely.
+- **You cannot preload just the subdomain.** hstspreload.org rejects subdomain submissions outright ("`fellows.globaldonut.com` is a subdomain. Please preload `globaldonut.com` instead") — the list only accepts whole registrable domains. So the only available action is preloading the **entire `globaldonut.com` zone** with `includeSubDomains`.
+- **That's a permanent, zone-wide commitment for unrelated services.** `just ct-check` shows the zone hosts third-party properties the app doesn't control — `pitch.globaldonut.com` (Pitch, Google Trust certs), `notify.pitch.globaldonut.com` (delegated to `lovable.cloud`). Preloading the apex forces those, and every future subdomain, to be HTTPS-only forever; removal from the list takes months to propagate.
+- **The marginal benefit here is small.** The app's entry point is an **HTTPS** magic-link in email, modern browsers already default to HTTPS-first for typed addresses, the HSTS header already covers repeat visits, and CAA + signed bundles + the email fingerprint already defend cert mis-issuance and install integrity. Preload would only close a narrow "user manually types `http://` on a hostile network, on their very first contact, in a browser that doesn't do HTTPS-first" gap.
+- **The distribution server is temporary by design.** A preload entry on `globaldonut.com` would **outlive** the fellows app (which is meant to be wound down) and keep encumbering the apex and its other subdomains indefinitely. Encumbering the whole personal domain, semi-permanently, to harden a soon-to-retire delivery channel is a bad trade.
 
-> **Why the subdomain and not the apex.** Preloading the apex with `includeSubDomains` forces **every** current and future `*.globaldonut.com` subdomain to HTTPS-only in browsers that ship the list, and removal takes months to propagate. The zone is *not* just the Caddy sites — `just ct-check` shows third-party-hosted subdomains (e.g. `pitch.globaldonut.com`) and non–Let's-Encrypt issuers in the apex. Preloading the whole apex would bet that all of those — and anything you add later — stay HTTPS-only forever. Scoping the preload to `fellows.globaldonut.com` gets the full first-visit protection for the app while leaving the rest of the zone alone. Only preload the apex if you've confirmed every `globaldonut.com` subdomain is, and will remain, HTTPS-only.
-
-This is opt-in but free; do it once.
+The `preload` token is left in the header (it's inert without a list submission and keeps the door open). **Revisit only if** `globaldonut.com` ever becomes a single-owner, all-HTTPS zone with no third-party subdomains — then preloading the apex would be low-risk.
 
 ### Certificate Transparency monitoring (optional but recommended)
 

--- a/docs/securityaudit.md
+++ b/docs/securityaudit.md
@@ -111,15 +111,24 @@ CAA / HSTS / crt.sh tracked below):
   never on the laptop in plaintext; a documented recovery path if the laptop
   holding the (encrypted) signing key is lost. *(Was Tier-3 in the prior
   tracking; promoted here because live probing confirmed it is threat #1.)*
-- ☐ **CAA DNS records for `fellows.globaldonut.com`** (operator console).
-  Tooling + docs done — `just check-env` warns when CAA is missing, and
-  `docs/DevOps.md` § Supporting DNS has the exact three records. Remaining: paste
-  them into Cloudflare. **Scope to the `fellows` subdomain, not the apex** — see
-  the zone finding below.
-- ☐ **HSTS preload submission for `fellows.globaldonut.com`** (operator console)
-  at <https://hstspreload.org/?domain=fellows.globaldonut.com>. The header
-  already advertises `preload`; submit the **subdomain, not the apex** (see
-  finding). ~5 min; inclusion lags weeks.
+- ✅ **CAA DNS records for `fellows.globaldonut.com`** (done 2026-05-31). Three
+  records added in Cloudflare (`issue "letsencrypt.org"`, `issuewild ";"`, `iodef
+  "mailto:richbodo@gmail.com"`), scoped to the `fellows` subdomain. Verified live:
+  `dig` returns exactly those three (no Cloudflare-injected extras, since
+  `fellows` is DNS-only), apex/`pitch` CAA untouched, `just check-env` → "OK:
+  Let's Encrypt is authorized." Caddy pinned to LE to match (see below).
+- ✅ **Pin Caddy to Let's Encrypt** (in the open Caddy/HSTS PR). Caddy's default
+  is LE + a ZeroSSL (Sectigo) fallback that the new CAA would block anyway;
+  `acme_ca` now pins issuance to LE so Caddy's behaviour matches the CAA. Applies
+  via `just bootstrap`.
+- ⊘ **HSTS preload — considered and declined** (decided 2026-05-31). hstspreload.org
+  only accepts whole registrable domains, so the only option was preloading the
+  entire `globaldonut.com` zone — a permanent, zone-wide HTTPS-only commitment
+  binding third-party subdomains (`pitch`, `notify.pitch`) and outliving this
+  soon-to-retire app. Marginal benefit is small (HTTPS magic-link entry, browsers
+  default HTTPS-first, header already covers repeat visits, CAA + signed bundles
+  cover integrity). **Header retained; not submitted.** Full rationale +
+  revisit condition in `docs/DevOps.md` § HSTS preload submission.
 - ☐ **crt.sh email-alert signup** (operator console). The in-repo half is done
   (`just ct-check`); remaining is the push-alert subscription for same-day
   notice of any new issuance.
@@ -134,11 +143,12 @@ CAA / HSTS / crt.sh tracked below):
 > **Zone finding (`just ct-check`, 2026-05-30):** the `globaldonut.com` zone is
 > **not** Let's-Encrypt-only — `pitch.globaldonut.com` uses Google Trust
 > Services and the apex has appeared with a Sectigo cert. Consequences (now
-> reflected in `docs/DevOps.md`): **(a)** CAA must be scoped to
+> reflected in `docs/DevOps.md`): **(a)** CAA was scoped to
 > `fellows.globaldonut.com` — an apex Let's-Encrypt-only record would break those
-> other CAs' renewals; **(b)** HSTS preload should target the `fellows` subdomain,
-> not the apex — apex + `includeSubDomains` would force every zone subdomain
-> HTTPS-only, permanently. Re-run `just ct-check` periodically.
+> other CAs' renewals; **(b)** HSTS preload was **declined** — the list only
+> accepts the whole `globaldonut.com` apex, and apex + `includeSubDomains` would
+> force every zone subdomain (including the third-party ones) HTTPS-only,
+> permanently, for little marginal gain. Re-run `just ct-check` periodically.
 
 ### Deliberately not done — would need a different app
 


### PR DESCRIPTION
Follows the CAA work — pins Caddy issuance to match the new CAA, and records the HSTS-preload decision.

## Changes
- **Pin Caddy to Let's Encrypt** (`acme_ca` in the Caddyfile global block). Caddy's default LE+ZeroSSL fallback can't issue under the new `issue "letsencrypt.org"` CAA anyway (ZeroSSL = Sectigo); this makes behaviour match the CAA and keeps issuance LE-only across all sites in the file.
- **Docs:** CAA marked done + verified; HSTS preload **considered and declined** with full rationale (`docs/DevOps.md`); `securityaudit.md` updated.

## Why HSTS preload was declined
hstspreload.org rejects subdomain submissions — the list only accepts whole registrable domains. So the only option was preloading the **entire `globaldonut.com` apex** with `includeSubDomains`:
- Permanent, zone-wide HTTPS-only commitment binding third-party subdomains the app doesn't control (`pitch.globaldonut.com` → Pitch; `notify.pitch` → lovable.cloud).
- Would **outlive** this soon-to-retire distribution server, encumbering the apex indefinitely.
- Small marginal benefit: entry is an HTTPS magic-link, browsers default HTTPS-first, the HSTS header already protects repeat visits, and CAA + signed bundles cover cert/install integrity.

Header (`max-age=…; includeSubDomains; preload`) is retained; only the list submission is skipped. Revisit if `globaldonut.com` ever becomes a single-owner all-HTTPS zone.

## CAA verification (already live, 2026-05-31)
`dig +short CAA fellows.globaldonut.com` → exactly the three records, no Cloudflare-injected extras (fellows is DNS-only); apex/pitch CAA untouched; current cert still Let's Encrypt; `just check-env` → "OK: Let's Encrypt is authorized."

## Maintainer QA after merge
1. `just bootstrap` (applies the Caddyfile change via the caddy role; full restart, brief blip).
2. `just smoke` — confirm HTTPS still healthy.
3. On the droplet: `sudo caddy validate --config /etc/caddy/Caddyfile` (optional) and confirm the next cert renewal logs Let's Encrypt only (no ZeroSSL attempt).

🤖 Generated with [Claude Code](https://claude.com/claude-code)