### PR TITLE
Add `just shell` — venv-activated sub-shell

### DIFF
--- a/justfile
+++ b/justfile
@@ -47,6 +47,25 @@ setup:
     fi
     echo "Setup complete."
 
+# Drop into a sub-shell with the venv activated (pytest/playwright/python on PATH).
+# A `just` recipe runs in a child process, so it cannot activate your *current*
+# shell — instead this `exec`s a new interactive shell with the venv active.
+# Type `exit` (or Ctrl-D) to return. Runs `just setup` only when .venv is
+# missing, so repeat invocations are instant; run `just setup` yourself to
+# refresh deps. The prompt may not show a `(.venv)` prefix, but
+# `which python` will point inside {{venv}}.
+[group('setup')]
+shell:
+    #!/usr/bin/env bash
+    set -euo pipefail
+    if [ ! -d {{venv}} ]; then
+        echo "No {{venv}} yet — running setup first…"
+        just setup
+    fi
+    source {{venv}}/bin/activate
+    echo "venv active: $(command -v python). Type 'exit' to leave."
+    exec "${SHELL:-/bin/sh}"
+
 # Sanity-check the dev environment.
 [group('setup')]
 doctor:


### PR DESCRIPTION
## What

`just shell` drops you into a sub-shell with `.venv` activated, so `pytest` / `playwright` / `python` are on PATH for running things **directly** (not only via `just`). `exit` or Ctrl-D returns to your normal shell.

A `just` recipe runs in a child process, so it **can't** activate your *current* shell (same reason a `cd` in a script doesn't move you). This `exec`s a new interactive shell with the venv active — the only way a command can leave you "in" the venv.

## Behavior

- Runs `just setup` **only when `.venv` is missing**, so repeat invocations are instant (no re-running pip/playwright/ansible). Run `just setup` yourself to refresh deps.
- Prints `venv active: …/.venv/bin/python` on entry so you can confirm.
- Caveat: the prompt may not show a `(.venv)` prefix (a fresh shell resets `PS1`), but `which python` points inside `.venv`.

## Manual QA

```sh
just shell
which python   # -> …/.venv/bin/python
which pytest   # -> …/.venv/bin/pytest
exit
```

Verified the venv env propagates through the `exec` (VIRTUAL_ENV set, pytest/python resolve inside `.venv`).

🤖 Generated with [Claude Code](https://claude.com/claude-code)