### PR TITLE
Private-data PR5 follow-ups: self-describing export name, folder marker, reconnect control

### DIFF
--- a/app/static/app.js
+++ b/app/static/app.js
@@ -9125,6 +9125,7 @@
         '</p>' +
         '<div id="settings-folder-actions" class="settings-folder-actions">' +
           '<button type="button" id="settings-folder-choose" class="settings-download" hidden>Choose folder…</button>' +
+          '<button type="button" id="settings-folder-reconnect" class="settings-download" hidden>🔄 Reconnect your folder</button>' +
           '<button type="button" id="settings-folder-lock" class="settings-download" hidden>🔒 Lock my private data</button>' +
           '<button type="button" id="settings-download-userdata" class="settings-download" hidden>' +
             '⬇ Download my private data' +
@@ -10140,6 +10141,12 @@
       // encryption — see plans / lock-my-data.)
       var lockBtn = document.getElementById('settings-folder-lock');
       if (lockBtn) lockBtn.hidden = !(supported && state.hasHandle);
+      // "Reconnect your folder" (EPIC PR5 follow-up): shown only when a folder
+      // is attached but its permission has lapsed (badge 'inaccessible', e.g.
+      // after a browser restart). One click re-grants on the stored handle —
+      // no re-pick — and re-unlocks. Data is never lost; the file still exists.
+      var reconnectBtn = document.getElementById('settings-folder-reconnect');
+      if (reconnectBtn) reconnectBtn.hidden = (b !== 'inaccessible');
       // Download button stays visible whenever local persistence is
       // available — folder-mode users still want backup files outside
       // the folder (cloud-sync conflicts, sneakernet to another machine,
@@ -10385,6 +10392,29 @@
             // private-data gate immediately so group surfaces appear without
             // a reload (EPIC PR4). Idempotent: a failed pick re-resolves to
             // the same locked state.
+            try { updatePrivateDataGate(); } catch (e) {}
+            return refresh();
+          });
+      });
+    }
+
+    var btnReconnect = document.getElementById('settings-folder-reconnect');
+    if (btnReconnect) {
+      btnReconnect.addEventListener('click', function () {
+        btnReconnect.disabled = true;
+        flashDetail('Reconnecting…');
+        // reconnect() re-grants permission on the STORED handle (a user-gesture
+        // requestPermission) — no re-pick. On success the gate re-unlocks.
+        FOLDER_CONTROLLER.reconnect()
+          .then(function (state) {
+            var ok = state && state.permission === 'granted';
+            flashDetail(ok ? 'Reconnected.' : 'Could not reconnect — try “Change folder” to re-pick.');
+          })
+          .catch(function () {
+            flashDetail('Could not reconnect — try “Change folder” to re-pick.');
+          })
+          .then(function () {
+            btnReconnect.disabled = false;
             try { updatePrivateDataGate(); } catch (e) {}
             return refresh();
           });

--- a/app/static/app.js
+++ b/app/static/app.js
@@ -2425,8 +2425,10 @@
     }
     return dataProvider.exportRelationshipsBytes().then(function (bytes) {
       if (!bytes || !bytes.byteLength) return null;
-      var ts = new Date().toISOString().replace(/[:.]/g, '-');
-      var filename = 'relationships-' + ts + '.db';
+      // Self-describing name (EPIC PR5 follow-up) so a restore-a-file pile is
+      // recognizable; same-day re-exports get the browser's "(1)" suffix.
+      var ts = new Date().toISOString().slice(0, 10);
+      var filename = 'ehf-fellows-private-data-' + ts + '.db';
       var blob = new Blob([bytes], { type: 'application/octet-stream' });
       return downloadBlob(blob, filename).then(function (result) {
         return {
@@ -9395,8 +9397,10 @@
               if (downloadStatus) downloadStatus.textContent = 'No data yet to download.';
               return;
             }
-            var ts = new Date().toISOString().replace(/[:.]/g, '-');
-            var filename = 'relationships-' + ts + '.db';
+            // Self-describing name (EPIC PR5 follow-up) — recognizable in a
+            // pile of downloads; same-day re-exports get the browser's "(1)".
+            var ts = new Date().toISOString().slice(0, 10);
+            var filename = 'ehf-fellows-private-data-' + ts + '.db';
             var blob = new Blob([bytes], { type: 'application/octet-stream' });
             return downloadBlob(blob, filename).then(function (result) {
               if (!downloadStatus) return;

--- a/app/static/vendor/sqlite-worker.js
+++ b/app/static/vendor/sqlite-worker.js
@@ -1834,6 +1834,21 @@ var FOLDER_IDB_STORE = 'handles';
 var FOLDER_IDB_KEY = 'relationships-folder';
 var FOLDER_SUBFOLDER_DEFAULT = 'Fellows';
 var FOLDER_RELATIONSHIPS_FILE = 'relationships.db';
+// Human-readable marker dropped next to relationships.db (EPIC PR5 follow-up)
+// so the folder is self-explanatory in Finder/Explorer and the migration path
+// is discoverable without the app.
+var FOLDER_MARKER_FILE = 'HOW-TO-MOVE-THIS-DATA.txt';
+var FOLDER_MARKER_TEXT =
+  'This folder holds your EHF Fellows private data.\n\n' +
+  '  relationships.db  — your saved groups, notes, and tags (a SQLite database).\n\n' +
+  'The Fellows app reads and writes this file. Nothing is uploaded anywhere.\n\n' +
+  'To move your data to another computer or browser:\n' +
+  '  1. In the app: Settings -> Private data folder -> "Download my private data".\n' +
+  '  2. On the new computer, install the app in a Chromium desktop browser\n' +
+  '     (Chrome / Edge / Brave / Arc), then Settings -> Restore from a file,\n' +
+  '     and pick the downloaded .db.\n' +
+  'Or just copy this whole folder to the new computer and pick it in the app.\n\n' +
+  'Keep this folder on local disk -- not a cloud-only / online-only folder.\n';
 // Web Locks name guarding folder writes. Lock is scoped per-origin
 // per-browser-profile; agents in the same context (this worker + its
 // page) share the namespace, so a page-side test or future takeover-
@@ -2578,6 +2593,19 @@ handlers.scanFellowsCandidates = async function (args) {
 // does NOT return the bytes — so feature-detecting showDirectoryPicker is
 // necessary but not sufficient for a *durable* store. Reason codes map to
 // anchors in docs/folder_troubleshooting.md.
+// Drop the human-readable "how to move this data" marker next to
+// relationships.db (idempotent overwrite; best-effort). EPIC PR5 follow-up.
+async function _writeFolderMarker(subHandle) {
+  try {
+    var fh = await subHandle.getFileHandle(FOLDER_MARKER_FILE, { create: true });
+    var w = await fh.createWritable();
+    await w.write(FOLDER_MARKER_TEXT);
+    await w.close();
+  } catch (e) {
+    trace('folder: marker write failed: ' + ((e && e.message) || e));
+  }
+}
+
 async function _probeWritableSentinel(subHandle) {
   var SENTINEL_NAME = '.fellows-probe';
   var token = 'fellows-probe-' + (
@@ -2720,6 +2748,8 @@ handlers.probeFolderWritable = async function (args) {
   }
   folderRecord.lastError = null;
   await _folderRecordPersist();
+  // Drop the human-readable marker so the folder is self-explanatory on disk.
+  await _writeFolderMarker(result.handle);
   trace('folder: probe ok parent=' + folderRecord.parentName +
     ' subfolder=' + folderRecord.subfolderName);
   return {

--- a/tests/e2e/mobile/test_download_share_routing.py
+++ b/tests/e2e/mobile/test_download_share_routing.py
@@ -77,7 +77,7 @@ def test_android_backup_saves_to_downloads_without_share(playwright, browser, ba
         with page.expect_download(timeout=20000) as dl_info:
             page.locator("#settings-download-userdata").click()
         download = dl_info.value
-        assert download.suggested_filename.startswith("relationships-")
+        assert download.suggested_filename.startswith("ehf-fellows-private-data-")
         assert download.suggested_filename.endswith(".db")
         # The whole point: the Android share-sheet → Drive dead-end is gone.
         assert page.evaluate("() => window.__shareCalls") == 0

--- a/tests/e2e/test_folder_probe.py
+++ b/tests/e2e/test_folder_probe.py
@@ -193,3 +193,29 @@ def test_scan_fellows_candidates(standalone_page, base_url_fixture):
     assert fellows[0]["groups"] == 1, fellows[0]
     assert fellows[0]["writeGeneration"] is not None, fellows[0]
     assert result["recommended"] == "Fellows", result
+
+
+def test_folder_marker_written_on_attach(standalone_page, base_url_fixture):
+    """EPIC PR5 follow-up: a HOW-TO-MOVE-THIS-DATA.txt marker is dropped next
+    to relationships.db when a folder is attached, so the folder is
+    self-explanatory on disk."""
+    page = standalone_page
+    _boot(page, base_url_fixture)
+    page.evaluate("() => window.__dataProvider._clearFolderHandle()")
+    page.evaluate("() => window.__resetE2EUserFolderMin && window.__resetE2EUserFolderMin()")
+    page.goto(base_url_fixture + "/#/settings", wait_until="domcontentloaded")
+    page.locator("#settings-folder-choose").wait_for(state="visible", timeout=5000)
+    page.locator("#settings-folder-choose").click()
+    page.wait_for_function(
+        "() => !document.body.classList.contains('no-private-data')", timeout=10000
+    )
+    has_marker = page.evaluate(
+        """async () => {
+            const root = await navigator.storage.getDirectory();
+            const parent = await root.getDirectoryHandle('__e2e_user_folder__');
+            const fellows = await parent.getDirectoryHandle('Fellows');
+            try { await fellows.getFileHandle('HOW-TO-MOVE-THIS-DATA.txt'); return true; }
+            catch (e) { return false; }
+        }"""
+    )
+    assert has_marker is True

--- a/tests/e2e/test_reset_everything.py
+++ b/tests/e2e/test_reset_everything.py
@@ -181,7 +181,7 @@ class TestResetEverythingBackupPrompt:
             with page.expect_download(timeout=5000) as dl_info:
                 page.click("#reset-backup-download")
             download = dl_info.value
-            assert download.suggested_filename.startswith("relationships-")
+            assert download.suggested_filename.startswith("ehf-fellows-private-data-")
             assert download.suggested_filename.endswith(".db")
 
             # After the download fires, the prompt closes and the


### PR DESCRIPTION
The deferred small follow-ups from #237 (the gate is merged on `main`).

## Done
- **Self-describing export filename** — "Download my private data" and the Reset-Everything safety backup now download as `ehf-fellows-private-data-<YYYY-MM-DD>.db` (was `relationships-<ts>.db`), so the right file is recognizable when restoring from a pile.
- **`HOW-TO-MOVE-THIS-DATA.txt` folder marker** — dropped next to `relationships.db` on folder attach (idempotent, best-effort), explaining the file + the download/install-Chrome/restore migration path so the folder is self-explanatory in Finder/Explorer.
- **"🔄 Reconnect your folder"** — one-click re-grant on permission lapse (badge `inaccessible`, e.g. after a browser restart): re-grants on the stored handle (no re-pick) and re-unlocks the gate live; data is never lost. Wires the existing `reconnect()` (its button was removed in PR #205).

## Test status
Full `just test`: **644 passed, 6 skipped, 0 failed**. New: marker-presence test. Filename assertions updated (reset + mobile download).

## Deferred (with reasons — tracked, not lost)
- **has-email localStorage purity guard** — *dropped from this PR.* It's a cleanliness item (browse-only writing a filter *bool* to dormant OPFS), **not** a data-safety one (the §3 guarantee that matters — no groups/notes in unlocked OPFS — already holds). Implementing it forced a conftest wipe-poll change that destabilized an unrelated self_email test (verified: 4/4 green without it, flaky with it). Full browse-only purity (has-email + self_email + orphan-scan all skip relationships.db) is a coherent separate cleanup if we want it — better done together, with the harness poll reworked deliberately.
- **Desktop "Enable on Chrome desktop →" CTA** — niche polish (Chromium-desktop-no-folder already gets the folder-push banner nudge to Settings; Safari/FF get the badge message). Hard to e2e (needs Safari/FF UA). Deferred.

## Coverage note
The reconnect button can't be e2e'd (the OPFS-handle test stub auto-grants, so permission never lapses) — verified by code + manual QA; it stays hidden in all existing folder tests.

🤖 Generated with [Claude Code](https://claude.com/claude-code)