### PR TITLE
fix(download): save to Downloads on Android instead of the share sheet

### DIFF
--- a/app/static/app.js
+++ b/app/static/app.js
@@ -7950,6 +7950,12 @@
       return /iPad|iPhone|iPod|Android/.test(ua) ||
              (navigator.platform === 'MacIntel' && navigator.maxTouchPoints > 1);
     }
+    function isIOS() {
+      // iPadOS 13+ reports as desktop Safari (MacIntel) but exposes touch.
+      var ua = navigator.userAgent || '';
+      return /iPad|iPhone|iPod/.test(ua) ||
+             (navigator.platform === 'MacIntel' && navigator.maxTouchPoints > 1);
+    }
     function triggerAnchorDownload() {
       return new Promise(function (resolve) {
         var url = URL.createObjectURL(blob);
@@ -7996,10 +8002,20 @@
       });
     }
 
-    // Mobile share sheet — only when the OS supports file shares
-    // and accepts this MIME. canShare guards both.
+    // iOS share sheet. iOS Safari historically ignores the <a download>
+    // attribute (it opens the file inline rather than saving it), so the
+    // Web Share API is the only reliable "save a file" path there.
+    //
+    // We deliberately do NOT take this branch on Android. Android's share
+    // sheet routes a .db (application/octet-stream) to Google Drive, which
+    // can't render it and shows "Couldn't load object" — the user's data
+    // never reaches local storage. On Android, navigator.canShare accepts
+    // the file (canShare returns true) so the old isMobileUA() gate sent
+    // every Android download down this dead end. Android instead falls
+    // through to the <a download> anchor below, which saves straight to
+    // the Downloads folder. canShare still guards iOS support + MIME.
     try {
-      if (isMobileUA() && navigator.canShare && typeof File === 'function') {
+      if (isIOS() && navigator.canShare && typeof File === 'function') {
         var file = new File([blob], filename, { type: blob.type || 'application/octet-stream' });
         if (navigator.canShare({ files: [file] })) {
           return navigator.share({ files: [file], title: filename })

--- a/docs/users_manual.md
+++ b/docs/users_manual.md
@@ -352,8 +352,9 @@ a portable file copy by hand:
 
 - **Download a backup.** Settings → Private data folder → *⬇ Download my
   private data*. Your browser asks you where to save it
-  (Chrome / Edge / Brave on desktop, share sheet on iOS / Android)
-  or drops it into your Downloads folder (Safari / Firefox).
+  (Chrome / Edge / Brave on desktop, share sheet on iOS)
+  or drops it straight into your Downloads folder
+  (Safari / Firefox / Android).
 - **Restore from a backup.** Settings → *Restore from backup →
   Restore from a file* → pick the `.db` file you downloaded earlier.
   The current data is captured into the auto-backup list first, so
@@ -549,8 +550,8 @@ action as the detail page.
 - **Private data folder → ⬇ Download my private data** — saves all
   your groups, notes, tags, and settings to a single `.db` file.
   Your browser opens its native save dialog (Chrome / Edge / Brave
-  on desktop) or share sheet (iOS / Android) so **you choose where
-  the file goes**; on Safari and Firefox the file lands in your
+  on desktop) or share sheet (iOS) so **you choose where the file
+  goes**; on Safari, Firefox, and Android the file lands in your
   Downloads folder. The app also auto-snapshots the same file before
   every upgrade and keeps the newest 3.
 - **Restore from backup → Restore from a file** — replace your current

--- a/tests/e2e/mobile/test_download_share_routing.py
+++ b/tests/e2e/mobile/test_download_share_routing.py
@@ -1,0 +1,100 @@
+"""Mobile download routing: Android saves to Downloads, iOS uses the share sheet.
+
+Regression guard for the Android "Couldn't load object" bug. `downloadBlob`
+(app/static/app.js) used to route *every* mobile download through
+`navigator.share()` whenever `navigator.canShare` accepted the file. On
+Android the share sheet hands a `.db` (application/octet-stream) to Google
+Drive, which can't render it — the user's data never lands locally. The fix
+restricts the share-sheet branch to iOS (where `<a download>` is unreliable)
+and lets Android fall through to the `<a download>` anchor, which saves
+straight to the Downloads folder.
+
+These tests pin both halves of that decision so a future "simplification"
+can't silently re-introduce the Android dead-end or regress iOS:
+
+  * Android UA  → anchor download fires (`relationships-*.db`), share NOT called.
+  * iOS UA      → `navigator.share` IS called, no anchor download.
+
+Both UAs get a stubbed `navigator.canShare` that returns true (matching real
+Android, where it does), so the test exercises the OS-discrimination branch
+rather than relying on Chromium's headless canShare being absent.
+"""
+from __future__ import annotations
+
+import pytest
+from playwright.sync_api import expect
+
+from tests.e2e.conftest import _STANDALONE_DISPLAY_INIT, make_worker_data
+
+
+# Standalone display shim (so the app boots to the directory) + the
+# showSaveFilePicker delete (the desktop branch must not fire under a
+# mobile UA, but deleting it is belt-and-suspenders) + a canShare that
+# accepts everything + a navigator.share spy that records calls and
+# resolves (so the iOS path completes without a real OS share sheet).
+_SHARE_SPY_INIT = _STANDALONE_DISPLAY_INIT + """
+(function () {
+  try { delete window.showSaveFilePicker; } catch (e) {
+    try { window.showSaveFilePicker = undefined; } catch (e2) {}
+  }
+  window.__shareCalls = 0;
+  try {
+    Object.defineProperty(navigator, 'canShare', {
+      configurable: true, writable: true, value: function () { return true; }
+    });
+    Object.defineProperty(navigator, 'share', {
+      configurable: true, writable: true,
+      value: function () { window.__shareCalls += 1; return Promise.resolve(); }
+    });
+  } catch (e) { /* leave native impls in place */ }
+})();
+"""
+
+
+def _seeded_settings_page(playwright, browser, device, base_url):
+    """Open a mobile-emulated page for `device`, seed a group, and land on
+    #/settings with the worker-backed download button visible. Returns
+    (context, page) — caller is responsible for context.close()."""
+    context = browser.new_context(**dict(playwright.devices[device]))
+    page = context.new_page()
+    page.add_init_script(_SHARE_SPY_INIT)
+    helper = make_worker_data(page, base_url)
+    if helper.wait() != "worker":
+        context.close()
+        pytest.skip("worker provider unavailable in this environment")
+    helper.wipe_relationships()
+    helper.create_group("download routing test")
+    page.evaluate("() => { location.hash = '#/settings'; }")
+    btn = page.locator("#settings-download-userdata")
+    btn.wait_for(state="visible", timeout=10000)
+    return context, page
+
+
+def test_android_backup_saves_to_downloads_without_share(playwright, browser, base_url_fixture):
+    """Android: the .db backup downloads via the anchor; share is never called."""
+    context, page = _seeded_settings_page(playwright, browser, "Pixel 5", base_url_fixture)
+    try:
+        with page.expect_download(timeout=20000) as dl_info:
+            page.locator("#settings-download-userdata").click()
+        download = dl_info.value
+        assert download.suggested_filename.startswith("relationships-")
+        assert download.suggested_filename.endswith(".db")
+        # The whole point: the Android share-sheet → Drive dead-end is gone.
+        assert page.evaluate("() => window.__shareCalls") == 0
+        expect(page.locator("#settings-download-status")).to_contain_text("Downloads folder")
+    finally:
+        context.close()
+
+
+def test_ios_backup_uses_share_sheet(playwright, browser, base_url_fixture):
+    """iOS: the share sheet is used (anchor download is unreliable there)."""
+    context, page = _seeded_settings_page(playwright, browser, "iPhone 13", base_url_fixture)
+    try:
+        page.locator("#settings-download-userdata").click()
+        # Share resolves → "Saved via the share sheet (N bytes)."; no download.
+        expect(page.locator("#settings-download-status")).to_contain_text(
+            "share sheet", timeout=10000
+        )
+        assert page.evaluate("() => window.__shareCalls") >= 1
+    finally:
+        context.close()


### PR DESCRIPTION
## The bug

On Android, **Settings → Download my private data** (and the reset-flow backup, and group export) failed with Google Drive's **"Couldn't load object."** The user's data never reached local storage.

**Root cause:** `downloadBlob` (`app/static/app.js`) preferred the Web Share API (`navigator.share`) for *all* mobile UAs whenever `navigator.canShare` accepted the file. On Android `canShare` accepts an `application/octet-stream` `.db`, so the share sheet fired and routed the file to Google Drive, which can't render a SQLite DB → "Couldn't load object." The reliable `<a download>` anchor path was never reached.

This was **present identically in prod (`00ce3d6`) and `main`** — the share/download code is byte-identical across the 18 commits between them. Not introduced by the pending ship.

## The fix

Restrict the share-sheet branch to **iOS only** (where `<a download>` is historically unreliable, so the share sheet is the only dependable "save a file" path). **Android** now falls through to the `<a download>` anchor and saves straight to the Downloads folder. Desktop (File System Access `showSaveFilePicker`) and iOS behavior are unchanged.

One-line behavioral change: the `navigator.share` branch is gated on `isIOS()` instead of `isMobileUA()`.

Fixes all three `downloadBlob` callers: Settings backup, reset-flow backup, group PDF/HTML export.

## Verification on a real device

Validated on a real **Android 10 / Chrome 148** phone over `adb` (USB), serving this branch via the dev server + `adb reverse`, in **worker mode** (`crossOriginIsolated: true`):

- `navigator.share` was **never called** (`__shareCalls === 0`).
- A valid `relationships-*.db` (98,304 bytes) landed in `/sdcard/Download`.
- Pulled it back: `file` reports `SQLite 3.x database, user version 1`; `PRAGMA integrity_check` → `ok`; the seeded group + note are intact.

## Tests

- New `tests/e2e/mobile/test_download_share_routing.py`: Android UA → anchor download of `relationships-*.db` with share never called; iOS UA → share sheet used. Both pass.
- `tests/e2e/test_groups_export.py`, `test_reset_everything.py`, `test_settings.py`, and the full `tests/e2e/mobile/` suite: **129 passed** (no regressions in the desktop/iOS download paths).

## Docs

`docs/users_manual.md` updated in two places: Android now saves to the Downloads folder (was described as "share sheet on iOS / Android").

## Maintainer QA (on your phone, post-merge + ship)

1. `just ship` to deploy this to prod, then `just whats-running` to confirm prod's SHA matches.
2. On your Android phone's installed PWA, create/keep a group, then **Settings → ⬇ Download my private data**.
3. Confirm: status reads *"Saved … to your browser's Downloads folder"*, **no** "Couldn't load object", and the `relationships-*.db` appears in your Downloads (Files app).
4. Optional iOS sanity check: on an iPhone, the same button should still open the **share sheet** (unchanged).

🤖 Generated with [Claude Code](https://claude.com/claude-code)