### PR TITLE
Planning + constraints finding for the private-data capability gate

### DIFF
--- a/docs/architectural_findings.md
+++ b/docs/architectural_findings.md
@@ -11,6 +11,163 @@ Newest first.
 
 ---
 
+## 2026-06-01 — A PWA can't give every platform a writable private store; "constraints" name the ceiling honestly
+
+### The finding
+
+A user's Private Data Ops MCP server stopped connecting to Claude Desktop.
+The proximate cause was mundane — the `.mcpb` extension pointed at a
+`relationships.db` export that had been relocated out of `~/Downloads` —
+but chasing *why the handoff was that fragile in the first place* surfaced
+a class-level ceiling we had been routing around without naming:
+
+> For a PNA delivered as a web app, the private-data half's writability and
+> external-readability is gated entirely by the browser's **File System
+> Access API** — which is Chromium-only. On every non-FSA browser (Safari,
+> Firefox, *all* of iOS), the private store can only live in the opaque
+> OPFS sandbox (invisible to the user and to companion tools like the app's
+> own MCP servers), is subject to silent browser eviction (Safari's
+> script-storage cap), and can escape to a real file only as a one-shot,
+> immediately-stale download snapshot. So on those browsers the private
+> half — the part that is supposed to be the user's sovereign, live,
+> manipulable, forever data — degrades to a **read-only snapshot at best**.
+
+This is a different *kind* of finding from the cloud-LLM exception below it.
+That one is a **privacy** deviation a user deliberately *raises* and the app
+*handles* honestly. This one is a **data-loss** ceiling the *platform*
+imposes — nobody raises it; it is a property of the medium. It is arguably
+the more serious of the two, because the failure mode is silent and the
+casualty is the user's own data.
+
+### Why it's the application class, not this app
+
+The ceiling falls out of the intersection `distribution:web-bundle` ×
+`storage:opfs-sqlite-wasm` × a browser-capability fact. Nothing about EHF,
+the fellows schema, or this app participates. **Any** PNA that makes those
+two axis picks inherits it — and inherits a whole family of sibling ceilings
+alongside it (eviction, no built-in sync, the single-owner OPFS architecture,
+the sandbox boundary that seals the store off from the user's other tools).
+A PNA is meant to be the *hub* the user's other tools (comms clients, LLMs,
+scripts, backups) act on; a store those tools cannot read is only half a PNA.
+That makes the sandbox boundary, not the FSA gap alone, the deepest edge here.
+
+### The resolution: constraints (the dual of exceptions)
+
+We model the ceiling as a first-class, named **constraint** — the dual of an
+[exception](#2026-05-30--users-want-a-cloud-llm-exceptions-let-a-pna-stay-honest-instead-of-forbidding-it).
+An exception is a deviation the *user* raises and the *app* catches and
+handles; a constraint is a limitation the *platform* imposes and the *app*
+must likewise catch and handle — never silently. Same "always know what mode
+you're in" philosophy, opposite origin.
+
+> A **constraint (`CST-*`)** is a platform- or substrate-imposed ceiling,
+> inherited automatically by one or more **axis picks** (raised by no one —
+> it's a property of the medium), that **removes or bounds functionality a
+> PNA would otherwise offer**. It obligates a documented **handling** —
+> typically honest capability reduction matched to what the platform can
+> actually deliver ("enough power to be useful, not enough to be
+> dangerous") — and a reference design stays conformant by handling it
+> honestly, *not* by overcoming it. Every constraint carries an explicit
+> **resolution frontier**: whether a viable workaround is known, or whether
+> (as of this version) none has been found.
+
+Each `CST-*` records: **Triggered by** (the axis pick[s]), **Ceiling** (what
+it removes/bounds), **Stresses** (the Goal/AC it bounds), **Handling** (the
+obligated response), **Frontier** (`Open` / `Mitigated` / `Solved-on-<platform>`
+/ `Inherent` — whether anyone has beaten it yet), and **Detectability** (how a
+builder knows they're under it on a given platform: clean feature-detect /
+empirical probe / **must-UA-sniff**).
+
+The **Frontier** field is the one that keeps a reference design honest. Our
+actual product decision — *drop private data on mobile and Safari, for now* —
+is the *handling*, and its frontier is **Open**: no viable workaround found as
+of Toolkit-Version 0.1, but there might be one (an encrypt-then-email-to-self
+portability pattern is a candidate, unproven). A future revision can flip a
+constraint from `Open` → worked-around and document *how*. We do not pretend
+to have solved what we have only reduced.
+
+### The ceilings we hit (the eight that earn a normative `CST-*`)
+
+| ID | Triggered by | Ceiling | Frontier |
+|---|---|---|---|
+| `CST-PWA-PRIVATE-SNAPSHOT` | web-bundle × opfs, non-FSA browser | Private store is read-only-snapshot-at-best off Chromium | **Open** (mitigated: drop private writes off Chromium; encrypted-email transport is an unproven candidate) |
+| `CST-PWA-SANDBOX-SEALED` | opfs storage | Store invisible to the user *and* unreadable by their other tools (MCP, backups, CLIs); the PWA also can't host native integration to bridge it — **the root of the MCP-handoff fragility** | Solved on Chromium via folder mode; **Open** otherwise |
+| `CST-PWA-STORAGE-EVICTABLE` | opfs / IndexedDB | Script storage is evictable; `persist()` is a request, not a guarantee; Safari caps it | **Open** (mitigated: backup ring + export discipline) |
+| `CST-PWA-NO-SYNC` | web-bundle × opfs | Origin- and device-local silos; zero built-in portability | **Open** (encrypted-email is the candidate pattern) |
+| `CST-PWA-DURABLE-SQL-ARCH` | opfs-sqlite-wasm | Durable SQL forces a worker-owned, cross-origin-isolated, single-connection architecture | **Inherent** (accepted cost; the worker-owned convention is the handling) |
+| `CST-PWA-SINGLE-OWNER` | opfs-sqlite-wasm | Multi-tab contention with no OS file lock | **Solved** (Web Locks + ownership-conflict detection) |
+| `CST-PWA-NO-BACKGROUND` | web-bundle | No reliable scheduled background execution (esp. iOS) → backups can only be opportunistic | **Open on iOS** (mitigated: per-boot debounced backup; never promise scheduled protection) |
+| `CST-PWA-SERVER-FLOOR` | web-bundle | Needs an origin + TLS + secure context; true serverless-local is unreachable | **Inherent** (handled by bounding the server to distribution/update — Never-SaaS) |
+
+Two **meta-principles** sit above the table and are more reusable than any
+single row:
+
+- **M1 — capability presence ≠ usefulness ≠ permanence.** `showDirectoryPicker
+  in window` is true on Android Chrome but only reaches an OS-clearable folder;
+  `persist()` returns true but Safari still evicts; `createSyncAccessHandle`
+  exists in a worker but not on the page. You must detect *useful, durable*
+  capability — often empirically — and distrust the obvious feature-check.
+  This is why the entry scheme carries a **Detectability** field at all.
+- **M3 — the handling pattern is per-platform capability reduction.** Match each
+  platform's *offered* features to the durability it can actually *keep*. Mobile
+  loses folder mode (it can't keep the promise; see PR #234 / `8392193`) and is
+  left with OPFS + manual backup. "Enough power to be useful, not enough to be
+  dangerous." For constraints this is the dual of the exception's "catch and
+  handle honestly."
+
+**Footgun companion (non-normative — recorded so builders don't re-derive
+them, but they don't carry a ceiling's weight):** service-worker staleness /
+"what code is actually running" ambiguity; no atomic factory reset (OPFS has no
+per-origin wipe API; the HttpOnly cookie needs a server round-trip); PWA install
++ manifest gotchas (WebAPK `related_applications`, POST `share_target`, iOS's
+hidden Add-to-Home-Screen). All navigable; none is a wall.
+
+### A note on "helpful constraints"
+
+Some platform ceilings happen to *serve* a PNA goal — a PWA can't send mail
+itself, only hand off a `mailto:` URL, which lands the app in exactly the
+"transports cannot read message contents" shape the spec wants (AC-18). These
+are real, but they are **not** builder/verifier advice in the way an adverse
+ceiling is — a builder will either already know, be pleasantly surprised, or
+harmlessly ignore one. They belong in a future *"things that worked well,
+proven true and useful"* channel, **not** the constraints registry. We park
+that channel deliberately; the registry is for ceilings that take capability
+away.
+
+### What this feeds back into the toolkit
+
+The plan to contribute this upstream — introducing **constraints** as a
+general PNA mechanism (dual to exceptions, applicable to any substrate, with
+the PWA ceilings above as the first populated set), via a new normative
+`spec/constraints.md` registry, a `lint-spec-ids.py` extension that traces
+`CST-*` / `Triggered-by:` / `Frontier:` the way it already traces `AC-*` and
+`EX-*`, axis-pick cross-references on Storage and Distribution, and
+fellows_local_db as the demonstrating reference design — will be staged in
+[`../plans/pna_toolkit_constraints_contribution.md`](../plans/pna_toolkit_constraints_contribution.md),
+mirroring the exceptions contribution. The decisions locked before drafting: the concept is a
+**general mechanism** (not a PWA-only catalog); **hard ceilings are normative,
+footguns are preserved as non-normative notes**; and the registry is
+**adverse-only** (no valence field — helpful ceilings are the separate
+channel above). Per the toolkit's reference-driven model, the spec change
+rides along with the working design that demonstrates it; this app is that
+design.
+
+The factual substrate matrix this finding generalizes already lives in
+[`browser_support.md`](browser_support.md) (capability floors; folder mode
+*required* for private data — the verified-folder gate, not an additive
+tier) and [`persistence_and_upgrades.md`](persistence_and_upgrades.md) (the
+per-substrate state-survival table; browse-only mode is localStorage-only
+with no durable private store). Both now point here for the *why /
+class-level* framing. The realization is the private-data capability gate
+([`../plans/private_data_capability_gate.md`](../plans/private_data_capability_gate.md)),
+attested in [`Architecture.md` § Constraint attestation](Architecture.md);
+the user-facing surfacing (per-platform feature availability, "Download my
+private data," browse-only on Safari/Firefox/phones) is documented in
+[`users_manual.md`](users_manual.md) and [`feature_platform_matrix.md`](feature_platform_matrix.md);
+the platform-tiering decisions are recorded in [`ac_decisions_log.md`](ac_decisions_log.md).
+
+---
+
 ## 2026-05-30 — Users want a cloud LLM; "exceptions" let a PNA stay honest instead of forbidding it
 
 ### The finding

--- a/plans/EPIC_phase0_findings.md
+++ b/plans/EPIC_phase0_findings.md
@@ -1,0 +1,73 @@
+# Phase 0 results — frozen interfaces (the contract the lanes build against)
+
+Produced by the Phase-0 analysis fan-out (2026-06-02). This is the **frozen interface** Lane CORE / WORKER / STYLE / DOCS / TESTS build against in parallel. Anchors verified against the working tree at that date. Companion to [`EPIC_private_data_and_mobile.md`](EPIC_private_data_and_mobile.md).
+
+## A. Worker↔page RPC contract (bump `WORKER_RPC_VERSION` 3 → 4)
+
+`WORKER_RPC_VERSION = 3` (`sqlite-worker.js:53`), `EXPECTED_WORKER_RPC_VERSION = 3` (`app.js:40`). Bump **both to 4** in lockstep. `RELATIONSHIPS_SCHEMA_VERSION` stays **1** — the identity stamp is rows in the existing `settings` table, not a schema change. Transport: `{id,op,args}` → `{id,ok,result|error,errorCode?}`; dispatch map `sqlite-worker.js:2640-2667`; page wrapper `createSqliteWorkerRpc` `app.js:3852-3900`; provider façade `createWorkerDataProvider` `app.js:3907-4080`; mutation skew gate `refuseIfVersionSkew` `app.js:3913`.
+
+New ops:
+
+| Op | Params | Returns | Mutates | Gating | Reuse |
+|---|---|---|---|---|---|
+| `probeFolderWritable` | `{handle, mode?='auto'}` | `{ok,parentName,subfolderName,sentinelVerified,permissionPersisted}` OR collision `{requiresChoice,existing{counts,size,lastModified},suggestion}` | yes (transient sentinel + persists handle on full pass) | version-**tolerant** (note the write exception in the `:46-52` contract comment) | `_findOrCreateSubfolder` :1914, `_folderQueryPermission` :2029, `_folderRecordPersist` :1871; **new** `_probeWritableSentinel(subHandle)` returning staged reason |
+| `scanFellowsCandidates` | `{handle}` (parent) | `{candidates:[{subfolderName,groups,members,notes,lastModified,deviceLabel,writeGeneration,invalid,invalidReason}],recommended}` | no | tolerant | enumerate `Fellows*` via `parentHandle.values()` (today's `auto` only previews default — the §7.1 bug); per-candidate `_probeSubfolder` :1993 + identity read; **sequential** (shared `RESTORE_STAGING_SLOT` :166) |
+| `getWorkspaceIdentity` | `{}` | `{workspace_uuid,device_label,created_at,last_written_at,write_generation}` (nulls if unset) | no | tolerant | `getSettings` :947 |
+| `ensureWorkspaceIdentity` | `{deviceLabel?}` | identity obj (mints `workspace_uuid` via `crypto.randomUUID()`, stamps `created_at` once) | yes | gated | `setSetting`/`dbRun` |
+| `migrateOpfsRelationshipsToFolder` | `{}` | `{ok,bytesWritten,lastSavedAt,counts}` | yes (writes `<folder>/Fellows/relationships.db`; **non-destructive** — OPFS copy intact until verified) | gated | **≈ `writeRelationshipsToFolder` :2509** — prefer reuse + call `ensureWorkspaceIdentity` first; new op optional sugar |
+
+Internal (not an RPC): `_stampWriteGeneration()` folded into the OPFS commit transaction of every mutating handler (`createGroup` :897, `updateGroup` :927, `deleteGroup` :937, `setSetting` :968) so `write_generation`/`last_written_at` advance **atomically with the data** and survive backup/restore.
+
+**Probe reason codes** (each → a troubleshooting-page anchor): `picker_cancelled`, `subfolder_create_failed`, `write_failed`, `readback_mismatch` (the durability proof — catches cloud/virtual folders), `permission_not_persisted`.
+
+**Reuse map (don't reinvent):** `_findOrCreateSubfolder` (auto/create-new/open-existing) :1914; `_probeSubfolder` :1993; `_folderQueryPermission` :2029; IndexedDB `fellows-fs-handles` persist/hydrate :1871/:1890; `_writeBytesToFolder` (atomic, Web-Lock-guarded) :2249; `writeRelationshipsToFolder`/`readRelationshipsFromFolder` :2509/:2571; `inspectBytes` (validate + counts) :582; backup ring :2315-2354; `getFolderHandleForReconnect` :2504; `_folderStateSnapshot` :2048.
+
+## B. DOM / CSS contract (STYLE ↔ CORE must agree on these exact names)
+
+- **Body flags:** `body.is-phone` (CORE sets at boot `app.js:11100`, layout only), `body.no-private-data` (CORE sets from `privateDataEnabled()`, feature gate). Scrollers (no rename): `#directory`, `#detail`, `#app-wrap`, `#site-header`, `.appbar`.
+- **Nav drawer (new DOM):** `#nav-drawer`(`.drawer`), `#nav-scrim`(reuses `.sheet-scrim`); `.drawer__head/__title/__nav`, `.drawer-link`(+`--active`), `.drawer__foot`, `.build-tag`. Hamburger = repurpose `#appbar-kebab`.
+- **Directory:** `.directory-row`, `.directory-row__name`, `.directory-row__go`(chevron); filter bar `.filterbar`, `.filter-btn`, `.filter-chip`, `.filter-chip__x`, `.filterbar__count` (state ids unchanged: `#filter-trigger`, `#has-email-filter`, `#filter-count`).
+- **Fellow detail:** `.contact-cta`; button family `.btn/.btn--primary/.btn--ghost/.btn--danger/.btn--block` (disabled via `aria-disabled="true"`); `.fellow-hero`, `.fellow-photo`, `.fellow-name`, `.fellow-tagline`, `.tag-chips`, `.tag-chip`, `.section-head`.
+- **Settings/About:** `.card`, `.stat-line(__label/__value)`, `.tool-row(--danger,__go)`, `.section-head`, `.hint`. Tool handlers reuse kebab proxy targets `#diag-toggle`, `#bug-report-button`, `#clear-app-cache-button`, `#reset-everything-button` (`app.js:3542-3582`).
+- **Desktop gate state (new, NOT in mobile mockup):** `.settings-section--unavailable`, `.settings-section-gate`, `.settings-section-gate__badge`(`--unsupported`), `.settings-section-gate__cta`. Gated on `folderStorageOffered()` `app.js:8659`.
+- **Shared, no rename:** `.appbar/.appbar__title/.appbar__kebab`, `.tabs` (CORE hides on phone, STYLE `body.is-phone .tabs{display:none}`), `.sheet/.sheet__handle/.sheet__head/.sheet-scrim`, `#filter-sheet`.
+
+## C. Surface inventory — gate treatment per site (the CORE worklist)
+
+Legend: **H**=hidden-on-phone (JS-skip render), **G**=grayed-on-desktop-no-folder (+ "Enable on Chrome desktop →"), **R**=route redirect/lock, **L**=leave-as-is.
+
+- Boot: add both body-class toggles next to `setShellVisible(true)` `app.js:11100`.
+- Directory select `.dir-mark` `5787-5800` (H+G); name link `5801-5806` (L); `#bulk-select-bar` `index.html:408` + `updateBulkBar` `6324` / `bulkToggleVisible` `6341` / `toggleDraftMember` `6306` (H+G/no-op).
+- Composer: `#group-rail` `index.html:419` + `renderRail` `6258`; `updateComposerFabFromDraft` `3592` (force-clear `has-selection`); `#composer-fab/-scrim` `index.html:439` + `initComposerFab` `3648` (H).
+- Fellow detail `renderDetail` `5888`: `.detail-add-to-group` `5906-5916` (H+G); `mailto:`/`tel:` rows `5951/5959` (L); add `.contact-cta` on phone.
+- Edit: `enterEditMode` `6449`, `#edit-mode-banner` `index.html:321` (H/R).
+- **`route()` `7171`** — NO guard exists today; add gate intercept before dispatch for `#/groups`, `#/groups/<id>`, `#/groups/<id>/directory`, `#/edit/<id>` (`7276-7296`): phone→`location.replace('#/')`; desktop-no-folder→unlock/help. Group sheets `index.html:453-494` (H).
+- Nav: Groups tab `index.html:276` + `#tabs` (H); desktop `.site-nav` Groups link `index.html:316` (G); kebab `#appbar-kebab`/`#kebab-sheet` (H→hamburger).
+- Settings `renderSettingsPage` `8975`: self-email `8984` (L, but H per mobile PR5); folder `8997` / download `9018` / restore `9037` / MCPB `9061` (H + G — these ARE the unlock entry / private surfaces); `wireFolderSection` `9895`; **dead-on-phone** badge branch `isMobileDevice()` `9945` (remove, don't leave).
+- Always-available: `#has-email-filter` + `applyFilters` `5478` + filter sheet `5698` (L); About stats `7034` (L).
+- CSS sites: scroll model `475/712`; desktop shell hide `4307`; mobile focus block `4323`; FAB/composer/group-sheet `4634-4740`.
+
+## D. Shared-mode leaks to fix in PR1 (the gate's §3 "localStorage-only" is not true today)
+
+1. **`saveHasEmailFilter()` `app.js:5246-5254`** mirrors to `relationships.settings`; **`reconcileHasEmailFilterOnBoot()` `5263-5283`** reads it back. In `no-private-data` mode these `dataProvider.setSetting/getSetting` calls must be no-ops (localStorage only) — else they open/write `relationships.db`, contradicting "do not open relationships.db for durable data when locked."
+2. **`persistDraft()` `app.js:6377`** — confirm it's localStorage-only (group draft); if it writes `relationships.db`, same fix.
+3. Self-email already localStorage (`FELLOWS_SELF_EMAIL_KEY` `app.js:258`) + mirrored to settings — same treatment: localStorage-only in shared mode.
+
+## E. Test plan (drives Lane TESTS)
+
+**Breaking (rewrite/fixture-change):** `mobile/test_mobile_interactions.py` (FAB/composer/create-group/kebab/groups-card — delete, add drawer/row→detail/CTA/redirect/reduced-settings); `mobile/test_routes.py` group screenshots (redirect state); `mobile/test_mobile_layout.py` (row selectors + assert bounded scroller); `mobile/test_folder_gate.py::test_download_button_stays_visible_on_mobile` (delete/invert); **desktop group suite** `test_groups_{index,compose,detail,edit,export}.py` (new **folder-attached fixture** that flips `privateDataEnabled()` true — behavior unchanged once unlocked); `test_settings.py` (split shared-mode email from folder-mode groups/restore); `test_route_focus_mode.py`, `test_unsupported_browser.py` (gated-copy).
+
+**New:** gate-locked-default; unlock happy path; 5 probe-failure paths (esp. `readback_mismatch` via a stub handle returning wrong bytes); same-browser OPFS→folder migration; reconnect re-grant (handle present); chooser disambiguation (seed `Fellows`+`Fellows 2` w/ different recency); in-db identity stamp; grayed-desktop vs hidden-phone; `#/groups` redirect/lock; mobile scroll container; Email/Call CTAs; self-describing export filename + `HOW-TO-MOVE-THIS-DATA.txt` marker.
+
+**Harness:** folder mode simulated by `_STUB_DIRECTORY_PICKER` (OPFS-backed real handle) `test_user_folder_storage.py:35-182`; mutations via `window.__dataProvider` (`WorkerDataHelper` `conftest.py:99-225`); gate read via new `window.__privateDataTier` / `body.classList`. Probe-failure tests need new stub variants that make the handle misbehave.
+
+**Port serialization (the real concurrency cap):** `tests/conftest.py:75-107` `_free_port(8765)` does `kill -9` on whatever holds 8765 → concurrent server-based runs across worktrees are **mutually destructive**, not just flaky. Rule: **treat 8765+8766 as one global mutex** — at most one worktree runs any server recipe (`test`/`test-fast`/`test-api`/`test-e2e`/`test-mobile`) at a time. Parallel-safe everywhere: `tests/test_database.py` (`just test-db`) + pure-logic unit files (no server, no port).
+
+## F. Resolved defaults for the small open decisions
+
+- **`.tag-chip` has no data source** off-folder (per-fellow tags live in the hidden `relationships.db`). **Decision:** defer tag chips on phone — do NOT derive from cohort/fellow_type for v1; STYLE ships the CSS unused. Revisit if wanted.
+- **`.fellow-photo` initials fallback** is new logic (current no-image path emits "Not Submitted" `app.js:5933-5936`). **Decision:** CORE computes initials from `name` for the phone hero square.
+- **`write_generation` monotonicity on restore:** restoring an older backup carries a lower generation → could mis-rank the chooser "recommended." **Decision:** on restore, re-stamp `write_generation = max(local, imported) + 1` so the just-restored store is canonical.
+- **`device_label` source:** **Decision:** UA-derived default string (editable later); `ensureWorkspaceIdentity` defaults it when the page passes nothing.
+- **Re-init after unlock:** after probe+migrate, `_storageMode` is only resolved at `init` (`:712`). **Decision:** the unlock flow forces a worker re-init (or an explicit "switch to folder mode now" op) so `_maybeWriteFolderAfterCommit` starts mirroring without a reload — confirm path during PR4.
+- **`auto` collision vs chooser overlap:** **Decision:** the chooser (`scanFellowsCandidates`, all `Fellows*`) supersedes `auto`-collision for re-pick; `probeFolderWritable` is used only for fresh-pick/create.

--- a/plans/EPIC_private_data_and_mobile.md
+++ b/plans/EPIC_private_data_and_mobile.md
@@ -1,0 +1,109 @@
+# EPIC — Private-Data Capability Gate + Mobile Rebuild (the controller)
+
+**Status:** ACTIVE controller. **Created:** 2026-06-02.
+**This file does not restate the child plans — it sequences them, declares the dependency graph and file-ownership lanes, defines integration checkpoints, and tracks status.** Read the children for the *what*; read this for the *order* and the *how-to-parallelize*.
+
+## Children (the cluster this controls)
+
+| # | Plan | Role | State |
+|---|---|---|---|
+| C1 | [`private_data_capability_gate.md`](private_data_capability_gate.md) | **Trunk.** Folder-gated private data; browse-only everywhere else. The feature-gating lives here. | not started |
+| C2 | [`mobile_redesign/PLAN_mobile_no_groups.md`](mobile_redesign/PLAN_mobile_no_groups.md) | Phone realization of browse-only mode + the `is-phone` layout (scroll/hamburger/CTAs/settings). | not started |
+| C3 | `docs/feature_platform_matrix.md` (rewrite) | The "what works where" truth. Currently says *groups work everywhere* — the gate makes that false. Rewrite is a DOCS-lane deliverable. | stale, contradicts C1 |
+| C4 | [`pna_toolkit_constraints_contribution.md`](pna_toolkit_constraints_contribution.md) | Upstream PNT PR. **Depends on building C1 first** (implement → learn → contribute). | PLAN ONLY, maintainer-gated |
+| C5 | [`pna_toolkit_exceptions_contribution.md`](pna_toolkit_exceptions_contribution.md) | Upstream PNT PR (in-app `EX-CLOUD-LLM` already shipped; only the contribution is pending). | PLAN ONLY, maintainer-gated |
+
+Already shipped and assumed as foundation (do not re-do): `user_folder_storage.md` (folder mode, PRs #181/#190/#191/#205/#209), `local_first_worker_architecture.md` Phases 1–5, `pre_ship_ui_fixes_2026-05-29.md` (PR #223). The pre-ship plan's #206 mobile baselines **will be redone** by C2 — expected.
+
+## Dependency graph
+
+```
+                 ┌─────────────────────────────────────────────┐
+                 │ Phase 0  analysis fan-out (read-only)        │  ← parallel, no isolation needed
+                 └─────────────────────────────────────────────┘
+                                     │ freezes the RPC contract + class names + edit-site map
+                                     ▼
+                 ┌─────────────────────────────────────────────┐
+                 │ Phase 1  KEYSTONE  C1 PR1+PR2                 │  ← sequential, single owner of app.js core
+                 │   gate resolver · body classes · shared-mode │
+                 │   = localStorage-only · same-browser migrate │
+                 └─────────────────────────────────────────────┘
+                                     │ (merged to the epic feature branch)
+        ┌───────────────┬───────────┴───────────┬───────────────┬──────────────┐
+        ▼               ▼                        ▼               ▼              ▼
+  Lane CORE       Lane WORKER              Lane STYLE       Lane DOCS      Lane TESTS
+  (app.js)        (sqlite-worker.js)       (css+html)       (docs/*)       (tests/e2e/*)
+  C1 PR3→PR4→PR5  probe·chooser·identity   C2 layout +      C3 + all C1    scaffolds vs
+  →C2 app-half    ·migrate-copy backends   grayed/CTA css   doc deltas     Phase-0 spec
+        └───────────────┴───────────┬───────────┴───────────────┴──────────────┘
+                                     ▼
+                 ┌─────────────────────────────────────────────┐
+                 │ Phase 3  integration (sequential)            │  ← merge lanes, full suite,
+                 │   resolve app.js↔css↔worker seams · re-base   │     re-baseline mobile snapshots LAST
+                 └─────────────────────────────────────────────┘
+                                     ▼
+                 ┌─────────────────────────────────────────────┐
+                 │ Phase 4  contribute upstream (maintainer-go) │  ← C4 (+C5), after real-device learning
+                 └─────────────────────────────────────────────┘
+```
+
+The hard rule the whole graph obeys: **`app.js` is a single IIFE (CLAUDE.md: no modules/classes) → it has exactly one owner (Lane CORE) and is never split across concurrent agents.** Everything else parallelizes around it against frozen interfaces.
+
+## Phases
+
+### Phase 0 — analysis fan-out (read-only)
+Five independent agents produce findings, no edits, nothing to isolate, nothing to coordinate → **plain parallel fan-out; no worktrees, no inter-agent comms.** Deliverables, which *freeze the interfaces* the lanes build against:
+1. **Surface inventory** — every private-data render/wire site in `app.js`/`index.html`, with the gate each needs (`hidden` on phone vs `grayed+CTA` on desktop).
+2. **Worker↔page RPC contract** — current RPCs + the new ones: folder probe, scan-all-`Fellows*` chooser, in-db identity read/write, OPFS→folder migrate-copy. Names, params, returns, `WORKER_RPC_VERSION` bump.
+3. **Mockup→CSS/DOM map** — `mockups_no_groups/` → `styles.css`/`index.html`: classes to port + the DOM hooks `app.js` must emit.
+4. **Test-gap audit** — existing e2e that breaks under the gate; new tests (lock/unlock, probe-failure, migration, chooser, reconnect); honors the port-8765 serialization rule.
+5. **Docs rewrite outline** — C3 contradictions + the full doc delta (matrix, users_manual, browser_support, Architecture constraint attestation, persistence_and_upgrades, the troubleshooting page keyed by probe `reason` codes).
+
+### Phase 1 — keystone (sequential)
+C1 PR1 (gate foundation: `privateDataEnabled()`, `body.no-private-data`/`body.is-phone`, shared-mode = localStorage-only, `window.__privateDataTier`) + PR2 (same-browser OPFS→folder migration). **Single owner.** Must land together — the migration protects existing Chrome users the moment the gate bites.
+
+### Phase 2 — lane fan-out (parallel worktrees, against the frozen Phase-0 interfaces)
+| Lane | Owns (files) | Work | Parallel? |
+|---|---|---|---|
+| **CORE** | `app/static/app.js` | C1 PR3 gating → PR4 unlock → PR5 reconnect → C2 app-half | critical path, **sequential, single owner** |
+| **WORKER** | `app/static/vendor/sqlite-worker.js` | probe backend, chooser scan, identity stamp, migrate-copy | ✅ vs CORE (RPC contract) |
+| **STYLE** | `app/static/styles.css`, `app/static/index.html` | C2 scroll/drawer/CTA + grayed-out styles, mockup port | ✅ (class/DOM-id contract) |
+| **DOCS** | `docs/*`, troubleshooting page | C3 + all C1/C2 doc deltas | ✅ fully parallel |
+| **TESTS** | `tests/e2e/*` | scaffold vs Phase-0 spec; finalize after features | ✅ (baselines deferred to Phase 3) |
+
+### Phase 3 — integration (sequential)
+Merge lanes onto the epic branch, resolve the `app.js`↔css↔worker seams, run the full suite, **re-baseline mobile snapshots last** (pixels move until the UI is final — the pre-ship plan's own hard-won rule).
+
+### Phase 4 — contribute upstream (maintainer-gated)
+C4 constraints PR (+ C5 exceptions if not yet filed), sharpened by what Phase 1–3 taught us: `CST-PWA-PRIVATE-SNAPSHOT` handling/Detectability, `CST-PWA-STORAGE-EVICTABLE` (avoided, not just mitigated), `CST-PWA-NO-SYNC` (in-db identity answers "which copy is canonical"). No PNT PRs until the maintainer says go.
+
+## Concurrency model (worktrees + agents)
+
+- **One worktree per *lane*, not per PR.** Splitting `app.js` across worktrees = merge pain; splitting by file ownership = clean merges. Lanes WORKER/STYLE/DOCS/TESTS get their own worktree + branch; CORE stays on the epic feature branch.
+- **Worktree setup:** `git worktree add ../fellows-wt-<lane> -b <lane-branch>` then `scripts/wt-setup.sh ../fellows-wt-<lane>` to symlink `.venv` + `app/fellows.db` (+ `mcp_servers/.venv`) so the worktree is test-ready instantly. Playwright browsers are a per-user global cache, shared once `.venv` is linked.
+- **Port 8765 is a global singleton (CLAUDE.md).** Server-based test runs (`just test-api`/`test-e2e`/`test-mobile`) in two worktrees at once collide. **Serialize server-based test execution across lanes**; only `tests/test_database.py` (no server) is parallel-safe. This — not raw agent count — is the real cap on concurrent verification.
+- **Inter-agent comms: not needed for fan-out.** Phase 0 and the Phase-2 lanes are *independent against frozen interfaces*; agents return findings/diffs to the orchestrator, which integrates. Reserve `SendMessage`-style coordination for the rare case where a lane discovers the frozen interface is wrong and the contract must change mid-flight — cheaper to let the orchestrator re-freeze and re-dispatch than to have lanes negotiate.
+- **Honest ceiling:** the speedup comes from offloading WORKER/STYLE/DOCS/TESTS while CORE proceeds — *not* from parallelizing `app.js`. Don't expect linear scaling; the single-file frontend + single test port bound it.
+
+## Status
+
+| Item | Phase | State | Notes |
+|---|---|---|---|
+| `scripts/wt-setup.sh` | infra | ✅ done | worktree env-share helper |
+| Phase 0 analysis fan-out | 0 | ✅ done | 5 agents → [`EPIC_phase0_findings.md`](EPIC_phase0_findings.md) (frozen interfaces) |
+| C1 **PR1** gate plumbing | 1 | ✅ done | `privateDataEnabled()`, `body.is-phone`/`no-private-data`, `window.__privateDataTier`; **inert** (nothing consumes the classes yet). Verified: `node --check` OK, `just test-fast` 96✓, `test_directory.py` 4✓ |
+| C1 **PR1 timing fix** | 1 | ✅ done | gate re-resolves at `provider_ready` (was stranding folder users in browse-only); diagnosed via runtime probe |
+| C1 **PR3** desktop surface gating | 2 | ✅ done | `worker_data_folder`/`folder_attached_page` fixtures + `attach_verified_folder`; group/copy suite migrated to folder; desktop entry-point + composer-rail CSS gate (`no-private-data:not(.is-phone)`); `route()` group-route redirect→Settings (desktop, gate-resolved). **Full `just test`: 636 passed / 6 skipped / 0 failed.** |
+| DOCS lane (PR7-docs) | 2 | ✅ done | 6 docs rewritten/created for the gate (pending maintainer review) |
+| C1 **PR2** same-browser migration | 1 | pending | OPFS→folder copy + identity stamp (worker RPC) |
+| C1 **PR4** unlock + probe | 2 | pending | new worker RPCs (probe/reason-codes) + unlock UI + troubleshooting page |
+| C1 **PR5** reconnect/chooser/identity | 2 | pending | new worker RPCs (scan-all-Fellows, identity stamp) |
+| C1 **PR6** mobile shell | 2 | pending | + the **phone** gating (hide on `is-phone`) and mobile group-test rewrites (the deferred phone half of PR3) |
+| PR3d has-email localStorage guard | 2 | deferred | shared-mode purity (filter bool only; churns the worker_data harness) |
+| Desktop grayed-out + "Enable on Chrome desktop →" CTA | 2 | deferred | PR3 currently *hides* desktop entry points (functionally correct); the discoverable CTA is a refinement (likely with PR4 unlock UI) |
+| Integration + re-baseline | 3 | pending | snapshots last |
+| C4/C5 upstream | 4 | pending | maintainer-gated (you authorized) |
+
+### Sequencing correction discovered during PR1 (important)
+
+The desktop e2e suite + the `worker_data` wipe fixture (`tests/e2e/conftest.py:188-212`) run in a **no-folder** context but *expect* `relationships.db` to work — which is exactly the state the gate turns into browse-only. So **the has-email "localStorage-only" fix, the surface-gating (PR3), and a new folder-attached test fixture cannot land green separately — they are one coordinated landing.** PR1 was therefore kept to pure inert plumbing. Next coordinated unit: introduce a `folder_attached` e2e fixture that flips `privateDataEnabled()` true (the desktop group suite depends on it, behavior unchanged once unlocked) **together with** PR3 surface-gating + the shared-mode localStorage-only guards.

--- a/plans/mobile_redesign/PLAN_mobile_no_groups.md
+++ b/plans/mobile_redesign/PLAN_mobile_no_groups.md
@@ -1,0 +1,320 @@
+# Phase 3 (mobile) — No-Private-Data Mobile Reduction
+
+**Status:** planned, not started. **Decided:** 2026-06-01.
+**Companion mockups:** [`mockups_no_groups/index.html`](mockups_no_groups/index.html) + `styles.css`.
+**Supersedes** the group-centric parts of [`DESIGN.md`](DESIGN.md) / [`css_porting_notes.md`](css_porting_notes.md) for phones.
+
+---
+
+## 1. What this is, in one paragraph
+
+The mobile redesign described in `css_porting_notes.md` **already shipped** —
+`app/static/index.html` has the `#appbar`, the `#tabs` strip, the `#kebab-sheet`,
+the `#composer-fab`, the bottom-sheet `#group-rail`, and the `#filter-sheet`, all
+wired in `app.js`. The maintainer's screenshot *is* that shipped state, and it's
+still unusable on a phone because (a) it's saturated with group chrome that wastes
+the screen, and (b) the list scrolls with no visible affordance. The
+2026-06-01 decision — **no private data on mobile** — lets us *delete* the
+group surface on phones rather than redesign it, freeing the space and fixing the
+scroll. This plan strips groups/selection/composer/notes from the phone experience,
+swaps the tab strip for a conventional hamburger drawer, rebuilds the directory as a
+proper scroll container, adds Email/Call call-to-actions to the fellow profile, and
+reduces mobile Settings to app-info + tools.
+
+The end state on a phone: **search the directory → open a fellow → email or call
+them.** Nothing else.
+
+---
+
+## 2. Decisions baked in (veto any of these before we start)
+
+1. **Feature-gate on `isMobileDevice()`, not viewport width.** Removing groups is a
+   *device* decision, gated by `isMobileDevice()` (`app.js:1226`, UA-based) — the
+   same lever the shipped folder policy uses (`folderStorageOffered()`,
+   `app.js:8659`). A desktop user with a narrow window keeps groups; only real
+   phones lose them. **Layout** adaptation stays width-driven (the existing
+   `≤1024px` media queries). Concretely: set `document.body.classList.toggle('is-phone', isMobileDevice())`
+   once at boot, then gate all new behavior on `body.is-phone`. All phones are also
+   `≤1024px`, so the is-phone rules *specialize* the existing mobile shell — they
+   never fight it.
+
+2. **No backup/restore on mobile Settings.** With groups, tags, and notes gone,
+   `relationships.db` on a phone holds only trivial prefs (has-email toggle). There
+   is nothing user-authored to lose, so the manual-backup/download/restore UI is
+   removed from mobile. **This supersedes** the "keep manual backup as the only
+   durability path on mobile" stance in the `mobile_folder_storage_policy` memory
+   (which assumed groups still existed on phones). Non-destructive: any groups a
+   user already created on a phone still live in their `relationships.db` and remain
+   visible on desktop; we only hide the phone UI.
+
+3. **Tools live in Settings; the kebab is retired on phones; the hamburger is the
+   one menu.** The appbar's single right-side button becomes a hamburger that opens
+   a **nav drawer** (Directory / Settings / About + build tag). Diagnostics / Report
+   a bug / Clear app cache move into a "Tools" section on the Settings page (reusing
+   the existing handlers). The `#kebab-sheet` is hidden on phones. Recovery is still
+   reachable: the boot-stuck/boot-error panels keep their own Clear-Cache buttons,
+   and `?diag=1` / `?gate=1` escapes are unchanged.
+
+4. **Deep links to group routes redirect on phones.** `#/groups`, `#/groups/<id>`,
+   `#/groups/<id>/directory`, and `#/edit/<id>` redirect to `#/` when
+   `isMobileDevice()`. No dead screens.
+
+5. **The worker and two-DB architecture are untouched.** This is a UI-gating change.
+   `relationships.db`, the worker, the data-provider tiers, auth, and the SW all
+   stay exactly as they are. Lower risk, easy revert.
+
+---
+
+## 3. Ground truth (verified file:line anchors)
+
+Routing / shell:
+- `route()` — `app.js:7171`; manages `route-*` body classes (7185-7199) and calls
+  `setShellChrome(routeKey, title)` (7246-7252).
+- `setShellChrome()` — `app.js:3472` (sets `#appbar-title`, toggles `.tabs__tab--active`).
+- `setShellVisible()` — `app.js:3465` (toggles `.hidden` on `#site-header` + `#appbar` + `#tabs`).
+- `isMobileDevice()` — `app.js:1226`. `folderStorageOffered()` — `app.js:8659`.
+- Kebab sheet — `openKebabSheet()`/`closeKebabSheet()`/`initKebabSheet()` `app.js:3516-3582`;
+  `data-kebab-action` proxies to the floating buttons (`#diag-toggle`,
+  `#bug-report-button`, `#clear-app-cache-button`, `#reset-everything-button`).
+
+Directory / selection / groups (all desktop-shared — gate, don't delete):
+- `renderDirectoryList()` — `app.js:5779`; per-row `.dir-mark` select button at 5787-5800,
+  name link at 5801-5804.
+- `groupDraft` state — `app.js:70`; `toggleDraftMember()` 6306; `updateComposerFabFromDraft()`
+  3592 (sets `body.has-selection`, `#composer-fab-count`).
+- `#bulk-select-bar` — `updateBulkBar()` 6324, `bulkToggleVisible()` 6341.
+- Composer — `renderRail()` 6258, `handleCreateGroupClick()` 6582, `openComposerSheet()`/
+  `closeComposerSheet()` 3624-3646.
+- Filters — `applyFilters()` 5478; has-email `#has-email-filter` (state `hasEmailOnly`,
+  `app.js:27`, persisted `loadHasEmailFilter()` 5237); filter sheet `initFilterSheet()` 5698.
+- Edit mode — `enterEditMode()` 6449, banner `#edit-mode-banner`.
+
+Render paths:
+- Fellow — `renderDetail()` `app.js:5888`; contact rows at 5951-5967 (`mailto:` 5951,
+  `tel:` 5960, copy buttons); add-to-group link at 5906-5915.
+- Settings — `renderSettingsPage()` `app.js:8975`; email field 8984, folder section 8997,
+  download 9018, restore section 9037, Claude-Desktop/MCPB section 9061.
+- About — `renderAboutPage()` `app.js:6698`; stats via `getStats()` ~7034.
+
+CSS (`app/static/styles.css`):
+- Desktop hides shell: `.appbar, .tabs { display:none }` at `≥1025px` (4307-4312).
+- Mobile focus-mode block at `≤1024px` (4323-4372); about/settings hide `#directory`/`#group-rail`
+  at all widths (4382-4385).
+- FAB/composer-sheet/group-detail-actionbar mobile rules (4631-4740).
+- **Scroll bug:** `.appbar` `position:sticky; top:0` (3940), `.tabs` `position:sticky; top:48px`
+  (3994); `#directory` has `max-height:75vh; overflow-y:auto` on desktop (475) but at `≤700px`
+  becomes `40vh` (712) and at `≤1024px` has **no height constraint** — the **body** is the
+  scroll container, so the list scrolls with no affordance. This is the headline fix.
+
+Tests / tooling:
+- `tests/e2e/mobile/` — devices Pixel 5 (393×851), iPhone 13 (390×844), narrow-360 (360×720)
+  in `conftest.py`. `test_mobile_layout.py` (overflow, ≥44px targets, no bottom element >40%vh),
+  `test_mobile_interactions.py` (**directory→detail→FAB→composer→create-group — these break and
+  must be rewritten**), `test_routes.py` (screenshot baselines in `__snapshots__/`),
+  `test_folder_gate.py`. Recipes: `just test-mobile`, `just test-mobile-functional`,
+  `just test-mobile-promote`, `just serve-lan`.
+
+---
+
+## 4. Implementation sequence (each PR independently shippable + revertible)
+
+Ship in order. Keep `just test-fast` + `just test-mobile-functional` green at every step.
+The maintainer's ship-and-iterate bias applies — PRs 1-2 are the ones that *feel* the change
+on a real phone; ship those first and gather feedback before the polish PRs.
+
+**Match-the-mock is in scope, not a later cleanup.** Each PR ports its matching component
+styles from [`mockups_no_groups/styles.css`](mockups_no_groups/styles.css) so the running app
+reads as the mock *at every step* (the **Match the mock** bullet in each PR lists the exact
+classes to lift). This is CSS porting onto the reused DOM — no new structure, no added risk —
+and it's cheaper than tuning the live UI screen-by-screen later. The only items deliberately
+left for a real-device polish pass are the truly subjective calls (final photo crop, whether
+the chip beats the checkbox once it's in hand).
+
+### PR 1 — `is-phone` flag + the scroll-container shell (the headline fix; highest risk)
+
+The one PR that fixes the screenshot. Layout reflow — QA hardest here.
+
+- **app.js:** at boot (next to the first `setShellVisible(true)`, `app.js:11100`), add
+  `document.body.classList.toggle('is-phone', isMobileDevice())`. No visible change yet.
+- **styles.css:** introduce a `body.is-phone` shell that turns the page into a fixed-height
+  flex column where the **content region is the only scroller**:
+  ```css
+  body.is-phone { height: 100dvh; overflow: hidden; display: flex; flex-direction: column; }
+  body.is-phone .appbar   { flex: 0 0 48px; }      /* fixed */
+  body.is-phone #site-header { flex: 0 0 auto; }   /* sticky search header on directory */
+  body.is-phone #app-wrap { flex: 1 1 auto; min-height: 0; display: flex; }
+  /* the one visible content child per route becomes the scroller */
+  body.is-phone #directory,
+  body.is-phone #detail   { flex: 1 1 auto; min-height: 0; overflow-y: auto;
+                            -webkit-overflow-scrolling: touch; overscroll-behavior: contain; }
+  ```
+  Remove the sticky/negative-margin treatment of `.appbar`/`.tabs` under `is-phone` (they're
+  now flex items, not sticky). `min-height:0` is the load-bearing line — without it the flex
+  child refuses to shrink and the scroll never appears.
+- **Verify:** on a phone, the appbar stays put, the directory list scrolls *inside* its region
+  with a visible scrollbar/affordance, and the search header doesn't scroll away. No
+  horizontal overflow (`test_mobile_layout.py` still green). Fellow/Settings/About each scroll
+  within `#detail`.
+- **Match the mock:** none — PR 1 is structural only (keeps it the clean, isolated reflow).
+  The directory-surface visuals (chip, chevron, row spacing) land in PR 3.
+- **Risk:** `100dvh` vs `100vh` and the iOS URL-bar resize; Android keyboard insets when the
+  search field is focused. Test both. Keep `#tabs` for now (removed in PR 2) so this PR is a
+  pure scroll fix.
+
+### PR 2 — Hamburger nav drawer; retire the tab strip on phones
+
+- **index.html:** add a hamburger button to `.appbar` (or convert `#appbar-kebab` into the
+  hamburger on phone) and a drawer + scrim near the other sheets:
+  ```html
+  <div id="nav-scrim" class="sheet-scrim hidden" hidden></div>
+  <aside id="nav-drawer" class="drawer hidden" role="dialog" aria-modal="true" aria-label="Menu" hidden>
+    <!-- head + Directory/Settings/About links + build-tag footer -->
+  </aside>
+  ```
+- **app.js:** wire `openNavDrawer()`/`closeNavDrawer()` by cloning the kebab-sheet pattern
+  (`app.js:3516-3582`) — click to open, scrim + Esc + link-click to close. Populate the build
+  tag from the same source the About page uses. Hide `.tabs` on `body.is-phone`.
+- **styles.css:** port `.drawer` / `.drawer-link` / `.drawer__foot` from
+  `mockups_no_groups/styles.css`; `body.is-phone .tabs { display:none }`.
+- **Decision in effect:** drawer is pure nav (no Groups). The kebab stays for now (its tools
+  move in PR 5).
+- **Match the mock:** port `.drawer`, `.drawer__head`, `.drawer__title`, `.drawer-link`
+  (+ `--active` inset-bar state), and `.drawer__foot` / `.build-tag` verbatim from
+  `mockups_no_groups/styles.css`. Reproduce the mock's drawer head ("Menu" + close ✕) and the
+  build-tag footer; use the mock's hamburger glyph (three lines) for the appbar control.
+- **Verify:** hamburger opens/closes the drawer; Directory/Settings/About navigate; no tab
+  strip on phone; desktop unchanged (drawer never shows ≥1025px / non-phone).
+
+### PR 3 — Strip group + selection chrome on phones; redirect group routes
+
+- **app.js `renderDirectoryList()` (5779):** when `body.is-phone`, render rows as plain
+  full-width links (no `.dir-mark` button) — matches the mockup. (JS-skip is cleaner than
+  CSS-hide here: it removes a dead 44px tap target rather than leaving an invisible one.)
+- **app.js `route()` (7171):** if `isMobileDevice()` and the hash is a group/edit route,
+  `location.replace('#/')` (or set hash to `#/`) before dispatch. Covers `#/groups`,
+  `#/groups/<id>`, `#/groups/<id>/directory`, `#/edit/<id>`.
+- **styles.css `body.is-phone`:** `display:none` on `#bulk-select-bar`, `.detail-add-to-group`,
+  `#composer-fab`, `#group-rail`, `#composer-scrim`, `#edit-mode-banner`, `.tabs__tab[data-tab="groups"]`
+  (defensive — the tab is already gone in PR 2), and the group action/card sheets.
+- **Match the mock (directory surface):**
+  - Rows: apply the mock's `.directory-row` padding / `min-height: 56px`, ink-colored name, and
+    add the trailing chevron (`.directory-row__go` `›` svg) so each row reads as a tap target.
+  - Search region: restyle the has-email control from the current `.filter-checkbox` into the
+    mock's removable `.filter-chip` (`has email ✕`) sitting next to a compact `.filter-btn`
+    "Filters" control, and change the count to the `142 / 515` form (`.filterbar__count`).
+    Port `.filterbar`, `.filter-btn`, `.filter-chip`, `.filter-chip__x`, and the
+    `.directory-row*` rules from `mockups_no_groups/styles.css`. Function is unchanged
+    (defeatable default; the chip's ✕ clears has-email exactly like unchecking did).
+- **Verify:** directory rows go straight to the profile, with a chevron affordance; no
+  FAB/composer ever appears; the has-email chip clears with one tap to reveal phone-only
+  fellows; visiting `#/groups` on a phone lands on the directory. Desktop selection/compose
+  untouched.
+
+### PR 4 — Fellow profile: Email/Call call-to-actions
+
+- **app.js `renderDetail()` (5888):** when `body.is-phone`, render a `.contact-cta` block near
+  the top of the detail (below the name/tagline) with an **Email** button (`mailto:`, primary)
+  and a **Call** button (`tel:`, ghost), each shown only when the corresponding field exists
+  (`fellow.contact_email` / `fellow.mobile_number`, already the guards at 5951/5960). When email
+  is absent, render the disabled "No email" state from the mockup. The existing inline contact
+  rows + copy buttons stay (paste-elsewhere path). The `detail-add-to-group` link (5906-5915) is
+  skipped on phone.
+- **Match the mock:** port `.contact-cta` (+ the disabled "No email" state), and bring the hero
+  to the mock layout — `.fellow-hero` ordering (photo, then name, then tagline), the
+  `.fellow-photo` square/centered treatment with an initials fallback, `.tag-chip` chips, and
+  `.section-head` for the bio/free-text blocks. Lift all of these from
+  `mockups_no_groups/styles.css`. (Final photo crop — square vs the current circular — is the
+  one subjective bit to confirm on a real device; default to the mock's square.)
+- **Verify:** the email+phone fellow shows both CTAs and the mock hero; the phone-only fellow
+  shows Call promoted and Email disabled; tapping launches the device mail/dialer.
+
+### PR 5 — Mobile Settings: app-info + tools only; retire the kebab on phones
+
+- **app.js `renderSettingsPage()` (8975):** when `body.is-phone`, omit the email field (8984),
+  folder section (8997), download (9018), restore section (9037), and Claude-Desktop/MCPB
+  section (9061). Render an **App info** block (build label, server label, fellow count, last
+  update — already computed for the About page) and a **Tools** block with Diagnostics / Report
+  a bug / Clear app cache, wired to the *existing* handlers (the same ones the kebab proxies to).
+- **index.html / app.js:** hide `#kebab-sheet` and the kebab button on `body.is-phone`; the
+  appbar's right-side control is the hamburger (PR 2). Keep Reset Everything reachable from the
+  Settings Tools block (danger styling) since it's no longer in a sheet.
+- **Match the mock:** render App info as a `.card` of `.stat-line` rows, the tools as
+  `.tool-row` buttons (icon + label + chevron, with `--danger` for Clear cache / Reset), section
+  labels as `.section-head`, and close with the mock's `.hint` line ("No folder, backup, or
+  email settings on mobile…"). Port `.card`, `.stat-line`, `.tool-row`, `.section-head`, `.hint`
+  from `mockups_no_groups/styles.css`.
+- **Verify:** mobile Settings matches the mock — App info card + tool rows + hint; no
+  email/folder/backup/MCPB; every tool works; desktop Settings unchanged.
+
+### PR 6 — Tests, docs, snapshot baselines
+
+- **tests/e2e/mobile/:**
+  - Rewrite `test_mobile_interactions.py`: delete the FAB/composer/create-group flow; add
+    *hamburger opens drawer*, *directory row → fellow detail*, *no group chrome present
+    (`.dir-mark`/`#composer-fab`/`#group-rail` absent or hidden)*, *Email/Call CTAs present on a
+    fellow with contact info*, *`#/groups` redirects to `#/`*, *Settings has no email/folder/backup*.
+  - Keep `test_mobile_layout.py` (overflow / ≥44px / bottom-bar) — should pass unchanged and now
+    also assert a real scroll container exists on the directory.
+  - Re-promote `test_routes.py` snapshot baselines via `just test-mobile-promote` after visual
+    review of `current_state/` (groups/group-detail baselines for phone devices either deleted or
+    captured as the redirect-to-directory state). Since match-the-mock is folded into PRs 2-5,
+    the promoted phone baselines should visually track `mockups_no_groups/` — eyeball them
+    against the gallery before promoting.
+- **Docs (per CLAUDE.md — UI/UX changes ship with the doc):**
+  - `docs/users_manual.md` — mobile section: hamburger menu, no groups on mobile, Email/Call,
+    reduced Settings.
+  - `docs/feature_platform_matrix.md` — extend "The mobile contract" to **browse + search +
+    contact** (drop "organize into groups + manual backup").
+  - Update the `mobile_folder_storage_policy` memory (backup removed; no private data on mobile)
+    and add a short project memory for this initiative.
+- **PR description (per CLAUDE.md):** the maintainer-only QA steps — `just serve-lan`, open on a
+  real Android phone, verify scroll/drawer/CTAs/redirects, and the iOS Safari pass.
+
+> Batching: PRs 3-5 are small and could ship together if the maintainer prefers fewer reviews.
+> PR 1 should stand alone (it's the riskiest reflow). PR 6 must land with whichever PR first
+> changes user-visible behavior, to keep the manual + tests honest.
+
+---
+
+## 5. The scroll fix, expanded (because it's the risky bit)
+
+Today the scroll model on a phone is: `<body>` (the scroller) → sticky `.appbar` (top:0) →
+sticky `.tabs` (top:48px) → `#site-header` (search) → `#app-wrap` → `#directory` (no height
+cap at ≤1024px). Because nothing has a bounded height, the list grows the document and the body
+scrolls — but the sticky headers and the absence of an inner scroll region mean there's **no
+scrollbar track the user can see**, which reads as "frozen." That's the screenshot.
+
+The fix flips it to: `<body class="is-phone">` is a `100dvh` non-scrolling flex column → fixed
+appbar → fixed search header → `#app-wrap`/`#directory` is `flex:1 1 auto; min-height:0;
+overflow-y:auto`. Now the *list* scrolls inside a bounded region with a real track, the chrome
+stays put, and momentum/overscroll are contained. Pitfalls to test explicitly:
+
+- `100dvh` (dynamic viewport) vs `100vh` on iOS Safari with the collapsing URL bar.
+- Android soft-keyboard insets when the search input is focused (the list region must shrink,
+  not get covered).
+- `min-height:0` on every flex ancestor of the scroller (without it, the child won't shrink).
+- Fellow/Settings/About use `#detail` as the scroller; confirm each route's single visible
+  content child gets the `overflow-y:auto` treatment (focus-mode already hides the others).
+
+---
+
+## 6. Out of scope / unchanged
+
+- Desktop (any non-phone): groups, composer, tabs/site-header, Settings folders/backup/MCPB —
+  **all unchanged.**
+- Auth / magic-link gate, the SW, the worker, `relationships.db`, the data-provider tiers.
+- The install landing and `?gate=1` / `?diag=1` flows.
+- The blue rebrand (already shipped) — tokens are reused, not re-applied.
+
+## 7. Decisions resolved (was: open questions)
+
+1. **Hamburger side — top-right, right-sliding drawer.** Confirmed 2026-06-01 (matches the
+   approved kebab position and the mock).
+2. **`#/groups` on a phone — silent redirect to `#/`.** Confirmed 2026-06-01. No toast.
+3. **has-email + Filters on mobile — kept.** Defeatable default as a removable chip (PR 3) plus
+   the compact Filters control; the structured filter sheet (cohort/type/region/citizenship)
+   stays on phones.
+
+Remaining real-device judgment calls (decide with the build in hand, not now):
+- Final fellow-photo crop (square per mock vs current circular).
+- Whether the has-email chip still beats a checkbox once it's on a phone.

--- a/plans/mobile_redesign/mockups_no_groups/index.html
+++ b/plans/mobile_redesign/mockups_no_groups/index.html
@@ -1,0 +1,332 @@
+<!doctype html>
+<html lang="en">
+<head>
+  <meta charset="utf-8">
+  <meta name="viewport" content="width=device-width, initial-scale=1, viewport-fit=cover">
+  <title>EHF Mobile (no-groups) — redesign mockups</title>
+  <link rel="stylesheet" href="styles.css">
+</head>
+<body>
+  <div class="gallery">
+    <h1>EHF Fellows — Mobile (no-groups) redesign</h1>
+    <p class="lede">Mobile reduced to three surfaces: <b>Directory</b> · <b>Fellow</b> ·
+    <b>Settings/About</b>, navigated by a hamburger drawer. No groups, no selection, no
+    composer, no FAB. The app is: search the directory → find someone → email or call them.
+    Open this file in a narrow window (or a phone) to see each frame fill the viewport.</p>
+
+    <!-- ============================================================
+         1. DIRECTORY — default (has-email default on)
+         ============================================================ -->
+    <div class="phone-wrap">
+      <span class="phone-tag">directory · home</span>
+      <div class="phone-frame">
+        <header class="appbar">
+          <div class="appbar__title">EHF Fellows</div>
+          <button class="appbar__btn" aria-label="Open menu" aria-expanded="false">
+            <svg class="ico" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2.2" stroke-linecap="round"><path d="M3 6h18M3 12h18M3 18h18"/></svg>
+          </button>
+        </header>
+
+        <div class="search-region">
+          <input class="input" type="search" placeholder="Search by name, tagline, cohort…">
+          <div class="filterbar">
+            <button class="filter-btn">
+              <svg class="ico-sm" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2"><path d="M3 5h18M6 12h12M10 19h4"/></svg>
+              Filters
+            </button>
+            <span class="filter-chip">has email
+              <button class="filter-chip__x" aria-label="Show fellows without email too">×</button>
+            </span>
+            <span class="filterbar__count">142 / 515</span>
+          </div>
+        </div>
+
+        <main class="content">
+          <div class="directory-list">
+            <a class="directory-row" href="#"><span class="directory-row__name">Aaron Bird</span><svg class="ico directory-row__go" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2"><path d="m9 6 6 6-6 6"/></svg></a>
+            <a class="directory-row" href="#"><span class="directory-row__name">Aaron McDonald</span><svg class="ico directory-row__go" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2"><path d="m9 6 6 6-6 6"/></svg></a>
+            <a class="directory-row" href="#"><span class="directory-row__name">Abraham Munoz Barbosa</span><svg class="ico directory-row__go" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2"><path d="m9 6 6 6-6 6"/></svg></a>
+            <a class="directory-row" href="#"><span class="directory-row__name">Adam Cohen</span><svg class="ico directory-row__go" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2"><path d="m9 6 6 6-6 6"/></svg></a>
+            <a class="directory-row" href="#"><span class="directory-row__name">Adam Grosser</span><svg class="ico directory-row__go" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2"><path d="m9 6 6 6-6 6"/></svg></a>
+            <a class="directory-row" href="#"><span class="directory-row__name">Adel A Yulghun</span><svg class="ico directory-row__go" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2"><path d="m9 6 6 6-6 6"/></svg></a>
+            <a class="directory-row" href="#"><span class="directory-row__name">Adrien Gheur</span><svg class="ico directory-row__go" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2"><path d="m9 6 6 6-6 6"/></svg></a>
+            <a class="directory-row" href="#"><span class="directory-row__name">Akshay Kothari</span><svg class="ico directory-row__go" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2"><path d="m9 6 6 6-6 6"/></svg></a>
+            <a class="directory-row" href="#"><span class="directory-row__name">Alan Guo</span><svg class="ico directory-row__go" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2"><path d="m9 6 6 6-6 6"/></svg></a>
+            <a class="directory-row" href="#"><span class="directory-row__name">Alana Scott</span><svg class="ico directory-row__go" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2"><path d="m9 6 6 6-6 6"/></svg></a>
+            <a class="directory-row" href="#"><span class="directory-row__name">Alanna Irving</span><svg class="ico directory-row__go" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2"><path d="m9 6 6 6-6 6"/></svg></a>
+            <a class="directory-row" href="#"><span class="directory-row__name">Alex Bayer</span><svg class="ico directory-row__go" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2"><path d="m9 6 6 6-6 6"/></svg></a>
+          </div>
+        </main>
+      </div>
+      <div class="phone-caption">Fixed bar + sticky search; the list is the only thing that scrolls.</div>
+    </div>
+
+    <!-- ============================================================
+         2. DIRECTORY — filters sheet open
+         ============================================================ -->
+    <div class="phone-wrap">
+      <span class="phone-tag">directory · filters sheet</span>
+      <div class="phone-frame">
+        <header class="appbar">
+          <div class="appbar__title">EHF Fellows</div>
+          <button class="appbar__btn" aria-label="Open menu">
+            <svg class="ico" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2.2" stroke-linecap="round"><path d="M3 6h18M3 12h18M3 18h18"/></svg>
+          </button>
+        </header>
+        <div class="search-region">
+          <input class="input" type="search" placeholder="Search by name, tagline, cohort…">
+          <div class="filterbar">
+            <button class="filter-btn" style="background:var(--accent-soft);border-color:var(--accent);">
+              <svg class="ico-sm" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2"><path d="M3 5h18M6 12h12M10 19h4"/></svg>
+              Filters
+            </button>
+            <span class="filter-chip">has email <button class="filter-chip__x" aria-label="clear">×</button></span>
+            <span class="filterbar__count">142 / 515</span>
+          </div>
+        </div>
+        <main class="content"></main>
+
+        <div class="scrim"></div>
+        <div class="sheet">
+          <div class="sheet__handle"></div>
+          <div class="sheet__head"><span class="sheet__title">Filters</span>
+            <a href="#" style="font-size:13px;color:var(--accent-deeper);">Reset</a>
+          </div>
+          <div class="checkrow">
+            <input type="checkbox" id="f-email" checked>
+            <div>
+              <label for="f-email">Only fellows with an email</label>
+              <div class="hint">On by default. Turn off to include phone-only fellows.</div>
+            </div>
+          </div>
+          <div class="field">
+            <label for="f-cohort">Cohort</label>
+            <select class="select" id="f-cohort"><option>All cohorts</option><option>2020</option><option>2019</option></select>
+          </div>
+          <div class="field">
+            <label for="f-type">Fellow type</label>
+            <select class="select" id="f-type"><option>All types</option><option>Fellow</option><option>Mentor</option></select>
+          </div>
+          <button class="btn btn--primary btn--block">Show 142 fellows</button>
+        </div>
+      </div>
+      <div class="phone-caption">has-email is a defeatable default — phone-only fellows are one tap away.</div>
+    </div>
+
+    <!-- ============================================================
+         3. NAV DRAWER (over directory)
+         ============================================================ -->
+    <div class="phone-wrap">
+      <span class="phone-tag">menu drawer</span>
+      <div class="phone-frame">
+        <header class="appbar">
+          <div class="appbar__title">EHF Fellows</div>
+          <button class="appbar__btn" aria-label="Close menu" aria-expanded="true" style="background:var(--accent-soft);color:var(--accent-deeper);">
+            <svg class="ico" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2.2" stroke-linecap="round"><path d="M3 6h18M3 12h18M3 18h18"/></svg>
+          </button>
+        </header>
+        <div class="search-region">
+          <input class="input" type="search" placeholder="Search by name, tagline, cohort…">
+          <div class="filterbar">
+            <button class="filter-btn"><svg class="ico-sm" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2"><path d="M3 5h18M6 12h12M10 19h4"/></svg> Filters</button>
+            <span class="filter-chip">has email <button class="filter-chip__x">×</button></span>
+            <span class="filterbar__count">142 / 515</span>
+          </div>
+        </div>
+        <main class="content"></main>
+
+        <div class="scrim"></div>
+        <aside class="drawer">
+          <div class="drawer__head">
+            <span class="drawer__title">Menu</span>
+            <button class="appbar__btn" aria-label="Close">
+              <svg class="ico" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2"><path d="M6 6l12 12M18 6 6 18"/></svg>
+            </button>
+          </div>
+          <nav class="drawer__nav">
+            <a class="drawer-link drawer-link--active" href="#">
+              <svg class="ico" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2"><circle cx="11" cy="11" r="7"/><path d="m20 20-3.5-3.5"/></svg>
+              Directory
+            </a>
+            <a class="drawer-link" href="#">
+              <svg class="ico" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2"><circle cx="12" cy="12" r="3"/><path d="M19 12a7 7 0 0 0-.1-1l2-1.5-2-3.4-2.3 1a7 7 0 0 0-1.7-1L16.5 2h-4l-.4 2.6a7 7 0 0 0-1.7 1l-2.3-1-2 3.4 2 1.5a7 7 0 0 0 0 2l-2 1.5 2 3.4 2.3-1a7 7 0 0 0 1.7 1l.4 2.6h4l.4-2.6a7 7 0 0 0 1.7-1l2.3 1 2-3.4-2-1.5c.07-.33.1-.66.1-1Z"/></svg>
+              Settings
+            </a>
+            <a class="drawer-link" href="#">
+              <svg class="ico" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2"><circle cx="12" cy="12" r="9"/><path d="M12 11v5M12 8h0"/></svg>
+              About
+            </a>
+          </nav>
+          <div class="drawer__foot">
+            <div class="build-tag">
+              <span>app <b>2026-06-01-805acc4</b></span>
+              <span>server <b>805acc4</b></span>
+            </div>
+          </div>
+        </aside>
+      </div>
+      <div class="phone-caption">Conventional nav drawer. Three destinations + build tag. Tools live in Settings.</div>
+    </div>
+
+    <!-- ============================================================
+         4. FELLOW DETAIL — has email + phone
+         ============================================================ -->
+    <div class="phone-wrap">
+      <span class="phone-tag">fellow · email + phone</span>
+      <div class="phone-frame">
+        <header class="appbar">
+          <button class="appbar__btn" aria-label="Back">
+            <svg class="ico" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2"><path d="m15 6-6 6 6 6"/></svg>
+          </button>
+          <div class="appbar__title">Fellow</div>
+          <button class="appbar__btn" aria-label="Open menu">
+            <svg class="ico" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2.2" stroke-linecap="round"><path d="M3 6h18M3 12h18M3 18h18"/></svg>
+          </button>
+        </header>
+        <main class="content padded">
+          <div class="fellow-hero">
+            <div class="fellow-photo">AG</div>
+            <div>
+              <h1 class="fellow-name">Adam Grosser</h1>
+              <p class="fellow-tagline">Investor & entrepreneur. Energy, climate, and deep-tech. Cohort 2019.</p>
+            </div>
+          </div>
+
+          <div class="contact-cta">
+            <a class="btn btn--primary" href="mailto:#">
+              <svg class="ico" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2"><rect x="3" y="5" width="18" height="14" rx="2"/><path d="m3 7 9 6 9-6"/></svg>
+              Email
+            </a>
+            <a class="btn btn--ghost" href="tel:#">
+              <svg class="ico" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2"><path d="M5 4h4l2 5-2.5 1.5a11 11 0 0 0 5 5L20 13l2 5v2a2 2 0 0 1-2 2A16 16 0 0 1 4 6a2 2 0 0 1 2-2Z"/></svg>
+              Call
+            </a>
+          </div>
+
+          <div class="tag-chips">
+            <span class="tag-chip">Climate</span><span class="tag-chip">Energy</span><span class="tag-chip">Investing</span><span class="tag-chip">Deep tech</span>
+          </div>
+
+          <div class="contact-row"><span class="contact-row__label">Email</span><span class="contact-row__value"><a href="mailto:#">adam@example.org</a></span><button class="contact-row__copy" aria-label="Copy email">⧉</button></div>
+          <div class="contact-row"><span class="contact-row__label">Phone</span><span class="contact-row__value"><a href="tel:#">+1 415 555 0142</a></span><button class="contact-row__copy" aria-label="Copy phone">⧉</button></div>
+          <div class="contact-row"><span class="contact-row__label">Based</span><span class="contact-row__value">San Francisco, USA</span></div>
+
+          <div class="prose-block">
+            <h3 class="section-head">Bio</h3>
+            <p>Adam works at the intersection of energy and climate finance, backing early-stage
+            hardware companies. Previously a general partner focused on resource efficiency.</p>
+          </div>
+        </main>
+      </div>
+      <div class="phone-caption">Email + Call are the headline action. Copy buttons stay for paste-elsewhere.</div>
+    </div>
+
+    <!-- ============================================================
+         5. FELLOW DETAIL — phone only (no email)
+         ============================================================ -->
+    <div class="phone-wrap">
+      <span class="phone-tag">fellow · phone only</span>
+      <div class="phone-frame">
+        <header class="appbar">
+          <button class="appbar__btn" aria-label="Back"><svg class="ico" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2"><path d="m15 6-6 6 6 6"/></svg></button>
+          <div class="appbar__title">Fellow</div>
+          <button class="appbar__btn" aria-label="Open menu"><svg class="ico" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2.2" stroke-linecap="round"><path d="M3 6h18M3 12h18M3 18h18"/></svg></button>
+        </header>
+        <main class="content padded">
+          <div class="fellow-hero">
+            <div class="fellow-photo">AY</div>
+            <div>
+              <h1 class="fellow-name">Adel A Yulghun</h1>
+              <p class="fellow-tagline">Community organizer. Cohort 2020.</p>
+            </div>
+          </div>
+          <div class="contact-cta">
+            <span class="btn btn--primary" aria-disabled="true" title="No email on file">
+              <svg class="ico" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2"><rect x="3" y="5" width="18" height="14" rx="2"/><path d="m3 7 9 6 9-6"/></svg>
+              No email
+            </span>
+            <a class="btn btn--ghost" href="tel:#">
+              <svg class="ico" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2"><path d="M5 4h4l2 5-2.5 1.5a11 11 0 0 0 5 5L20 13l2 5v2a2 2 0 0 1-2 2A16 16 0 0 1 4 6a2 2 0 0 1 2-2Z"/></svg>
+              Call
+            </a>
+          </div>
+          <div class="contact-row"><span class="contact-row__label">Phone</span><span class="contact-row__value"><a href="tel:#">+64 21 555 0199</a></span><button class="contact-row__copy" aria-label="Copy phone">⧉</button></div>
+          <div class="contact-row"><span class="contact-row__label">Based</span><span class="contact-row__value">Auckland, NZ</span></div>
+        </main>
+      </div>
+      <div class="phone-caption">Phone-only fellow — the reason has-email must be defeatable, not a hard gate.</div>
+    </div>
+
+    <!-- ============================================================
+         6. SETTINGS — app info + tools only
+         ============================================================ -->
+    <div class="phone-wrap">
+      <span class="phone-tag">settings</span>
+      <div class="phone-frame">
+        <header class="appbar">
+          <button class="appbar__btn" aria-label="Back"><svg class="ico" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2"><path d="m15 6-6 6 6 6"/></svg></button>
+          <div class="appbar__title">Settings</div>
+          <button class="appbar__btn" aria-label="Open menu"><svg class="ico" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2.2" stroke-linecap="round"><path d="M3 6h18M3 12h18M3 18h18"/></svg></button>
+        </header>
+        <main class="content padded">
+          <h3 class="section-head" style="margin-top:4px;">App info</h3>
+          <div class="card">
+            <div class="stat-line"><span class="stat-line__label">App build</span><span class="stat-line__value">2026-06-01-805acc4</span></div>
+            <div class="stat-line"><span class="stat-line__label">Server build</span><span class="stat-line__value">805acc4</span></div>
+            <div class="stat-line"><span class="stat-line__label">Directory data</span><span class="stat-line__value">515 fellows</span></div>
+            <div class="stat-line"><span class="stat-line__label">Last updated</span><span class="stat-line__value">2026-05-30</span></div>
+          </div>
+
+          <h3 class="section-head">Tools</h3>
+          <button class="tool-row">
+            <svg class="ico" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2"><circle cx="12" cy="12" r="9"/><path d="M12 8v4M12 16h0"/></svg>
+            Diagnostics
+            <svg class="ico tool-row__go" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2"><path d="m9 6 6 6-6 6"/></svg>
+          </button>
+          <button class="tool-row">
+            <svg class="ico" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2"><path d="M8 5h8l-1 6h-6zM10 11v8M14 11v8M7 19h10"/></svg>
+            Report a bug
+            <svg class="ico tool-row__go" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2"><path d="m9 6 6 6-6 6"/></svg>
+          </button>
+          <button class="tool-row tool-row--danger">
+            <svg class="ico" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2"><path d="M3 12a9 9 0 0 1 15-6.7L21 8M21 3v5h-5"/><path d="M21 12a9 9 0 0 1-15 6.7L3 16M3 21v-5h5"/></svg>
+            Clear app cache &amp; reload
+          </button>
+          <p class="hint" style="margin-top:14px;">No folder, backup, or email settings on mobile — your data
+          stays in this browser, and email uses your phone's mail app.</p>
+        </main>
+      </div>
+      <div class="phone-caption">Settings = app info + tools. No "your email", no folders, no backups.</div>
+    </div>
+
+    <!-- ============================================================
+         7. ABOUT
+         ============================================================ -->
+    <div class="phone-wrap">
+      <span class="phone-tag">about</span>
+      <div class="phone-frame">
+        <header class="appbar">
+          <button class="appbar__btn" aria-label="Back"><svg class="ico" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2"><path d="m15 6-6 6 6 6"/></svg></button>
+          <div class="appbar__title">About</div>
+          <button class="appbar__btn" aria-label="Open menu"><svg class="ico" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2.2" stroke-linecap="round"><path d="M3 6h18M3 12h18M3 18h18"/></svg></button>
+        </header>
+        <main class="content padded">
+          <h1 class="page-title">About this directory</h1>
+          <p class="page-lede">A local-only directory of Edmund Hillary Fellowship fellows. Search,
+          find someone, and reach them by email or phone. Your copy lives in this browser — never on a server.</p>
+          <div class="card">
+            <div class="stat-line"><span class="stat-line__label">Total fellows</span><span class="stat-line__value">515</span></div>
+            <div class="stat-line"><span class="stat-line__label">With email</span><span class="stat-line__value">142</span></div>
+            <div class="stat-line"><span class="stat-line__label">Cohorts</span><span class="stat-line__value">9</span></div>
+          </div>
+          <p class="hint" style="margin-top:16px;">
+            <a href="#">User guide</a> · <a href="#">Source on GitHub</a>
+          </p>
+        </main>
+      </div>
+      <div class="phone-caption">About keeps the stats; chrome it shared with Settings lives there now.</div>
+    </div>
+
+  </div>
+</body>
+</html>

--- a/plans/mobile_redesign/mockups_no_groups/styles.css
+++ b/plans/mobile_redesign/mockups_no_groups/styles.css
@@ -1,0 +1,352 @@
+/* ============================================================
+   EHF Fellows Directory — MOBILE (no-groups) redesign mockup
+   ------------------------------------------------------------
+   Supersedes the group-centric parts of ../mockups/ for the
+   "no private data on mobile" decision (2026-06-01). Mobile is
+   reduced to three surfaces: Directory · Fellow · Settings/About,
+   navigated by a hamburger drawer (no tab bar, no groups, no
+   selection/composer/FAB).
+
+   Reuses the approved blue tokens from ../mockups/styles.css
+   verbatim. New here: the nav drawer, the Email/Call contact
+   CTAs, the compact filter chip, and a hardened scroll container
+   (fixed app bar + sticky search + a single scrolling list region)
+   that fixes the "you can scroll but can't tell" bug.
+   ============================================================ */
+
+/* ---------- tokens (identical to approved set) ---------- */
+:root {
+  --paper:        #eaf0f6;
+  --surface:      #ffffff;
+  --surface-soft: #f5f8fc;
+  --surface-alt:  #d6e2ee;
+
+  --border:       #c4d0e0;
+  --border-strong:#a8b8cc;
+  --border-grey:  #cccccc;
+
+  --ink:          #0f172a;
+  --ink-deep:     #0a1220;
+  --subink:       #334155;
+  --muted:        #475569;
+  --muted-soft:   #64748b;
+
+  --accent:       #0066cc;
+  --accent-hover: #004499;
+  --accent-deeper:#003366;
+  --accent-soft:  #dbeafe;
+  --accent-tint:  #eaf2fc;
+
+  --link:         #0066cc;
+  --link-hover:   #004499;
+
+  --warn-bg:      #fff3cd;
+  --warn-border:  #ffe69c;
+  --warn-text:    #664d03;
+
+  --danger:       #7a1f1f;
+  --danger-hover: #671717;
+  --danger-bg:    #fde2e2;
+  --danger-border:#f0bcbc;
+
+  --r-sm: 3px;
+  --r-md: 6px;
+  --r-lg: 12px;
+
+  --shadow-sm: 0 1px 2px rgba(0,0,0,0.08);
+  --shadow-md: 0 4px 14px rgba(0,0,0,0.12);
+  --shadow-lg: 0 8px 28px rgba(0,0,0,0.18);
+
+  --font-body: system-ui, -apple-system, BlinkMacSystemFont, "Segoe UI", Roboto, sans-serif;
+  --font-mono: ui-monospace, "Cascadia Code", Menlo, Monaco, Consolas, monospace;
+}
+
+* { box-sizing: border-box; }
+
+html, body {
+  margin: 0; padding: 0;
+  background: var(--paper);
+  color: var(--ink);
+  font-family: var(--font-body);
+  font-size: 16px;
+  line-height: 1.5;
+}
+a { color: var(--link); }
+a:hover { color: var(--link-hover); }
+
+/* ---------- gallery wrapper (desktop preview only) ---------- */
+.gallery {
+  display: flex; flex-wrap: wrap; gap: 32px;
+  padding: 32px; background: var(--paper); min-height: 100vh;
+}
+.gallery h1 {
+  font-size: 22px; font-weight: 600; width: 100%;
+  margin: 0 0 6px; color: var(--ink-deep);
+}
+.gallery p.lede {
+  width: 100%; font-size: 15px; color: var(--muted);
+  margin: 0 0 16px; max-width: 760px; line-height: 1.5;
+}
+.phone-frame {
+  width: 360px; height: 760px; background: var(--paper);
+  border-radius: 16px; box-shadow: var(--shadow-md), 0 0 0 6px #18324f;
+  overflow: hidden; position: relative;
+  display: flex; flex-direction: column;
+}
+.phone-caption { width: 360px; font-size: 13px; color: var(--muted); margin-top: 8px; text-align: center; }
+.phone-tag {
+  display: inline-block; font-family: var(--font-mono); font-size: 10px;
+  letter-spacing: 0.04em; text-transform: uppercase; color: var(--muted-soft); margin-bottom: 4px;
+}
+.phone-wrap { display: flex; flex-direction: column; align-items: center; }
+
+/* On a real phone the frame becomes the viewport. */
+@media (max-width: 480px) {
+  .gallery { padding: 0; gap: 0; }
+  .gallery h1, .gallery p.lede { display: none; }
+  .phone-frame { width: 100%; height: 100vh; border-radius: 0; box-shadow: none; }
+  .phone-caption, .phone-tag { display: none; }
+  .phone-wrap { width: 100%; }
+}
+
+/* ---------- type ---------- */
+.display-xl, .display-l, .display-m, h1, h2, h3 {
+  margin: 0; color: var(--ink-deep); font-weight: 600;
+}
+.display-xl { font-size: 24px; line-height: 1.2; }
+.display-l  { font-size: 20px; line-height: 1.25; }
+.display-m  { font-size: 16px; line-height: 1.3; }
+.mono { font-family: var(--font-mono); font-size: 12px; }
+
+/* ============================================================
+   App bar — FIXED (never scrolls). Hamburger right, back left.
+   ============================================================ */
+.appbar {
+  height: 48px; flex: 0 0 48px;
+  display: flex; align-items: center;
+  padding: 0 4px; background: var(--surface);
+  border-bottom: 1px solid var(--border);
+  position: relative; z-index: 5;
+}
+.appbar__title {
+  flex: 1; font-size: 16px; font-weight: 600; color: var(--ink-deep);
+  margin: 0; padding: 0 4px; white-space: nowrap; overflow: hidden; text-overflow: ellipsis;
+}
+.appbar__btn {
+  width: 44px; height: 44px; border: 0; background: transparent;
+  border-radius: var(--r-md); display: flex; align-items: center; justify-content: center;
+  cursor: pointer; color: var(--accent); flex-shrink: 0;
+}
+.appbar__btn:hover { background: var(--accent-soft); }
+.appbar__btn:focus-visible { outline: 2px solid var(--accent); outline-offset: 2px; }
+
+/* ============================================================
+   Content region — the SINGLE scroll container.
+   Fixed app bar + sticky search sit above; this is what scrolls.
+   ============================================================ */
+main.content {
+  flex: 1 1 auto;
+  min-height: 0;                 /* lets the flex child actually scroll */
+  overflow-y: auto;
+  -webkit-overflow-scrolling: touch;
+  overscroll-behavior: contain;
+  background: var(--paper);
+}
+main.content.padded { padding: 16px 12px 24px; }
+main.content.padded > * + * { margin-top: 12px; }
+
+.page-title { font-size: 22px; font-weight: 600; color: var(--ink-deep); margin: 0 0 4px; line-height: 1.25; }
+.page-lede  { font-size: 14px; color: var(--muted); margin: 0 0 16px; line-height: 1.5; }
+.section-head { font-size: 13px; font-weight: 700; text-transform: uppercase; letter-spacing: 0.05em; color: var(--muted); margin: 18px 0 8px; }
+
+/* ---------- cards / buttons / inputs ---------- */
+.card { background: var(--surface); border: 1px solid var(--border); border-radius: var(--r-md); padding: 12px; }
+.card + .card { margin-top: 10px; }
+
+.btn {
+  font: inherit; font-size: 14px; font-weight: 600; border-radius: var(--r-md);
+  padding: 10px 14px; min-height: 44px;
+  display: inline-flex; align-items: center; justify-content: center; gap: 6px;
+  cursor: pointer; text-decoration: none; border: 1px solid transparent; white-space: nowrap;
+}
+.btn:focus-visible { outline: 2px solid var(--accent); outline-offset: 2px; }
+.btn--primary { background: var(--accent); color: #fff; border-color: var(--accent); }
+.btn--primary:hover { background: var(--accent-hover); }
+.btn--ghost { background: var(--surface); color: var(--accent); border-color: var(--accent); }
+.btn--ghost:hover { background: var(--accent-soft); }
+.btn--danger { background: var(--surface); color: var(--danger); border-color: var(--danger); }
+.btn--danger:hover { background: var(--danger-bg); }
+.btn--block { width: 100%; }
+.btn:disabled, .btn[aria-disabled="true"] { opacity: 0.5; cursor: not-allowed; }
+
+.input {
+  font: inherit; font-size: 16px; width: 100%; padding: 10px 12px;
+  background: var(--surface); border: 1px solid var(--border-strong);
+  border-radius: var(--r-md); color: var(--ink); min-height: 44px;
+}
+.input:focus { outline: 2px solid var(--accent); outline-offset: 1px; border-color: var(--accent); }
+.input::placeholder { color: var(--muted-soft); }
+.hint { font-size: 13px; color: var(--muted); line-height: 1.5; margin-top: 6px; }
+
+/* ---------- app-info stat lines (Settings / About) ---------- */
+.stat-line { display: flex; justify-content: space-between; align-items: baseline; font-size: 15px; padding: 9px 0; border-bottom: 1px solid var(--border); }
+.stat-line:last-child { border-bottom: 0; }
+.stat-line__label { color: var(--subink); }
+.stat-line__value { font-family: var(--font-mono); font-size: 13px; font-weight: 600; color: var(--ink-deep); font-variant-numeric: tabular-nums; }
+
+/* ============================================================
+   Hamburger nav drawer (replaces the tab bar)
+   ============================================================ */
+.scrim { position: absolute; inset: 0; background: rgba(15, 23, 42, 0.5); z-index: 11; }
+
+.drawer {
+  position: absolute; top: 0; right: 0; bottom: 0;
+  width: 80%; max-width: 296px;
+  background: var(--surface); box-shadow: var(--shadow-lg);
+  z-index: 12; display: flex; flex-direction: column;
+  padding-top: env(safe-area-inset-top, 0);
+}
+.drawer__head {
+  height: 48px; flex: 0 0 48px; display: flex; align-items: center; justify-content: space-between;
+  padding: 0 4px 0 16px; border-bottom: 1px solid var(--border);
+}
+.drawer__title { font-size: 16px; font-weight: 700; color: var(--ink-deep); }
+.drawer__nav { flex: 1 1 auto; overflow-y: auto; padding: 8px 0; }
+.drawer-link {
+  display: flex; align-items: center; gap: 14px; padding: 12px 16px; min-height: 48px;
+  font-size: 16px; color: var(--ink-deep); text-decoration: none;
+}
+.drawer-link:hover { background: var(--accent-tint); }
+.drawer-link--active { background: var(--accent-soft); color: var(--accent-deeper); font-weight: 600; box-shadow: inset 3px 0 0 var(--accent); }
+.drawer-link .ico { color: var(--muted); }
+.drawer-link--active .ico { color: var(--accent); }
+.drawer__foot { padding: 12px 16px calc(12px + env(safe-area-inset-bottom, 0)); border-top: 1px solid var(--border); }
+.build-tag {
+  display: flex; flex-direction: column; gap: 2px;
+  font-family: var(--font-mono); font-size: 11px; color: var(--muted); line-height: 1.5;
+}
+.build-tag b { color: var(--ink-deep); font-weight: 600; }
+
+/* ============================================================
+   Search region (directory) — STICKY, never part of the scroll
+   ============================================================ */
+.search-region {
+  flex: 0 0 auto; background: var(--surface); border-bottom: 1px solid var(--border);
+  padding: 10px 12px; display: flex; flex-direction: column; gap: 8px;
+}
+.filterbar { display: flex; align-items: center; gap: 8px; flex-wrap: wrap; }
+.filter-btn {
+  display: inline-flex; align-items: center; gap: 6px;
+  font: inherit; font-size: 13px; font-weight: 600;
+  padding: 6px 12px; min-height: 34px; cursor: pointer;
+  background: var(--surface); color: var(--accent);
+  border: 1px solid var(--border-strong); border-radius: var(--r-md);
+}
+.filter-btn:hover { background: var(--accent-soft); border-color: var(--accent); }
+.filter-btn:focus-visible { outline: 2px solid var(--accent); outline-offset: 2px; }
+.filterbar__count { margin-left: auto; font-size: 13px; color: var(--muted); font-variant-numeric: tabular-nums; }
+
+/* removable active-filter chip — has-email is a default, not a gate */
+.filter-chip {
+  display: inline-flex; align-items: center; gap: 4px;
+  padding: 5px 6px 5px 11px; min-height: 34px;
+  background: var(--accent-soft); color: var(--accent-deeper);
+  border: 1px solid var(--border); border-radius: 999px;
+  font-size: 13px; font-weight: 600;
+}
+.filter-chip__x {
+  width: 24px; height: 24px; border: 0; background: transparent;
+  color: var(--accent); cursor: pointer; font-size: 16px; line-height: 1;
+  border-radius: 50%; display: inline-flex; align-items: center; justify-content: center;
+}
+.filter-chip__x:hover { background: rgba(0,0,0,0.06); }
+
+/* ============================================================
+   Directory list — full-width tap rows, chevron, NO select button
+   ============================================================ */
+.directory-list { display: flex; flex-direction: column; }
+.directory-row {
+  display: flex; align-items: center; gap: 10px;
+  padding: 12px; border-bottom: 1px solid var(--border);
+  background: var(--surface); text-decoration: none; min-height: 56px;
+}
+.directory-row:active { background: var(--accent-soft); }
+.directory-row__name { flex: 1; font-size: 16px; color: var(--ink-deep); }
+.directory-row__sub { font-size: 13px; color: var(--muted); display: block; margin-top: 2px; }
+.directory-row__go { color: var(--muted-soft); flex-shrink: 0; }
+.directory-row__nomail {
+  font-size: 11px; font-weight: 700; text-transform: uppercase; letter-spacing: 0.03em;
+  color: var(--muted); background: var(--surface-soft); border: 1px solid var(--border);
+  padding: 2px 7px; border-radius: 999px; flex-shrink: 0;
+}
+
+/* ============================================================
+   Bottom sheet (filters)
+   ============================================================ */
+.sheet {
+  position: absolute; inset: auto 0 0 0; background: var(--surface);
+  border-top: 1px solid var(--border-strong); border-radius: var(--r-lg) var(--r-lg) 0 0;
+  box-shadow: var(--shadow-lg); padding: 10px 14px calc(16px + env(safe-area-inset-bottom, 0));
+  z-index: 12;
+}
+.sheet__handle { width: 40px; height: 4px; background: var(--border-strong); border-radius: 2px; margin: 0 auto 10px; }
+.sheet__head { display: flex; justify-content: space-between; align-items: baseline; margin-bottom: 12px; }
+.sheet__title { font-size: 16px; font-weight: 600; color: var(--ink-deep); }
+.field { margin-bottom: 14px; }
+.field > label { display: block; font-size: 13px; font-weight: 600; color: var(--ink-deep); margin-bottom: 6px; }
+.checkrow { display: flex; align-items: center; gap: 10px; padding: 8px 0; }
+.checkrow input { width: 22px; height: 22px; accent-color: var(--accent); }
+.checkrow label { font-size: 15px; color: var(--ink); }
+.checkrow .hint { margin: 2px 0 0; }
+.select {
+  font: inherit; font-size: 16px; width: 100%; padding: 10px 12px; min-height: 44px;
+  background: var(--surface); border: 1px solid var(--border-strong); border-radius: var(--r-md); color: var(--ink);
+}
+
+/* ============================================================
+   Fellow detail — hero + contact CTAs (the core mobile action)
+   ============================================================ */
+.fellow-hero { display: flex; flex-direction: column; align-items: flex-start; gap: 10px; margin-bottom: 12px; }
+.fellow-photo {
+  width: 168px; height: 168px; border-radius: var(--r-lg); background: var(--surface-alt);
+  display: flex; align-items: center; justify-content: center; font-size: 52px; font-weight: 600;
+  color: var(--muted-soft); border: 1px solid var(--border); align-self: center;
+}
+.fellow-name { font-size: 24px; font-weight: 600; color: var(--ink-deep); margin: 0; line-height: 1.2; }
+.fellow-tagline { font-size: 15px; color: var(--subink); line-height: 1.45; margin: 0; }
+
+/* the primary reason mobile exists: contact this person */
+.contact-cta { display: flex; gap: 8px; margin: 4px 0 8px; }
+.contact-cta .btn { flex: 1; font-size: 15px; min-height: 50px; }
+.contact-cta .ico { width: 18px; height: 18px; }
+
+.tag-chips { display: flex; flex-wrap: wrap; gap: 6px; margin: 8px 0; }
+.tag-chip { font-size: 12px; padding: 3px 10px; background: var(--surface-alt); color: var(--accent-deeper); border: 1px solid var(--border); border-radius: 999px; font-weight: 600; }
+
+.contact-row { display: flex; align-items: center; padding: 10px 0; border-bottom: 1px solid var(--border); gap: 10px; }
+.contact-row__label { font-size: 12px; color: var(--muted); font-weight: 600; text-transform: uppercase; letter-spacing: 0.04em; width: 52px; flex-shrink: 0; }
+.contact-row__value { flex: 1; font-size: 15px; color: var(--ink); word-break: break-word; }
+.contact-row__value a { color: var(--link); text-decoration: underline; }
+.contact-row__copy { width: 40px; height: 40px; border: 1px solid var(--border-strong); border-radius: var(--r-md); background: var(--surface); color: var(--muted); cursor: pointer; flex-shrink: 0; }
+.contact-row__copy:hover { background: var(--accent-soft); border-color: var(--accent); color: var(--accent); }
+
+.prose-block { margin-top: 16px; }
+.prose-block p { font-size: 15px; color: var(--ink); line-height: 1.55; margin: 6px 0 0; }
+
+/* ---------- tool rows (Settings) ---------- */
+.tool-row {
+  display: flex; align-items: center; gap: 12px; width: 100%;
+  padding: 14px 12px; font: inherit; font-size: 15px; text-align: left;
+  background: var(--surface); border: 1px solid var(--border); border-radius: var(--r-md);
+  color: var(--ink-deep); cursor: pointer; min-height: 52px;
+}
+.tool-row + .tool-row { margin-top: 8px; }
+.tool-row:hover { background: var(--accent-tint); border-color: var(--accent); }
+.tool-row .ico { color: var(--accent); }
+.tool-row--danger { color: var(--danger); border-color: var(--danger-border); }
+.tool-row--danger .ico { color: var(--danger); }
+.tool-row--danger:hover { background: var(--danger-bg); border-color: var(--danger); }
+.tool-row__go { margin-left: auto; color: var(--muted-soft); }
+
+.ico { width: 18px; height: 18px; flex-shrink: 0; }
+.ico-sm { width: 14px; height: 14px; }

--- a/plans/pna_toolkit_constraints_contribution.md
+++ b/plans/pna_toolkit_constraints_contribution.md
@@ -1,0 +1,567 @@
+# Plan — Contributing the **Constraints** concept to the Personal Network Toolkit (PNT)
+
+> **Status: PLAN ONLY.** This document stages a future contribution to the
+> [`personal_network_toolkit`](https://github.com/richbodo/personal_network_toolkit) (PNT) repo.
+> It is **not** the contribution itself, and nothing here has been executed. No issues or PRs are
+> to be filed into PNT until the maintainer explicitly says so. This file lives in the
+> `fellows_local_db` repo (`plans/`) as a design record the maintainer reviews first.
+>
+> Local paths referenced below (confirmed against the current checkout):
+> - PNT repo: `/Users/richbodo/src/personal_network_toolkit` (spec files under `spec/`; `VERSION` = `0.1.0-draft`)
+> - Demonstrating design (this repo): `/Users/richbodo/src/fellows_local_db`
+>
+> **Companion to** [`pna_toolkit_exceptions_contribution.md`](pna_toolkit_exceptions_contribution.md).
+> Constraints are the **dual** of Exceptions; this plan deliberately mirrors that one's shape so the
+> two land as a matched pair. The canonical lesson-learned that motivates it is
+> [`../docs/architectural_findings.md` § 2026-06-01](../docs/architectural_findings.md).
+
+---
+
+## 1. Summary + motivation
+
+### The discovery
+
+A fellow's Private Data Ops MCP server stopped connecting to Claude Desktop. The proximate cause was
+mundane — the `.mcpb` extension pointed at a `relationships.db` export that had been relocated out of
+`~/Downloads`. But chasing *why the handoff was that fragile in the first place* surfaced a
+class-level ceiling the app had been routing around without naming:
+
+> For a PNA delivered as a web app, the private-data half's writability and external-readability is
+> gated entirely by the browser's **File System Access API** — which is Chromium-only. On every
+> non-FSA browser (Safari, Firefox, all of iOS), the private store can only live in the opaque OPFS
+> sandbox (invisible to the user and to companion tools like the app's own MCP servers), is subject
+> to silent browser eviction, and can escape to a real file only as a one-shot, immediately-stale
+> download snapshot. So on those browsers the private half degrades to a **read-only snapshot at
+> best**.
+
+This is a different *kind* of finding from `EX-CLOUD-LLM`. That one is a **privacy** deviation a
+user deliberately *raises* and the app *handles*. This is a **data-loss** ceiling the *platform*
+imposes — nobody raises it; it is a property of the medium. The app's honest response was to
+**reduce capability per platform**: folder mode (a real, user-visible, MCP-readable file) on
+Chromium desktop; on Safari/Firefox/mobile, drop the durable private store and offer only
+OPFS + manual backup — *for now*. The fellows decision log already reached for the word "constraint"
+informally (`docs/ac_decisions_log.md` § 2026-05-22: *"This constraint is **fundamental to the
+browser platform**, not something our code [can fix]"*); this contribution formalizes it.
+
+### The tension is structural, not a fellows wart
+
+The PNA Spec commits to private-data sovereignty (Goal 1) and to portable, durable, recoverable user
+data (Goal 4; `spec/PNA_Spec.md`), and AC-1 commits to a read-write, locally-owned Private store. But
+there is no first-class way for a PNA to say *"the platform I'm running on **cannot** deliver this
+capability, here is the ceiling, here is how I reduced scope to stay honest, and here is whether
+anyone has found a way around it yet."* The spec models conformance as *honoring every AC*; real
+deployments need a way to declare **what the substrate forbids** and to be judged on *handling the
+ceiling honestly* rather than on impossibly clearing it.
+
+Any PNA that picks `distribution:web-bundle` × `storage:opfs-sqlite-wasm` inherits this ceiling and a
+family of siblings (eviction, no built-in sync, the single-owner OPFS architecture, the sandbox
+boundary that seals the store off from the user's other tools). It is a property of the application
+*class*, which is exactly what the toolkit exists to capture.
+
+### The resolution
+
+Introduce a new first-class PNT concept — **Constraints** — the dual of Exceptions. A Constraint is a
+stable-ID'd (`CST-*`) **platform- or substrate-imposed ceiling**, inherited automatically by one or
+more **axis picks**, that *removes or bounds functionality a PNA would otherwise offer*. Unlike an
+Exception, **no one raises it** — it is a property of the medium. It obligates a documented
+**handling** (typically per-platform capability reduction — "enough power to be useful, not enough to
+be dangerous") and carries an explicit **resolution frontier**: whether a viable workaround is known,
+or whether (as of this version) none has been found.
+
+**Crucial difference from Exceptions:** handling a Constraint **does not exit PNA mode.** A
+capability-reduced PNA that honestly handles its inherited ceilings is *fully a PNA* — just a smaller
+one on that platform. The dishonest failure mode is *pretending the ceiling isn't there* — promising
+durability the platform can't keep (the Android-folder-mode "false durability" bug fellows fixed in
+PR #234). That is a conformance failure, but it is not a "mode."
+
+### Why this belongs upstream, not just in fellows
+
+Per `pna-build-eval-contrib/SKILL.md` § Contribute → Preflight, the most valuable submission pattern
+is a **new architectural concept the spec doesn't yet name**, with a demonstrating reference design.
+Constraints are exactly that, and fellows already *ships* the handling (folder mode, per-platform
+capability reduction, the mobile gate, manual-backup durability path) — so the reference-design half
+is in far better shape here than it was for the not-yet-built `EX-CLOUD-LLM` handler. The spec change
+rides along with working code, as `CONTRIBUTING.md` requires.
+
+---
+
+## 2. The Constraints concept
+
+### Compile-time-error metaphor (the dual of the Exception's runtime-error metaphor)
+
+Exceptions borrow the *runtime* exception metaphor (raise / catch / handle). Constraints borrow the
+*compile-time* one: the platform's type system won't admit the program you wanted, so you restructure
+to a smaller program that *does* type-check.
+
+| Software | PNA Constraint |
+|---|---|
+| A compile-time / type error: the platform won't admit the program you intended | A capability the PNA **cannot express** on a given platform, given its axis picks |
+| Not caught at runtime — you restructure the program to fit | Handled by **reducing the feature set** to what the platform can actually keep |
+| The error names exactly what's unsupported | Every constraint has a stable `CST-*` ID naming the ceiling |
+| `#ifdef PLATFORM` / capability shims | **Per-platform capability reduction** ("enough power to be useful, not dangerous") |
+| A `// TODO: unsupported on X` with an issue link | The **Frontier** field: `Open` (no known workaround) vs `Solved`/`Mitigated` (here's how) |
+
+### Inherited / detected / handled
+
+- **Inherited** — a Constraint attaches automatically to one or more axis picks. Picking
+  `storage:opfs-sqlite-wasm` *is* taking on `CST-PWA-SANDBOX-SEALED`; no action raises it.
+- **Detected** — the app must determine, per platform/session, whether the ceiling is active, and do
+  so **honestly** (see the Detectability field — capability presence ≠ usefulness ≠ permanence).
+- **Handled** — the app reduces capability to match what the platform can deliver, and **declares the
+  frontier honestly** (does not claim to solve what it only mitigated). A reference design stays
+  conformant by handling, not by overcoming.
+
+### Constraints do not change PNA mode
+
+> **Exceptions exit PNA mode; Constraints do not.** A PNA that honestly handles an inherited
+> Constraint remains in PNA mode — it is simply capability-reduced on that platform. The conformance
+> question for a Constraint is not "is it active?" (it always is, on the triggering platform) but
+> "is it **handled honestly** — capability matched to deliverable durability, frontier declared
+> truthfully, no false promises?"
+
+### The adverse-only registry decision (recorded for the PR)
+
+Some platform ceilings happen to *serve* a PNA goal (a PWA can't send mail itself, only hand off a
+`mailto:` URL — landing the app in exactly the "transports cannot read message contents" shape AC-18
+wants). These are real but are **not** builder/verifier advice the way an adverse ceiling is. The
+constraints registry is therefore **adverse-only**: it catalogs ceilings that *take capability away*.
+"Helpful constraints" belong in a separate, future *"things that worked well, proven true and
+useful"* channel — explicitly **out of scope** for this contribution. (No `valence` field; the
+concept was considered and deferred — see § 5.)
+
+### Validation, not certification (same framing the exceptions work promotes)
+
+This contribution reinforces the framing the Exceptions plan makes load-bearing:
+
+> **PNT validates behaviors against the Goals; it does not certify.** For Constraints, the evaluate
+> flow detects each inherited ceiling and verifies that the candidate *handles it honestly* —
+> capability reduced to match the platform, frontier declared truthfully — reporting by `CST-*` ID.
+> "This design inherits `CST-PWA-PRIVATE-SNAPSHOT` and handles it by dropping private writes
+> off-Chromium (frontier: Open)" is a finding, not a grade.
+
+The backstop, dual to the Exceptions backstop: where the Exceptions evaluate pass catches *undeclared
+deviations* (the app violates an AC without raising an exception), the Constraints evaluate pass
+catches *undeclared over-reach* — the app promises a capability the platform cannot keep without
+acknowledging the ceiling (**false durability**). Both are silent dishonesty; both are conformance
+failures.
+
+### Terminology note (recorded for the PR)
+
+The concept was considered as *limitation*, *ceiling*, and *constraint*. **Constraint** is preferred:
+it pairs cleanly with Exception (the runtime/compile-time dual), the fellows decision log already used
+the word, and "limitation" reads as an apology where "constraint" reads as a design boundary. See § 5
+for residual terminology questions.
+
+---
+
+## 3. Proposed PNT artifacts
+
+Each sub-plan is concrete enough to be mechanical to execute, with DRAFT text where it helps. None of
+it is to be applied to PNT yet.
+
+### 3a. NEW file: `spec/constraints.md`
+
+A new spec file (sibling to `spec/axes.md`, `spec/use_cases.md`, `spec/exceptions.md`). It carries
+four things: the concept, the header conventions (`Triggered-by:` / `Bounds:` / `Frontier:` /
+`Detectability:`), the constraint registry (eight `CST-PWA-*` entries), and a non-normative
+implementation-notes appendix (the "footguns").
+
+#### DRAFT — front matter + concept
+
+```markdown
+# PNA Constraints
+
+> **Spec-Version:** tracks the PNA Spec version in spec/PNA_Spec.md.
+>
+> This file defines **Constraints**: stable-ID'd ceilings (`CST-*`) that a platform or storage
+> substrate imposes on a PNA, inherited automatically by one or more axis picks (spec/axes.md).
+> Constraints are the dual of Exceptions (spec/exceptions.md): an Exception is a deviation the USER
+> raises and the app handles; a Constraint is a limitation the PLATFORM imposes and the app must
+> likewise handle — never silently.
+
+## Concept
+
+A Constraint is **inherited** (by an axis pick — raised by no one), must be **detected** honestly per
+platform, and must be **handled** by reducing capability to what the platform can actually deliver
+("enough power to be useful, not enough to be dangerous").
+
+**Handling a Constraint does NOT exit PNA mode.** A capability-reduced PNA that handles its inherited
+ceilings honestly is fully a PNA. The failure mode is over-reach: promising a capability the platform
+cannot keep (false durability) without acknowledging the ceiling.
+
+PNT validates behaviors against the Goals; it does not certify. The evaluate flow detects each
+inherited Constraint and verifies that the candidate handles it honestly, reporting by `CST-*` ID.
+
+The registry is **adverse-only**: it catalogs ceilings that remove or bound capability. Ceilings that
+happen to serve a PNA goal are out of scope here.
+```
+
+#### DRAFT — header conventions (mirroring exceptions' `Relaxes:`/`Reversible:`)
+
+```markdown
+## Header conventions
+
+These mirror the `Realizes: AC-...` header in `contracts/` and the `Relaxes:`/`Reversible:` headers
+in `exceptions.md`. They appear in a constraint's registry entry and in any reference design's
+constraint-attestation declaration.
+
+- **`Triggered-by:`** — names the axis pick(s) that inherit this constraint. Each token is an
+  axis-pick identifier of the form `<axis>:<pick>` as defined in axes.md (e.g.
+  `storage:opfs-sqlite-wasm`, `distribution:web-bundle`). Multiple tokens are comma-separated and
+  mean "any of these picks inherits it" unless the entry says the combination is required.
+  Example: `Triggered-by: distribution:web-bundle, storage:opfs-sqlite-wasm`
+- **`Bounds:`** — names the Goal(s)/AC(s) whose full achievement the ceiling limits. The PNA still
+  TRIES to honor them; the constraint bounds how completely it can on the triggering platform. Tokens
+  are `AC-*`, `Goal-N`, or the literal `PNA-DEFINITION`. Example: `Bounds: AC-1, Goal-4`
+- **`Frontier:`** — the resolution status. One of `Open` (no viable workaround found this version),
+  `Mitigated` (partial handling exists; ceiling not removed), `Solved-on-<platform>` (removed on the
+  named platform — e.g. `Solved-on-chromium`), or `Inherent` (cannot be removed; it is the medium).
+  If `Mitigated` or `Solved-*`, a `Workaround:` field MUST follow naming the mechanism (a control,
+  route, or code reference the validation flow can confirm).
+  Example: `Frontier: Solved-on-chromium` / `Workaround: File System Access folder mode writes a
+  real, user-visible file; see <design>'s Architecture.md.`
+- **`Detectability:`** *(builder-actionable)* — how a builder determines whether the ceiling is active
+  on a given platform. One of `feature-detect` (a clean capability check suffices), `empirical-probe`
+  (the feature check lies; you must actually exercise it), or `ua-sniff` (no reliable capability
+  signal; user-agent inference is the only handle). Example: `Detectability: ua-sniff`
+```
+
+> **`PNA-DEFINITION` token.** Reused from the Exceptions plan (§ 3a there) — the PNA definition lives
+> in prose (`vocab-pna`), not in the AC table, so `Bounds:` references it via the same literal
+> sentinel the lint already resolves for `Relaxes:`. No new special-case if the Exceptions
+> contribution lands first.
+
+#### DRAFT — constraint registry (all eight entries; the two headliners in full)
+
+```markdown
+## Constraint registry
+
+| CST | Name | Triggered-by | Bounds | Frontier | Detectability |
+|---|---|---|---|---|---|
+| CST-PWA-PRIVATE-SNAPSHOT | Private store read-only off FSA browsers | distribution:web-bundle, storage:opfs-sqlite-wasm | AC-1, Goal-4 | Open | feature-detect (page-side `showDirectoryPicker`) |
+| CST-PWA-SANDBOX-SEALED | OPFS store invisible + non-interoperable | storage:opfs-sqlite-wasm | AC-1, Goal-4, AC-MCP-A | Solved-on-chromium | feature-detect |
+| CST-PWA-STORAGE-EVICTABLE | Script storage is evictable | storage:opfs-sqlite-wasm | Goal-4 | Mitigated | empirical-probe (`persist()` is advisory) |
+| CST-PWA-NO-SYNC | Origin/device-local silos; no built-in portability | distribution:web-bundle, storage:opfs-sqlite-wasm | Goal-4 | Open | feature-detect |
+| CST-PWA-DURABLE-SQL-ARCH | Durable SQL forces worker-owned single-connection arch | storage:opfs-sqlite-wasm | (none — bounds the build space, not a user AC) | Inherent | feature-detect (in-worker) |
+| CST-PWA-SINGLE-OWNER | Multi-tab contention, no OS file lock | storage:opfs-sqlite-wasm | AC-11 | Solved-on-chromium | empirical-probe |
+| CST-PWA-NO-BACKGROUND | No reliable scheduled background execution | distribution:web-bundle | Goal-4 | Mitigated | feature-detect (Periodic Sync absent on iOS) |
+| CST-PWA-SERVER-FLOOR | Origin + TLS + secure context required | distribution:web-bundle | PNA-DEFINITION | Inherent | feature-detect (`isSecureContext`) |
+
+### CST-PWA-PRIVATE-SNAPSHOT — Private store is read-only off File-System-Access browsers
+
+**Triggered-by:** distribution:web-bundle, storage:opfs-sqlite-wasm
+**Bounds:** AC-1, Goal-4
+**Frontier:** Open — no viable workaround found as of Spec-Version 0.x for keeping a LIVE, writable,
+externally-readable private store off Chromium. An encrypt-then-email-to-self portability pattern is
+a candidate (snapshot transport, not live), unproven.
+**Detectability:** feature-detect — page-side `'showDirectoryPicker' in window`. (Necessary but not
+sufficient; see CST-PWA-STORAGE-EVICTABLE and the Android caveat in CST-PWA-NO-BACKGROUND for why a
+positive check still doesn't guarantee a *durable* store.)
+
+**Ceiling:** The File System Access API (the only browser API granting a web app a persistent
+writable handle to a user-chosen, user-visible file) is Chromium-only. On Safari, Firefox, and all
+iOS browsers the private store can live only in the opaque OPFS sandbox or escape as a frozen
+download snapshot. The "private half" of the PNA — meant to be the user's sovereign, live,
+manipulable data — degrades to read-only-snapshot-at-best.
+
+**Recommended handling:** per-platform capability reduction. On FSA-capable platforms, offer folder
+mode (a real file). On non-FSA platforms, do not promise a durable live private store; offer
+OPFS + an explicit manual backup/export path and SAY SO. Demonstrated by `fellows_local_db`
+(reference_designs/fellows_local_db/).
+
+### CST-PWA-SANDBOX-SEALED — OPFS store is invisible to the user and to their other tools
+
+**Triggered-by:** storage:opfs-sqlite-wasm
+**Bounds:** AC-1, Goal-4, AC-MCP-A
+**Frontier:** Solved-on-chromium
+**Workaround:** File System Access folder mode relocates the store to a real, user-visible file that
+companion tools (MCP servers, backups, CLIs) can read directly; the sandbox boundary dissolves. Off
+Chromium the boundary stands and only snapshot export bridges it.
+**Detectability:** feature-detect.
+
+**Ceiling:** OPFS is an origin-scoped sandbox. The store is invisible in the user's file manager and
+unreadable by any other program on the machine, and a PWA cannot host native integration (no stdio,
+no sockets, no local server) to bridge it — so the app's own MCP servers must ship as separate native
+processes that can only read an EXPORTED copy. **This is the root cause of the MCP-handoff fragility
+that surfaced this whole finding.** A PNA is meant to be the hub the user's other tools act on; a
+store those tools cannot read is half a PNA.
+
+**Recommended handling:** folder mode where available (dissolves the boundary); elsewhere, an explicit
+export/import bridge with honest messaging that companion tools see a snapshot, not the live store.
+Demonstrated by `fellows_local_db`.
+```
+
+> **Remaining six entries** (CST-PWA-STORAGE-EVICTABLE, -NO-SYNC, -DURABLE-SQL-ARCH, -SINGLE-OWNER,
+> -NO-BACKGROUND, -SERVER-FLOOR) follow the identical block shape; full prose is drafted from the
+> 8-row analysis in `../docs/architectural_findings.md` § 2026-06-01 when this plan is executed. Each
+> already has its Triggered-by / Bounds / Frontier / Detectability fixed in the table above.
+
+#### DRAFT — non-normative implementation notes (the "footguns")
+
+```markdown
+## Implementation notes (non-normative)
+
+These are navigable PWA footguns — recorded so builders don't re-derive them, but they are NOT
+ceilings and carry no `CST-*` ID. (Per the contribution's "ceilings normative, footguns noted"
+decision.)
+
+- **Service-worker staleness.** A cached app shell can pin users to old code; "what code is running"
+  is ambiguous. Handle with source-tied build labels + an explicit update banner.
+- **No atomic factory reset.** OPFS has no per-origin wipe API; an HttpOnly session cookie needs a
+  server round-trip. A full reset must reach each layer deliberately.
+- **PWA install + manifest gotchas.** WebAPK `related_applications` can trigger Play-Store
+  verification failures; POST `share_target` silently fails on some WebAPK servers; iOS hides install
+  behind Share → Add to Home Screen. Keep the manifest minimal; document per-platform install flows.
+```
+
+#### Meta-principles (promoted alongside the registry)
+
+```markdown
+## Meta-principles
+
+- **M1 — capability presence ≠ usefulness ≠ permanence.** `showDirectoryPicker in window` is true on
+  Android Chrome but only reaches an OS-clearable folder; `persist()` returns true but Safari still
+  evicts; `createSyncAccessHandle` exists in a worker but not on the page. Detect USEFUL, DURABLE
+  capability — often empirically. This is why every entry carries a `Detectability:` field.
+- **M3 — the handling pattern is per-platform capability reduction.** Match each platform's offered
+  features to the durability it can actually keep: "enough power to be useful, not enough to be
+  dangerous."
+```
+
+### 3b. ONE-LINE pointers from `spec/PNA_Spec.md` and `spec/axes.md`
+
+The lightest touch that keeps the AC-ID lint green (the lint reads `PNA_Spec.md` + `axes.md` for AC
+rows and does not parse free text; prose pointers add no `| AC-X |` rows).
+
+- **`spec/PNA_Spec.md`** — a one-line pointer in § Vocabulary or near the Goal-4 (durability)
+  statement, since Constraints are precisely where Goal-4 meets platform reality. DRAFT:
+
+  ```markdown
+  > A platform or storage substrate may impose a ceiling that bounds how fully a PNA can honor a Goal
+  > or AC on a given platform — a **Constraint** (see [`constraints.md`](constraints.md)). A PNA stays
+  > conformant by handling each inherited Constraint honestly (capability reduced to what the platform
+  > can keep, frontier declared truthfully); handling a Constraint does not exit PNA mode.
+  ```
+
+- **`spec/axes.md`** — one cross-reference note on each triggering pick (the `storage:opfs-sqlite-wasm`
+  pick and the `distribution:web-bundle*` picks), pointing at the constraints they inherit. DRAFT
+  (storage pick): `Inherits CST-PWA-SANDBOX-SEALED, CST-PWA-STORAGE-EVICTABLE,
+  CST-PWA-DURABLE-SQL-ARCH, CST-PWA-SINGLE-OWNER (see constraints.md).` This is the **generative**
+  half — a builder reading the axis sees what they're taking on.
+
+**Lint-safety check (when executing):** after editing, run `python tools/lint-spec-ids.py` from the
+PNT root; confirm `OK` and the same AC count. Pointer text must not contain a line starting with
+`| AC-`.
+
+### 3c. Extend `tools/lint-spec-ids.py`
+
+Mirror the AC machinery (and the EX machinery, if the Exceptions contribution lands first) for
+constraints. **Design-level, not final code:**
+
+**New regexes (mirror `AC_RE` / `REALIZES_RE` / `REVERSIBLE_RE`):**
+
+```python
+# Mirrors AC_RE. Collects CST-* IDs from registry rows in spec/constraints.md.
+CST_RE = re.compile(r"^\| (CST-[A-Z0-9-]+?)(?=\s|\*|\|)", re.MULTILINE)
+
+# Mirrors REALIZES_RE. Triggered-by tokens are axis-pick identifiers (<axis>:<pick>).
+TRIGGERED_RE = re.compile(r"Triggered-by:\s*((?:[a-z0-9-]+:[a-z0-9-]+(?:\s*,\s*)?)+)", re.IGNORECASE)
+
+# Bounds tokens may be AC-*, Goal-N, or PNA-DEFINITION.
+BOUNDS_RE = re.compile(
+    r"Bounds:\s*((?:(?:AC-[A-Z0-9-]+|Goal-[0-9]+|PNA-DEFINITION)(?:\s*,\s*)?)+)",
+    re.IGNORECASE,
+)
+
+# Frontier: Open | Mitigated | Solved-on-<platform> | Inherent. Solved/Mitigated require Workaround:.
+FRONTIER_RE = re.compile(r"Frontier:\s*(Open|Mitigated|Solved-on-[a-z0-9-]+|Inherent)\b", re.IGNORECASE)
+
+# Detectability: feature-detect | empirical-probe | ua-sniff.
+DETECT_RE = re.compile(r"Detectability:\s*(feature-detect|empirical-probe|ua-sniff)\b", re.IGNORECASE)
+```
+
+**New collection + checks in `main()` (mirror the existing AC loop):**
+
+1. `collect_constraint_ids()` — read `spec/constraints.md`, `CST_RE.findall`, return the `CST-*` set.
+   Absent file → empty set (lint stays green on repos that haven't adopted constraints).
+2. For every `Triggered-by:` token: it MUST resolve to a known axis pick in `axes.md`. (Requires
+   collecting `<axis>:<pick>` identifiers from axes.md — a small new collector; if axes.md doesn't yet
+   expose pick IDs in a machine-readable form, the first cut MAY validate only the `<axis>:` prefix
+   against the known axis list. Flag in § 5.) Failure: `f"{src}: Triggered-by names {tok}, not a known
+   axis pick."`
+3. For every `Bounds:` token: MUST resolve to a known `AC-*`, a `Goal-N`, or `PNA-DEFINITION`. Exact
+   inverse of the existing "claims to realize {ac}" check.
+4. For every entry: `Frontier:` MUST match `FRONTIER_RE`; if `Mitigated`/`Solved-*`, a `Workaround:`
+   field MUST be present. `Detectability:` MUST match `DETECT_RE`. Failures name the malformed field.
+
+**What the lint deliberately does NOT do:** it does not assert the ceiling is genuinely detected or
+handled at runtime, nor that the workaround works — that is the LLM evaluate layer (§ 3e). It
+validates declaration shape (presence + traceability), exactly as the tool does for `Realizes:`.
+
+**Output + docstring:** extend the success summary with `spec defines N constraint IDs` /
+`M Triggered-by header(s) resolved`; add the CST/Triggered-by/Bounds/Frontier checks to the module
+docstring.
+
+### 3d. Strengthen the "validation, not certification" framing (constraints angle)
+
+If the Exceptions contribution already added the framing callout to `spec/PNA_Spec.md` § Building a
+PNA, extend it with one clause; otherwise add it. DRAFT addition:
+
+```markdown
+> For Constraints, the evaluate flow detects each ceiling a design's axis picks inherit and verifies
+> it is handled honestly — capability reduced to what the platform can keep, frontier declared
+> truthfully — reporting by `CST-*` ID. Over-reach (promising a capability the platform cannot keep)
+> is a silent conformance failure, the dual of an undeclared Exception.
+```
+
+### 3e. Add a constraint pass to the SKILL flows (`pna-build-eval-contrib/SKILL.md`)
+
+Constraints are most generative in the **Build** flow and most checkable in the **Evaluate** flow.
+
+**Build flow — new step (after axis selection):**
+
+```markdown
+N. **Enumerate inherited Constraints.** From the chosen axis picks, list every Constraint they
+   inherit (spec/constraints.md `Triggered-by:`). For each, state the handling you will implement
+   (per-platform capability reduction) and its frontier. A web-bundle × opfs-sqlite-wasm PNA inherits
+   the full CST-PWA-* family; plan the folder-mode-vs-OPFS-only split and the honest non-Chromium
+   messaging up front, not as an afterthought.
+```
+
+**Evaluate flow — new step (after the exceptions pass, mirroring it):**
+
+```markdown
+3c. **Detect and verify Constraints.** For each Constraint the candidate's axis picks inherit:
+    - **Detected honestly?** Confirm the app determines whether the ceiling is active using a sound
+      signal for that constraint's Detectability class (feature-detect / empirical-probe / ua-sniff).
+      Flag capability checks trusted where presence ≠ usefulness (M1).
+    - **Handled by capability reduction?** Confirm the app offers only what the platform can keep, and
+      that any durability promise (badges, "saved" affordances) matches reality. Cite code/UX.
+    - **Frontier honest?** Read the `Frontier:` declaration; confirm the design does not claim to
+      Solve what it only Mitigated, and that a `Workaround:` (where claimed) actually exists in
+      code/UX.
+    - **Over-reach (the backstop).** If the candidate promises a capability the platform cannot keep
+      WITHOUT acknowledging the ceiling — false durability — that is a silent conformance failure.
+      Flag it and name the `CST-*` it should have handled.
+    Report each finding by `CST-*` ID.
+```
+
+The three-layer split matches the Exceptions contribution:
+- **Lint (mechanical):** `CST-*` defined; `Triggered-by:` resolves to axis picks; `Bounds:`
+  traceable; `Frontier:`/`Detectability:` well-formed (§ 3c).
+- **Evaluate (LLM):** detection sound, handling real, frontier honest, over-reach caught (this step).
+- **Human:** final judgment at PR time (`CONTRIBUTING.md` § Acceptance — unchanged).
+
+### 3f. `fellows_local_db` as the demonstrating reference design
+
+Unlike the Exceptions contribution (whose `EX-CLOUD-LLM` handler was unbuilt at plan time), fellows
+**already ships** the constraint handling — folder mode on Chromium, per-platform capability reduction
+off it, the mobile data-folder gate (PR #234), the "Download my private data" backup path, the
+browser-only badge. So the reference-design half is largely a *documentation* task, not new feature
+work.
+
+**(i) Design record — `reference_designs/fellows_local_db/README.md`** — add a *Contributions to the
+spec* bullet for this PR (Constraints concept + CST-PWA-* registry, demonstrated by fellows' folder
+mode + capability reduction).
+
+**(ii) Architecture.md copy — `reference_designs/fellows_local_db/Architecture.md`** — PNT keeps its
+own copy at acceptance; copy fellows' `docs/Architecture.md` *with* the new Constraints section.
+
+**(iii) Constraint attestation in fellows' `docs/Architecture.md`** — a new section mirroring the
+existing *Exception attestation* table, copied into the PNT Architecture.md. DRAFT:
+
+```markdown
+## Constraint attestation
+
+| CST | Inherited by | Handling (capability reduction) | Frontier | Verification | Status |
+|---|---|---|---|---|---|
+| CST-PWA-PRIVATE-SNAPSHOT | web-bundle × opfs | Folder mode (real file) on Chromium desktop; off-Chromium drop durable private store, offer OPFS + manual "Download my private data". Code: `app/static/vendor/sqlite-worker.js` (folder write path), `app/static/app.js` (`folderStorageOffered()`, badges, download button). | Open | e2e `test_user_folder_storage.py`, `test_unsupported_browser.py`; `docs/browser_support.md`; LLM rubric: "off-Chromium, confirm no durable-private-store promise and a visible manual-backup path." | handled (frontier Open) |
+| CST-PWA-SANDBOX-SEALED | opfs | Folder mode dissolves the boundary (MCP reads the live file); off-Chromium the `.mcpb` reads an exported snapshot, disclosed in the setup flow. Code: folder write path; `mcp_servers/private_data_ops.py` reads an external file. | Solved-on-chromium | `tests/test_private_data_ops.py`; `docs/architectural_findings.md` § 2026-06-01. | handled |
+| CST-PWA-STORAGE-EVICTABLE | opfs | `navigator.storage.persist()` best-effort once per install; 5-slot backup ring; manual export. Code: `app.js` persist path (`~4171`), `sqlite-worker.js` backup ring. | Mitigated | e2e backup/restore tests; AC-9 row. | handled |
+| CST-PWA-SINGLE-OWNER | opfs | Web Lock `fellows-relationships-folder-write` + `OWNERSHIP_CONFLICT` panel. Code: `sqlite-worker.js` (`isOwnershipConflictError`, locks). | Solved-on-chromium | `test_user_folder_storage.py::TestPhase2WriteLock`; AC-11 row. | handled |
+| CST-PWA-NO-BACKGROUND | web-bundle | Per-boot debounced auto-backup; no scheduled-protection promise. Code: `maybeBackupRelationshipsDb`. | Mitigated | AC-9 row; code inspection. | handled |
+| CST-PWA-SERVER-FLOOR | web-bundle | Server bounded to distribution/update only (Never-SaaS); no per-user RW endpoints. Code: `deploy/server.py`. | Inherent | `test_deploy_auth_round_trip.py`; AC-2 row. | handled |
+```
+
+> The two entries with no user-facing handling — `CST-PWA-NO-SYNC` (frontier Open; the
+> encrypted-email pattern is a candidate, unbuilt) and `CST-PWA-DURABLE-SQL-ARCH` (Inherent; realized
+> as the worker-owned architecture, AC-3) — are attested as `Open` / `Inherent` respectively. Honest
+> frontiers, not hidden gaps.
+
+#### Gap analysis — fellows' current `docs/Architecture.md`
+
+Much lighter than the Exceptions plan's gap analysis, because the AC attestation table **already
+exists** with Realization / Verification / Status columns (`docs/Architecture.md` § Universal ACs +
+§ Flavor-derived ACs) and an *Exception attestation* section is already present. The remaining work:
+
+1. **Add a § Constraint attestation** (the table above) — the only substantive doc addition.
+2. **Add a short "Constraints triggered by fellows's picks" note** alongside the existing
+   "Flavor-derived ACs triggered by fellows's picks" section, cross-referencing the CST IDs.
+3. **No new feature code required** — the handling is already shipped (folder mode, capability
+   reduction, mobile gate, backup path). This is the key difference from the Exceptions contribution
+   and makes the reference-design half low-risk.
+
+---
+
+## 4. Sequencing + how this is driven through the SKILL Contribute flow
+
+Stays a **PLAN in the fellows repo** until the maintainer approves. When approved:
+
+1. **Decide ordering relative to the Exceptions contribution.** Constraints reuse the
+   `PNA-DEFINITION` sentinel and the validation-not-certification callout the Exceptions plan
+   introduces. **Recommend landing Exceptions first**, then Constraints as the matched dual (smaller
+   lint delta, shared framing already in place). They can also land together as one "Exceptions +
+   Constraints" pair if the maintainer prefers a single version bump.
+2. **Add the § Constraint attestation to fellows' `docs/Architecture.md`** (§ 3f gap #1–#2). No
+   feature code — the handling already ships.
+3. **Run the SKILL preflight** against fellows: validate the Architecture doc's constraint rows
+   against the code/tests; iterate until clean.
+4. **Author the PNT changes on a branch in a PNT checkout** (still no PR): `spec/constraints.md`
+   (§ 3a), the `PNA_Spec.md` + `axes.md` pointers (§ 3b), the `lint-spec-ids.py` extension (§ 3c), the
+   framing clause (§ 3d), the SKILL build + evaluate steps (§ 3e), and the reference-design record +
+   Architecture.md copy + constraint attestation (§ 3f). Run `python tools/lint-spec-ids.py`; confirm
+   green.
+5. **Only on the maintainer's explicit go-ahead:** open the PNT PR per `SKILL.md` § PR authoring /
+   `CONTRIBUTING.md` § PR contents. Version bump is **Minor** per `CONTRIBUTING.md` § Versioning
+   (additive: a new spec file, a new concept, new header conventions, a new lint check — no existing
+   AC altered, no pick removed).
+6. **Post-merge** (maintainer): Software Heritage archival at the accepted commit; record the SWHID in
+   the design record.
+
+**Explicit decision recorded here:** no issues or PRs are filed into PNT from this plan. This document
+is the artifact the maintainer reviews; everything downstream waits on approval.
+
+---
+
+## 5. Open questions / terminology notes
+
+1. **Land order vs Exceptions.** Recommend Exceptions first (Constraints reuse its `PNA-DEFINITION`
+   sentinel + framing callout), or ship them as one paired bump. Maintainer's call.
+2. **Naming.** "Constraint" over "limitation"/"ceiling" (pairs with Exception; the decision log
+   already used it). Confirm the compile-time/runtime dual is the framing the PR leads with.
+3. **Are machine-readable axis-pick IDs available for the lint (§ 3c check 2)?** `Triggered-by:`
+   resolution needs `<axis>:<pick>` identifiers collectable from `axes.md`. If axes.md doesn't expose
+   them in a stable form, either (a) add pick IDs to axes.md (a small, independently-useful change),
+   or (b) have the first cut validate only the `<axis>:` prefix against the known axis list. Recommend
+   (a) if cheap, else (b) with a TODO.
+4. **`Bounds:` vs a non-normative `Stresses:`.** `Bounds:` says the constraint *limits how fully* an
+   AC/Goal can be met (the app still tries). Is that the right verb, or should some entries use a
+   softer `Stresses:` (pressure without strict bounding), as exceptions do? Recommend `Bounds:` as
+   primary with `Stresses:` available for Goal-level pressure that doesn't bound a specific AC.
+5. **Valence / "helpful constraints" — deferred, confirm.** The registry is adverse-only; ceilings
+   that serve a goal (mailto-only → AC-18) are parked for a future "what worked well, proven true and
+   useful" channel. Confirm this stays out of the constraints registry for v1.
+6. **`CST-PWA-*` namespace vs a flatter `CST-*`.** The general mechanism is substrate-agnostic, but
+   the first eight entries are all PWA/web ceilings, so they're namespaced `CST-PWA-*`, leaving room
+   for `CST-NATIVEFS-*`, `CST-MOBILE-NATIVE-*`, etc. Confirm the per-substrate namespace (vs flat
+   `CST-1..`); recommend keeping it — it makes "which substrate forbids this" legible at a glance.
+7. **Does the lint collect `Triggered-by:`/`Frontier:` from reference-design Architecture docs too, or
+   only from `spec/constraints.md`?** Mirror the Exceptions § 5.6 answer: lint the spec registry
+   first; extend to design-doc attestations if/when a second substrate's constraints land.
+8. **Should `CST-PWA-DURABLE-SQL-ARCH` be in the registry at all?** It bounds the *build space* (you
+   must use a worker-owned single-connection architecture), not a user-facing AC — its `Bounds:` is
+   empty. It's a real inherited ceiling a builder must know, but it's a different flavor from the
+   functionality-dropping ones. Recommend keeping it (the registry's job is "what you inherit by
+   picking this axis," which includes architecture-forcing ceilings) but flag it in the PR as the
+   one builder-facing-rather-than-user-facing entry.
+```

--- a/plans/private_data_capability_gate.md
+++ b/plans/private_data_capability_gate.md
@@ -1,0 +1,180 @@
+# Plan — Private-Data Capability Gate (folder-required private store; browse-only everywhere else)
+
+**Status:** PLAN ONLY. Not started. **Decided:** 2026-06-02.
+**Supersedes** the phone-only framing of [`mobile_redesign/PLAN_mobile_no_groups.md`](mobile_redesign/PLAN_mobile_no_groups.md) — that plan's *feature* reduction is folded in here as the phone realization of **browse-only mode**; its *layout* work (scroll container, hamburger, CTAs, mobile Settings) survives unchanged as the `is-phone` shell.
+**Motivated by** [`../docs/architectural_findings.md` § 2026-06-01](../docs/architectural_findings.md) and staged for upstream as [`pna_toolkit_constraints_contribution.md`](pna_toolkit_constraints_contribution.md).
+
+---
+
+## 1. The decision in one paragraph
+
+A PWA cannot reliably preserve a user's private data on browsers without the File System Access API (Safari, Firefox, all of iOS) or on any browser where no durable real file backs the store. That is a **data-loss ceiling** (`CST-PWA-PRIVATE-SNAPSHOT` / `CST-PWA-STORAGE-EVICTABLE`), not a fellows wart. Rather than ship a "sketchy but full-featured" app that silently risks losing groups, fellows gates **all private data — groups, group members, fellow tags, fellow notes, and the group-related settings — behind a verified, attached folder** (a real file on disk we have proven we can write and read back). Until that folder exists, every install runs in **shared-data-only mode**: browse the directory, search, open a fellow, email or call them. Nothing private. The unlock can happen at any time on a Chromium desktop browser; off Chromium (and on every phone) there is no in-app unlock, and the documented migration path is *back up your `.db` → install on Chrome → restore into a new folder*. This makes fellows a **compliant, useful PNA** on every platform — just a smaller one where the platform can't keep the durability promise — instead of an over-reaching one. The architectural fix (a real durable cross-platform private store) is a future-version concern; for now we soldier ahead honestly.
+
+---
+
+## 2. The two orthogonal gates (the load-bearing idea)
+
+Two independent questions, each with its own signal. **Conflating them is the trap** the prior mobile-only framing fell into.
+
+| Gate | Question | Signal | Reliable? | Cost if wrong |
+|---|---|---|---|---|
+| **Feature gate** — `privateDataEnabled()` → `body.no-private-data` | Is there a **verified, attached, permission-granted folder** backing a durable real file? | feature-detect (FSA) + empirical probe + live permission | **Yes** | — (all data-loss consequences ride here) |
+| **Layout gate** — `isMobileDevice()` → `body.is-phone` | Is this a **phone** (mobile shell)? | UA (`app.js:1226`) | Fuzzy | **Cosmetic only** — a cramped/hidden UI, never data loss |
+
+The principle: **every data-loss / sovereignty consequence rides on a reliable feature-detect; only the cosmetic shell choice rides on the fuzzy UA signal.** A phone misread as desktop is harmless. The one error to avoid — a real desktop misread as a phone — is contained by keeping `isMobileDevice()` conservative (true phones only).
+
+### The three real cells
+
+| Cell | Resolves to | Private-data UX | Shell |
+|---|---|---|---|
+| Chromium desktop **with verified folder** | `privateDataEnabled() === true` | **Full**: groups/notes/tags/composer/private settings/MCP | desktop |
+| Chromium desktop **without a folder** · Safari desktop · Firefox desktop | `no-private-data && !is-phone` | **Grayed-out** with an **"Enable on Chrome desktop →"** unlock affordance | desktop |
+| All phones (Android + iOS) | `no-private-data && is-phone` | **Hidden** (group chrome deleted, screen reclaimed — the mobile plan) | mobile |
+
+> "Hidden on phones, grayed-out-with-CTA on non-Chromium/no-folder desktop." On a phone there is no action the user can take to unlock on that device, so a grayed-out control is noise — delete it and reclaim the screen. On desktop there *is* a path (install/switch to Chrome, pick a folder), so a discoverable affordance belongs there.
+
+`folderStorageOffered()` (`app.js:8660` = `browserSupportsFolderPicker() && !isMobileDevice()`) already draws the FSA-capable-desktop boundary — but it answers "should we *offer* folder mode?", not "is a folder *attached and verified*?". The feature gate is the stricter, attached-and-verified condition (§ 5).
+
+---
+
+## 3. Shared-data-only mode — `relationships.db` stays dormant
+
+In shared mode the app **never relies on `relationships.db` for durable data**. Its two trivial prefs live in `localStorage` only:
+
+- `fellows_self_email` — the user's "me" email for `mailto:?to=…`. Optional and editable (some users want a separate "fellows" address). Recoverable: auto-captured at the magic-link gate; on a phone it's filled from the launching device anyway.
+- `ehf_has_email_only` — the has-email filter pref.
+
+Nothing we care about ever lands in evictable OPFS. This is a stronger handling than "mitigate eviction" — we **avoid** `CST-PWA-STORAGE-EVICTABLE` for private data entirely.
+
+**One read-only exception (legacy rescue):** on boot, a Chromium-desktop-no-folder user's OPFS `relationships.db` is *peeked* (counts only) to detect pre-existing groups and drive the migration prompt (§ 6). That's a read to rescue legacy data, not a durable write — the "no durable data off-folder" guarantee holds.
+
+---
+
+## 4. Ground truth (verified file:line anchors)
+
+Gates / detection:
+- `isMobileDevice()` — `app.js:1226` (UA). `detectBrowserSupport()` — `app.js:1232` (UA → name/version, for messaging).
+- `folderStorageOffered()` — `app.js:8660`; `browserSupportsFolderPicker()` nearby.
+- `navigator.storage.persist()` best-effort once/install — `app.js:4171`.
+
+Folder controller (`app/static/vendor/sqlite-worker.js`):
+- `FOLDER_SUBFOLDER_DEFAULT = 'Fellows'` — `1770`; folder lives at `<parent>/Fellows/relationships.db`.
+- `_findOrCreateSubfolder(parent, mode)` — `1914`: `open-existing` / `create-new` (numbered `Fellows`, `Fellows 2`, …) / `auto` (probes default; on hit returns `requiresChoice` with **counts, size, lastModified** + suggested next name) — `1949-1969`.
+- `queryPermission` wrapper — `2028`, `2444`; `requestPermission` (user-gesture) — `2501`.
+- Handle persisted in IndexedDB `fellows-fs-handles` (key `relationships-folder`); hydrate at `1872-1906`.
+- Backup ring `relationships.db.bak.<ISO>` (5-slot) — folder- or OPFS-resident per mode.
+
+Folder UI / reconnect (`app/static/app.js`):
+- `getFolderHandleForReconnect` — `4070`; `reconnect()` — `8774-8808`.
+- Settings folder section glue `wireFolderSection()` — `9895`; collision dialog `settings-folder-collision-dialog` — `9901`; `badge()` states — `8719`, `BADGE_COPY` — `9908`.
+- Manual backup download filename `relationships-<ts>.db` — `app.js:2429`.
+
+Surfaces to gate (all desktop-shared — gate via body class, don't delete):
+- `renderDirectoryList()` `5779` (per-row `.dir-mark` select); `groupDraft` `70`; `renderRail()` (composer) `6258`; `#bulk-select-bar`/`updateBulkBar()` `6324`; `enterEditMode()` `6449`.
+- `renderDetail()` `5888` (contact rows `5951`/`5960`; add-to-group `5906-5915`).
+- `renderSettingsPage()` `8975` (email `8984`, folder `8997`, download `9018`, restore `9037`, MCPB `9061`).
+- `route()` `7171` (group/edit routes to redirect/lock when `no-private-data`).
+- `RELATIONSHIPS_SCHEMA_SQL` mirror in `app.js` (the `settings` table that will hold the in-db identity stamp, § 7).
+
+Tests: `tests/e2e/mobile/` (Pixel 5 / iPhone 13 / narrow-360); `test_user_folder_storage.py` (folder write/lock/migration); `test_unsupported_browser.py`; `test_settings.py` (restore). Recipes `just test-mobile`, `just serve-lan`, `just serve-prod`.
+
+---
+
+## 5. The unlock flow (Chromium desktop) + the empirical probe
+
+Entry points to unlock: tapping a grayed-out private surface (e.g. **Create group**) or Settings → folder picker. Flow:
+
+1. **Warning.** "Saved groups live in a folder on your computer and need a Chromium desktop browser (Chrome, Edge, Brave, Arc). Pick a folder to enable them." (On non-Chromium/phone this control is grayed/hidden and routes to the help page instead — no picker.)
+2. **Pick** a parent folder (`showDirectoryPicker({ mode:'readwrite', id:'fellows-data-folder' })` — `id` makes Chromium reopen the last-used location). Resolve the subfolder via `_findOrCreateSubfolder` (§ 7 biases this toward **adopt**).
+3. **Probe — the gate.** Unlock only if **every** stage passes; each failure carries a stable `reason` code mapped to an anchor on the GitHub troubleshooting page (§ 8):
+   - `picker_cancelled` — no handle returned.
+   - `subfolder_create_failed` — `getDirectoryHandle({create:true})` threw → *"couldn't create the data folder — permissions?"*
+   - `write_failed` — sentinel write threw → *"couldn't write — read-only folder, denied permission, or disk full?"*
+   - `readback_mismatch` — wrote sentinel, read back ≠ what we wrote → *"the folder didn't return what we wrote — this looks like a cloud-only (OneDrive/Dropbox online-only) or virtual folder; pick a real local folder."* **This stage is what proves the location is genuinely durable**, per M1 (capability presence ≠ usefulness).
+   - `permission_not_persisted` — handle won't persist / re-query `granted` fails → *"the browser won't remember this folder."*
+4. **Migrate** any existing OPFS `relationships.db` with data into the chosen folder (§ 6), then **unlock**: `privateDataEnabled()` flips true, group surfaces light up, `relationships.db` becomes live in the folder.
+
+Probe failure → stay in shared mode, show the reasoned message + help link, never half-unlock.
+
+---
+
+## 6. Migration
+
+**Same-browser (existing Chrome user with OPFS groups) — automatic, ships with the foundation.** On boot, if `no-private-data` resolves but the legacy OPFS `relationships.db` holds real rows (the read-only peek, § 3), show **"You have saved groups — pick a folder to keep using them."** On folder pick + probe pass, copy the OPFS `relationships.db` into `<folder>/Fellows/relationships.db` (reuse the worker's existing folder-write path), stamp identity (§ 7), and unlock. Non-destructive: the OPFS copy is left intact until the folder write is verified. **This must land with the gate** — otherwise existing Chrome users lose sight of their groups the moment the gate ships.
+
+**Cross-browser / cross-device (Safari-with-groups → Chrome) — manual, deferred.** ~1–2 real users. The path is the shipped backup/restore machinery: **back up `.db` to Desktop → install on Chrome → restore into a new folder.** Handled with a personal email + video walk-through rather than auto-migration code. The self-describing export name (§ 7) and the restore preview's row-count delta make the right file recognizable.
+
+---
+
+## 7. Reconnect & disambiguation (the cork) — design
+
+**Most reconnects need zero file-finding.** When permission lapses on restart, the handle is still in IndexedDB; a one-gesture `requestPermission` re-grants the *exact same folder*. In the gated world this becomes a **"Reconnect your folder to use groups"** prompt: features re-lock on a lapse, the re-grant re-unlocks, and **the data is never hidden or destroyed** (the file still exists). Only when the stored handle is *gone* (cleared site data / new install / new device) does a re-pick happen — and that's the only place the "which `relationships.db`?" confusion can arise. Fixes:
+
+1. **Content-previewed chooser (generalize the existing collision dialog).** On re-pick, scan **all** `Fellows*` subfolders in the chosen parent (not just the default — today's `auto` mode only previews `Fellows`, so data in `Fellows 2` is invisible). Present each candidate as *groups N · members N · notes N · last changed `<date>` · created on `<device>`*. Recommend the newest; the user picks **by content, never by filename**. Because the user always picks a **folder, not a file**, the `.db`/`.bak.*` siblings inside are never something they choose among.
+2. **In-db identity stamp** (survives backup/restore as a unit — read for free when we count rows). Add to the `settings` table: `workspace_uuid`, `device_label`, `created_at`, `last_written_at`, `write_generation` (monotonic). `write_generation`/`last_written_at` give a canonical "most recent" winner; `device_label` makes "created on this Chrome" legible. In-db (not a sidecar) so it can't desync.
+3. **Bias to adopt.** A folder is now mandatory, so a *second* store is almost never intended — it is the source of the mess. Make **"Use the existing data here"** the default action in the collision/chooser dialog; demote create-new to an escape hatch. Stops most proliferation at the source.
+4. **Self-describing exports.** Rename the manual backup from `relationships-<ts>.db` to `ehf-fellows-private-data-<YYYY-MM-DD>.db`. Combined with the restore preview's row-count delta, the restore-a-file pile becomes recognizable.
+5. **Folder marker.** Drop a human-readable `HOW-TO-MOVE-THIS-DATA.txt` in the data folder ("this folder is your EHF private data; to move computers, copy the whole folder / the `.db` file; the app reads/writes `relationships.db`"). Makes Finder/Explorer navigation and the manual migration self-explanatory.
+
+**Out of scope:** two computers with genuinely divergent data (a merge). Restore stays full-replace (consistent with today); the chooser shows both summaries and the user decides, flagged as replace-not-merge.
+
+---
+
+## 8. Implementation sequence (each PR independently shippable + revertible)
+
+Ship in order; keep `just test-fast` + `just test-mobile-functional` green at each step.
+
+### PR 1 — Feature-gate foundation (keystone)
+- `privateDataEnabled()` resolver (verified-folder-attached + permission `granted`); `body.no-private-data` toggled from it; keep `body.is-phone` purely for layout. Expose `window.__privateDataTier` + a `?diag=1` line (mirrors `window.__dataProvider`).
+- Shared mode = `localStorage`-only; do not open `relationships.db` for durable data when locked (legacy read-only peek allowed, § 3).
+- **No visible feature change yet** beyond diagnostics — this PR just establishes the gate and the body classes.
+
+### PR 2 — Same-browser migration prompt (must ship with/just after the gate)
+- Boot detection of legacy OPFS groups → "pick a folder to keep using them" → folder pick + probe + copy OPFS→folder + identity stamp + unlock (§ 6, § 5, § 7.2). Protects existing Chrome users before the gate bites.
+
+### PR 3 — Browse-only feature reduction (serves Safari/FF desktop AND phones)
+- Gate every group/selection/composer/notes/private-settings surface on `body.no-private-data`. **Phones (`is-phone`): hidden** (delete chrome, reclaim screen — the mobile plan's PR3). **Desktop (`no-private-data && !is-phone`): grayed-out with "Enable on Chrome desktop →"** CTA. Redirect/lock `#/groups*` and `#/edit/*` when `no-private-data` (redirect on phone; route to unlock/help on desktop).
+
+### PR 4 — Unlock flow + empirical probe + troubleshooting page
+- The full Create-group → warning → pick → staged probe → unlock flow (§ 5). Add `docs/` or a GitHub-repo troubleshooting page keyed by `reason` code; wire each failure message to its anchor.
+
+### PR 5 — Reconnect & disambiguation hardening
+- "Reconnect your folder" re-grant prompt (handle-present); features re-lock on lapse without hiding data. Content-previewed chooser scanning all `Fellows*` (handle-gone); bias-to-adopt. In-db identity stamp. Self-describing export filename + `HOW-TO-MOVE-THIS-DATA.txt` (§ 7).
+
+### PR 6 — Mobile shell (the mobile plan's layout PRs, `is-phone`-gated)
+- Scroll container (mobile plan PR1), hamburger drawer (PR2), Email/Call CTAs on fellow detail (PR4), reduced mobile Settings (PR5). These are pure layout and stay gated on `is-phone` — they compose on top of the browse-only reduction from PR3.
+
+### PR 7 — Docs, tests, baselines, memory
+- `docs/users_manual.md` (folder-required groups, browse-only mode, mobile flow, unlock + reconnect + migration), `docs/feature_platform_matrix.md` ("private data = verified folder only"), `docs/browser_support.md` (the gate, not just folder-mode-as-additive), `docs/Architecture.md` **Constraint attestation** (§ 9), `docs/persistence_and_upgrades.md` (shared-mode = localStorage-only).
+- Rewrite `tests/e2e/mobile/test_mobile_interactions.py` per the mobile plan; new e2e for the gate (locked → unlock → migrate → reconnect), the probe failure paths (mock `readback_mismatch`), and the chooser. Re-promote mobile snapshot baselines.
+- Pre-install/gate guidance (a *recommendation*, not a blocklist, per `browser_support.md`): "for saved groups you control as a real file, use a Chromium desktop browser; on Safari/Firefox/phones it's browse-and-contact."
+- Update memory: supersede `mobile_folder_storage_policy` and the `project_mobile_no_groups` framing with this gate; add a project memory for the capability gate.
+
+> Batching: PRs 1–2 land together (gate + migration are a unit). PRs 3–5 are the substantive new UX/flows. PR 6 is the mobile polish. PR 7 lands with whichever PR first changes user-visible behavior, per CLAUDE.md (docs ship with the feature).
+
+---
+
+## 9. Upstream impact (we implement first, then sharpen the contribution)
+
+Building this before filing [`pna_toolkit_constraints_contribution.md`](pna_toolkit_constraints_contribution.md) sharpens four spec fields with evidence:
+
+- **`CST-PWA-PRIVATE-SNAPSHOT` — handling.** Becomes "the private store *requires* a verified real file; absent one, there is **no** private store" — and the timestamped `.db` export is the honest **portability bridge**. Stronger than the speculative encrypted-email candidate. Frontier stays **Open** (the real fix is an architecture change), declared truthfully.
+- **`CST-PWA-PRIVATE-SNAPSHOT` — Detectability.** Currently `feature-detect`. The empirical probe (`readback_mismatch` catching cloud-placeholder/virtual folders) proves that FSA presence is necessary but **not sufficient** for a *durable, useful* store — so the durable-folder question is really `feature-detect` **+ `empirical-probe`**. A concrete correction to the registry.
+- **`CST-PWA-STORAGE-EVICTABLE` — frontier.** We **avoid** it for private data (nothing durable in evictable OPFS) rather than merely `Mitigated`. Document the avoidance pattern.
+- **`CST-PWA-NO-SYNC` — "which copy is canonical?"** The in-db workspace identity (`workspace_uuid` + `write_generation`) is a concrete answer the registry can cite.
+
+The **Constraint attestation** table (§ 3f of the contribution plan) gets a `docs/Architecture.md` section mirroring the existing *Exception attestation*, with this gate as the realization — no false durability anywhere, which is exactly the "over-reach = silent conformance failure" backstop the contribution defines, now demonstrably satisfied by fellows itself.
+
+---
+
+## 10. Out of scope / unchanged
+- The worker, two-DB architecture, auth/magic-link gate, SW, data-provider tiers — untouched (this is UI-gating + a folder-unlock flow on top of shipped folder machinery).
+- Desktop Chromium **with** a folder: full app, unchanged.
+- Cross-device sync; DB merge; encrypted backups; server-side storage of private data — all still out, consistent with `persistence_and_upgrades.md`.
+- The architectural fix (a real durable cross-platform private store) — a future-version concern, not this plan.
+
+## 11. Open questions (decide with the build in hand)
+1. Exact `device_label` source (UA-derived string vs user-set nickname). Default: UA-derived, editable later.
+2. Whether the grayed-out desktop CTA also appears inside an empty `#/groups` route or only on the directory/compose affordances. Default: both, routed to the unlock/help flow.
+3. Whether to write the `HOW-TO-MOVE-THIS-DATA.txt` marker once at unlock or refresh it on schema changes. Default: write once; rewrite only if the copy changes.
+4. Phone copy for "groups live on desktop" — a one-liner in mobile Settings/About, or nothing at all. Default: a single quiet line in mobile Settings.


### PR DESCRIPTION
## What

Design records and the constraints lesson-learned behind the private-data capability gate (implementation: #235). Docs/plans only — no code, no test impact.

- **`docs/architectural_findings.md § 2026-06-01`** — the **constraints (`CST-*`) finding**: a PWA can't give every platform a writable private store; name the ceiling honestly. (PR #235's gate docs cross-link this section — merging this resolves that anchor on `main`.)
- **`plans/private_data_capability_gate.md`** — the gate design (folder-required private data; browse-only elsewhere; unlock/probe/reconnect/migration).
- **`plans/EPIC_private_data_and_mobile.md` + `EPIC_phase0_findings.md`** — the controller (sequencing, file-ownership lanes, frozen interfaces) + Phase-0 analysis output.
- **`plans/pna_toolkit_constraints_contribution.md`** — staged upstream PNT contribution (constraints as the dual of exceptions). **Not executed yet** — exceptions landed upstream (PNT PR #8); constraints has no `spec/constraints.md` upstream, that's separate maintainer-gated work.
- **`plans/mobile_redesign/PLAN_mobile_no_groups.md` + `mockups_no_groups/`** — phone realization of browse-only mode.

## Why a separate PR

These are the *concept/lesson + design records* feeding the gate; PR #235 is the concrete implementation. Splitting keeps the implementation reviewable on its own.

🤖 Generated with [Claude Code](https://claude.com/claude-code)