### PR TITLE
docs(arch): declare Toolkit-Version (was Spec-Version)

### DIFF
--- a/docs/Architecture.md
+++ b/docs/Architecture.md
@@ -8,7 +8,7 @@ Universal PNA architecture — vocabulary, goals, the two-store ownership split,
 
 ## Spec conformance
 
-**Spec-Version:** [0.1 (draft)](https://github.com/richbodo/personal_network_toolkit/blob/main/CHANGELOG.md)
+**Toolkit-Version:** [0.1 (draft)](https://github.com/richbodo/personal_network_toolkit/blob/main/CHANGELOG.md) — the PNT version (spec + contracts + skill + lint + templates) this design was built and validated against.
 **Use case:** [Directory Archive](https://github.com/richbodo/personal_network_toolkit/blob/main/use_cases.md#directory-archive)
 
 ### Flavor — fellows's six axis picks


### PR DESCRIPTION
Renames the Architecture doc's conformance field `Spec-Version` → `Toolkit-Version`, matching the toolkit's reconciled single version name (personal_network_toolkit PR #10). The design declares the PNT version it was built/validated against. Keeps the same value + CHANGELOG link.

🤖 Generated with [Claude Code](https://claude.com/claude-code)