### PR TITLE
fix(gate): refuse durable private writes off-folder at the data layer (#252)

### DIFF
--- a/app/static/app.js
+++ b/app/static/app.js
@@ -4120,14 +4120,16 @@
         return rpc.call('countRelationships');
       },
       importRelationshipsBytes: function (bytes) {
-        return refuseIfVersionSkew('importRelationshipsBytes') ||
+        return refuseIfBrowseOnly('importRelationshipsBytes') ||
+          refuseIfVersionSkew('importRelationshipsBytes') ||
           rpc.call('importRelationshipsBytes', { bytes: bytes });
       },
       listRelationshipsBackups: function () {
         return rpc.call('listRelationshipsBackups');
       },
       restoreRelationshipsBackup: function (name) {
-        return refuseIfVersionSkew('restoreRelationshipsBackup') ||
+        return refuseIfBrowseOnly('restoreRelationshipsBackup') ||
+          refuseIfVersionSkew('restoreRelationshipsBackup') ||
           rpc.call('restoreRelationshipsBackup', { name: name });
       },
       // Reset Everything — closes both DBs, tears down SAH-pool VFS,

--- a/app/static/vendor/sqlite-worker.js
+++ b/app/static/vendor/sqlite-worker.js
@@ -946,7 +946,32 @@ handlers.getGroup = async function (args) {
   return row;
 };
 
+// ---- Load-bearing durable-private-write guard (#252) -----------------------
+// A mutating relationships.db RPC may durably persist only when a verified
+// folder backs the store (folder mode = the store is canonical). Off-folder
+// (browse-only) there is NO durable private store, so these RPCs are refused
+// HERE, at the worker — the OPFS owner — not merely at the page
+// (refuseIfBrowseOnly is defense-in-depth, bypassable from the DevTools
+// console). Dynamic check (matches _maybeWriteFolderAfterCommit) so a
+// mid-session folder attach is honored; the page's privateDataEnabled()
+// resolves to the same condition. Error shape mirrors the page's
+// BrowseOnlyError — `name` survives the worker→page envelope (errorName) and
+// `code` rides errorCode; the boolean flag does not cross, so callers key on
+// those.
+async function _refuseDurablePrivateWriteOffFolder(op) {
+  var granted = false;
+  if (folderRecord.parentHandle) {
+    try { granted = (await _folderQueryPermission()) === 'granted'; } catch (e) {}
+  }
+  if (granted) return;
+  var err = new Error(op + ' refused: browse-only mode — no durable private store off-folder (connect a data folder)');
+  err.name = 'BrowseOnlyError';
+  err.code = 'BROWSE_ONLY';
+  throw err;
+}
+
 handlers.createGroup = async function (data) {
+  await _refuseDurablePrivateWriteOffFolder('createGroup');
   if (!relDb) throw new Error('relationships db not open');
   var name = data && data.name;
   var note = (data && typeof data.note === 'string') ? data.note : '';
@@ -976,6 +1001,7 @@ handlers.createGroup = async function (data) {
 };
 
 handlers.updateGroup = async function (args) {
+  await _refuseDurablePrivateWriteOffFolder('updateGroup');
   if (!relDb) throw new Error('relationships db not open');
   var id = args && args.id;
   var patch = (args && args.patch) || {};
@@ -1006,6 +1032,7 @@ handlers.updateGroup = async function (args) {
 };
 
 handlers.deleteGroup = async function (args) {
+  await _refuseDurablePrivateWriteOffFolder('deleteGroup');
   if (!relDb) throw new Error('relationships db not open');
   var id = args && args.id;
   var existing = dbSelectOne(relDb, 'SELECT 1 AS x FROM groups WHERE id = ?', [id]);
@@ -1030,6 +1057,7 @@ handlers.getSettings = async function () {
 };
 
 handlers.setSetting = async function (args) {
+  await _refuseDurablePrivateWriteOffFolder('setSetting');
   if (!relDb) throw new Error('relationships db not open');
   var key = args && args.key;
   var value = args && args.value;
@@ -1069,6 +1097,9 @@ handlers.countRelationships = async function () {
 };
 
 handlers.importRelationshipsBytes = async function (args) {
+  // Guard FIRST — before inspect/snapshot — so an off-folder call writes
+  // nothing (not even a pre-restore backup) into evictable OPFS (#252).
+  await _refuseDurablePrivateWriteOffFolder('importRelationshipsBytes');
   if (!poolUtil) throw new Error('pool util unavailable');
   var bytes = args && args.bytes;
   var inspection = await inspectBytes(bytes);

--- a/tests/e2e/test_private_data_enforcement.py
+++ b/tests/e2e/test_private_data_enforcement.py
@@ -101,6 +101,51 @@ def test_browse_only_refuses_create_group(standalone_page, base_url_fixture):
     assert r.get("browseOnly") is True, r
 
 
+def test_browse_only_refuses_import_relationships_bytes(standalone_page, base_url_fixture):
+    """#252 no-bypass audit. importRelationshipsBytes (the restore path, and the
+    future email-import path) must NOT durably write private data off-folder.
+    Unlike createGroup/setSetting it carries no page-side refuseIfBrowseOnly and
+    the worker handler has no folder guard — so a console/restore call could land
+    a durable private store in the OPFS slot in browse-only mode, bypassing the
+    gate (CLAUDE.md: "a gated capability whose RPC still succeeds from the
+    DevTools console is not reduced"). Export is a read (fine); the import must be
+    refused."""
+    page = standalone_page
+    _boot_browse_only(page, base_url_fixture)
+    r = _attempt(
+        page,
+        "() => window.__dataProvider.exportRelationshipsBytes()"
+        ".then(function (b) { return window.__dataProvider.importRelationshipsBytes(b); })",
+    )
+    assert r.get("threw") is True, f"import must be refused browse-only, got: {r}"
+    assert r.get("browseOnly") is True, r
+
+
+def test_worker_is_load_bearing_off_folder_via_raw_rpc(standalone_page, base_url_fixture):
+    """#252 'full data-layer hardening': the WORKER itself — not just the page —
+    refuses durable private writes off-folder. Calls the raw worker RPC
+    (`window.__dataProvider._rpc`) directly, bypassing the page-side
+    refuseIfBrowseOnly, and asserts every mutating relationships.db op is refused
+    at the OPFS owner with a BrowseOnlyError. This is the load-bearing half: a
+    DevTools-console call can't write durable private data in browse-only mode
+    (CLAUDE.md — capability reductions enforce at the data layer, never UI-only)."""
+    page = standalone_page
+    _boot_browse_only(page, base_url_fixture)
+    ops = [
+        ("createGroup", "{name:'x', note:'', fellow_record_ids:[]}"),
+        ("updateGroup", "{id:1, patch:{name:'y'}}"),
+        ("deleteGroup", "{id:1}"),
+        ("setSetting", "{key:'self_email', value:'me@example.com'}"),
+        ("importRelationshipsBytes", "{bytes:new Uint8Array(0)}"),
+    ]
+    for op, args in ops:
+        r = _attempt(page, f"() => window.__dataProvider._rpc.call('{op}', {args})")
+        assert r.get("threw") is True, (op, r)
+        # name survives the worker→page error envelope (errorName); the
+        # browseOnly boolean does not, so key on name (set by the worker guard).
+        assert r.get("name") == "BrowseOnlyError", (op, r)
+
+
 def test_browse_only_refuses_set_setting(standalone_page, base_url_fixture):
     page = standalone_page
     _boot_browse_only(page, base_url_fixture)

--- a/tests/e2e/test_user_folder_storage.py
+++ b/tests/e2e/test_user_folder_storage.py
@@ -722,26 +722,38 @@ class TestPhase2Pivot:
     # visible whenever local persistence is available, so the
     # hide-on-folder-active behavior no longer applies.
 
-    def test_opfs_only_mode_keeps_backups_in_opfs(
+    def test_no_folder_writes_nothing_durable_not_even_opfs_backups(
         self, folder_page, base_url_fixture
     ):
-        """Regression check: a user who has NOT picked a folder still
-        gets OPFS-resident backups. Migration only kicks in when
-        folder mode is active.
+        """Capability gate (#244/#252): with NO folder picked, the app keeps no
+        durable private store — not even an OPFS backup ring.
+
+        This replaces the former test_opfs_only_mode_keeps_backups_in_opfs, which
+        asserted that an off-folder user still gets OPFS-resident backups. That
+        was the pre-gate leak written down as a feature: the import path seeded
+        durable private data into evictable OPFS off-folder, contradicting
+        CST-PWA-PRIVATE-SNAPSHOT ("off-folder there is no private store"). The
+        durable-write guard (#252) now refuses that import at the worker, so the
+        gate-consistent truth is: nothing durable lands off-folder.
         """
         _open_settings(folder_page, base_url_fixture)
-        # Don't pick a folder. Trigger a snapshot via the same
-        # export/import round-trip used in the folder-mode test.
-        folder_page.evaluate("""
+        # No folder picked → off-folder. The export/import round-trip that used
+        # to seed an OPFS backup is now refused (export is a read and succeeds;
+        # the import is the durable write and is refused at page + worker).
+        r = folder_page.evaluate("""
           async () => {
             var dp = window.__dataProvider;
-            var bytes = await dp.exportRelationshipsBytes();
-            await dp.importRelationshipsBytes(bytes);
+            try {
+              var bytes = await dp.exportRelationshipsBytes();
+              await dp.importRelationshipsBytes(bytes);
+              return { refused: false };
+            } catch (e) { return { refused: true, name: e.name }; }
           }
         """)
+        assert r["refused"] is True, f"off-folder import must be refused; got {r}"
         opfs_backups = folder_page.evaluate("() => window.__listE2EOpfsBackups()")
-        assert opfs_backups, (
-            f"OPFS-only mode should write snapshots to OPFS; OPFS backups={opfs_backups!r}"
+        assert opfs_backups == [], (
+            f"off-folder = no durable private store → no OPFS backups; got {opfs_backups!r}"
         )
         # No folder was picked, so the stub folder shouldn't exist at all.
         probe = folder_page.evaluate("() => window.__probeE2EUserFolder()")

--- a/tests/e2e/test_versioned_fellows_db.py
+++ b/tests/e2e/test_versioned_fellows_db.py
@@ -294,10 +294,16 @@ def test_failed_refresh_preserves_previous_db_and_records_failure(
 
 
 def test_relationships_restore_does_not_refetch_fellows_db(
-    standalone_page, base_url_fixture
+    folder_attached_page, base_url_fixture
 ):
     """Restoring a relationships.db backup must not desync fellows.db
     freshness — invariant L8 in the local-first worker plan.
+
+    Boots with a verified folder attached (``folder_attached_page``): under the
+    capability gate, createGroup + importRelationshipsBytes are durable-write
+    ops, refused off-folder at both the page and the worker (#244/#252), so the
+    restore round-trip this test needs requires a folder. fellows.db freshness
+    (the thing under test) is independent of the relationships folder.
 
     The whole reason `fellows.db.meta.json` lives at the OPFS root
     (sibling of the SAH-pool dir, not inside relationships.settings) is
@@ -306,7 +312,7 @@ def test_relationships_restore_does_not_refetch_fellows_db(
     a real importRelationshipsBytes round-trip, a reload must produce
     zero GET /fellows.db requests because meta.sha still matches.
     """
-    page = standalone_page
+    page = folder_attached_page
 
     # Cold-start boot to populate fellows.db + record its sha in meta.
     page.goto(base_url_fixture + "/", wait_until="domcontentloaded")


### PR DESCRIPTION
Closes a real private-data leak found **test-first** while building the #252 workspace user-mediation invariant ("the proposer stages; the human disposes; no path mutates the store except through the gate").

## The bug

The capability gate's promise — *off-folder there is no durable private store* — was enforced **page-side only** and leaked. `importRelationshipsBytes` (the *Restore from a file* path, and the future email-import path #257) had **neither** a page-side `refuseIfBrowseOnly` **nor** a worker-side folder guard. So in browse-only mode a *Restore* click — or a DevTools-console call — durably wrote a private store (plus a pre-restore backup) into evictable OPFS. That violates `CST-PWA-PRIVATE-SNAPSHOT` / `CST-PWA-STORAGE-EVICTABLE` and CLAUDE.md ("a gated capability whose RPC still succeeds from the DevTools console is not reduced").

The no-bypass test made it red:
```
import must be refused browse-only, got:
{'ok': True, 'value': {'counts': {...}, 'preRestoreSnapshot': 'relationships.db.bak.…'}}
```

## The fix (data-layer, load-bearing)

- **Worker:** `_refuseDurablePrivateWriteOffFolder()` guards `createGroup` / `updateGroup` / `deleteGroup` / `setSetting` / `importRelationshipsBytes`, using the dynamic folder-permission check (matches `_maybeWriteFolderAfterCommit`; honors mid-session attach). The OPFS owner refuses now — not just the page.
- **Page (defense-in-depth):** `refuseIfBrowseOnly` added to `importRelationshipsBytes` + `restoreRelationshipsBackup`.
- `applyFellowsDbSwap` deliberately **not** guarded — it swaps shared `fellows.db` (directory data), legitimately allowed off-folder.

## Tests

- **new** `test_browse_only_refuses_import_relationships_bytes` (page) and `test_worker_is_load_bearing_off_folder_via_raw_rpc` (calls the raw worker `_rpc`, bypassing the page guard — proves the worker itself refuses).
- **flipped** `test_opfs_only_mode_keeps_backups_in_opfs` → `test_no_folder_writes_nothing_durable_not_even_opfs_backups`. The old test asserted the *leak* (durable OPFS backups off-folder) as a feature; it now asserts the gate-consistent truth.
- **fixed** `test_relationships_restore_does_not_refetch_fellows_db` — boots folder-attached (restore needs a durable store to land in). This was a pre-existing red on `main` (#244 fallout), not a regression here.

**Green:** 61 passed across enforcement / worker-rpc / versioned / user-folder-storage / settings / folder-probe / browse-only-durability / local-first-boot.

## Verified product impact

Almost none. Off-folder users were already browse-only (`createGroup` already refused). The one real change: a Safari/Firefox/no-folder user who used *Restore from a file* could previously load a backup into OPFS; that's now refused — the gate finally doing what it always promised.

## Deferred (tracked, picked up next)

- **#259** — decide what off-folder users should get (nothing / ephemeral viewer / …) + tidy the now-visible-but-refusing Restore button.
- **#260** — pre-existing off-folder-write red tests (directory-update ×2, orphan-scan) + move the orphan-scan marker to localStorage off-folder + cite these new guards in the attestation.
- **#252** — the upstream (PNT) lesson this demonstrates: capability reductions must enforce at the *data layer*, and you find the leaks by auditing *every* mutation entry point.
