### PR TITLE
test(security): Tier-1 boundary regression nets (CSP egress, bundle egress, stored-XSS, gate)

### DIFF
--- a/tests/e2e/test_browse_only_durability.py
+++ b/tests/e2e/test_browse_only_durability.py
@@ -1,26 +1,19 @@
-"""Security-adjacent invariants of the private-data capability gate.
+"""Security-adjacent invariant of the private-data capability gate.
 
 The gate is a DURABILITY control, not a confidentiality boundary
 (plans/private_data_capability_gate.md): off-folder the app is meant to be
-browse-only with NO durable private store. Two guards live here:
+browse-only with NO durable private store.
 
-1. test_gate_defaults_to_browse_only_without_folder (GREEN) — the gate must
-   never default to "private enabled" without a verified folder. A regression
-   that flipped it open would let the app create private data it cannot keep
-   (silent loss) and would expose a store the user didn't ask for.
+This file guards the gate's *default*: it must never resolve to "private
+enabled" without a verified folder. A regression that flipped it open would let
+the app create private data it cannot keep (silent loss) and expose a store the
+user didn't ask for.
 
-2. test_no_durable_private_write_when_browse_only (XFAIL, strict) — the
-   INTENDED invariant: a browse-only session must not durably persist private
-   data. This is NOT YET ENFORCED on main — EPIC PR1's gate is deliberately
-   INERT (see the gate block in app/static/app.js), so off-folder mutations
-   still land in OPFS. Enforcement (browse-only => localStorage-only / refuse
-   private writes) lands in C1 PR3 of plans/private_data_capability_gate.md.
-   When it does, this test XPASSes; strict xfail turns that into a failure so
-   we notice, drop the marker, and promote it to a hard guard.
+The companion invariant — "a browse-only mutation writes nothing durable" — is
+now ENFORCED at the data layer and pinned by the hard guards in
+tests/e2e/test_private_data_enforcement.py (this file previously held a
+strict-xfail placeholder for it, removed once enforcement landed).
 """
-import pytest
-
-from tests.e2e.conftest import make_worker_data
 
 
 def _boot_no_folder(page, base_url):
@@ -50,44 +43,3 @@ def test_gate_defaults_to_browse_only_without_folder(standalone_page, base_url_f
     assert state["tier"] == "browse-only-desktop", state
     assert state["enabled"] is False, "gate must not enable private data without a folder"
     assert state["noPrivateClass"] is True, "body must carry no-private-data when locked"
-
-
-@pytest.mark.xfail(
-    strict=True,
-    reason=(
-        "EPIC PR1 gate is INERT: off-folder still persists to OPFS. Enforcement "
-        "(browse-only => no durable private store) lands in C1 PR3 of "
-        "plans/private_data_capability_gate.md. An XPASS here means it landed — "
-        "remove this marker and promote to a hard guard."
-    ),
-)
-def test_no_durable_private_write_when_browse_only(standalone_page, base_url_fixture):
-    page = standalone_page
-    wd = make_worker_data(page, base_url_fixture)
-    if wd.provider_kind() != "worker":
-        pytest.skip("needs worker provider")
-    wd.wipe_relationships()
-    # Confirm we really are browse-only (no folder attached).
-    assert page.evaluate("() => window.__privateDataEnabled()") is False
-    # Attempt a private mutation; swallow a future 'refused' error so the test
-    # reflects the durability OUTCOME, not the throw shape.
-    page.evaluate(
-        """async () => {
-            try {
-                await window.__dataProvider.createGroup(
-                    { name: 'browse-only-should-not-persist', note: '', fellow_record_ids: [] }
-                );
-            } catch (e) { /* future: refused off-folder — fine */ }
-        }"""
-    )
-    # Reload: only a DURABLE store survives a fresh boot. Off-folder, nothing
-    # private should.
-    _boot_no_folder(page, base_url_fixture)
-    groups = wd.list_groups()
-    try:
-        assert groups == [], f"browse-only session durably persisted a group: {groups}"
-    finally:
-        try:
-            wd.wipe_relationships()
-        except Exception:
-            pass

--- a/tests/e2e/test_browse_only_durability.py
+++ b/tests/e2e/test_browse_only_durability.py
@@ -1,0 +1,93 @@
+"""Security-adjacent invariants of the private-data capability gate.
+
+The gate is a DURABILITY control, not a confidentiality boundary
+(plans/private_data_capability_gate.md): off-folder the app is meant to be
+browse-only with NO durable private store. Two guards live here:
+
+1. test_gate_defaults_to_browse_only_without_folder (GREEN) — the gate must
+   never default to "private enabled" without a verified folder. A regression
+   that flipped it open would let the app create private data it cannot keep
+   (silent loss) and would expose a store the user didn't ask for.
+
+2. test_no_durable_private_write_when_browse_only (XFAIL, strict) — the
+   INTENDED invariant: a browse-only session must not durably persist private
+   data. This is NOT YET ENFORCED on main — EPIC PR1's gate is deliberately
+   INERT (see the gate block in app/static/app.js), so off-folder mutations
+   still land in OPFS. Enforcement (browse-only => localStorage-only / refuse
+   private writes) lands in C1 PR3 of plans/private_data_capability_gate.md.
+   When it does, this test XPASSes; strict xfail turns that into a failure so
+   we notice, drop the marker, and promote it to a hard guard.
+"""
+import pytest
+
+from tests.e2e.conftest import make_worker_data
+
+
+def _boot_no_folder(page, base_url):
+    page.goto(base_url + "/", wait_until="domcontentloaded")
+    page.wait_for_function(
+        "() => window.__dataProvider && window.__dataProvider.kind === 'worker'",
+        timeout=15000,
+    )
+
+
+def test_gate_defaults_to_browse_only_without_folder(standalone_page, base_url_fixture):
+    page = standalone_page
+    _boot_no_folder(page, base_url_fixture)
+    # Let the gate resolve against the ready worker provider.
+    page.wait_for_function(
+        "() => window.__privateDataTier "
+        "&& window.__privateDataTier.indexOf('browse-only') === 0",
+        timeout=10000,
+    )
+    state = page.evaluate(
+        """() => ({
+            tier: window.__privateDataTier,
+            enabled: window.__privateDataEnabled ? window.__privateDataEnabled() : null,
+            noPrivateClass: document.body.classList.contains('no-private-data')
+        })"""
+    )
+    assert state["tier"] == "browse-only-desktop", state
+    assert state["enabled"] is False, "gate must not enable private data without a folder"
+    assert state["noPrivateClass"] is True, "body must carry no-private-data when locked"
+
+
+@pytest.mark.xfail(
+    strict=True,
+    reason=(
+        "EPIC PR1 gate is INERT: off-folder still persists to OPFS. Enforcement "
+        "(browse-only => no durable private store) lands in C1 PR3 of "
+        "plans/private_data_capability_gate.md. An XPASS here means it landed — "
+        "remove this marker and promote to a hard guard."
+    ),
+)
+def test_no_durable_private_write_when_browse_only(standalone_page, base_url_fixture):
+    page = standalone_page
+    wd = make_worker_data(page, base_url_fixture)
+    if wd.provider_kind() != "worker":
+        pytest.skip("needs worker provider")
+    wd.wipe_relationships()
+    # Confirm we really are browse-only (no folder attached).
+    assert page.evaluate("() => window.__privateDataEnabled()") is False
+    # Attempt a private mutation; swallow a future 'refused' error so the test
+    # reflects the durability OUTCOME, not the throw shape.
+    page.evaluate(
+        """async () => {
+            try {
+                await window.__dataProvider.createGroup(
+                    { name: 'browse-only-should-not-persist', note: '', fellow_record_ids: [] }
+                );
+            } catch (e) { /* future: refused off-folder — fine */ }
+        }"""
+    )
+    # Reload: only a DURABLE store survives a fresh boot. Off-folder, nothing
+    # private should.
+    _boot_no_folder(page, base_url_fixture)
+    groups = wd.list_groups()
+    try:
+        assert groups == [], f"browse-only session durably persisted a group: {groups}"
+    finally:
+        try:
+            wd.wipe_relationships()
+        except Exception:
+            pass

--- a/tests/e2e/test_stored_xss.py
+++ b/tests/e2e/test_stored_xss.py
@@ -1,0 +1,51 @@
+"""Stored-XSS regression: user-authored text rendered into innerHTML must be
+HTML-escaped, so a payload can never inject a live DOM node.
+
+escapeHtml() (app/static/app.js) is the sink defense; the CSP without
+'unsafe-inline' (tests/test_api.py) is the backstop. This test isolates the
+ESCAPING from the CSP backstop: it asserts that no payload element is injected
+into the DOM at all — true regardless of whether CSP would also have neutered
+an inline handler. Group name + note are the user-authored fields rendered via
+escapeHtml in renderGroupsList(); they're the realistic stored-XSS surface.
+
+Uses worker_data_folder (a verified folder attached) so the group surfaces are
+available now AND after the capability gate's PR3 hides them off-folder.
+"""
+
+# Distinct markers so we can prove the payload still RENDERED (as inert text)
+# while the active <img>/<svg> were never created.
+NAME_PAYLOAD = 'PWNZNAME<img src="x" onerror="window.__xssFired=true">'
+NOTE_PAYLOAD = 'PWNZNOTE<svg onload="window.__xssFired=true"></svg>'
+
+
+def test_group_name_and_note_are_escaped_on_index(worker_data_folder, base_url_fixture):
+    wd = worker_data_folder
+    wd.create_group(NAME_PAYLOAD, note=NOTE_PAYLOAD)
+
+    page = wd.page
+    page.goto(base_url_fixture + "/#/groups", wait_until="domcontentloaded")
+    page.locator("#groups-list-wrap .groups-name-link").first.wait_for(timeout=10000)
+
+    # Scope the assertions to the payload's OWN signatures (its handler
+    # attributes + the img[src=x]), not "any svg/img" — the mobile card list
+    # legitimately renders a decorative kebab <svg>. An injected node would
+    # carry onerror/onload; an escaped one is inert text with no such element.
+    res = page.evaluate(
+        """() => {
+            const wrap = document.getElementById('groups-list-wrap');
+            return {
+                fired: window.__xssFired === true,
+                payloadImg: wrap ? wrap.querySelectorAll('img[src="x"]').length : -1,
+                onerrorEls: wrap ? wrap.querySelectorAll('[onerror]').length : -1,
+                onloadEls: wrap ? wrap.querySelectorAll('[onload]').length : -1,
+                text: wrap ? wrap.innerText : ''
+            };
+        }"""
+    )
+    assert res["fired"] is False, "XSS payload executed — escaping failed"
+    assert res["payloadImg"] == 0, "payload injected a live <img> node — name not escaped"
+    assert res["onerrorEls"] == 0, "an element carries an onerror handler — name not escaped"
+    assert res["onloadEls"] == 0, "an element carries an onload handler — note not escaped"
+    # The payload still rendered — just as inert, escaped text.
+    assert "PWNZNAME" in res["text"], res["text"]
+    assert "PWNZNOTE" in res["text"], res["text"]

--- a/tests/test_api.py
+++ b/tests/test_api.py
@@ -21,6 +21,49 @@ sys.path.insert(0, REPO_ROOT)
 from app.server import PORT
 
 
+# --- CSP / Permissions-Policy parsing (for the egress-wall assertions) ------
+# The CSP `connect-src 'self'` is the wall between an XSS and full OPFS
+# exfiltration (see app/server.py:Handler.end_headers). The private-data
+# capability gate is a DURABILITY control, not a confidentiality boundary
+# (plans/private_data_capability_gate.md), so on-device confidentiality
+# actually lives here — pin it exactly so any widening is a deliberate,
+# reviewed change rather than an accident.
+_EXPECTED_CSP_DIRECTIVES = {
+    "default-src": ["'self'"],
+    "script-src": ["'self'", "'wasm-unsafe-eval'"],
+    "worker-src": ["'self'"],
+    "connect-src": ["'self'"],
+    "img-src": ["'self'", "data:"],
+    "style-src": ["'self'"],
+    "font-src": ["'self'"],
+    "object-src": ["'none'"],
+    "base-uri": ["'self'"],
+    "frame-ancestors": ["'none'"],
+}
+
+
+def _parse_csp(csp):
+    """Parse a CSP header into {directive: [values...]} (order-tolerant)."""
+    out = {}
+    for part in csp.split(";"):
+        toks = part.split()
+        if toks:
+            out[toks[0]] = toks[1:]
+    return out
+
+
+def _parse_permissions_policy(pp):
+    """Return the set of features locked to `()` in a Permissions-Policy."""
+    locked = set()
+    for part in pp.split(","):
+        part = part.strip()
+        if "=" in part:
+            feat, val = part.split("=", 1)
+            if val.strip() == "()":
+                locked.add(feat.strip())
+    return locked
+
+
 def get(path, query=None):
     path_with_query = path
     if query:
@@ -78,6 +121,57 @@ class TestSecurityHeaders:
         assert h.get("cross-origin-resource-policy") == "same-origin"
         assert h.get("x-content-type-options") == "nosniff"
         assert h.get("referrer-policy") == "strict-origin-when-cross-origin"
+
+    def test_csp_directives_exact_and_egress_locked(self):
+        """Pin the full CSP and assert the egress wall specifically.
+
+        The exact-directive pin fails loudly on ANY drift (added/renamed/
+        widened directive). The sharpened assertions below restate the
+        load-bearing properties independently, so they survive a benign
+        reorder but still catch the dangerous changes: an external
+        connect-src target (exfil path) or an 'unsafe-inline' /
+        'unsafe-eval' relaxation (XSS execution path).
+        """
+        _, h = get_headers("/")
+        parsed = _parse_csp(h.get("content-security-policy", ""))
+        assert parsed == _EXPECTED_CSP_DIRECTIVES, (
+            "CSP drifted from the pinned policy — this is the OPFS-exfil "
+            "wall. If you widened it on purpose, update "
+            "_EXPECTED_CSP_DIRECTIVES and justify it in review.\n"
+            f"expected={_EXPECTED_CSP_DIRECTIVES}\nactual={parsed}"
+        )
+        # Egress: nothing but same-origin may be a connect target.
+        assert parsed.get("connect-src") == ["'self'"], (
+            "connect-src must be exactly 'self' — any external target is an "
+            "XSS exfiltration path for the OPFS-resident DBs"
+        )
+        # Execution: no inline/eval script (only the wasm carve-out).
+        script_src = parsed.get("script-src", [])
+        assert "'unsafe-inline'" not in script_src, "script-src must not allow 'unsafe-inline'"
+        assert "'unsafe-eval'" not in script_src, (
+            "script-src must not allow 'unsafe-eval' (only 'wasm-unsafe-eval')"
+        )
+        # No external/wildcard origin anywhere in the policy.
+        for name, vals in parsed.items():
+            for v in vals:
+                assert not v.startswith(
+                    ("http://", "https://", "ws://", "wss://", "//", "*")
+                ), f"external/wildcard origin {v!r} in directive {name!r}"
+
+    def test_permissions_policy_locks_sensitive_features(self):
+        """Powerful device APIs the app never uses must be disabled, so an
+        XSS that lands has less leverage. Set in app/server.py and mirrored
+        in deploy/server.py."""
+        _, h = get_headers("/")
+        pp = h.get("permissions-policy", "")
+        assert pp, "Permissions-Policy header is missing"
+        locked = _parse_permissions_policy(pp)
+        for feat in (
+            "geolocation", "camera", "microphone", "payment", "usb",
+            "bluetooth", "serial", "midi", "accelerometer", "gyroscope",
+            "magnetometer",
+        ):
+            assert feat in locked, f"{feat!r} must be locked to () in Permissions-Policy"
 
 
 @pytest.mark.usefixtures("app_server")

--- a/tests/test_bundle_egress.py
+++ b/tests/test_bundle_egress.py
@@ -1,0 +1,84 @@
+"""Static egress canary: first-party JS must not reach any external origin.
+
+The runtime backstop is the CSP `connect-src 'self'` (asserted in
+tests/test_api.py::TestSecurityHeaders), which blocks exfiltration at the
+browser. This file is defense-in-depth at the *source*: a deterministic,
+dependency-free scan that fires the moment someone adds a fetch/importScripts
+to an absolute external URL, or introduces a new network primitive
+(WebSocket/EventSource/sendBeacon/XHR) the egress story hasn't accounted for.
+
+Why this matters here specifically: the private-data capability gate is a
+DURABILITY control, not a confidentiality boundary
+(plans/private_data_capability_gate.md) — a DevTools session by the data's
+owner reaching their own data is in-design, not a breach. The real on-device
+confidentiality boundary is the egress wall (CSP + no external network calls),
+so it earns a regression net at two layers.
+"""
+import os
+import re
+
+REPO_ROOT = os.path.dirname(os.path.dirname(os.path.abspath(__file__)))
+
+# First-party scripts only. Third-party vendored files (sqlite3.js, jspdf) are
+# covered by SRI + the signed bundle (tests/test_build_pwa.py, test_sign_bundle.py);
+# scanning their minified bodies here would only add false positives.
+FIRST_PARTY_JS = [
+    "app/static/app.js",
+    "app/static/sw.js",
+    "app/static/vendor/sqlite-worker.js",
+]
+
+# fetch(...) / importScripts(...) with a STRING-LITERAL target. The negative
+# lookbehind excludes `prefetch(` (and any identifier-suffixed name) while
+# still matching bare `fetch(` and `window.fetch(`. Calls with a variable
+# target (e.g. fetch(url, opts)) aren't matched — those are fed same-origin
+# paths internally and the CSP is their runtime backstop.
+_CALL_LITERAL = re.compile(r"(?<![A-Za-z])(?:fetch|importScripts)\(\s*(['\"`])([^'\"`]+)\1")
+
+# Anything that looks like a URI scheme (http:, https:, ws:, wss:, data:, ...).
+_SCHEME = re.compile(r"^[a-z][a-z0-9+.\-]*:")
+
+# Network primitives the app deliberately does not use today. If one appears,
+# the egress audit must be revisited on purpose — route it same-origin and
+# update this list with a rationale.
+_FORBIDDEN_PRIMITIVES = (
+    "new WebSocket(",
+    "new EventSource(",
+    "navigator.sendBeacon(",
+    "new XMLHttpRequest(",
+)
+
+
+def _read(rel):
+    with open(os.path.join(REPO_ROOT, rel), encoding="utf-8") as f:
+        return f.read()
+
+
+def test_fetch_and_import_targets_are_same_origin():
+    offenders = []
+    for rel in FIRST_PARTY_JS:
+        for m in _CALL_LITERAL.finditer(_read(rel)):
+            target = m.group(2)
+            # Same-origin = root-relative ("/x") or relative ("./x", "../x").
+            # Reject any scheme (http:/https:/ws:/data:) or protocol-relative
+            # "//host".
+            if target.startswith("//") or _SCHEME.match(target):
+                offenders.append((rel, target))
+    assert not offenders, (
+        "fetch()/importScripts() targets an external origin — this breaches "
+        f"the connect-src 'self' egress wall. Offenders: {offenders}"
+    )
+
+
+def test_no_unaccounted_network_primitives():
+    offenders = []
+    for rel in FIRST_PARTY_JS:
+        src = _read(rel)
+        for prim in _FORBIDDEN_PRIMITIVES:
+            if prim in src:
+                offenders.append((rel, prim))
+    assert not offenders, (
+        "A network primitive outside the egress audit appeared. If intentional, "
+        "keep it same-origin and update _FORBIDDEN_PRIMITIVES with rationale. "
+        f"Offenders: {offenders}"
+    )


### PR DESCRIPTION
Tier-1 of the security-invariant test work. The private-data capability gate is a *durability* control, not a confidentiality boundary, so the real on-device confidentiality wall is CSP egress + bundle hygiene + injection-sink encoding. This PR pins those:

- **`tests/test_api.py`** — exact CSP directive pin + egress assertions (`connect-src 'self'`, no `unsafe-inline`/`unsafe-eval`, no external/wildcard origin) + Permissions-Policy lock.
- **`tests/test_bundle_egress.py`** (new) — source scan: first-party `fetch()`/`importScripts()` targets must be same-origin; no unaccounted network primitives.
- **`tests/e2e/test_stored_xss.py`** (new) — group name/note payloads render as inert text (no injected handler element).
- **`tests/e2e/test_browse_only_durability.py`** (new) — the gate must not default to "private enabled" without a folder.

Second commit drops a superseded strict-xfail placeholder (the durable-write invariant is now a hard guard in the private-data-enforcement PR).

## QA
Pure tests; `just test-fast` + the e2e files are green. No product code changed.

🤖 Generated with [Claude Code](https://claude.com/claude-code)