### PR TITLE
Private data: unlock flow, empirical probe, lock control + folder chooser (PR4 + PR5)

### DIFF
--- a/app/static/app.js
+++ b/app/static/app.js
@@ -8773,6 +8773,19 @@
       return p._setFolderHandle({ handle: handle, mode: mode || 'auto' });
     }
 
+    // Like setHandle, but runs the empirical durability probe (write a
+    // sentinel + read it back) before committing — the unlock path (EPIC
+    // PR4). Resolves to { ok, requiresChoice, ... } like setHandle on the
+    // happy/collision paths; REJECTS with err.code = a reason code
+    // (subfolder_create_failed / write_failed / readback_mismatch /
+    // permission_not_persisted / picker_cancelled) on probe failure, and
+    // persists nothing in that case (never half-unlock).
+    function probeHandle(handle, mode) {
+      var p = workerProvider();
+      if (!p) return Promise.reject(new Error('worker provider unavailable'));
+      return p._probeFolderWritable({ handle: handle, mode: mode || 'auto' });
+    }
+
     function clearHandle() {
       var p = workerProvider();
       if (!p) return Promise.reject(new Error('worker provider unavailable'));
@@ -8822,6 +8835,7 @@
       badge: badge,
       pickParentFolder: pickParentFolder,
       setHandle: setHandle,
+      probeHandle: probeHandle,
       clearHandle: clearHandle,
       writeNow: writeNow,
       readNow: readNow,
@@ -10187,14 +10201,14 @@
               flashDetail('No folder selected.');
               return null;
             }
-            return FOLDER_CONTROLLER.setHandle(handle, 'auto').then(function (res) {
+            return FOLDER_CONTROLLER.probeHandle(handle, 'auto').then(function (res) {
               if (res && res.requiresChoice) {
                 return askCollision(res.parentName, res.existing, res.suggestion).then(function (choice) {
                   if (!choice) {
                     flashDetail('Cancelled.');
                     return null;
                   }
-                  return FOLDER_CONTROLLER.setHandle(handle, choice).then(function (resolved) {
+                  return FOLDER_CONTROLLER.probeHandle(handle, choice).then(function (resolved) {
                     return { picked: resolved, mode: choice };
                   });
                 });
@@ -10220,10 +10234,35 @@
             return FOLDER_CONTROLLER.writeNow().then(function () { flashDetail('Saved.'); });
           })
           .catch(function (e) {
-            flashDetail('Could not set folder: ' + (e && e.message || String(e)));
+            // Empirical-probe failures carry a stable reason code (EPIC PR4);
+            // map to a plain-language message + a link to the troubleshooting
+            // page anchored on that code. readback_mismatch is the cloud-only/
+            // virtual-folder case worth calling out.
+            var code = e && e.code;
+            var REASONS = {
+              subfolder_create_failed: 'Couldn’t create the data folder — check the folder’s permissions.',
+              write_failed: 'Couldn’t write to the folder — it may be read-only or permission was denied.',
+              readback_mismatch: 'This looks like a cloud-only or virtual folder. Pick a real local folder (one whose files are fully downloaded/available offline).',
+              permission_not_persisted: 'The browser won’t remember this folder. Make sure site data isn’t cleared on exit, or pick another folder.'
+            };
+            if (code === 'picker_cancelled') { flashDetail('No folder selected.'); return; }
+            var msg = REASONS[code] || ('Could not set folder: ' + (e && e.message || String(e)));
+            if (detailEl2) {
+              var help = code
+                ? ' <a href="https://github.com/richbodo/fellows_local_db/blob/main/docs/folder_troubleshooting.md#' +
+                  encodeURIComponent(code) + '" target="_blank" rel="noopener">Why? →</a>'
+                : '';
+              detailEl2.innerHTML = escapeHtml(msg) + help;
+              detailEl2.hidden = false;
+            }
           })
           .then(function () {
             btnChoose.disabled = false;
+            // A successful pick attaches a verified folder → flip the
+            // private-data gate immediately so group surfaces appear without
+            // a reload (EPIC PR4). Idempotent: a failed pick re-resolves to
+            // the same locked state.
+            try { updatePrivateDataGate(); } catch (e) {}
             return refresh();
           });
       });

--- a/app/static/app.js
+++ b/app/static/app.js
@@ -8950,10 +8950,10 @@
     } else {
       bannerEl.classList.remove('folder-push-banner--error');
       bannerEl.setAttribute('role', 'status');
-      if (leadEl) leadEl.textContent = 'Save your fellows data to disk.';
+      if (leadEl) leadEl.textContent = 'Saved groups need a data folder.';
       if (detailEl) {
         detailEl.textContent =
-          'Your groups and notes are only in browser storage right now. Pick a folder for durable storage.';
+          'Choose a local private data folder to use group features.';
       }
       if (ctaEl) ctaEl.textContent = 'Set up data folder';
       if (dismissEl) dismissEl.hidden = false;
@@ -10008,11 +10008,11 @@
 
     var BADGE_COPY = {
       'unsupported': {
-        text: 'Browser-only — this browser doesn\'t support saving to a folder',
+        text: 'Private data (groups, notes) isn’t available in this browser — use a Chromium desktop browser',
         cls: 'settings-folder-badge--warning'
       },
       'browser-only': {
-        text: 'Browser-only — your data is not yet saved to a folder',
+        text: 'Private data (groups, notes) isn’t connected — pick a folder to enable it',
         cls: 'settings-folder-badge--warning'
       },
       'saved': {

--- a/app/static/app.js
+++ b/app/static/app.js
@@ -37,7 +37,7 @@
   // app/static/vendor/sqlite-worker.js (`WORKER_RPC_VERSION`,
   // `RELATIONSHIPS_SCHEMA_VERSION`). See plans/local_first_worker_architecture.md
   // §"Why build label is not the gate".
-  var EXPECTED_WORKER_RPC_VERSION = 4;
+  var EXPECTED_WORKER_RPC_VERSION = 5;
   var EXPECTED_RELATIONSHIPS_SCHEMA_VERSION = 1;
 
   // Thrown by mutating dataProvider methods when the worker reports a
@@ -4073,6 +4073,10 @@
           rpc.call('clearFolderHandle');
       },
       _checkFolderPermission: function () { return rpc.call('checkFolderPermission'); },
+      // Read-only scan of all Fellows* stores in a parent (EPIC PR5 chooser).
+      // Version-tolerant — it's a read, and the chooser must work to let a
+      // stale page recover/pick a store.
+      _scanFellowsCandidates: function (args) { return rpc.call('scanFellowsCandidates', args); },
       _getFolderHandleForReconnect: function () { return rpc.call('getFolderHandleForReconnect'); },
       _writeRelationshipsToFolder: function () {
         return refuseIfVersionSkew('writeRelationshipsToFolder') ||
@@ -8693,6 +8697,7 @@
           _getFolderState: function () { return warmWorker.rpc.call('getFolderState'); },
           _setFolderHandle: function (a) { return warmWorker.rpc.call('setFolderHandle', a); },
           _probeFolderWritable: function (a) { return warmWorker.rpc.call('probeFolderWritable', a); },
+          _scanFellowsCandidates: function (a) { return warmWorker.rpc.call('scanFellowsCandidates', a); },
           _clearFolderHandle: function () { return warmWorker.rpc.call('clearFolderHandle'); },
           _checkFolderPermission: function () { return warmWorker.rpc.call('checkFolderPermission'); },
           _getFolderHandleForReconnect: function () { return warmWorker.rpc.call('getFolderHandleForReconnect'); },
@@ -8780,10 +8785,22 @@
     // (subfolder_create_failed / write_failed / readback_mismatch /
     // permission_not_persisted / picker_cancelled) on probe failure, and
     // persists nothing in that case (never half-unlock).
-    function probeHandle(handle, mode) {
+    function probeHandle(handle, mode, subfolderName) {
       var p = workerProvider();
       if (!p) return Promise.reject(new Error('worker provider unavailable'));
-      return p._probeFolderWritable({ handle: handle, mode: mode || 'auto' });
+      return p._probeFolderWritable({
+        handle: handle, mode: mode || 'auto', subfolderName: subfolderName
+      });
+    }
+
+    // Scan a chosen parent for all Fellows* stores + their contents (EPIC PR5
+    // chooser). Read-only. Returns { candidates, recommended }.
+    function scanCandidates(handle) {
+      var p = workerProvider();
+      if (!p || typeof p._scanFellowsCandidates !== 'function') {
+        return Promise.reject(new Error('worker provider unavailable'));
+      }
+      return p._scanFellowsCandidates({ handle: handle });
     }
 
     function clearHandle() {
@@ -8836,6 +8853,7 @@
       pickParentFolder: pickParentFolder,
       setHandle: setHandle,
       probeHandle: probeHandle,
+      scanCandidates: scanCandidates,
       clearHandle: clearHandle,
       writeNow: writeNow,
       readNow: readNow,
@@ -9132,6 +9150,17 @@
           '<p id="settings-folder-error-more" class="settings-hint" hidden></p>' +
           '<menu class="settings-folder-dialog-actions">' +
             '<button type="submit" value="close" class="settings-folder-dialog-primary">OK</button>' +
+          '</menu>' +
+        '</form>' +
+      '</dialog>' +
+      '<dialog id="settings-folder-chooser-dialog" class="settings-folder-dialog">' +
+        '<form method="dialog">' +
+          '<h4>Choose your data store</h4>' +
+          '<p class="settings-hint">This folder has saved data. Pick which store to use, or save to a new one.</p>' +
+          '<div id="settings-folder-chooser-list"></div>' +
+          '<menu class="settings-folder-dialog-actions">' +
+            '<button type="submit" value="__create_new__" class="settings-folder-dialog-secondary">Save to a new store</button>' +
+            '<button type="submit" value="cancel" class="settings-folder-dialog-cancel">Cancel</button>' +
           '</menu>' +
         '</form>' +
       '</dialog>' +
@@ -10239,40 +10268,95 @@
       });
     }
 
+    // Content-previewed chooser (EPIC PR5): when a chosen parent already has
+    // saved data, list every Fellows* store with its contents so the user
+    // picks one BY CONTENT — or creates a new one. Supersedes the old binary
+    // collision dialog (askCollision) for re-pick. Resolves to
+    // { action:'open', subfolderName } | { action:'create-new' } | null.
+    function askChooser(candidates, recommended) {
+      var dlg = document.getElementById('settings-folder-chooser-dialog');
+      var listEl = document.getElementById('settings-folder-chooser-list');
+      if (!dlg || !listEl || typeof dlg.showModal !== 'function') {
+        return Promise.resolve(recommended
+          ? { action: 'open', subfolderName: recommended }
+          : { action: 'create-new' });
+      }
+      var html = '';
+      candidates.forEach(function (c) {
+        var bits = [];
+        if (c.invalid) bits.push('unreadable');
+        else {
+          bits.push(c.groups + ' group' + (c.groups === 1 ? '' : 's'));
+          if (c.members != null) bits.push(c.members + ' member' + (c.members === 1 ? '' : 's'));
+        }
+        if (c.lastModified) {
+          bits.push('changed ' + formatRelativeTime(new Date(c.lastModified).toISOString()));
+        }
+        if (c.deviceLabel) bits.push(escapeHtml(c.deviceLabel));
+        var rec = (c.subfolderName === recommended)
+          ? ' <span class="settings-folder-chooser-rec">most recent</span>' : '';
+        html += '<button type="submit" value="' + escapeHtml(c.subfolderName) +
+          '" class="settings-folder-chooser-item"' + (c.invalid ? ' disabled' : '') + '>' +
+          '<strong>' + escapeHtml(c.subfolderName) + '</strong> — ' + bits.join(' · ') + rec +
+          '</button>';
+      });
+      listEl.innerHTML = html;
+      return new Promise(function (resolve) {
+        dlg.addEventListener('close', function once() {
+          dlg.removeEventListener('close', once);
+          var v = dlg.returnValue;
+          if (v === '__create_new__') resolve({ action: 'create-new' });
+          else if (v && v !== 'cancel') resolve({ action: 'open', subfolderName: v });
+          else resolve(null);
+        });
+        try { dlg.showModal(); } catch (e) { resolve(null); }
+      });
+    }
+
     if (btnChoose) {
       btnChoose.addEventListener('click', function () {
         btnChoose.disabled = true;
         flashDetail('Pick a folder…');
+        var parent = null;
         FOLDER_CONTROLLER.pickParentFolder()
           .then(function (handle) {
-            if (!handle) {
-              flashDetail('No folder selected.');
-              return null;
+            if (!handle) { flashDetail('No folder selected.'); return null; }
+            parent = handle;
+            // Scan for existing Fellows* stores so we can offer the chooser.
+            return FOLDER_CONTROLLER.scanCandidates(handle)
+              .catch(function () { return { candidates: [] }; });
+          })
+          .then(function (scan) {
+            if (!parent) return null;
+            var cands = (scan && scan.candidates) || [];
+            if (!cands.length) {
+              // Empty parent → fresh store.
+              return FOLDER_CONTROLLER.probeHandle(parent, 'auto').then(function (res) {
+                if (res && res.requiresChoice) {
+                  // Defensive (a store exists but scan couldn't read it).
+                  return FOLDER_CONTROLLER.probeHandle(parent, 'create-new')
+                    .then(function (r) { return { picked: r, mode: 'create-new' }; });
+                }
+                return { picked: res, mode: 'auto' };
+              });
             }
-            return FOLDER_CONTROLLER.probeHandle(handle, 'auto').then(function (res) {
-              if (res && res.requiresChoice) {
-                return askCollision(res.parentName, res.existing, res.suggestion).then(function (choice) {
-                  if (!choice) {
-                    flashDetail('Cancelled.');
-                    return null;
-                  }
-                  return FOLDER_CONTROLLER.probeHandle(handle, choice).then(function (resolved) {
-                    return { picked: resolved, mode: choice };
-                  });
-                });
+            return askChooser(cands, scan.recommended).then(function (choice) {
+              if (!choice) { flashDetail('Cancelled.'); return null; }
+              if (choice.action === 'create-new') {
+                return FOLDER_CONTROLLER.probeHandle(parent, 'create-new')
+                  .then(function (r) { return { picked: r, mode: 'create-new' }; });
               }
-              return { picked: res, mode: 'auto' };
+              return FOLDER_CONTROLLER.probeHandle(parent, 'open-named', choice.subfolderName)
+                .then(function (r) { return { picked: r, mode: 'open-named' }; });
             });
           })
           .then(function (outcome) {
             if (!outcome || !outcome.picked || !outcome.picked.ok) return;
-            // Newly-attached folder: do an immediate save so the badge
-            // flips to "Saved" right away on create-new, and (for the
-            // happy-path "auto" case where the subfolder was empty) the
-            // file exists. open-existing skips the write and instead
-            // reads the existing data into OPFS.
-            if (outcome.mode === 'open-existing') {
-              flashDetail('Loading existing data from folder…');
+            // open-named = switching to an existing store: load ITS data into
+            // OPFS so the app shows that store's groups (EPIC PR5). Otherwise
+            // (auto / create-new) write the current data into the new store.
+            if (outcome.mode === 'open-named') {
+              flashDetail('Loading data from folder…');
               return FOLDER_CONTROLLER.readNow().then(function (result) {
                 flashDetail('Loaded ' + (result && result.counts ? fmtCountsSummary(result.counts) : '') +
                   ' from the folder.');

--- a/app/static/app.js
+++ b/app/static/app.js
@@ -9124,6 +9124,16 @@
           '</menu>' +
         '</form>' +
       '</dialog>' +
+      '<dialog id="settings-folder-error-dialog" class="settings-folder-dialog">' +
+        '<form method="dialog">' +
+          '<h4 id="settings-folder-error-title">Couldn’t use that folder</h4>' +
+          '<p id="settings-folder-error-body"></p>' +
+          '<p id="settings-folder-error-more" class="settings-hint" hidden></p>' +
+          '<menu class="settings-folder-dialog-actions">' +
+            '<button type="submit" value="close" class="settings-folder-dialog-primary">OK</button>' +
+          '</menu>' +
+        '</form>' +
+      '</dialog>' +
       '<div class="settings-section" id="settings-restore-section">' +
         '<h3 class="settings-section-title">Restore from backup</h3>' +
         '<p class="settings-hint">' +
@@ -10133,6 +10143,37 @@
       detailEl2.hidden = false;
     }
 
+    // Prominent, plain-language folder-error dialog (EPIC PR4). The "why" is
+    // explained INLINE so it resolves without leaving the app; a supplementary
+    // troubleshooting link is included. Probe reason codes refine the cause;
+    // uncoded errors (e.g. a NoModificationAllowedError from a cloud-synced
+    // folder, which throws before the sentinel step) get the generic cloud/
+    // read-only cause — the most common real reason.
+    function showFolderError(code, rawMessage) {
+      var CAUSES = {
+        readback_mismatch: 'This looks like a cloud-only or virtual folder (Google Drive, OneDrive, or iCloud set to “online only”). Those can’t reliably hold a live database. Pick a folder on your local disk whose files are fully downloaded.',
+        write_failed: 'The app couldn’t write to that folder — it may be read-only, permission was denied, or it’s a cloud-synced location. Pick a folder on your local disk.',
+        subfolder_create_failed: 'The app couldn’t create its data folder there. The location may be read-only or cloud-synced. Pick a folder on your local disk you can write to.',
+        permission_not_persisted: 'Your browser won’t remember access to that folder. Make sure site data isn’t cleared on exit, or pick another folder.'
+      };
+      var cause = CAUSES[code] ||
+        'That folder can’t hold your private data — it’s most likely a cloud-synced folder (Google Drive, OneDrive, iCloud) or a read-only location. Pick a folder on your local disk.';
+      var bodyEl = document.getElementById('settings-folder-error-body');
+      var moreEl = document.getElementById('settings-folder-error-more');
+      if (bodyEl) bodyEl.textContent = cause;
+      if (moreEl) {
+        var anchor = code ? ('#' + encodeURIComponent(code)) : '';
+        moreEl.innerHTML = 'More help: <a href="https://github.com/richbodo/fellows_local_db/blob/main/docs/folder_troubleshooting.md' +
+          anchor + '" target="_blank" rel="noopener">folder troubleshooting →</a>';
+        moreEl.hidden = false;
+      }
+      var dlg = document.getElementById('settings-folder-error-dialog');
+      if (dlg && typeof dlg.showModal === 'function') {
+        try { dlg.showModal(); return; } catch (e) { /* already open / unsupported */ }
+      }
+      window.alert(cause);
+    }
+
     function fmtCountsSummary(c) {
       if (!c) return '';
       return c.groups + ' group' + (c.groups === 1 ? '' : 's') +
@@ -10234,27 +10275,14 @@
             return FOLDER_CONTROLLER.writeNow().then(function () { flashDetail('Saved.'); });
           })
           .catch(function (e) {
-            // Empirical-probe failures carry a stable reason code (EPIC PR4);
-            // map to a plain-language message + a link to the troubleshooting
-            // page anchored on that code. readback_mismatch is the cloud-only/
-            // virtual-folder case worth calling out.
+            // Probe/write failure. picker_cancelled (user closed the picker)
+            // is a quiet no-op; everything else gets the prominent, plain-
+            // language dialog (the jargony raw DOMException must never reach
+            // the user). EPIC PR4.
             var code = e && e.code;
-            var REASONS = {
-              subfolder_create_failed: 'Couldn’t create the data folder — check the folder’s permissions.',
-              write_failed: 'Couldn’t write to the folder — it may be read-only or permission was denied.',
-              readback_mismatch: 'This looks like a cloud-only or virtual folder. Pick a real local folder (one whose files are fully downloaded/available offline).',
-              permission_not_persisted: 'The browser won’t remember this folder. Make sure site data isn’t cleared on exit, or pick another folder.'
-            };
             if (code === 'picker_cancelled') { flashDetail('No folder selected.'); return; }
-            var msg = REASONS[code] || ('Could not set folder: ' + (e && e.message || String(e)));
-            if (detailEl2) {
-              var help = code
-                ? ' <a href="https://github.com/richbodo/fellows_local_db/blob/main/docs/folder_troubleshooting.md#' +
-                  encodeURIComponent(code) + '" target="_blank" rel="noopener">Why? →</a>'
-                : '';
-              detailEl2.innerHTML = escapeHtml(msg) + help;
-              detailEl2.hidden = false;
-            }
+            flashDetail('Could not use that folder.');
+            showFolderError(code, e && e.message);
           })
           .then(function () {
             btnChoose.disabled = false;

--- a/app/static/app.js
+++ b/app/static/app.js
@@ -37,7 +37,7 @@
   // app/static/vendor/sqlite-worker.js (`WORKER_RPC_VERSION`,
   // `RELATIONSHIPS_SCHEMA_VERSION`). See plans/local_first_worker_architecture.md
   // §"Why build label is not the gate".
-  var EXPECTED_WORKER_RPC_VERSION = 3;
+  var EXPECTED_WORKER_RPC_VERSION = 4;
   var EXPECTED_RELATIONSHIPS_SCHEMA_VERSION = 1;
 
   // Thrown by mutating dataProvider methods when the worker reports a
@@ -4061,6 +4061,12 @@
       _setFolderHandle: function (args) {
         return refuseIfVersionSkew('setFolderHandle') ||
           rpc.call('setFolderHandle', args);
+      },
+      // EPIC PR4 unlock probe: setFolderHandle + empirical write/read-back
+      // durability check. Mutating (persists the handle) → version-gated.
+      _probeFolderWritable: function (args) {
+        return refuseIfVersionSkew('probeFolderWritable') ||
+          rpc.call('probeFolderWritable', args);
       },
       _clearFolderHandle: function () {
         return refuseIfVersionSkew('clearFolderHandle') ||
@@ -8686,6 +8692,7 @@
           kind: 'worker-warm',
           _getFolderState: function () { return warmWorker.rpc.call('getFolderState'); },
           _setFolderHandle: function (a) { return warmWorker.rpc.call('setFolderHandle', a); },
+          _probeFolderWritable: function (a) { return warmWorker.rpc.call('probeFolderWritable', a); },
           _clearFolderHandle: function () { return warmWorker.rpc.call('clearFolderHandle'); },
           _checkFolderPermission: function () { return warmWorker.rpc.call('checkFolderPermission'); },
           _getFolderHandleForReconnect: function () { return warmWorker.rpc.call('getFolderHandleForReconnect'); },

--- a/app/static/app.js
+++ b/app/static/app.js
@@ -9105,6 +9105,7 @@
         '</p>' +
         '<div id="settings-folder-actions" class="settings-folder-actions">' +
           '<button type="button" id="settings-folder-choose" class="settings-download" hidden>Choose folder…</button>' +
+          '<button type="button" id="settings-folder-lock" class="settings-download" hidden>🔒 Lock my private data</button>' +
           '<button type="button" id="settings-download-userdata" class="settings-download" hidden>' +
             '⬇ Download my private data' +
           '</button>' +
@@ -10100,6 +10101,12 @@
         btnChoose.hidden = !supported;
         btnChoose.textContent = state.hasHandle ? 'Change folder…' : 'Choose folder…';
       }
+      // "Lock my private data" (EPIC PR4): the user-friendly disconnect —
+      // shown only when a folder is connected. Returns to browse-only; the
+      // data stays safe in the folder file. (Future: combine with at-rest
+      // encryption — see plans / lock-my-data.)
+      var lockBtn = document.getElementById('settings-folder-lock');
+      if (lockBtn) lockBtn.hidden = !(supported && state.hasHandle);
       // Download button stays visible whenever local persistence is
       // available — folder-mode users still want backup files outside
       // the folder (cloud-sync conflicts, sneakernet to another machine,
@@ -10291,6 +10298,31 @@
             // a reload (EPIC PR4). Idempotent: a failed pick re-resolves to
             // the same locked state.
             try { updatePrivateDataGate(); } catch (e) {}
+            return refresh();
+          });
+      });
+    }
+
+    var btnLock = document.getElementById('settings-folder-lock');
+    if (btnLock) {
+      btnLock.addEventListener('click', function () {
+        var ok = window.confirm(
+          'Lock your private data?\n\n' +
+          'This disconnects the data folder and returns the app to browse-only. ' +
+          'Your groups and notes stay safe in the folder file — unlock again ' +
+          'anytime by picking the folder. (A future update will let you ' +
+          'encrypt this file.)'
+        );
+        if (!ok) return;
+        btnLock.disabled = true;
+        FOLDER_CONTROLLER.clearHandle()
+          .catch(function () { /* already gone — still go browse-only */ })
+          .then(function () {
+            // Flip the gate live → browse-only; the data folder file is
+            // untouched, so re-picking it unlocks again.
+            try { updatePrivateDataGate(); } catch (e) {}
+            flashDetail('Locked — data folder disconnected. Pick a folder to unlock again.');
+            btnLock.disabled = false;
             return refresh();
           });
       });

--- a/app/static/styles.css
+++ b/app/static/styles.css
@@ -4936,3 +4936,36 @@ body.no-private-data:not(.is-phone) #bulk-select-bar,
 body.no-private-data:not(.is-phone) #group-rail {
   display: none !important;
 }
+
+/* ===== Folder store chooser (EPIC PR5) ===================================
+   Pick which Fellows* store to use, by its contents. Each candidate is a
+   full-width button listing groups / members / recency / device. */
+#settings-folder-chooser-list {
+  display: flex;
+  flex-direction: column;
+  gap: 8px;
+  margin: 12px 0;
+}
+.settings-folder-chooser-item {
+  display: block;
+  width: 100%;
+  text-align: left;
+  padding: 10px 12px;
+  border: 1px solid var(--border, #ccc);
+  border-radius: 8px;
+  background: var(--surface, #fff);
+  cursor: pointer;
+  font: inherit;
+}
+.settings-folder-chooser-item:hover:not([disabled]) {
+  border-color: var(--accent, #2a6);
+  background: var(--surface-hover, #f5f7f6);
+}
+.settings-folder-chooser-item[disabled] { opacity: 0.55; cursor: default; }
+.settings-folder-chooser-rec {
+  display: inline-block;
+  margin-left: 6px;
+  font-size: 0.8em;
+  font-weight: 600;
+  color: var(--accent, #2a6);
+}

--- a/app/static/vendor/sqlite-worker.js
+++ b/app/static/vendor/sqlite-worker.js
@@ -50,7 +50,7 @@ importScripts('./sqlite3.js');
 // are version-tolerant — the page is allowed to read folder state even
 // against a stale worker — but the mutating ops are version-gated alongside
 // the existing relationships.db writes.
-var WORKER_RPC_VERSION = 4;
+var WORKER_RPC_VERSION = 5;
 
 // Same value as relationships.db's PRAGMA user_version. Bumped only on
 // schema migrations. Mirrored from app/relationships.py:SCHEMA_VERSION.
@@ -665,6 +665,15 @@ async function inspectBytes(bytes) {
           '. Is this a relationships.db backup?'
       };
     }
+    // Workspace identity (EPIC PR5) — best-effort; absent on pre-PR5 stores.
+    var identity = {};
+    try {
+      dbSelectAll(tmp,
+        "SELECT key, value FROM settings WHERE key IN " +
+        "('workspace_uuid','device_label','created_at','write_generation','last_written_at')",
+        null
+      ).forEach(function (r) { identity[r.key] = r.value; });
+    } catch (e) { /* older store / no identity rows */ }
     return {
       valid: true,
       counts: {
@@ -673,7 +682,8 @@ async function inspectBytes(bytes) {
         tags: dbSelectOne(tmp, 'SELECT COUNT(*) AS n FROM fellow_tags', null).n,
         notes: dbSelectOne(tmp, 'SELECT COUNT(*) AS n FROM fellow_notes', null).n,
         settings: dbSelectOne(tmp, 'SELECT COUNT(*) AS n FROM settings', null).n
-      }
+      },
+      identity: identity
     };
   } catch (e) {
     return { valid: false, error: (e && e.message) || String(e) };
@@ -1966,15 +1976,29 @@ async function _hydrateFolderRecord() {
 
 // ----- Subfolder helpers ----------------------------------------------------
 
-async function _findOrCreateSubfolder(parentHandle, mode) {
+async function _findOrCreateSubfolder(parentHandle, mode, targetName) {
   // mode: 'open-existing' → must use the existing default name; throws if
   //   it doesn't exist or doesn't contain relationships.db.
+  // 'open-named' → open the specific `targetName` store the chooser picked
+  //   (EPIC PR5); throws subfolder_missing if it's gone.
   // 'create-new' → pick the lowest-numbered unused name from "Fellows",
   //   "Fellows 2", "Fellows 3", ...
   // 'auto' (or null) → if "Fellows" exists with a relationships.db,
   //   return { requiresChoice: true, ... }; otherwise behave like
   //   'create-new' picking "Fellows".
   var name = FOLDER_SUBFOLDER_DEFAULT;
+  if (mode === 'open-named') {
+    var wanted = targetName || name;
+    var picked;
+    try {
+      picked = await parentHandle.getDirectoryHandle(wanted);
+    } catch (e) {
+      var nmErr = new Error('"' + wanted + '" subfolder not found in this folder');
+      nmErr.code = 'subfolder_missing';
+      throw nmErr;
+    }
+    return { handle: picked, subfolderName: wanted };
+  }
   if (mode === 'open-existing') {
     var existing;
     try {
@@ -2046,7 +2070,7 @@ async function _suggestNextName(parentHandle) {
 // over it (without touching the live OPFS pool slot). Used both by the
 // collision probe and by readRelationshipsFromFolder.
 async function _probeSubfolder(parentHandle, subfolderName) {
-  var out = { exists: false, hasFile: false, counts: null, invalid: false, invalidReason: null, size: 0, lastModified: null };
+  var out = { exists: false, hasFile: false, counts: null, identity: null, invalid: false, invalidReason: null, size: 0, lastModified: null };
   var sub;
   try {
     sub = await parentHandle.getDirectoryHandle(subfolderName);
@@ -2069,6 +2093,7 @@ async function _probeSubfolder(parentHandle, subfolderName) {
     var inspection = await inspectBytes(bytes);
     if (inspection.valid) {
       out.counts = inspection.counts;
+      out.identity = inspection.identity || {};
     } else {
       out.invalid = true;
       out.invalidReason = inspection.error || 'unreadable';
@@ -2488,6 +2513,63 @@ handlers.getFolderState = async function () {
   return _folderStateSnapshot();
 };
 
+// Content-previewed chooser scan (EPIC PR5). Enumerate every Fellows* store in
+// a chosen parent and return each one's group/member/note counts + identity, so
+// the page can let the user pick a store BY CONTENT — instead of the picker
+// always resolving to the default "Fellows". Recommends the most-recently-
+// written valid store (highest write_generation, then file mtime). Read-only:
+// persists nothing. Sequential because inspectBytes shares one staging slot.
+handlers.scanFellowsCandidates = async function (args) {
+  var parentHandle = args && args.handle;
+  if (!parentHandle) {
+    var e0 = new Error('no folder selected'); e0.code = 'picker_cancelled'; throw e0;
+  }
+  var perm = 'granted';
+  if (typeof parentHandle.queryPermission === 'function') {
+    try { perm = await parentHandle.queryPermission({ mode: 'readwrite' }); }
+    catch (e) { perm = 'denied'; }
+  }
+  if (perm !== 'granted') {
+    var pe = new Error('folder permission not granted (' + perm + ')');
+    pe.code = 'permission_required'; throw pe;
+  }
+  var names = [];
+  try {
+    for await (var entry of parentHandle.values()) {
+      if (entry.kind === 'directory' && /^Fellows( \d+)?$/.test(entry.name)) {
+        names.push(entry.name);
+      }
+    }
+  } catch (e) { trace('scan: enumerate failed: ' + ((e && e.message) || e)); }
+  names.sort();
+  var candidates = [];
+  for (var i = 0; i < names.length; i++) {
+    var probed = await _probeSubfolder(parentHandle, names[i]);
+    if (!probed.hasFile) continue;
+    var id = probed.identity || {};
+    candidates.push({
+      subfolderName: names[i],
+      groups: probed.counts ? probed.counts.groups : null,
+      members: probed.counts ? probed.counts.members : null,
+      notes: probed.counts ? probed.counts.notes : null,
+      lastModified: probed.lastModified,
+      deviceLabel: id.device_label || null,
+      writeGeneration: (id.write_generation != null) ? (parseInt(id.write_generation, 10) || 0) : null,
+      invalid: probed.invalid,
+      invalidReason: probed.invalidReason
+    });
+  }
+  var recommended = null, best = -1;
+  candidates.forEach(function (c) {
+    if (c.invalid) return;
+    // write_generation dominates; file mtime breaks ties (and ranks pre-PR5
+    // stores that have no generation).
+    var rank = (c.writeGeneration != null ? c.writeGeneration : 0) * 1e15 + (c.lastModified || 0);
+    if (rank > best) { best = rank; recommended = c.subfolderName; }
+  });
+  return { candidates: candidates, recommended: recommended };
+};
+
 // Empirical durability probe (EPIC PR4). Write a unique sentinel file into
 // `subHandle`, read it back, verify the bytes match, then delete it. Returns
 // null on success or a staged reason-code string on failure. The read-back
@@ -2611,7 +2693,7 @@ handlers.probeFolderWritable = async function (args) {
     throw pe;
   }
   var mode = (args && args.mode) || 'auto';
-  var result = await _findOrCreateSubfolder(parentHandle, mode);
+  var result = await _findOrCreateSubfolder(parentHandle, mode, args && args.subfolderName);
   if (result.requiresChoice) {
     // Existing data present — let the page choose adopt vs create-new; don't
     // probe or persist yet (it re-invokes with open-existing / create-new).

--- a/app/static/vendor/sqlite-worker.js
+++ b/app/static/vendor/sqlite-worker.js
@@ -258,10 +258,65 @@ function bootstrapRelationshipsSchema(db) {
   db.exec('PRAGMA foreign_keys = ON;');
   db.exec(RELATIONSHIPS_SCHEMA_SQL);
   db.exec('PRAGMA user_version = ' + RELATIONSHIPS_SCHEMA_VERSION);
+  _ensureWorkspaceIdentity(db);
 }
 
 function nowIsoSecond() {
   return new Date().toISOString().replace(/\.\d+Z$/, 'Z');
+}
+
+// ----- Workspace identity (EPIC PR5) ---------------------------------------
+// A few stable rows in the relationships `settings` table that travel WITH the
+// DB (and so with a folder store and any backup of it). They let the
+// content-previewed folder chooser say "created on this Chrome · last changed
+// 2 days ago" and recommend the most-recently-written store. Settings rows, not
+// a schema change — RELATIONSHIPS_SCHEMA_VERSION stays 1.
+function _identityPut(db, k, v) {
+  dbRun(db,
+    'INSERT INTO settings(key, value) VALUES (?, ?) ' +
+    'ON CONFLICT(key) DO UPDATE SET value = excluded.value', [k, v]);
+}
+
+function _deviceLabelGuess() {
+  var ua = (self.navigator && self.navigator.userAgent) || '';
+  var os = /Mac/.test(ua) ? 'Mac' : /Win/.test(ua) ? 'Windows'
+    : /CrOS/.test(ua) ? 'ChromeOS' : /Linux/.test(ua) ? 'Linux' : 'this device';
+  var br = /Edg\//.test(ua) ? 'Edge' : /OPR\//.test(ua) ? 'Opera'
+    : /Chrome\//.test(ua) ? 'Chrome' : /Firefox\//.test(ua) ? 'Firefox'
+    : /Safari\//.test(ua) ? 'Safari' : 'browser';
+  return br + ' on ' + os;
+}
+
+// Mint identity once if absent (called from bootstrap — fresh + restored DBs).
+function _ensureWorkspaceIdentity(db) {
+  try {
+    var existing = dbSelectOne(db, 'SELECT value FROM settings WHERE key = ?', ['workspace_uuid']);
+    if (existing && existing.value) return;
+    var uuid = (self.crypto && typeof self.crypto.randomUUID === 'function')
+      ? self.crypto.randomUUID()
+      : ('ws-' + Date.now() + '-' + Math.random().toString(16).slice(2));
+    var now = nowIsoSecond();
+    _identityPut(db, 'workspace_uuid', uuid);
+    _identityPut(db, 'device_label', _deviceLabelGuess());
+    _identityPut(db, 'created_at', now);
+    _identityPut(db, 'write_generation', '0');
+    _identityPut(db, 'last_written_at', now);
+  } catch (e) {
+    trace('identity: ensure failed: ' + ((e && e.message) || e));
+  }
+}
+
+// Bump the monotonic write generation + last_written_at on each committed
+// mutation, so the chooser can rank stores by recency.
+function _stampWriteGeneration(db) {
+  try {
+    var row = dbSelectOne(db, 'SELECT value FROM settings WHERE key = ?', ['write_generation']);
+    var n = (row && row.value ? (parseInt(row.value, 10) || 0) : 0) + 1;
+    _identityPut(db, 'write_generation', String(n));
+    _identityPut(db, 'last_written_at', nowIsoSecond());
+  } catch (e) {
+    trace('identity: stamp failed: ' + ((e && e.message) || e));
+  }
 }
 
 function dedupeRecordIds(ids) {
@@ -2392,6 +2447,10 @@ async function _maybeWriteFolderAfterCommit() {
     // to write — would just fail and populate lastError with noise.
     return;
   }
+  // Stamp the write generation into the live DB BEFORE exporting, so the
+  // folder copy (and any backup of it) carries the recency the chooser ranks
+  // by (EPIC PR5). Runs only in folder mode — the only stores the chooser sees.
+  if (relDb) _stampWriteGeneration(relDb);
   var bytes;
   try {
     bytes = poolUtil.exportFile(RELATIONSHIPS_DB_SLOT);

--- a/app/static/vendor/sqlite-worker.js
+++ b/app/static/vendor/sqlite-worker.js
@@ -50,7 +50,7 @@ importScripts('./sqlite3.js');
 // are version-tolerant — the page is allowed to read folder state even
 // against a stale worker — but the mutating ops are version-gated alongside
 // the existing relationships.db writes.
-var WORKER_RPC_VERSION = 3;
+var WORKER_RPC_VERSION = 4;
 
 // Same value as relationships.db's PRAGMA user_version. Bumped only on
 // schema migrations. Mirrored from app/relationships.py:SCHEMA_VERSION.
@@ -2429,6 +2429,48 @@ handlers.getFolderState = async function () {
   return _folderStateSnapshot();
 };
 
+// Empirical durability probe (EPIC PR4). Write a unique sentinel file into
+// `subHandle`, read it back, verify the bytes match, then delete it. Returns
+// null on success or a staged reason-code string on failure. The read-back
+// match is the load-bearing check: a cloud-only / virtual placeholder folder
+// (OneDrive/iCloud "online only", a streamed location) accepts the write but
+// does NOT return the bytes — so feature-detecting showDirectoryPicker is
+// necessary but not sufficient for a *durable* store. Reason codes map to
+// anchors in docs/folder_troubleshooting.md.
+async function _probeWritableSentinel(subHandle) {
+  var SENTINEL_NAME = '.fellows-probe';
+  var token = 'fellows-probe-' + (
+    (self.crypto && typeof self.crypto.randomUUID === 'function')
+      ? self.crypto.randomUUID()
+      : (String(Date.now()) + '-' + Math.random())
+  );
+  var bytes = new TextEncoder().encode(token);
+  var fh;
+  try {
+    fh = await subHandle.getFileHandle(SENTINEL_NAME, { create: true });
+  } catch (e) {
+    return 'subfolder_create_failed';
+  }
+  try {
+    var w = await fh.createWritable();
+    await w.write(bytes);
+    await w.close();
+  } catch (e) {
+    return 'write_failed';
+  }
+  try {
+    var rf = await subHandle.getFileHandle(SENTINEL_NAME);
+    var back = await (await rf.getFile()).text();
+    if (back !== token) return 'readback_mismatch';
+  } catch (e) {
+    return 'readback_mismatch';
+  }
+  // Best-effort cleanup; a leftover sentinel is non-fatal (read-back already
+  // succeeded, so a delete failure can't mask a mismatch).
+  try { await subHandle.removeEntry(SENTINEL_NAME); } catch (e) {}
+  return null;
+}
+
 // Step one of the picker flow. Page passes the handle returned by
 // window.showDirectoryPicker. `mode` controls the collision policy:
 //   - undefined / 'auto' — happy path; if the default subfolder already
@@ -2482,6 +2524,69 @@ handlers.setFolderHandle = async function (args) {
     ok: true,
     parentName: folderRecord.parentName,
     subfolderName: folderRecord.subfolderName
+  };
+};
+
+// Unlock probe (EPIC PR4). Like setFolderHandle (permission check + subfolder
+// resolution + collision handling + persist), but inserts the empirical
+// write→read-back→verify durability probe before committing. Staged failures
+// surface a stable reason code (picker_cancelled / subfolder_create_failed /
+// write_failed / readback_mismatch / permission_not_persisted) → the page
+// links each to docs/folder_troubleshooting.md. On any probe failure NOTHING
+// is persisted — the app stays browse-only ("never half-unlock").
+handlers.probeFolderWritable = async function (args) {
+  var parentHandle = args && args.handle;
+  if (!parentHandle) {
+    var e0 = new Error('no folder selected');
+    e0.code = 'picker_cancelled';
+    throw e0;
+  }
+  var perm = 'granted';
+  if (typeof parentHandle.queryPermission === 'function') {
+    try { perm = await parentHandle.queryPermission({ mode: 'readwrite' }); }
+    catch (e) { perm = 'denied'; }
+  }
+  if (perm !== 'granted') {
+    var pe = new Error('folder permission not persisted (' + perm + ')');
+    pe.code = 'permission_not_persisted';
+    throw pe;
+  }
+  var mode = (args && args.mode) || 'auto';
+  var result = await _findOrCreateSubfolder(parentHandle, mode);
+  if (result.requiresChoice) {
+    // Existing data present — let the page choose adopt vs create-new; don't
+    // probe or persist yet (it re-invokes with open-existing / create-new).
+    return {
+      ok: false,
+      requiresChoice: true,
+      parentName: parentHandle.name || null,
+      existing: result.existing,
+      suggestion: result.suggestion
+    };
+  }
+  var reason = await _probeWritableSentinel(result.handle);
+  if (reason) {
+    var re = new Error('folder probe failed: ' + reason);
+    re.code = reason;
+    throw re;
+  }
+  // Probe passed → commit (same persistence as setFolderHandle).
+  folderRecord.parentHandle = parentHandle;
+  folderRecord.parentName = parentHandle.name || null;
+  folderRecord.subfolderName = result.subfolderName;
+  if (mode === 'create-new' || folderRecord.lastSavedAt === undefined) {
+    folderRecord.lastSavedAt = null;
+  }
+  folderRecord.lastError = null;
+  await _folderRecordPersist();
+  trace('folder: probe ok parent=' + folderRecord.parentName +
+    ' subfolder=' + folderRecord.subfolderName);
+  return {
+    ok: true,
+    parentName: folderRecord.parentName,
+    subfolderName: folderRecord.subfolderName,
+    sentinelVerified: true,
+    permissionPersisted: true
   };
 };
 

--- a/tests/e2e/test_folder_probe.py
+++ b/tests/e2e/test_folder_probe.py
@@ -67,3 +67,31 @@ def test_probe_picker_cancelled_surfaces_reason_code(standalone_page, base_url_f
     # Nothing persisted on a failed probe — stays browse-only.
     state = page.evaluate("() => window.__folderController.getState()")
     assert state["hasHandle"] is False, state
+
+
+def test_settings_pick_unlocks_private_data_without_reload(standalone_page, base_url_fixture):
+    """The PR4b unlock UI: picking a folder in Settings runs the empirical
+    probe and flips the private-data gate IMMEDIATELY (no reload) — group
+    surfaces become available in the same session."""
+    page = standalone_page
+    _boot(page, base_url_fixture)
+    page.evaluate("() => window.__dataProvider._clearFolderHandle()")
+    page.evaluate("() => window.__resetE2EUserFolderMin && window.__resetE2EUserFolderMin()")
+    # Start locked (desktop, no folder).
+    page.goto(base_url_fixture + "/#/settings", wait_until="domcontentloaded")
+    page.locator("#settings-folder-choose").wait_for(state="visible", timeout=5000)
+    page.wait_for_function(
+        "() => document.body.classList.contains('no-private-data')", timeout=5000
+    )
+    # Pick a folder → probe runs → write → gate flips, NO reload.
+    page.locator("#settings-folder-choose").click()
+    page.wait_for_function(
+        "async () => { try { var s = await window.__folderController.getState();"
+        " return !!s.hasHandle; } catch (e) { return false; } }",
+        timeout=10000,
+    )
+    page.wait_for_function(
+        "() => document.body && !document.body.classList.contains('no-private-data')",
+        timeout=8000,
+    )
+    assert page.evaluate("() => window.__privateDataTier") == "private-folder"

--- a/tests/e2e/test_folder_probe.py
+++ b/tests/e2e/test_folder_probe.py
@@ -127,3 +127,34 @@ def test_lock_my_private_data_returns_to_browse_only(standalone_page, base_url_f
     state = page.evaluate("() => window.__folderController.getState()")
     assert state["hasHandle"] is False, state
     assert page.evaluate("() => window.__privateDataTier") == "browse-only-desktop"
+
+
+def test_workspace_identity_and_write_generation_stamp(standalone_page, base_url_fixture):
+    """EPIC PR5 foundation: relationships.db carries a workspace identity
+    (minted at bootstrap) and a write_generation that strictly increases on
+    each committed mutation in folder mode — the recency the chooser ranks by."""
+    page = standalone_page
+    _boot(page, base_url_fixture)
+    # Identity is minted when relationships.db is bootstrapped at boot.
+    uuid = page.evaluate("() => window.__dataProvider.getSetting('workspace_uuid')")
+    assert uuid, "workspace_uuid should be minted at bootstrap"
+    # Attach a folder so the post-commit folder write (which stamps) runs.
+    page.evaluate("() => window.__dataProvider._clearFolderHandle()")
+    page.evaluate("() => window.__resetE2EUserFolderMin && window.__resetE2EUserFolderMin()")
+    page.goto(base_url_fixture + "/#/settings", wait_until="domcontentloaded")
+    page.locator("#settings-folder-choose").wait_for(state="visible", timeout=5000)
+    page.locator("#settings-folder-choose").click()
+    page.wait_for_function(
+        "() => !document.body.classList.contains('no-private-data')", timeout=10000
+    )
+    rid = page.evaluate("() => window.__dataProvider.getFull().then(f => f[0].record_id)")
+    page.evaluate(
+        "(rid) => window.__dataProvider.createGroup({name:'g1', note:'', fellow_record_ids:[rid]})",
+        rid,
+    )
+    gen1 = page.evaluate("() => window.__dataProvider.getSetting('write_generation')")
+    page.evaluate(
+        "() => window.__dataProvider.createGroup({name:'g2', note:'', fellow_record_ids:[]})"
+    )
+    gen2 = page.evaluate("() => window.__dataProvider.getSetting('write_generation')")
+    assert gen1 and gen2 and int(gen2) > int(gen1), (gen1, gen2)

--- a/tests/e2e/test_folder_probe.py
+++ b/tests/e2e/test_folder_probe.py
@@ -17,6 +17,8 @@ pins the happy path (verify + persist) and reason-code propagation
 """
 from __future__ import annotations
 
+from playwright.sync_api import expect
+
 from tests.e2e.conftest import _FOLDER_PICKER_STUB_MIN
 
 
@@ -95,3 +97,33 @@ def test_settings_pick_unlocks_private_data_without_reload(standalone_page, base
         timeout=8000,
     )
     assert page.evaluate("() => window.__privateDataTier") == "private-folder"
+
+
+def test_lock_my_private_data_returns_to_browse_only(standalone_page, base_url_fixture):
+    """The 'Lock my private data' control disconnects the folder and flips the
+    gate back to browse-only live (no reload). The folder file is untouched —
+    re-picking unlocks again."""
+    page = standalone_page
+    _boot(page, base_url_fixture)
+    page.evaluate("() => window.__dataProvider._clearFolderHandle()")
+    page.evaluate("() => window.__resetE2EUserFolderMin && window.__resetE2EUserFolderMin()")
+    # Unlock first.
+    page.goto(base_url_fixture + "/#/settings", wait_until="domcontentloaded")
+    page.locator("#settings-folder-choose").wait_for(state="visible", timeout=5000)
+    page.locator("#settings-folder-choose").click()
+    page.wait_for_function(
+        "() => !document.body.classList.contains('no-private-data')", timeout=10000
+    )
+    # The lock control appears only when a folder is connected.
+    lock = page.locator("#settings-folder-lock")
+    expect(lock).to_be_visible()
+    # Accept the confirm() prompt, then lock.
+    page.once("dialog", lambda d: d.accept())
+    lock.click()
+    # Gate flips back to browse-only, live.
+    page.wait_for_function(
+        "() => document.body.classList.contains('no-private-data')", timeout=8000
+    )
+    state = page.evaluate("() => window.__folderController.getState()")
+    assert state["hasHandle"] is False, state
+    assert page.evaluate("() => window.__privateDataTier") == "browse-only-desktop"

--- a/tests/e2e/test_folder_probe.py
+++ b/tests/e2e/test_folder_probe.py
@@ -1,0 +1,69 @@
+"""E2E for the folder-writable empirical probe (EPIC PR4).
+
+`probeFolderWritable` is the unlock gate: pick a folder → write a sentinel →
+read it back → verify the bytes → persist. The read-back check is what proves
+a *durable* local folder (vs a cloud-only / virtual placeholder that accepts
+writes but doesn't return them). On any failure it throws a stable reason code
+(picker_cancelled / subfolder_create_failed / write_failed / readback_mismatch
+/ permission_not_persisted) that the page links to docs/folder_troubleshooting.md.
+
+Coverage note: the folder-BEHAVIOUR reason codes (readback_mismatch,
+write_failed, subfolder_create_failed) can't be simulated here — the picked
+handle crosses to the worker via structured clone (page-side proxies don't
+survive), and the OPFS-backed stub folder is reliable. Those are covered by
+code inspection + manual QA on a real cloud/online-only folder. This file
+pins the happy path (verify + persist) and reason-code propagation
+(picker_cancelled), which exercise the RPC + error envelope.
+"""
+from __future__ import annotations
+
+from tests.e2e.conftest import _FOLDER_PICKER_STUB_MIN
+
+
+def _boot(page, base_url):
+    page.add_init_script(_FOLDER_PICKER_STUB_MIN)
+    page.goto(base_url + "/", wait_until="domcontentloaded")
+    page.wait_for_function(
+        "() => window.__dataProvider && window.__dataProvider.kind === 'worker'",
+        timeout=15000,
+    )
+
+
+def test_probe_happy_path_verifies_and_persists(standalone_page, base_url_fixture):
+    page = standalone_page
+    _boot(page, base_url_fixture)
+    page.evaluate("() => window.__dataProvider._clearFolderHandle()")
+    page.evaluate("() => window.__resetE2EUserFolderMin && window.__resetE2EUserFolderMin()")
+    result = page.evaluate(
+        """async () => {
+            const handle = await window.showDirectoryPicker();
+            return await window.__dataProvider._probeFolderWritable({ handle });
+        }"""
+    )
+    assert result["ok"] is True, result
+    assert result.get("sentinelVerified") is True, result
+    assert result.get("permissionPersisted") is True, result
+    # Handle persisted → folder state reports it (the unlock precondition).
+    state = page.evaluate("() => window.__folderController.getState()")
+    assert state["hasHandle"] is True, state
+    assert state["permission"] == "granted", state
+
+
+def test_probe_picker_cancelled_surfaces_reason_code(standalone_page, base_url_fixture):
+    page = standalone_page
+    _boot(page, base_url_fixture)
+    err = page.evaluate(
+        """async () => {
+            try {
+                await window.__dataProvider._probeFolderWritable({ handle: null });
+                return { threw: false };
+            } catch (e) {
+                return { threw: true, code: e.code, message: String(e.message || e) };
+            }
+        }"""
+    )
+    assert err["threw"] is True, err
+    assert err["code"] == "picker_cancelled", err
+    # Nothing persisted on a failed probe — stays browse-only.
+    state = page.evaluate("() => window.__folderController.getState()")
+    assert state["hasHandle"] is False, state

--- a/tests/e2e/test_folder_probe.py
+++ b/tests/e2e/test_folder_probe.py
@@ -158,3 +158,38 @@ def test_workspace_identity_and_write_generation_stamp(standalone_page, base_url
     )
     gen2 = page.evaluate("() => window.__dataProvider.getSetting('write_generation')")
     assert gen1 and gen2 and int(gen2) > int(gen1), (gen1, gen2)
+
+
+def test_scan_fellows_candidates(standalone_page, base_url_fixture):
+    """EPIC PR5b: scanFellowsCandidates enumerates Fellows* stores in a parent
+    with their group counts + identity, and recommends one."""
+    page = standalone_page
+    _boot(page, base_url_fixture)
+    page.evaluate("() => window.__dataProvider._clearFolderHandle()")
+    page.evaluate("() => window.__resetE2EUserFolderMin && window.__resetE2EUserFolderMin()")
+    # Attach a folder + create a group so Fellows/relationships.db has content.
+    page.goto(base_url_fixture + "/#/settings", wait_until="domcontentloaded")
+    page.locator("#settings-folder-choose").wait_for(state="visible", timeout=5000)
+    page.locator("#settings-folder-choose").click()
+    page.wait_for_function(
+        "() => !document.body.classList.contains('no-private-data')", timeout=10000
+    )
+    rid = page.evaluate("() => window.__dataProvider.getFull().then(f => f[0].record_id)")
+    page.evaluate(
+        "(rid) => window.__dataProvider.createGroup({name:'Scan g', note:'', fellow_record_ids:[rid]})",
+        rid,
+    )
+    # Scan the same parent (the stub folder) for Fellows* stores.
+    result = page.evaluate(
+        """async () => {
+            const root = await navigator.storage.getDirectory();
+            const parent = await root.getDirectoryHandle('__e2e_user_folder__');
+            return await window.__folderController.scanCandidates(parent);
+        }"""
+    )
+    cands = result["candidates"]
+    fellows = [c for c in cands if c["subfolderName"] == "Fellows"]
+    assert fellows, result
+    assert fellows[0]["groups"] == 1, fellows[0]
+    assert fellows[0]["writeGeneration"] is not None, fellows[0]
+    assert result["recommended"] == "Fellows", result

--- a/tests/e2e/test_user_folder_storage.py
+++ b/tests/e2e/test_user_folder_storage.py
@@ -244,11 +244,11 @@ class TestUserFolderStorage:
         self, folder_page, base_url_fixture
     ):
         _open_settings(folder_page, base_url_fixture)
-        # On a fresh state, badge says "Browser-only" and the single
-        # Choose folder… button is visible (Save now / Reload from
-        # folder / Reconnect / Disconnect removed in PR #205).
+        # On a fresh state the badge says private data isn't connected (the
+        # capability-gate framing — was "Browser-only" before the gate) and
+        # the single Choose folder… button is visible.
         badge_text = folder_page.locator("#settings-folder-badge .settings-folder-badge-text")
-        expect(badge_text).to_contain_text("Browser-only")
+        expect(badge_text).to_contain_text("isn’t connected")
         choose = folder_page.locator("#settings-folder-choose")
         expect(choose).to_be_visible()
         expect(choose).to_have_text("Choose folder…")

--- a/tests/e2e/test_user_folder_storage.py
+++ b/tests/e2e/test_user_folder_storage.py
@@ -289,20 +289,88 @@ class TestUserFolderStorage:
         folder_page.locator("#settings-folder-choose").click()
         badge_text = folder_page.locator("#settings-folder-badge .settings-folder-badge-text")
         expect(badge_text).to_contain_text("Saved to", timeout=10000)
-        # Click Change folder and re-pick the same parent. The worker
-        # probes, finds Fellows/ already with a relationships.db, returns
-        # requiresChoice → the collision dialog opens. Post-PR-#205 the
-        # "disconnect first, then pick" flow is gone; users now hit
-        # collision by re-picking via Change folder directly.
+        # Re-pick the same parent. The content-previewed chooser (EPIC PR5,
+        # which supersedes the old binary collision dialog) lists the existing
+        # Fellows store by content; choosing "Save to a new store" → Fellows 2.
         folder_page.locator("#settings-folder-choose").click()
-        dialog = folder_page.locator("#settings-folder-collision-dialog")
-        expect(dialog).to_be_visible(timeout=5000)
-        # Click "Create Fellows 2".
-        folder_page.locator("#settings-folder-collision-create").click()
+        chooser = folder_page.locator("#settings-folder-chooser-dialog")
+        expect(chooser).to_be_visible(timeout=5000)
+        expect(
+            folder_page.locator("#settings-folder-chooser-list .settings-folder-chooser-item")
+        ).to_contain_text("Fellows")
+        folder_page.locator(
+            "#settings-folder-chooser-dialog button[value='__create_new__']"
+        ).click()
         expect(badge_text).to_contain_text("Saved to", timeout=10000)
         probe = folder_page.evaluate("() => window.__probeE2EUserFolder()")
         assert probe["hasFellows"] is True, "original Fellows/ should be untouched"
         assert probe["hasFellows2"] is True, "Fellows 2/ should have been created"
+
+    def test_switching_stores_via_chooser_loads_that_stores_groups(
+        self, folder_page, base_url_fixture
+    ):
+        """EPIC PR5: two stores in one parent — the chooser lets you pick by
+        content, and opening one loads ITS groups (the 'switch folders →
+        groups change' the old binary collision dialog couldn't do)."""
+        _open_settings(folder_page, base_url_fixture)
+        badge_text = folder_page.locator("#settings-folder-badge .settings-folder-badge-text")
+        # Store "Fellows": attach + 1 group.
+        folder_page.locator("#settings-folder-choose").click()
+        expect(badge_text).to_contain_text("Saved to", timeout=10000)
+        rid = folder_page.evaluate("() => window.__dataProvider.getFull().then(f => f[0].record_id)")
+        folder_page.evaluate(
+            "(rid) => window.__dataProvider.createGroup({name:'F1 only', note:'', fellow_record_ids:[rid]})",
+            rid,
+        )
+        # Store "Fellows 2": re-pick → chooser → new store; then add a 2nd group.
+        folder_page.locator("#settings-folder-choose").click()
+        folder_page.locator(
+            "#settings-folder-chooser-dialog button[value='__create_new__']"
+        ).click()
+        # Wait for the switch to Fellows 2 to COMPLETE before adding a group:
+        # the badge can still read the stale "Saved to Fellows" for a moment,
+        # so gate on the live subfolder, not the badge (else g2 races into the
+        # old store).
+        folder_page.wait_for_function(
+            "async () => { const s = await window.__folderController.getState();"
+            " return s.subfolderName === 'Fellows 2'; }",
+            timeout=10000,
+        )
+        folder_page.evaluate(
+            "() => window.__dataProvider.createGroup({name:'F2 extra', note:'', fellow_record_ids:[]})"
+        )
+        assert folder_page.evaluate(
+            "() => window.__dataProvider.listGroups().then(g => g.length)"
+        ) == 2
+        scan_dump = folder_page.evaluate(
+            """async () => {
+                const root = await navigator.storage.getDirectory();
+                const parent = await root.getDirectoryHandle('__e2e_user_folder__');
+                const s = await window.__folderController.scanCandidates(parent);
+                return s.candidates.map(c => c.subfolderName + '=' + c.groups);
+            }"""
+        )
+        assert sorted(scan_dump) == ["Fellows 2=2", "Fellows=1"], f"per-store counts: {scan_dump}"
+        # Switch back to "Fellows" via the chooser → loads its 1 group.
+        folder_page.locator("#settings-folder-choose").click()
+        expect(folder_page.locator("#settings-folder-chooser-dialog")).to_be_visible(timeout=5000)
+        folder_page.locator(
+            "#settings-folder-chooser-dialog button[value='Fellows']"
+        ).click()
+        expect(folder_page.locator("#settings-folder-detail")).to_contain_text(
+            "Loaded", timeout=10000
+        )
+        detail = folder_page.locator("#settings-folder-detail").inner_text()
+        sub = folder_page.evaluate(
+            "() => window.__folderController.getState().then(s => s.subfolderName)"
+        )
+        count = folder_page.evaluate(
+            "() => window.__dataProvider.listGroups().then(g => g.length)"
+        )
+        assert count == 1, (
+            f"expected Fellows's 1 group after switch, got {count}; "
+            f"active subfolder={sub!r}; detail={detail!r}"
+        )
 
     # test_open_existing_loads_data_back was removed in PR #205. It
     # used Disconnect (now removed) to break the OPFS→folder auto-save


### PR DESCRIPTION
**Stacked on #235** (the gate). Review/merge #235 first; this retargets to `main` once it lands.

Builds the *private-data lifecycle* on top of the gate: unlock, lock, switch, and the honest failure UX — all driven by an empirical durability probe.

## PR4 — unlock + probe + lock
- **`probeFolderWritable`** — empirical durability probe: write a sentinel → read it back → verify, before committing. The read-back is what proves a *real local* folder (a cloud-only/virtual folder accepts the write but doesn't return it). Staged reason codes.
- **Unlock UI** — picking a folder runs the probe and flips the gate **live** (no reload); group surfaces appear.
- **Folder-error dialog** — a prominent, plain-language dialog ("Couldn't use that folder" + inline cause) replaces the raw `NoModificationAllowedError` jargon a Google-Drive folder produced.
- **"Lock my private data"** — friendly disconnect → browse-only live; data stays in the folder file, re-pick to unlock. (Noted to combine with at-rest encryption later.)
- **Copy** — locked-state badge + nudge banner now read accurately for the gate.

## PR5 — content-previewed chooser + live switching
- **Workspace identity + write-generation stamp** (settings rows that travel with the DB) — recency the chooser ranks by.
- **`scanFellowsCandidates`** — enumerate every `Fellows*` store in a parent with its group/member/note counts + identity; recommend the most-recent.
- **The chooser** — re-picking a parent with saved data lists stores *by content* ("4 groups · 12 members · changed 2 days ago · Chrome on Mac") instead of the binary collision dialog. Pick one → opens it (`open-named`) and loads ITS groups. This is the **"switch folders → groups change"** capability the old flow couldn't do.
- `WORKER_RPC_VERSION` 4→5.

## Test status
Full `just test`: **643 passed, 6 skipped, 0 failed**. New e2e: probe happy/cancelled, unlock-without-reload, lock→browse-only, identity/write-gen, scan, and two-store switch (which caught a real test race). Collision test rewritten to drive the chooser.

## Coverage caveat (unchanged)
Folder-*behaviour* probe reasons (`readback_mismatch`, `write_failed`) can't be simulated with the OPFS stub (structured clone defeats page-side handle mocks; OPFS is reliable) — covered by code + manual QA (the Google-Drive case was verified by hand).

## Follow-ups (small, deferred)
Self-describing export filename + a `HOW-TO-MOVE-THIS-DATA.txt` marker + a one-click "Reconnect your folder" prompt on permission lapse; the has-email localStorage purity guard; the desktop "Enable on Chrome desktop →" CTA polish.

🤖 Generated with [Claude Code](https://claude.com/claude-code)