### PR TITLE
docs: record EAR decision — reject for live store, encrypt in-transit (#256)

### DIFF
--- a/docs/Architecture.md
+++ b/docs/Architecture.md
@@ -130,6 +130,20 @@ version beats them and documents *how*. We claim only what we have done
 ceiling we merely reduced — over-reach (false durability) would itself be
 a silent conformance failure, which this gate exists to prevent.
 
+**Non-goal — encryption-at-rest for the live private store.** App-layer
+EAR of `relationships.db` is **intentionally not done** (decision
+2026-06-07; see [`./ac_decisions_log.md`](./ac_decisions_log.md) +
+[`./architectural_findings.md`](./architectural_findings.md),
+[#256](https://github.com/richbodo/fellows_local_db/issues/256)). It is
+*dominated* by device full-disk encryption and *contradicts*
+`CST-PWA-SANDBOX-SEALED` — a `.locked` file is unreadable by the
+MCP/CLI/backup tools folder mode exists to feed, so "encrypted" and
+"tool-readable" are mutually exclusive. Encryption's sanctioned home is
+**in-transit**: the encrypted portable export
+([#257](https://github.com/richbodo/fellows_local_db/issues/257)), where
+the live store stays tool-readable. Device FDE is the recommended at-rest
+layer.
+
 ---
 
 ## HTTP API

--- a/docs/ac_decisions_log.md
+++ b/docs/ac_decisions_log.md
@@ -18,6 +18,41 @@ link to the newer entry. Newest first.
 
 ---
 
+## 2026-06-07 — Encryption-at-rest is rejected for the live private store; encryption belongs in-transit (the portable export)
+
+**Why this is worth recording.** A "Lock my user data" branch (PR #155)
+built opt-in app-layer encryption-at-rest (EAR) for `relationships.db`
+(PBKDF2/AES-GCM, non-extractable worker-memory key) and reached phases 1–3
+before stalling. A future contributor seeing a security-review line item
+"encrypt user data at rest" — or the harvested crypto in the closed PR —
+would reasonably resume it. We are deciding **not to**: app-EAR for the
+*live* store is rejected. Full analysis in
+[`architectural_findings.md`](architectural_findings.md) (2026-06-07);
+discussion in [#256](https://github.com/richbodo/fellows_local_db/issues/256).
+
+**The constraint that shaped the decision.** App-EAR for the live store is
+both *dominated* and *contradictory*:
+
+- **Dominated by device FDE.** Its entire defended-threat-set (stolen/
+  discarded device, offline drive image) is a strict subset of what
+  FileVault/BitLocker/LUKS already cover, in hardware, for the whole
+  device — while it *adds* a forgotten-passphrase → permanent-data-loss
+  risk.
+- **Contradicts `CST-PWA-SANDBOX-SEALED`.** Folder mode exists so
+  `relationships.db` is *a real file the user's other tools read* (MCP
+  `private_data_ops`, sqlite3 CLI, backups). A `.locked` ciphertext is
+  opaque to them, so "locked" and "tool-readable folder mode" are mutually
+  exclusive. EAR re-seals exactly the boundary the PNA model opens.
+
+**What we do instead.** Recommend device FDE (the stronger, OS-managed
+at-rest layer). Encryption's right home in a PNA is **in-transit**: an
+encrypted, versioned *portable export* crossing an untrusted commodity
+channel (email, etc.), where the live store stays plaintext/tool-readable
+and the passphrase cost lands on an occasional, deliberate "move my data"
+action. That is the sanctioned direction
+([#257](https://github.com/richbodo/fellows_local_db/issues/257)); the
+harvested crypto envelope from PR #155 (`eb66109`) is the reusable part.
+
 ## 2026-05-30 — Cloud-LLM integration is allowed but treated as a named, reversible "exception" that exits PNA mode, not forbidden and not silent
 
 **Why this is worth recording.** The PNA definition is "local-only,

--- a/docs/architectural_findings.md
+++ b/docs/architectural_findings.md
@@ -11,6 +11,67 @@ Newest first.
 
 ---
 
+## 2026-06-07 — Encryption-at-rest is mis-fit for a PNA's live store; encryption belongs in-transit
+
+### The finding
+
+A "Lock my user data" effort (PR #155, phases 1–3 built — PBKDF2/AES-GCM,
+non-extractable worker-memory key) implemented opt-in app-layer
+encryption-at-rest (EAR) for the private store. Working it through surfaced
+that the stall was never code — it was an unmade architectural question —
+and that the answer generalizes beyond this app:
+
+> **For a PNA, encryption-at-rest of the *live* private store is the wrong
+> layer. Encryption's value is in-transit — sealing the portable copy that
+> crosses an untrusted channel — not at-rest on the user's own device.**
+
+### Why EAR is mis-fit for the live store
+
+1. **Dominated by device FDE.** The branch's own threat model defends
+   exactly one thing — a stolen/discarded device read offline — a strict
+   subset of what FileVault/BitLocker/LUKS already cover, in hardware, for
+   the whole device. App-EAR adds nothing to that threat and *adds* a
+   forgotten-passphrase → permanent-data-loss failure mode.
+2. **It contradicts the PNA openness promise** — the PNA-specific point the
+   original plan never reconciled. A PNA's private store is meant to be *a
+   real file the user's other tools read* (`CST-PWA-SANDBOX-SEALED` — MCP,
+   CLIs, backups). An encrypted-at-rest file is opaque to that ecosystem,
+   so "encrypted" and "tool-readable" are mutually exclusive. EAR re-seals
+   exactly the boundary the PNA model opens; a store your own tools can't
+   read is only half a PNA.
+3. **A browser PWA has nowhere honest to hold the key** for the live store:
+   a per-session passphrase kills the convenience that justifies a local
+   tool, a stored key is theater. (The branch chose the honest option —
+   passphrase-gated, key in worker memory — at the cost of manual-lock-only
+   UX and no recovery.)
+
+### Where encryption *does* belong: in-transit
+
+The same crypto, pointed at the portable **export/backup that leaves the
+device**, inverts every objection: the live store stays
+plaintext/tool-readable (no openness conflict), and the passphrase cost
+lands on an occasional, deliberate "move my data to my other device"
+action (no per-session friction). The untrusted commodity channel (email,
+a shared drive) is a genuine at-rest-on-someone-else's-disk exposure that
+device FDE does *not* cover — so the encryption does real work. This is the
+sanctioned direction (#257), and it reframes `CST-PWA-NO-SYNC`'s
+"encrypt-then-email-to-self" frontier from a vague candidate into a scoped
+feature.
+
+### What this feeds back into the toolkit
+
+A reusable PNA principle: **encrypt the artifact that crosses a trust
+boundary, not the store that sits behind your own OS.** EAR-at-rest for a
+local-first private store is dominated by the platform (FDE) and in tension
+with the spec's tool-readability goal; EAR-in-transit is the conformant
+placement. Candidate guidance alongside the constraints/exceptions work.
+Decision recorded in [`ac_decisions_log.md`](ac_decisions_log.md)
+(2026-06-07); discussion in
+[#256](https://github.com/richbodo/fellows_local_db/issues/256), feature
+space in [#257](https://github.com/richbodo/fellows_local_db/issues/257).
+
+---
+
 ## 2026-06-07 — The workspace is the user's actuation surface; test the gate, not the human
 
 ### The finding


### PR DESCRIPTION
Records the encryption-at-rest decision from #256 (no code change).

**Decision:** app-layer EAR for the **live** private store is **rejected**; the sanctioned direction is encryption **in-transit** (the encrypted portable export, #257). Recommend device FDE for at-rest.

**Why** (both points stronger than "the OS already does it"):
- **Dominated by device FDE** — the lock-my-data branch's own threat model defends only "stolen/discarded device, offline read," a strict subset of what FileVault/BitLocker/LUKS cover in hardware; app-EAR adds nothing there and adds a forgotten-passphrase → data-loss risk.
- **Contradicts `CST-PWA-SANDBOX-SEALED`** — folder mode exists so `relationships.db` is a real file MCP/CLIs/backups read; a `.locked` ciphertext is opaque to them, so "encrypted" and "tool-readable" are mutually exclusive. EAR re-seals the boundary the PNA model opens.

**Recorded on three surfaces** (per the #256 decision):
- `docs/ac_decisions_log.md` — the decision entry.
- `docs/Architecture.md` — a "non-goal" note in the constraint attestation.
- `docs/architectural_findings.md` — the PNT-facing finding ("encrypt the artifact that crosses a trust boundary, not the store behind your own OS").

Deliberately **not** touching SECURITY.md / adding user-facing FDE copy (per the decision). Conformance unchanged (28/0/0; report rows untouched — prose-only).

Closes the decision half of #256; the feature half lives in #257.
