### PR TITLE
PR2: rescue prompt + OPFS→folder migration for existing groups

### DIFF
--- a/app/static/app.js
+++ b/app/static/app.js
@@ -8942,7 +8942,7 @@
   //   'browser-only'  — cream nag pushing OPFS-only users to pick a folder.
   //   'write-failed'  — urgent (amber/red) warning that the most recent
   //                     folder write failed (#221).
-  function renderFolderPushBanner(bannerEl, mode, state) {
+  function renderFolderPushBanner(bannerEl, mode, state, count) {
     var leadEl = bannerEl.querySelector('.folder-push-banner-lead');
     var detailEl = bannerEl.querySelector('.folder-push-banner-detail');
     var ctaEl = document.getElementById('folder-push-cta');
@@ -8967,6 +8967,25 @@
       // The warning must persist until the next write succeeds — don't let
       // the user dismiss away an unsaved-data warning.
       if (dismissEl) dismissEl.hidden = true;
+    } else if (mode === 'migrate') {
+      // EPIC PR2 rescue prompt: the dormant OPFS relationships.db already holds
+      // groups (a user from before the gate / before they picked a folder).
+      // Nudge them to pick a folder so the data lands somewhere durable —
+      // picking writes the current OPFS (groups included) to the folder.
+      bannerEl.classList.remove('folder-push-banner--error');
+      bannerEl.setAttribute('role', 'status');
+      var nGroups = count || 0;
+      if (leadEl) {
+        leadEl.textContent = 'Save your ' + nGroups + ' saved group' +
+          (nGroups === 1 ? '' : 's') + ' to a folder.';
+      }
+      if (detailEl) {
+        detailEl.textContent =
+          'They live only in this browser right now and could be lost if it ' +
+          'clears its data. Pick a folder to keep them safe.';
+      }
+      if (ctaEl) ctaEl.textContent = 'Save my groups';
+      if (dismissEl) dismissEl.hidden = false;
     } else {
       bannerEl.classList.remove('folder-push-banner--error');
       bannerEl.setAttribute('role', 'status');
@@ -9025,6 +9044,19 @@
       if (isFolderPushDismissed() || !state.supported ||
           !state.workerAvailable || state.hasHandle) {
         bannerEl.classList.add('hidden');
+        return;
+      }
+      // EPIC PR2: if the dormant OPFS relationships.db already holds groups,
+      // upgrade the generic nag to a "save your N groups" rescue prompt. The
+      // count read is the §3 legacy-rescue peek; migration itself is the normal
+      // pick→writeNow (current OPFS, groups included, is written to the folder).
+      if (dataProvider && typeof dataProvider.countRelationships === 'function') {
+        dataProvider.countRelationships().then(function (counts) {
+          var n = (counts && counts.groups) || 0;
+          renderFolderPushBanner(bannerEl, n > 0 ? 'migrate' : 'browser-only', state, n);
+        }).catch(function () {
+          renderFolderPushBanner(bannerEl, 'browser-only', state);
+        });
         return;
       }
       renderFolderPushBanner(bannerEl, 'browser-only', state);

--- a/tests/e2e/test_user_folder_storage.py
+++ b/tests/e2e/test_user_folder_storage.py
@@ -745,6 +745,68 @@ class TestPhase2Pivot:
             "no folder mode → no Fellows/ subfolder should exist"
         )
 
+    def test_opfs_groups_show_rescue_banner(self, folder_page, base_url_fixture):
+        """EPIC PR2: a user with groups in OPFS but no folder (e.g. from before
+        the gate) sees the folder-push banner upgraded to a 'save your N groups'
+        rescue prompt. The migration itself is the normal pick → writeNow (the
+        current OPFS, groups included, is written to the chosen folder), covered
+        by test_choose_folder_writes_file_and_flips_badge_to_saved.
+
+        No re-navigation (would conflict with the warm worker over OPFS):
+        createGroup fires afterFolderMutation → refreshFolderPushBanner, so the
+        banner re-evaluates with the groups present.
+        """
+        rid = folder_page.evaluate(
+            "() => window.__dataProvider.getFull().then(f => f[0].record_id)"
+        )
+        folder_page.evaluate(
+            "(rid) => window.__dataProvider.createGroup({name:'Legacy g1', note:'', fellow_record_ids:[rid]})",
+            rid,
+        )
+        folder_page.evaluate(
+            "() => window.__dataProvider.createGroup({name:'Legacy g2', note:'', fellow_record_ids:[]})"
+        )
+        banner = folder_page.locator("#folder-push-banner")
+        expect(banner).to_be_visible(timeout=8000)
+        expect(banner).to_contain_text("2 saved groups")
+        expect(banner).to_contain_text("Save my groups")
+
+    def test_picking_folder_migrates_opfs_groups(self, folder_page, base_url_fixture):
+        """EPIC PR2: picking a folder writes the existing OPFS groups into it
+        (migration) — they survive and become durable, and the gate unlocks."""
+        # Navigate first (reuse the fixture's worker — no second nav after
+        # seeding, which would race the warm worker over OPFS), then seed.
+        _open_settings(folder_page, base_url_fixture)
+        rid = folder_page.evaluate(
+            "() => window.__dataProvider.getFull().then(f => f[0].record_id)"
+        )
+        folder_page.evaluate(
+            "(rid) => window.__dataProvider.createGroup({name:'M1', note:'', fellow_record_ids:[rid]})",
+            rid,
+        )
+        folder_page.evaluate(
+            "() => window.__dataProvider.createGroup({name:'M2', note:'', fellow_record_ids:[]})"
+        )
+        folder_page.locator("#settings-folder-choose").click()
+        expect(
+            folder_page.locator("#settings-folder-badge .settings-folder-badge-text")
+        ).to_contain_text("Saved to", timeout=10000)
+        # Groups survived + the gate unlocked.
+        count = folder_page.evaluate(
+            "() => window.__dataProvider.listGroups().then(g => g.length)"
+        )
+        assert count == 2, count
+        # And the folder file holds them (not just bytes — the actual groups).
+        scan = folder_page.evaluate(
+            """async () => {
+                const root = await navigator.storage.getDirectory();
+                const parent = await root.getDirectoryHandle('__e2e_user_folder__');
+                return await window.__folderController.scanCandidates(parent);
+            }"""
+        )
+        fellows = [c for c in scan["candidates"] if c["subfolderName"] == "Fellows"]
+        assert fellows and fellows[0]["groups"] == 2, scan
+
 
 class TestPhase2WriteLock:
     """Web Locks guard around folder writes per plans/user_folder_storage.md


### PR DESCRIPTION
**Stacked on #239** (retargets to `main` once #239 merges).

An existing user with groups in OPFS but no folder — from before the gate, or who never picked one — is in browse-only mode: their groups are hidden and sit in evictable browser storage. PR2 surfaces and rescues them.

## What
- **Detection:** the folder-push banner reads the dormant OPFS `relationships.db` group count (`countRelationships` — the §3 legacy-rescue peek). When > 0, it upgrades from the generic "set up a folder" nag to a **"Save your N saved groups to a folder"** rescue prompt ("…could be lost if it clears its data").
- **Migration:** picking a folder is the *existing* flow — `auto`/`create-new` writes the current OPFS (groups included) into the chosen folder via `writeNow`, and the gate flips to `private-folder`. So the groups become durable **and** visible again. Non-destructive (OPFS untouched until the folder write succeeds).

No new migration code — it's detection + prompt + the existing pick→writeNow. The cross-browser case (Safari/FF, can't pick a folder in-browser) is still the documented back-up→install-Chrome→restore path.

## Test status
Full `just test`: **646 passed, 6 skipped, 0 failed**. New: rescue banner shows "2 saved groups / Save my groups" once groups exist; picking a folder migrates them (folder store ends with 2 groups, gate unlocked). Both avoid re-navigation (which races the warm worker over OPFS).

🤖 Generated with [Claude Code](https://claude.com/claude-code)