### PR TITLE
fix(mobile): gate durable data-folder off phones; keep manual backup visible

### DIFF
--- a/app/static/app.js
+++ b/app/static/app.js
@@ -1214,6 +1214,21 @@
   //     onIos: boolean,         // iPhone/iPad/iPod, including iPadOS desktop UA
   //     minVersion: number|null // floor for this browser, or null if unknown
   //   }
+  // True on phones/tablets. Used to gate the durable-folder feature, which
+  // we deliberately do NOT offer on mobile: Android's directory picker
+  // routes through the Storage Access Framework (forces a Downloads
+  // subfolder the OS can clear — failing the feature's durability promise)
+  // and iOS Safari has no directory picker at all. On mobile the app is
+  // OPFS-only + manual backup. The worker makes the same call in
+  // _isMobileWorker(); keep the two heuristics in sync. (downloadBlob has
+  // its own local isMobileUA() with the same shape — left in place to keep
+  // that self-contained function dependency-free.)
+  function isMobileDevice() {
+    var ua = (navigator && navigator.userAgent) || '';
+    return /iPad|iPhone|iPod|Android/.test(ua) ||
+      (navigator.platform === 'MacIntel' && navigator.maxTouchPoints > 1);
+  }
+
   function detectBrowserSupport() {
     var ua = (navigator.userAgent || '');
     var onIos = /iPad|iPhone|iPod/.test(ua) ||
@@ -2849,7 +2864,9 @@
         lines.push('  (folder controller not initialized)');
       } else {
         var fState = await folderCtrl.getState();
-        lines.push('  browser supports showDirectoryPicker: ' + !!fState.supported);
+        lines.push('  showDirectoryPicker present: ' + !!fState.pickerApiPresent);
+        lines.push('  folder storage offered here: ' + !!fState.supported +
+          (fState.pickerApiPresent && !fState.supported ? ' (gated off on mobile)' : ''));
         lines.push('  worker reachable: ' + !!fState.workerAvailable);
         lines.push('  handle persisted: ' + !!fState.hasHandle);
         if (fState.hasHandle) {
@@ -8626,8 +8643,21 @@
   // Settings page consumes it through render-time callbacks.
 
   var FOLDER_CONTROLLER = (function () {
+    // Literal capability: does this browser expose the directory picker
+    // API? Kept truthful (not folded together with the mobile policy) so
+    // the diagnostics panel can report the real API presence — Android
+    // Chrome answers true here even though we don't offer the feature.
     function browserSupportsFolderPicker() {
       return typeof window.showDirectoryPicker === 'function';
+    }
+
+    // Policy: do we OFFER durable-folder storage in this environment? The
+    // API has to exist AND we're not on mobile (see isMobileDevice for the
+    // why). Everything user-facing — the Settings section, the picker, the
+    // folder-push banner, the badge — keys off this, while the worker
+    // enforces the matching OPFS-only mode in _isMobileWorker().
+    function folderStorageOffered() {
+      return browserSupportsFolderPicker() && !isMobileDevice();
     }
 
     function workerProvider() {
@@ -8657,7 +8687,8 @@
       var p = workerProvider();
       if (!p) {
         return Promise.resolve({
-          supported: browserSupportsFolderPicker(),
+          supported: folderStorageOffered(),
+          pickerApiPresent: browserSupportsFolderPicker(),
           workerAvailable: false,
           hasHandle: false,
           parentName: null,
@@ -8669,14 +8700,17 @@
         });
       }
       return p._getFolderState().then(function (raw) {
-        raw.supported = browserSupportsFolderPicker();
+        raw.supported = folderStorageOffered();
+        raw.pickerApiPresent = browserSupportsFolderPicker();
         raw.workerAvailable = true;
         return raw;
       });
     }
 
     // Compute the badge state from a state snapshot. Returns one of:
-    //   'unsupported'   — browser has no showDirectoryPicker.
+    //   'unsupported'   — folder storage isn't offered here (browser has no
+    //                     showDirectoryPicker, OR we're on mobile, where the
+    //                     feature is gated off — see folderStorageOffered).
     //   'browser-only'  — supported but no folder chosen.
     //   'saved'         — folder chosen and last write succeeded.
     //   'pending'       — folder chosen but no write yet (open-existing path).
@@ -8699,7 +8733,7 @@
     // Returns the FileSystemDirectoryHandle, or null on user-cancel /
     // unsupported.
     function pickParentFolder() {
-      if (!browserSupportsFolderPicker()) return Promise.resolve(null);
+      if (!folderStorageOffered()) return Promise.resolve(null);
       return window.showDirectoryPicker({ mode: 'readwrite', id: 'fellows-data-folder' })
         .catch(function (e) {
           // AbortError = user cancelled the picker. Treat as null, not a
@@ -8763,6 +8797,7 @@
 
     return {
       browserSupportsFolderPicker: browserSupportsFolderPicker,
+      folderStorageOffered: folderStorageOffered,
       getState: getState,
       badge: badge,
       pickParentFolder: pickParentFolder,
@@ -9901,6 +9936,18 @@
       if (!state) return;
       var b = FOLDER_CONTROLLER.badge(state);
       var copy = BADGE_COPY[b] || BADGE_COPY['browser-only'];
+      // The 'unsupported' badge serves two audiences: desktop Safari/Firefox
+      // (genuinely no directory-picker API) and phones (API may exist on
+      // Android, but we gate the feature off there). Give mobile users an
+      // accurate, actionable message instead of "this browser doesn't
+      // support it" — point them at the manual backup that IS their
+      // durability path on a phone.
+      if (b === 'unsupported' && isMobileDevice()) {
+        copy = {
+          text: 'On phones, your data stays in this browser. Use “Download my private data” below to keep a backup.',
+          cls: copy.cls
+        };
+      }
       var dotEl = badgeEl && badgeEl.querySelector('.settings-folder-badge-dot');
       var textEl = badgeEl && badgeEl.querySelector('.settings-folder-badge-text');
       if (badgeEl) {
@@ -9958,8 +10005,17 @@
       // the folder (cloud-sync conflicts, sneakernet to another machine,
       // etc., per issue #202). The renderSettingsPage init hides it
       // when localPersistenceAvailable is false.
+      //
+      // Gate this on WORKER availability, NOT on `supported` (folder
+      // offered). The two diverge wherever the folder feature is absent
+      // but the worker is alive: desktop Safari/Firefox (no picker API)
+      // and ALL mobile (gated off). In those environments the download is
+      // the only durability path the user has, so it must show — keying it
+      // off `supported` previously hid it for exactly the users who need
+      // it most.
+      var canDownload = (state.workerAvailable !== false);
       var dlBtn = document.getElementById('settings-download-userdata');
-      if (dlBtn && dlBtn.hidden && supported) {
+      if (dlBtn && dlBtn.hidden && canDownload) {
         // Only un-hide if we're not in the localPersistenceAvailable=false
         // path (which sets hidden=true on init). Heuristic: if the
         // fallback panel is shown, leave it hidden.

--- a/app/static/vendor/sqlite-worker.js
+++ b/app/static/vendor/sqlite-worker.js
@@ -722,6 +722,38 @@ handlers.init = async function () {
     ' (handle=' + (folderRecord.parentHandle ? 'yes' : 'no') +
     ' permission=' + folderPermission + ')');
 
+  // Mobile de-migration. The durable-folder feature is not offered on
+  // phones (see _isMobileWorker). If a folder handle survives — from a
+  // build that used to offer the picker on Android, or a desktop handle
+  // synced over — bring the worker back in line with the OPFS-only page
+  // UI rather than silently keep writing to a Downloads subfolder the UI
+  // claims doesn't exist. When the folder is readable, pull its (canonical
+  // in folder mode) bytes into the OPFS working buffer first; then retire
+  // the IDB handle and force OPFS-only for this and every future mobile
+  // session. The physical folder file is never deleted — clearFolderHandle
+  // only drops the IDB record — so it stays in Downloads as a recoverable
+  // artifact and this path cannot lose data.
+  if (_isMobileWorker() && folderRecord.parentHandle) {
+    if (folderPermission === 'granted') {
+      try {
+        await _hydrateOpfsBufferFromFolder();
+        trace('mobile de-migration: pulled folder data into OPFS before retiring handle');
+      } catch (e) {
+        trace('mobile de-migration: folder hydrate failed (' +
+          ((e && e.message) || e) +
+          '); folder file left in place, retiring handle anyway');
+      }
+    } else {
+      trace('mobile de-migration: folder permission=' + folderPermission +
+        ' — cannot read folder; retiring handle (folder file left in place)');
+    }
+    folderRecord = _emptyFolderRecord();
+    try { await _folderIdbDelete(); }
+    catch (e) { trace('mobile de-migration: folder IDB delete failed: ' + ((e && e.message) || e)); }
+    _storageMode = 'opfs';
+    folderPermission = 'no-handle';
+  }
+
   // Folder mode: one-time migration (if Phase 1 hybrid state exists)
   // for relationships.db, then OPFS→folder backup-ring migration, then
   // hydrate the OPFS working buffer from folder bytes. After this
@@ -1742,6 +1774,22 @@ var FOLDER_RELATIONSHIPS_FILE = 'relationships.db';
 // page) share the namespace, so a page-side test or future takeover-
 // handoff window cannot race the worker's _writeBytesToFolder.
 var FOLDER_WRITE_LOCK_NAME = 'fellows-relationships-folder-write';
+
+// True when this worker is running on a phone/tablet. The durable-folder
+// feature is NOT offered on mobile: Android's directory picker routes
+// through the Storage Access Framework, which forces the user into a
+// Downloads subfolder the OS can clear at will (so it fails the feature's
+// whole durability promise), and iOS has no directory picker at all. On
+// mobile the app is OPFS-only + manual backup. The page UI hides the
+// feature (see app.js isMobileDevice / folderStorageOffered); this lets the
+// worker make the same call so the two never disagree about storage mode.
+// Mirrors the UA/touch heuristic used page-side. Workers expose navigator.
+function _isMobileWorker() {
+  var ua = (self.navigator && self.navigator.userAgent) || '';
+  return /iPad|iPhone|iPod|Android/.test(ua) ||
+    (self.navigator && self.navigator.platform === 'MacIntel' &&
+     self.navigator.maxTouchPoints > 1);
+}
 
 // In-memory mirror of what's persisted in IDB. Reloaded on init, mutated
 // alongside every IDB write. Shape: see _emptyFolderRecord().

--- a/docs/feature_platform_matrix.md
+++ b/docs/feature_platform_matrix.md
@@ -24,7 +24,7 @@ If you're going to create groups and want a smooth experience, **install in one 
 | **Save groups, tags, notes** | yes | yes | yes | yes | yes | yes |
 | **Manual backup download** | yes | yes | yes | yes (share sheet) | yes | yes |
 | **Auto-backups** (in browser storage) | yes | yes | yes | yes | yes | yes |
-| **Private data folder** (stable file on disk for `relationships.db`) | yes | no[^3] | no[^3] | no | no | no |
+| **Private data folder** (stable file on disk for `relationships.db`) | yes | no[^3] | no[^3] | no | no[^5] | no[^5] |
 | **Claude Desktop AI integration — easy path** | yes | no | no | N/A[^4] | N/A | N/A |
 | **Claude Desktop AI integration — secondary path** | yes | yes (manual re-export per change) | yes (manual re-export per change) | N/A | N/A | N/A |
 | **Per-install codename** (debugging multi-install confusion) | yes | yes | yes | yes | yes | yes |
@@ -34,6 +34,7 @@ If you're going to create groups and want a smooth experience, **install in one 
 [^2]: Firefox dropped PWA install on desktop in 2021. You can use the app in a tab.
 [^3]: `window.showDirectoryPicker` is Chromium-only. Without it, the app uses in-browser OPFS storage with the manual backup / restore path for durability.
 [^4]: Claude Desktop is macOS / Windows / Linux only. Mobile platforms can't host MCP servers.
+[^5]: **Intentionally gated off on mobile, not an API gap.** Android Chrome *does* expose `showDirectoryPicker`, but it routes through the Storage Access Framework, which forces the file into a Downloads subfolder the OS can clear at will — so the folder can't keep the feature's core promise of *durable* storage, and offering the choice is misleading. On mobile (both Android and iOS) the app is OPFS-only; durability comes from the manual backup download. See *[The mobile contract](#the-mobile-contract)*.
 
 ## What "easy path" vs "secondary path" means
 
@@ -53,6 +54,39 @@ Browsers don't share storage. If you install the app in two
 browsers on the same device, you get two independent data stores.
 Recommended: **install in one browser only**. If you've already
 done multiple installs, see *[Migrating from another browser](users_manual.md#migrating-from-another-browser)*.
+
+## The mobile contract
+
+Phones and tablets can't provide a **stable, externally-readable file at a
+known path** — and several features are built on exactly that. So the mobile
+experience is deliberately narrower than desktop, and the line is
+architectural, not a "not yet":
+
+**What mobile does** — browse the directory, search, save groups / tags /
+notes, and **download a manual backup** of your data. That's the whole
+contract. Your `relationships.db` lives in the browser's private storage
+(OPFS); durability comes from exporting a backup file you store yourself.
+
+**What mobile can't do, and why:**
+
+- **Durable data folder** — Android's picker only reaches a Downloads
+  subfolder the OS can clear; iOS has no picker. A folder we can't trust to
+  persist would be worse than honest browser-only storage, because the
+  "saved to disk" badge would imply a safety that isn't there. Gated off on
+  both. (Footnote 5 above.)
+- **Claude Desktop / MCP integration** — Claude Desktop is desktop-only and
+  phones can't host an MCP server. (Footnote 4.)
+- **Anything that assumes external tools can read your data file** —
+  command-line `sqlite3`, a sync agent (Dropbox / iCloud / Syncthing)
+  replicating the folder, multi-client reads. All need a durable local file
+  mobile doesn't have.
+
+A note on OPFS durability on mobile: browser storage can be evicted (iOS
+notably reclaims it after long periods of non-use, and Android's *Clear
+Storage* wipes it). **The manual backup is the floor** — encourage it, and it
+must keep working. That's why the *Download my private data* button stays
+available on every mobile browser even though the data-folder feature is
+hidden.
 
 ## See also
 

--- a/docs/users_manual.md
+++ b/docs/users_manual.md
@@ -256,12 +256,21 @@ across clearing site data or switching browsers. The app prompts
 you to set this up via a banner at the top of the screen on first
 launch.
 
-If you skip the prompt or you're on a browser that doesn't support
-folder selection (Safari, Firefox, iOS, Android), the app falls
-back to **browser-only mode** — your data still works, but it lives
-in private browser storage that can be lost when you clear site
-data or switch browsers. Use the **Download a backup** feature
-(below) to make file copies you can save anywhere.
+If you skip the prompt, or you're on a browser without folder support
+(Safari and Firefox lack the API), or **you're on a phone or tablet**
+(the data folder is intentionally not offered on mobile — see below),
+the app runs in **browser-only mode** — your data still works, but it
+lives in private browser storage that can be lost when you clear site
+data or switch browsers. Use the **Download a backup** feature (below)
+to make file copies you can save anywhere.
+
+**On phones and tablets, browser-only is the only mode.** Android's
+folder picker can only reach a Downloads subfolder the system clears at
+will, and iOS has no picker at all — so a "data folder" there couldn't
+actually keep your data safe, and the app doesn't pretend otherwise.
+Your durability on mobile is the manual backup: **download a backup file
+and store it somewhere you trust** (your cloud drive, email it to
+yourself). See *[Backup and restore](#backup-and-restore-works-in-every-browser)*.
 
 ### Setting up a private data folder (Chrome / Edge / Brave on desktop)
 
@@ -341,9 +350,15 @@ current state of your data:
   appears across the top of the app — *"Your latest change wasn't
   saved."* — and clears itself the moment the next save succeeds.
 - **Browser-only — this browser doesn't support saving to a folder**
-  (yellow) — Safari, Firefox, iOS, and Android Chrome don't ship the
-  File System Access API. Use *Download my private data* (below) for
-  manual backup instead.
+  (yellow) — desktop **Safari** and **Firefox** don't ship the File
+  System Access API. Use *Download my private data* (below) for manual
+  backup instead.
+- **On phones, your data stays in this browser…** (yellow) — the
+  message you'll see on **any phone or tablet**. The data folder is
+  intentionally not offered on mobile (Android can only save into a
+  Downloads subfolder the system clears; iOS has no picker). The
+  *Download my private data* button right below the badge is your backup
+  path — use it and store the file somewhere you trust.
 
 ### Backup and restore (works in every browser)
 
@@ -378,8 +393,10 @@ offer to *Open existing*, and your groups / notes / tags come back.
 in Android Settings wipes everything this app has saved, including
 the auto-backups. On **iOS**, *Settings → Safari → Clear History and
 Website Data* does the same. Both bypass the app's own confirm
-dialogs — download a backup yourself before doing either. (Phones
-don't yet support the private data folder feature.)
+dialogs — download a backup yourself before doing either. (Phones run
+in browser-only mode by design — the private data folder is a
+desktop-only feature, so on a phone the downloaded backup is your only
+durable copy.)
 
 **Switching browsers or devices.** If you set up a private data
 folder inside a cloud-sync folder (Dropbox / iCloud Drive /

--- a/plans/pna_toolkit_exceptions_contribution.md
+++ b/plans/pna_toolkit_exceptions_contribution.md
@@ -59,8 +59,9 @@ The cloud-LLM tension then resolves into a third option:
 
 3. **Allow it as a caught, handled Exception** — `EX-CLOUD-LLM`. Consent gate before raising,
    persistent "not a PNA right now" signal while active, in-app explainer of the active exception
-   set, and a declared return-to-PNA-mode path. The app is honest, conformant *in non-PNA mode*,
-   and the user gets the feature they asked for with eyes open.
+   set, declared return-to-PNA-mode path, and **required user acceptance** (consent/signals reach the
+   human in the workspace — AI agents MUST NOT proxy-accept). The app is honest, conformant *in
+   non-PNA mode*, and the user gets the feature they asked for with eyes open.
 
 This is the same ship-and-iterate bias the project already runs on: rather than block the feature
 until local models are practical for 500 people, ship the honest non-PNA mode and refine the
@@ -85,7 +86,7 @@ accepted").
 | A condition that interrupts normal control flow | A condition under which a PNA departs from a baseline guarantee |
 | `raise` / `throw` | **Raised** by a specific user action (e.g. connecting a cloud MCP client) |
 | Uncaught exception crashes / leaks | A *silent* deviation is the failure mode — exceptions MUST be **caught** |
-| `try/except` handler | A defined **solution** (consent gate + signal + explainer + reversal path) |
+| `try/except` handler | A defined **solution** (consent gate + signal + explainer + reversal path + **required user acceptance**, not proxy acceptance) |
 | Stack trace identifies the exception | Every exception has a stable `EX-*` ID and a canonical definition |
 
 ### Raise / catch / handle
@@ -98,6 +99,34 @@ accepted").
   and a persistent signal is shown *while active*.
 - **Handle** — the app runs the exception's **solution**: the consent surface, the persistent
   signal, the active-exception explainer, and the declared reversibility path.
+
+### AI-as-proxy failure mode (required user acceptance)
+
+The first recommended solution component for less-faithful (non-PNA-mode) operation is **required
+user acceptance**: consent and ongoing exception notification MUST reach the **ultimate human user
+interface**, not be satisfied by an AI agent acting as proxy.
+
+When a cloud MCP client drives a PNA, the agent sits between the MCP servers and the human. EX-H2
+consent that lives only in the agent's chat transcript — or that the agent "accepts" on the user's
+behalf without opening the PNA workspace — is **proxy acceptance**, not the informed consent the
+handler contract requires. The same applies while an exception is active: EX-H3's persistent signal
+and EX-H4's explainer MUST be visible to the human in the workspace; an agent paraphrasing them in
+chat is not a substitute where the workspace is reachable.
+
+**Division of responsibility:**
+
+- **PNA (normative in `exceptions.md`):** consent and active-exception surfaces MUST be
+  human-reachable in the workspace; they MUST NOT be satisfiable solely by an MCP tool return value
+  or agent-side acknowledgment (EX-H7).
+- **AI agent (normative in `SKILL.md` § Principles + Evaluate flow):** when operating a PNA that
+  can raise an exception, the agent MUST propagate pre-raise consent prompts and active-exception
+  notifications to the user in the PNA workspace and MUST NOT substitute its own acceptance — where
+  viable (the workspace is installed and the user can reach it). If the agent cannot propagate
+  (headless-only install, no UI), it MUST refuse to raise or MUST surface the blocker explicitly;
+  it MUST NOT silently proceed in non-PNA mode.
+
+Future exceptions may add further solution components; **required user acceptance** is the first and
+applies to every exception whose raise or handling has a workspace UX surface.
 
 ### PNA mode vs non-PNA mode
 
@@ -169,6 +198,11 @@ is spec-conformant in non-PNA mode **iff** every active exception is handled to 
 
 PNT validates behaviors against the Goals; it does not certify. The evaluate flow detects
 exceptions and verifies how each is handled, reporting by `EX-*` ID.
+
+The first recommended solution component for exceptions with a workspace UX is **required user
+acceptance** (handler clause EX-H7): consent and active-exception notification MUST reach the
+human in the workspace; AI clients MUST NOT substitute proxy acceptance where the workspace is
+reachable.
 ```
 
 #### DRAFT — normative handler contract (RFC 2119; refined from the maintainer's brief)
@@ -200,10 +234,19 @@ For each exception it can raise, a conforming PNA:
   Reversibility refers to **MODE ONLY**: a handler MUST NOT imply that returning to PNA mode undoes
   consequences already incurred (e.g. data already disclosed to a third party).
 - **EX-H6 — Recommended solution.** SHOULD name a recommended solution in its registry entry,
-  demonstrated by a reference design.
+  demonstrated by a reference design. The first recommended solution component for exceptions with
+  a workspace UX is **required user acceptance** (EX-H7): see the registry entry's Recommended
+  solution column.
+- **EX-H7 — Required user acceptance, not proxy acceptance.** The consent surface (EX-H2) and,
+  while active, the persistent signal (EX-H3) and active-set explainer (EX-H4) MUST be reachable
+  by the human user in the workspace. They MUST NOT be satisfiable solely by an MCP tool return,
+  agent chat acknowledgment, or any proxy acting on the user's behalf. Where the workspace is
+  installed and reachable, an AI client driving the PNA MUST propagate these prompts and
+  notifications to that workspace UI; proxy acceptance MUST NOT count as consent or as
+  acknowledgment of the non-PNA-mode signal.
 ```
 
-> **Sub-contract IDs.** `EX-H1..EX-H6` follow PNT's existing sub-contract convention
+> **Sub-contract IDs.** `EX-H1..EX-H7` follow PNT's existing sub-contract convention
 > (`<prefix>-<integer>`, monotonic, never renumbered — see `PNA_Spec.md` § Sub-contracts per slot).
 > Using `EX-H*` keeps them distinct from the `EX-*` exception-registry IDs while staying in the
 > same family namespace. **Open question for the maintainer (§ 5): are sub-contract IDs wanted here,
@@ -245,7 +288,7 @@ design's handler declaration.
 
 | EX | Name | Relaxes | Stresses | Reversible | Recommended solution |
 |---|---|---|---|---|---|
-| EX-CLOUD-LLM | Cloud-hosted AI over PNA data | PNA-DEFINITION, AC-MCP-A | Goal 1 | yes (mode only) | pre-raise consent gate + persistent dismissable "not a PNA" banner + in-app active-exception explainer + return-to-PNA-mode — demonstrated by fellows_local_db |
+| EX-CLOUD-LLM | Cloud-hosted AI over PNA data | PNA-DEFINITION, AC-MCP-A | Goal 1 | yes (mode only) | required user acceptance (EX-H7) + pre-raise consent gate + persistent dismissable "not a PNA" banner + in-app active-exception explainer + return-to-PNA-mode — demonstrated by fellows_local_db |
 
 ### EX-CLOUD-LLM — Cloud-hosted AI over PNA data
 
@@ -259,11 +302,20 @@ Returning to PNA mode does NOT undo any disclosure already made to the cloud pro
 model, ChatGPT desktop) to a PNA's MCP servers that can return Private DB rows. The canonical
 trigger is the Private Data Ops server (see PNA_Spec.md § Vocabulary, MCP server).
 
-**Recommended solution:** pre-raise consent gate (EX-H2) + persistent dismissable "not a PNA right
-now" banner naming EX-CLOUD-LLM (EX-H3) + in-app active-exception explainer (EX-H4) +
-return-to-PNA-mode control (EX-H5). Demonstrated by `fellows_local_db`
-(reference_designs/fellows_local_db/).
+**Recommended solution:** required user acceptance — consent and active-exception UX MUST reach the
+human in the workspace, not proxy acceptance by the AI client (EX-H7) + pre-raise consent gate
+(EX-H2) + persistent dismissable "not a PNA right now" banner naming EX-CLOUD-LLM (EX-H3) +
+in-app active-exception explainer (EX-H4) + return-to-PNA-mode control (EX-H5). Demonstrated by
+`fellows_local_db` (reference_designs/fellows_local_db/).
 ```
+
+> **Why EX-H7 leads the solution list.** Cloud MCP is the canonical case where an AI agent can
+> interpose between the raise (Settings consent gate / MCP wiring) and the human. The workspace
+> consent gate in fellows is deliberately not an MCP tool — the human must open Settings and accept
+> there. AI agents operating the PNA MUST tell the user to do that and MUST NOT treat their own
+> tool-use approval or chat "OK" as raising the exception. Additional solution components for other
+> less-faithful modes may land in future registry entries; required user acceptance is the
+> cross-cutting first one.
 
 > **Table format and the lint.** Each registry row begins `| EX-... |`, mirroring the `| AC-X |`
 > rows the lint already scans. § 3c adds an `EX_RE` that mirrors `AC_RE` exactly.
@@ -392,7 +444,12 @@ ID. Add an exceptions pass. **Proposed wording**, inserted as a new step after t
     Architecture document's exception/handler table, or inferred from the source where undeclared):
     - **Caught & handled?** Confirm consent is obtained before the raise (EX-H2), a persistent
       non-PNA-mode signal is shown while active (EX-H3), and a runtime active-set explainer exists
-      (EX-H4). Cite the code/UX for each.
+      (EX-H4). Confirm required user acceptance (EX-H7): consent/signal/explainer are workspace-
+      reachable and not satisfiable by MCP-only or agent proxy. Cite the code/UX for each.
+    - **AI agent propagation?** When evaluating an AI-driven workflow (MCP client + PNA), confirm
+      the agent instructions / skill surface require propagating consent and active-exception
+      notification to the human workspace UI and forbid proxy acceptance where the workspace is
+      reachable. Cite SKILL.md § Principles or the candidate's operator docs.
     - **Reversibility claimed?** Read the `Reversible:` declaration. If `yes`, trace the declared
       `Reversal:` mechanism and decide whether the code/UX actually delivers a practical,
       user-reachable path back to PNA mode. Cite the control or route. Reversibility is MODE only —
@@ -409,6 +466,18 @@ grade" framing is explicit:
 ```markdown
 - **Validation, not certification.** Report findings — conformant/non-conformant/exception-handled
   — by AC or EX ID. There is no overall pass/fail grade and no badge.
+- **Required user acceptance, not proxy acceptance.** When driving or evaluating a PNA that can
+  raise an exception, propagate pre-raise consent and active-exception notifications to the human
+  in the PNA workspace; do not accept on the user's behalf where the workspace is reachable.
+```
+
+Also add one sentence to `PNA_Spec.md` § Building a PNA (alongside § 3d's validation callout).
+DRAFT:
+
+```markdown
+When an AI operates a PNA in non-PNA mode (an active Exception), it MUST propagate consent and
+active-exception notifications to the human user in the workspace and MUST NOT substitute proxy
+acceptance — see [`exceptions.md`](exceptions.md) EX-H7.
 ```
 
 The three-layer split the maintainer wants is then complete and explicit:
@@ -451,7 +520,7 @@ DRAFT row (Verification column is mandatory — see gap analysis):
 
 | EX | Handled? | Realization | Reversible | Verification | Status |
 |---|---|---|---|---|---|
-| EX-CLOUD-LLM | yes | Consent gate before a cloud MCP client can reach Private Data Ops; persistent dismissable "not a PNA right now" banner naming EX-CLOUD-LLM; in-app active-exception explainer route; "Return to PNA mode" control that disconnects the cloud client. Code: `mcp_servers/private_data_ops.py` (consent gate), `app/static/app.js` (banner + explainer route + return control). | yes (mode only) | LLM rubric: "trace the cloud-MCP code path; confirm consent precedes any Private-DB row return (EX-H2), a persistent signal naming EX-CLOUD-LLM is shown while active (EX-H3), the explainer route exists and lists the active set (EX-H4), and the return-to-PNA control disconnects the client (EX-H5)." Plus a deterministic test asserting the consent gate refuses Private-DB tools until consent is recorded. | conformant (once handler ships) / planned |
+| EX-CLOUD-LLM | yes | Required user acceptance (EX-H7): consent gate in Settings workspace UI only — not an MCP tool; persistent dismissable "not a PNA right now" banner naming EX-CLOUD-LLM; in-app active-exception explainer route; "Return to PNA mode" control that disconnects the cloud client. Code: `app/static/app.js` (consent gate + banner + explainer route + return control); MCP servers read consent state from shared storage. Operator docs: `docs/use_with_claude_desktop.md`, `mcp_servers/README.md` § Cloud LLM caveat. | yes (mode only) | LLM rubric: "trace the cloud-MCP code path; confirm consent is workspace-only and precedes any Private-DB row return (EX-H2, EX-H7 — agent chat approval does not count); a persistent signal naming EX-CLOUD-LLM is shown while active (EX-H3); the explainer route exists and lists the active set (EX-H4); the return-to-PNA control disconnects the client (EX-H5). Confirm operator docs instruct the AI to propagate consent to Settings, not proxy-accept." Plus deterministic tests: consent gate refuses Private-DB tools until consent is recorded; e2e `test_pna_exception_mode.py`. | conformant (once handler ships) / planned |
 | | | | | | |
 ```
 
@@ -563,7 +632,7 @@ plan. This document is the artifact the maintainer reviews; everything downstrea
    zero special-casing — cleaner lint, but it puts the foundational definition into the AC table,
    which may be conceptually heavier than wanted. Maintainer's call.
 
-5. **Handler clause IDs `EX-H1..EX-H6` (§ 3a).** Keep them as citable sub-contracts (recommended —
+5. **Handler clause IDs `EX-H1..EX-H7` (§ 3a).** Keep them as citable sub-contracts (recommended —
    the evaluate flow can cite "fails EX-H3") or leave the handler contract prose-only? If kept,
    confirm the `EX-H*` namespace doesn't collide with the `EX-*` registry namespace in the lint
    (the regexes in § 3c anchor registry IDs to `| EX-...` table rows, so `EX-H*` clauses in prose
@@ -583,4 +652,11 @@ plan. This document is the artifact the maintainer reviews; everything downstrea
    raised in a headless server the user isn't looking at? Worth flagging in the PR as a known
    limitation of the first handler even if fellows solves it pragmatically (e.g. the workspace polls
    or the MCP consent is recorded in a place the workspace reads).
-```
+
+8. **How far does EX-H7 reach beyond the PNA repo?** Required user acceptance splits cleanly:
+   the PNA MUST implement workspace-reachable consent (enforceable in code + e2e); the AI agent
+   MUST propagate (enforceable via SKILL.md + operator docs, verified in Evaluate flow). Should
+   PNT also add a one-line norm in `contracts/mcp-private-data-ops.schema.json` description
+   ("consent is workspace-only; MCP clients must not proxy-accept") or keep EX-H7 entirely in
+   `exceptions.md` + SKILL for v1? Recommend: `exceptions.md` + SKILL + operator docs first;
+   contract prose in a follow-on if a second exception needs it.

--- a/tests/e2e/mobile/test_folder_gate.py
+++ b/tests/e2e/mobile/test_folder_gate.py
@@ -1,0 +1,111 @@
+"""Mobile gating of the durable data-folder feature.
+
+The private data folder is deliberately NOT offered on phones / tablets:
+Android's directory picker only reaches a Downloads subfolder the OS can
+clear at will (so it can't keep the feature's durability promise) and iOS
+has no picker at all. On mobile the app is OPFS-only, and the manual
+backup download is the durability path. See docs/feature_platform_matrix.md
+§ The mobile contract.
+
+These tests pin the page-side gate (app.js: isMobileDevice /
+folderStorageOffered) under a mobile UA:
+
+  * folderStorageOffered() is false, even though the picker API is present
+    (Chromium-under-iOS/Android-UA in Playwright) — proving the gate is a
+    policy choice, not an API-absence accident.
+  * The folder badge resolves to the 'unsupported' state with the
+    phone-specific copy; the "Choose folder…" button stays hidden; the
+    top-of-app folder-push banner never appears.
+  * CRITICAL regression guard: the "Download my private data" button stays
+    VISIBLE. It's the only durability path on mobile, and its un-hide was
+    previously coupled to folder support — gating folder off must not take
+    the backup button with it.
+
+Note on the harness: Playwright emulates iOS/Android via UA + viewport but
+the engine is Chromium, which ships showDirectoryPicker. That's why we can
+assert pickerApiPresent is true while folderStorageOffered() is false — the
+exact distinction the gate encodes.
+"""
+from __future__ import annotations
+
+import pytest
+from playwright.sync_api import expect
+
+from tests.e2e.conftest import _STANDALONE_DISPLAY_INIT, make_worker_data
+
+
+# Standalone shim (so the app boots straight to the directory) plus the
+# showSaveFilePicker delete the other mobile interaction tests use, so a
+# stray native save dialog can't hang anything.
+_GATE_INIT = _STANDALONE_DISPLAY_INIT + """
+(function () {
+  try { delete window.showSaveFilePicker; } catch (e) {
+    try { window.showSaveFilePicker = undefined; } catch (e2) {}
+  }
+})();
+"""
+
+# Pixel 5 = Android UA, iPhone 13 = iOS UA. Both must gate identically.
+_MOBILE_DEVICES = ("Pixel 5", "iPhone 13")
+
+
+def _seeded_settings_page(playwright, browser, device, base_url):
+    """Open a mobile-emulated page, seed a group, land on #/settings.
+    Returns (context, page); caller closes the context."""
+    context = browser.new_context(**dict(playwright.devices[device]))
+    page = context.new_page()
+    page.add_init_script(_GATE_INIT)
+    helper = make_worker_data(page, base_url)
+    if helper.wait() != "worker":
+        context.close()
+        pytest.skip("worker provider unavailable in this environment")
+    helper.wipe_relationships()
+    helper.create_group("folder gate test")
+    page.evaluate("() => { location.hash = '#/settings'; }")
+    # The download button is the load-bearing element on mobile; wait for
+    # the settings page to have rendered the folder section.
+    page.locator("#settings-download-userdata").wait_for(state="visible", timeout=10000)
+    return context, page
+
+
+@pytest.mark.parametrize("device", _MOBILE_DEVICES)
+def test_folder_storage_not_offered_but_api_present(playwright, browser, base_url_fixture, device):
+    """The feature is gated off as policy, not because the API is missing."""
+    context, page = _seeded_settings_page(playwright, browser, device, base_url_fixture)
+    try:
+        offered = page.evaluate("() => window.__folderController.folderStorageOffered()")
+        assert offered is False, f"{device}: folder storage should not be offered on mobile"
+        state = page.evaluate("() => window.__folderController.getState()")
+        # getState() returns a Promise; evaluate awaits thenables automatically.
+        assert state["supported"] is False, f"{device}: state.supported should be false on mobile"
+        assert state["pickerApiPresent"] is True, (
+            f"{device}: Chromium-under-mobile-UA exposes showDirectoryPicker; the gate "
+            "is a policy choice, so pickerApiPresent must stay truthful"
+        )
+    finally:
+        context.close()
+
+
+@pytest.mark.parametrize("device", _MOBILE_DEVICES)
+def test_folder_ui_hidden_with_phone_copy(playwright, browser, base_url_fixture, device):
+    """Choose-folder button hidden, folder-push banner absent, badge shows
+    the phone-specific message."""
+    context, page = _seeded_settings_page(playwright, browser, device, base_url_fixture)
+    try:
+        expect(page.locator("#settings-folder-choose")).to_be_hidden()
+        expect(page.locator("#folder-push-banner")).to_be_hidden()
+        badge = page.locator("#settings-folder-badge .settings-folder-badge-text")
+        expect(badge).to_contain_text("On phones", timeout=10000)
+    finally:
+        context.close()
+
+
+@pytest.mark.parametrize("device", _MOBILE_DEVICES)
+def test_download_button_stays_visible_on_mobile(playwright, browser, base_url_fixture, device):
+    """Regression guard: gating folder off mobile must NOT hide the backup
+    button — it's the only durability path on a phone."""
+    context, page = _seeded_settings_page(playwright, browser, device, base_url_fixture)
+    try:
+        expect(page.locator("#settings-download-userdata")).to_be_visible()
+    finally:
+        context.close()


### PR DESCRIPTION
## Why

You hit this on the shipped app: on Android you're offered a "data folder," but the OS picker only lets you create a subfolder of **Downloads**, which can be cleared at any time — so the choice is both confusing and a false durability promise.

Root cause: the folder feature only feature-detected `window.showDirectoryPicker`. Android Chrome **ships that API**, so folder mode leaked onto Android — contradicting the plan's `Q3` ("mobile = OPFS-only") and `docs/feature_platform_matrix.md` (which already lists the folder as unsupported on mobile). The plan's intent was never enforced in code.

This makes the code match the intent: **the durable data folder is gated off all mobile (Android + iOS).** Phones are OPFS-only; durability is the manual backup download.

## What changed

**`app/static/app.js`**
- `isMobileDevice()` (module scope) + `FOLDER_CONTROLLER.folderStorageOffered()` = picker API present **and** not mobile. `state.supported` keys off this, so the badge → `unsupported`, the *Choose folder…* button hides, the folder-push banner never appears, and the picker no-ops on mobile.
- `browserSupportsFolderPicker()` stays literal (truthful) so `?diag=1` reports `pickerApiPresent` and flags "gated off on mobile".
- **Decouple the *Download my private data* button** from folder-`supported` → gate on worker availability. It's the only durability path on mobile/Safari/Firefox and must stay visible. (Side benefit: fixes a latent case where desktop Safari/Firefox could lose the button.)
- Phone-specific `unsupported` badge copy pointing at the backup.

**`app/static/vendor/sqlite-worker.js`**
- `_isMobileWorker()` + a boot **de-migration**: if a folder handle survives on mobile (e.g. you already picked one on the current prod app), hydrate its data into OPFS when readable, retire the IDB handle, force `_storageMode='opfs'`. **The physical folder file is never deleted** (only the IDB record), so it stays in Downloads as a recoverable artifact — this path cannot lose data.

**Docs:** `feature_platform_matrix.md` footnote `[^5]` + new *The mobile contract* section; `users_manual.md` badge-states + where-data-is-stored corrected (it falsely claimed Android lacks the API).

## Tests
- New `tests/e2e/mobile/test_folder_gate.py` (Android + iOS UAs): folder not offered though API present, badge/banner/Choose-button hidden, **download button stays visible**.
- Green locally: mobile e2e (116), desktop folder+settings (19), worker/boot (18), fast units (96).

## Related (not in this PR)
The Android backup-download "Couldn't load object" bug is already fixed on `main` (`a8dd8a9`) but **not yet deployed** — `just ship` will carry both it and this. Until then the prod app lacks both.

## Maintainer QA (real devices — emulation can't catch storage/engine quirks)

**Android Chrome (the reported case):**
1. On the *current* prod app (pre-deploy), confirm you're offered a data folder / see the folder-push banner. Deploy this branch.
2. After update: Settings → *Private data folder* shows the **"On phones, your data stays in this browser…"** badge; **no** *Choose folder…* button; **no** top-of-app folder banner.
3. *⬇ Download my private data* is **visible** and saves a `relationships-*.db` into **Downloads** (no Drive share sheet, no "Couldn't load object").
4. If you had already picked a folder: your groups/notes are intact (worker de-migrated folder→OPFS); the old `Downloads/Fellows/relationships.db` file is still physically there.
5. `?diag=1` → *Data folder*: `showDirectoryPicker present: true`, `folder storage offered here: false (gated off on mobile)`.

**iOS Safari (PWA):** same Settings/badge/banner expectations; *Download my private data* visible and uses the share sheet.

**Desktop Chromium regression check:** folder picker, *Saved* badge, auto-save, and banner all still work unchanged.