### PR TITLE
chore(hooks): scope conformance-guard to the working tree (stop the post-commit nudge loop)

### DIFF
--- a/.claude/hooks/utils/conformance_guard.py
+++ b/.claude/hooks/utils/conformance_guard.py
@@ -63,21 +63,29 @@ def _git(args):
 
 
 def _changed_files():
+    # Working-tree scope only (`diff HEAD`): the guard is a *nudge while you
+    # edit*, not a branch-wide gate. A former `main...HEAD` arm re-fired the
+    # nudge on every Stop for the whole life of a branch — even after the change
+    # was committed and the pytest gate (test_attestation_has_evidence.py) was
+    # green — which is pure noise, especially for test-first PRs whose tests
+    # landed in an earlier PR. The committed-branch case is already enforced by
+    # that pytest gate in CI; this hook only needs to cover the live editing
+    # window, then go quiet on commit. Fails open.
     files = set()
-    for spec in (["diff", "--name-only", "HEAD"], ["diff", "--name-only", "main...HEAD"]):
-        for line in _git(spec).splitlines():
-            line = line.strip()
-            if line:
-                files.add(line)
+    for line in _git(["diff", "--name-only", "HEAD"]).splitlines():
+        line = line.strip()
+        if line:
+            files.add(line)
     return files
 
 
 def _added_lines(path):
+    # Working-tree scope only — see _changed_files for why the `main...HEAD` arm
+    # is intentionally gone.
     added = []
-    for spec in (["diff", "HEAD", "--", path], ["diff", "main...HEAD", "--", path]):
-        for line in _git(spec).splitlines():
-            if line.startswith("+") and not line.startswith("+++"):
-                added.append(line[1:])
+    for line in _git(["diff", "HEAD", "--", path]).splitlines():
+        if line.startswith("+") and not line.startswith("+++"):
+            added.append(line[1:])
     return added
 
 

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -60,6 +60,16 @@ Target) honest. See [`plans/conformance_discipline.md`](plans/conformance_discip
   RPC still succeeds from the DevTools console is not reduced.
 - **Everything fails loudly.** Convert an absent guarantee into a red test or a
   blocking hook — never a silent pass.
+- **The conformance-guard stop-hook is a nudge, not the gate.** It fires while
+  you're *editing* `docs/Architecture.md`'s attestation without touching
+  `tests/`. If `pytest tests/test_attestation_has_evidence.py` is green and the
+  change is framing-only (cites already-green tests) or an honest
+  `partial`/`Open` row, **acknowledge once and move on — don't re-run the gate
+  or re-explain on later stops.** If a row is intentionally not-yet-true
+  (test-first), say so and name the PR/step that makes it conform; it carries a
+  `partial`/`Open` status or a strict-xfail until then. The pytest gate in CI is
+  the enforcement; the hook only nudges while you edit (and goes quiet once you
+  commit — it is working-tree-scoped).
 
 ## Two-DB architecture
 

--- a/tests/test_conformance_guard.py
+++ b/tests/test_conformance_guard.py
@@ -71,3 +71,25 @@ def test_unrelated_change_allows():
         added_by_file={},
     )
     assert msg is None
+
+
+def test_diff_collection_is_working_tree_scoped(monkeypatch):
+    """The guard nudges *while you edit* and goes quiet on commit, so it must
+    diff only the working tree (`HEAD`) — never `main...HEAD`. A branch-wide arm
+    re-fired the nudge on every Stop for the whole life of a committed branch
+    (pure noise, esp. for test-first PRs whose tests landed earlier). This pins
+    the scope so that arm can't silently return."""
+    calls = []
+
+    def fake_git(args):
+        calls.append(list(args))
+        return ""
+
+    monkeypatch.setattr(guard, "_git", fake_git)
+    guard._changed_files()
+    guard._added_lines(ARCH)
+
+    flat = " ".join(" ".join(a) for a in calls)
+    assert "main...HEAD" not in flat, calls   # no branch-wide arm
+    assert all("HEAD" in a for a in calls)     # everything is HEAD-scoped
+    assert calls                                # and it actually diffed


### PR DESCRIPTION
## Summary

The conformance-guard Stop hook (`.claude/hooks/utils/conformance_guard.py`)
fires when `docs/Architecture.md`'s attestation changes without a `tests/`
change — a useful *nudge* to add a negative test while editing. But it diffed
both `HEAD` **and** `main...HEAD`, so once a branch touched the attestation it
**re-fired on every Stop for the whole life of the branch** — even after the
change was committed and the pytest gate (`test_attestation_has_evidence.py`)
was green.

That's a structural false-positive for **test-first** work: when the tests
already landed in an earlier PR, a later attestation-only PR is correctly
"attestation without tests," and the nudge has no way to know that's fine —
so it loops.

## Change

- **`conformance_guard.py`** — scope `_changed_files()` / `_added_lines()` to
  the **working tree** (`diff HEAD` only); drop the `main...HEAD` arm. The guard
  now nudges *while you edit* and goes quiet the moment you commit. The
  committed-branch case is already enforced by the pytest gate in CI; the hook
  only needs to cover the live editing window. Fails open, as before.
- **`tests/test_conformance_guard.py`** — new hermetic test
  (`test_diff_collection_is_working_tree_scoped`, monkeypatches `_git`) pinning
  the scope so the `main...HEAD` arm can't silently return. The 6 existing
  `_decide` tests are unaffected.
- **`CLAUDE.md` § Conformance discipline** — document the convention: the guard
  is a *nudge, not the gate*. If the pytest gate is green and the change is
  framing-only (cites already-green tests) or an honest `partial`/`Open` row,
  acknowledge once and move on — don't re-run or re-explain on later stops. If
  mid test-first, say so and name the PR/step that makes the row conform.

## Verification

- `pytest tests/test_conformance_guard.py` — **7 passed** (6 existing + 1 new).
- Live check against a tree whose attestation change is *committed*: the guard
  now returns `None` (silent), where the old `main...HEAD` arm kept flagging it.

## Scope

Split out of the user-mediation attestation work (#265) on purpose — that PR is
the attestation content; this is hook/process tuning. No runtime, deploy, or
UI/UX change.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
