### PR TITLE
feat(conformance): deterministic evaluate-report emitter (toolkit [verify].entrypoint)

### DIFF
--- a/docs/conformance/README.md
+++ b/docs/conformance/README.md
@@ -1,0 +1,89 @@
+# docs/conformance/
+
+Generated conformance artifacts for `fellows_local_db`. The **source of truth**
+for every claim is the attestation table in [`../Architecture.md`](../Architecture.md)
+(the Security Target); everything here is a deterministic serialization of it.
+Nothing in this directory is hand-edited.
+
+## Two artifacts, two audiences
+
+| File | Format | Audience | Emitted by |
+|---|---|---|---|
+| `report.json` / `report.md` | **fellows-format** | this repo's ship gate + a human reading "are we honest?" | `scripts/conformance_report.py` |
+| `evaluate-report.json` | **PNT toolkit schema** | the upstream Personal Network Toolkit (PNT) — its keystone `[verify].entrypoint` | `scripts/evaluate_report.py` |
+
+Both are derived from the same attestation rows via the shared
+`scripts/conformance_lib.py`, so they cannot disagree about what a row cites or
+whether a cited test is a live, non-deferred assertion.
+
+### `report.{json,md}` — the deterministic gate readout
+
+Verifies that every `conformant` row in `Architecture.md` is backed by **live,
+executable evidence** (a resolvable, non-`xfail`/`skip` test ref or a declared
+verification kind), counts strict-xfail deferrals against the cap, and flags
+abandoned deferrals. This is the *fellows* readout; it does **not** validate
+against the toolkit's render schema. See
+[`../../plans/conformance_report_and_gate.md`](../../plans/conformance_report_and_gate.md).
+
+### `evaluate-report.json` — the toolkit render-contract artifact
+
+The machine-comparable form the PNT evaluate flow produces, conforming to
+`personal_network_toolkit/tools/evaluate-report.schema.json`. The toolkit
+consumes this as the keystone's `[verify].entrypoint` output: a schema-valid
+report is what lets the toolkit's `design.toml` flip `archival` to `archived`.
+
+**This is the deterministic emitter, not an LLM audit.** It is reproducible and
+CI-able: same `candidate.commit` + same attestation → byte-identical output (no
+wall-clock timestamp is stamped).
+
+The toolkit schema is **AC-keyed** — `findings[].ac_id` must match
+`^AC-[A-Z0-9-]+$`, and the schema's own `$comment` places `EX-*`/`CST-*` "as
+references inside the AC findings they bear on." So the emitter:
+
+- emits **one finding per AC row** (Universal ACs, Flavor-derived ACs, and the
+  not-applicable table);
+- **folds each `EX-*`/`CST-*` row into the `evidence` of the AC(s) it bears on**,
+  via `EXTENSION_AC_HOME` in `scripts/evaluate_report.py`. A declared
+  exception/constraint with no AC home makes the emitter **raise** — it cannot
+  be silently dropped (same fail-loudly discipline as the rest of the gate);
+- maps status: `conformant` → `conformant`; `not-applicable` →
+  `not-applicable` (+ the row's Reason as `rationale`); `partial-conformance` →
+  `conformant` + `needs_human_review: true` (the schema has no `partial`
+  status, so the residual is recorded honestly as a review flag with the
+  original Status text preserved in the evidence prose).
+
+The fellows-local `UM-*` user-mediation rows and the mediated-boundary registry
+sit *beneath* the AC families and are out of scope for the AC-keyed toolkit
+model; they remain in `report.{json,md}`.
+
+## Regenerate / validate
+
+```bash
+just evaluate-report
+```
+
+Emits `evaluate-report.json` and validates it against PNT's render contract. It
+runs the authoritative toolkit lint when the PNT checkout is present
+(`$HOME/src/personal_network_toolkit`, or `PNT_REPO=<path>` to override) and
+falls back to the emitter's built-in render-contract check otherwise. The raw
+form the toolkit documents as the success criterion:
+
+```bash
+python3 ~/src/personal_network_toolkit/tools/report-fixtures-lint.py \
+    docs/conformance/evaluate-report.json
+# -> "satisfies the render contract"
+```
+
+> **Don't lint the whole directory.** `report-fixtures-lint.py docs/conformance/`
+> would also try to lint `report.json` (fellows-format, not toolkit-schema) and
+> fail. Always point the lint at the **file** `evaluate-report.json`.
+
+## How it stays current (the gate wiring)
+
+- `scripts/conformance_report.py`'s write path also re-emits
+  `evaluate-report.json`, so `just conformance`, `just conformance-refresh`, and
+  the staleness refresh inside `just test` all keep it in sync with `report.json`.
+- `deploy-preflight` runs `scripts/evaluate_report.py --check` (hermetic, no
+  toolkit needed) so every deploy route gates on its render-contract validity.
+- `tests/test_evaluate_report.py` validates the render contract under `just test`
+  and runs the real toolkit lint when the checkout is present.

--- a/docs/conformance/evaluate-report.json
+++ b/docs/conformance/evaluate-report.json
@@ -1,0 +1,606 @@
+{
+  "report_schema_version": "0.1",
+  "generated_by": "scripts/evaluate_report.py (deterministic; derived from docs/Architecture.md attestation)",
+  "candidate": {
+    "name": "fellows_local_db",
+    "repo_url": "https://github.com/richbodo/fellows_local_db",
+    "commit": "658b28d5bef688cbd3bb21f92a16d64f3fc553e4",
+    "pna_spec_version": "0.1",
+    "picks_source": "declared",
+    "axis_picks": {
+      "distribution": "web-bundle-with-magic-link",
+      "storage-substrate": "opfs-sqlite-wasm",
+      "ingestion-shape": "single-source-static-mirror",
+      "workspace-shell": "vanilla-js-spa",
+      "comms-transport-set": "mailto-only",
+      "mcp-exposure": "shared+private+comms"
+    }
+  },
+  "summary": {
+    "posture": "conformant",
+    "headline": "fellows_local_db is deterministically attested conformant to PNA Spec 0.1 for its declared flavor: 23 conformant, 2 not-applicable, 0 non-conformant across 25 evaluated ACs. 3 AC(s) carry self-attested partial-conformance flagged for human review (AC-16, AC-PRM-A, AC-MCP-A); the EX-CLOUD-LLM exception and the CST-PWA-* platform constraints are handled honestly and folded into the AC findings they bear on. Derived from docs/Architecture.md by scripts/evaluate_report.py — not an LLM audit.",
+    "leading_concerns": [
+      "AC-16",
+      "AC-PRM-A",
+      "AC-MCP-A"
+    ]
+  },
+  "findings": [
+    {
+      "ac_id": "AC-1",
+      "ac_source": "universal",
+      "status": "conformant",
+      "citations": [
+        {
+          "path": "tests/test_relationships.py",
+          "note": "cited test: test_attach_fellows_readonly_allows_select"
+        },
+        {
+          "path": "tests/test_database.py"
+        }
+      ],
+      "evidence": [
+        {
+          "source": "deterministic",
+          "tool": "conformance-attestation-gate",
+          "detail": "Attestation gate (scripts/conformance_lib.py) resolved 2 cited test ref(s), all non-deferred: tests/test_relationships.py::test_attach_fellows_readonly_allows_select -> live; tests/test_database.py -> live. Static existence + marker-state only — pass/fail is enforced by the suite (`just test`)."
+        }
+      ]
+    },
+    {
+      "ac_id": "AC-4",
+      "ac_source": "universal",
+      "status": "conformant",
+      "citations": [
+        {
+          "path": "tests/e2e/test_version_handshake.py",
+          "note": "cited test: test_version_skew_refuses_mutations_but_allows_reads"
+        },
+        {
+          "path": "tests/e2e/test_worker_rpc.py"
+        }
+      ],
+      "evidence": [
+        {
+          "source": "deterministic",
+          "tool": "conformance-attestation-gate",
+          "detail": "Attestation gate (scripts/conformance_lib.py) resolved 2 cited test ref(s), all non-deferred: tests/e2e/test_version_handshake.py::test_version_skew_refuses_mutations_but_allows_reads -> live; tests/e2e/test_worker_rpc.py -> live. Static existence + marker-state only — pass/fail is enforced by the suite (`just test`)."
+        }
+      ]
+    },
+    {
+      "ac_id": "AC-6",
+      "ac_source": "universal",
+      "status": "conformant",
+      "citations": [
+        {
+          "path": "tests/e2e/test_email_gate.py"
+        },
+        {
+          "path": "tests/e2e/test_reset_everything.py"
+        },
+        {
+          "path": "tests/e2e/test_clear_app_cache.py"
+        }
+      ],
+      "evidence": [
+        {
+          "source": "deterministic",
+          "tool": "conformance-attestation-gate",
+          "detail": "Attestation gate (scripts/conformance_lib.py) resolved 3 cited test ref(s), all non-deferred: tests/e2e/test_email_gate.py -> live; tests/e2e/test_reset_everything.py -> live; tests/e2e/test_clear_app_cache.py -> live. Static existence + marker-state only — pass/fail is enforced by the suite (`just test`)."
+        }
+      ]
+    },
+    {
+      "ac_id": "AC-7",
+      "ac_source": "universal",
+      "status": "conformant",
+      "citations": [
+        {
+          "path": "tests/e2e/test_diagnostics_panel.py"
+        },
+        {
+          "path": "tests/e2e/test_boot_watchdog.py"
+        },
+        {
+          "path": "tests/e2e/test_boot_error_panel.py"
+        },
+        {
+          "path": "tests/e2e/test_bug_report.py"
+        },
+        {
+          "path": "tests/e2e/test_boot_beacon.py"
+        }
+      ],
+      "evidence": [
+        {
+          "source": "deterministic",
+          "tool": "conformance-attestation-gate",
+          "detail": "Attestation gate (scripts/conformance_lib.py) resolved 5 cited test ref(s), all non-deferred: tests/e2e/test_diagnostics_panel.py -> live; test_boot_watchdog.py -> live; test_boot_error_panel.py -> live; test_bug_report.py -> live; test_boot_beacon.py -> live. Static existence + marker-state only — pass/fail is enforced by the suite (`just test`)."
+        }
+      ]
+    },
+    {
+      "ac_id": "AC-9",
+      "ac_source": "universal",
+      "status": "conformant",
+      "citations": [
+        {
+          "path": "tests/e2e/test_user_folder_storage.py",
+          "note": "cited test: test_snapshot_lands_in_folder_when_folder_mode_active"
+        },
+        {
+          "path": "tests/e2e/test_settings.py"
+        }
+      ],
+      "evidence": [
+        {
+          "source": "deterministic",
+          "tool": "conformance-attestation-gate",
+          "detail": "Attestation gate (scripts/conformance_lib.py) resolved 2 cited test ref(s), all non-deferred: tests/e2e/test_user_folder_storage.py::test_snapshot_lands_in_folder_when_folder_mode_active -> live; tests/e2e/test_settings.py -> live. Static existence + marker-state only — pass/fail is enforced by the suite (`just test`)."
+        },
+        {
+          "source": "human",
+          "detail": "docs/Architecture.md also declares a non-test verification kind for this row (human-review / code inspection / by construction / by bounding)."
+        },
+        {
+          "source": "human",
+          "detail": "Bears on constraint CST-PWA-PRIVATE-SNAPSHOT (**conformant** (as a *handling*): the capability reduction is complete — UI/route reduction **plus** data-layer refusal of off-folder durable writes (worker-side load-bearing + page-side defense-in-depth, PR #244 `d2706a9`, extended in PR #261 to the restore/email-import path with a raw-RPC no-bypass proof; [`../plans/private_data_enforcement.md`](../plans/private_data_enforcement.md)). The negative invariant is now a hard guard, not a strict-xfail. Frontier stays **Open**: this is honest handling, not a durable cross-platform store.); declared and handled in docs/Architecture.md § Constraint attestation, folded here per the toolkit schema rule that EX-*/CST-* live as references inside the AC findings they bear on."
+        },
+        {
+          "source": "human",
+          "detail": "Bears on constraint CST-PWA-STORAGE-EVICTABLE (**conformant**: the two prefs (`has_email_only` / `self_email`) are localStorage-only off-folder — the boot reconciles no longer write `settings` to OPFS in browse-only mode (PR #244 `d2706a9`; [`../plans/private_data_enforcement.md`](../plans/private_data_enforcement.md)). #248 closed the last residual: the worker no longer mints workspace-identity metadata into OPFS off-folder either (it's minted only when a store becomes canonical — the first folder write), so the browse-only settings store is now *literally* empty. `test_off_folder_settings_are_empty` is a hard guard, not a strict-xfail. The \"Avoided\" claim holds in its strongest reading.); declared and handled in docs/Architecture.md § Constraint attestation, folded here per the toolkit schema rule that EX-*/CST-* live as references inside the AC findings they bear on."
+        },
+        {
+          "source": "human",
+          "detail": "Bears on constraint CST-PWA-NO-SYNC (conformant: canonical-copy disambiguation shipped (durably on disk, verified byte-level); sync explicitly out of scope); declared and handled in docs/Architecture.md § Constraint attestation, folded here per the toolkit schema rule that EX-*/CST-* live as references inside the AC findings they bear on."
+        },
+        {
+          "source": "human",
+          "detail": "Bears on constraint CST-PWA-NO-BACKGROUND (conformant: opportunistic-only, honestly framed); declared and handled in docs/Architecture.md § Constraint attestation, folded here per the toolkit schema rule that EX-*/CST-* live as references inside the AC findings they bear on."
+        }
+      ]
+    },
+    {
+      "ac_id": "AC-10",
+      "ac_source": "universal",
+      "status": "conformant",
+      "citations": [
+        {
+          "path": "tests/e2e/test_directory_data_update_flow.py",
+          "note": "cited test: test_apply_with_group_impact_shows_dialog_and_can_cancel"
+        },
+        {
+          "path": "tests/e2e/test_orphan_soft_scan.py"
+        },
+        {
+          "path": "tests/e2e/test_versioned_fellows_db.py"
+        }
+      ],
+      "evidence": [
+        {
+          "source": "deterministic",
+          "tool": "conformance-attestation-gate",
+          "detail": "Attestation gate (scripts/conformance_lib.py) resolved 3 cited test ref(s), all non-deferred: tests/e2e/test_directory_data_update_flow.py::test_apply_with_group_impact_shows_dialog_and_can_cancel -> live; test_orphan_soft_scan.py -> live; test_versioned_fellows_db.py -> live. Static existence + marker-state only — pass/fail is enforced by the suite (`just test`)."
+        }
+      ]
+    },
+    {
+      "ac_id": "AC-11",
+      "ac_source": "universal",
+      "status": "conformant",
+      "citations": [
+        {
+          "path": "tests/e2e/test_user_folder_storage.py",
+          "note": "cited test: TestPhase2WriteLock"
+        },
+        {
+          "path": "tests/e2e/test_worker_spawn_failure.py"
+        }
+      ],
+      "evidence": [
+        {
+          "source": "deterministic",
+          "tool": "conformance-attestation-gate",
+          "detail": "Attestation gate (scripts/conformance_lib.py) resolved 2 cited test ref(s), all non-deferred: tests/e2e/test_user_folder_storage.py::TestPhase2WriteLock -> live; test_worker_spawn_failure.py -> live. Static existence + marker-state only — pass/fail is enforced by the suite (`just test`)."
+        },
+        {
+          "source": "human",
+          "detail": "Bears on constraint CST-PWA-SINGLE-OWNER (conformant); declared and handled in docs/Architecture.md § Constraint attestation, folded here per the toolkit schema rule that EX-*/CST-* live as references inside the AC findings they bear on."
+        }
+      ]
+    },
+    {
+      "ac_id": "AC-15",
+      "ac_source": "universal",
+      "status": "conformant",
+      "citations": [
+        {
+          "path": "tests/test_build_pwa.py"
+        },
+        {
+          "path": "tests/e2e/test_update_check.py"
+        },
+        {
+          "path": "tests/e2e/test_bug_report.py"
+        },
+        {
+          "path": "tests/e2e/test_boot_beacon.py"
+        }
+      ],
+      "evidence": [
+        {
+          "source": "deterministic",
+          "tool": "conformance-attestation-gate",
+          "detail": "Attestation gate (scripts/conformance_lib.py) resolved 4 cited test ref(s), all non-deferred: tests/test_build_pwa.py -> live; tests/e2e/test_update_check.py -> live; test_bug_report.py -> live; test_boot_beacon.py -> live. Static existence + marker-state only — pass/fail is enforced by the suite (`just test`)."
+        }
+      ]
+    },
+    {
+      "ac_id": "AC-16",
+      "ac_source": "universal",
+      "status": "conformant",
+      "citations": [
+        {
+          "path": "tests/e2e/test_groups_export.py"
+        },
+        {
+          "path": "tests/test_comms.py"
+        }
+      ],
+      "needs_human_review": true,
+      "evidence": [
+        {
+          "source": "deterministic",
+          "tool": "conformance-attestation-gate",
+          "detail": "Attestation gate (scripts/conformance_lib.py) resolved 2 cited test ref(s), all non-deferred: tests/e2e/test_groups_export.py -> live; tests/test_comms.py -> live. Static existence + marker-state only — pass/fail is enforced by the suite (`just test`)."
+        },
+        {
+          "source": "human",
+          "detail": "docs/Architecture.md self-attests partial-conformance: \"partial-conformance (conformant to the `mailto-only` axis pick; richer transports planned)\". The toolkit schema has no 'partial' status, so this is recorded as conformant with needs_human_review to keep the residual visible."
+        }
+      ]
+    },
+    {
+      "ac_id": "AC-17",
+      "ac_source": "universal",
+      "status": "conformant",
+      "citations": [
+        {
+          "path": "tests/test_database.py"
+        },
+        {
+          "path": "build/diff_fellows_db.py"
+        }
+      ],
+      "evidence": [
+        {
+          "source": "deterministic",
+          "tool": "conformance-attestation-gate",
+          "detail": "Attestation gate (scripts/conformance_lib.py) resolved 2 cited test ref(s), all non-deferred: tests/test_database.py -> live; build/diff_fellows_db.py -> live. Static existence + marker-state only — pass/fail is enforced by the suite (`just test`)."
+        },
+        {
+          "source": "human",
+          "detail": "docs/Architecture.md also declares a non-test verification kind for this row (human-review / code inspection / by construction / by bounding)."
+        }
+      ]
+    },
+    {
+      "ac_id": "AC-18",
+      "ac_source": "universal",
+      "status": "conformant",
+      "citations": [
+        {
+          "path": "tests/test_comms.py"
+        },
+        {
+          "path": "tests/test_private_data_ops.py"
+        }
+      ],
+      "evidence": [
+        {
+          "source": "deterministic",
+          "tool": "conformance-attestation-gate",
+          "detail": "Attestation gate (scripts/conformance_lib.py) resolved 2 cited test ref(s), all non-deferred: tests/test_comms.py -> live; tests/test_private_data_ops.py -> live. Static existence + marker-state only — pass/fail is enforced by the suite (`just test`)."
+        },
+        {
+          "source": "human",
+          "detail": "docs/Architecture.md also declares a non-test verification kind for this row (human-review / code inspection / by construction / by bounding)."
+        }
+      ]
+    },
+    {
+      "ac_id": "AC-19",
+      "ac_source": "universal",
+      "status": "conformant",
+      "citations": [
+        {
+          "path": "tests/e2e/test_groups_export.py"
+        },
+        {
+          "path": "tests/e2e/test_groups_compose.py"
+        }
+      ],
+      "evidence": [
+        {
+          "source": "deterministic",
+          "tool": "conformance-attestation-gate",
+          "detail": "Attestation gate (scripts/conformance_lib.py) resolved 2 cited test ref(s), all non-deferred: tests/e2e/test_groups_export.py -> live; tests/e2e/test_groups_compose.py -> live. Static existence + marker-state only — pass/fail is enforced by the suite (`just test`)."
+        }
+      ]
+    },
+    {
+      "ac_id": "AC-PRM-A",
+      "ac_source": "universal",
+      "status": "conformant",
+      "citations": [
+        {
+          "path": "tests/e2e/test_pna_exception_mode.py"
+        },
+        {
+          "path": "tests/e2e/test_mcpb_settings.py"
+        }
+      ],
+      "needs_human_review": true,
+      "evidence": [
+        {
+          "source": "deterministic",
+          "tool": "conformance-attestation-gate",
+          "detail": "Attestation gate (scripts/conformance_lib.py) resolved 2 cited test ref(s), all non-deferred: tests/e2e/test_pna_exception_mode.py -> live; test_mcpb_settings.py -> live. Static existence + marker-state only — pass/fail is enforced by the suite (`just test`)."
+        },
+        {
+          "source": "human",
+          "detail": "docs/Architecture.md self-attests partial-conformance: \"partial-conformance (cloud opt-in via per-install consent; per-call prompt visibility is the cloud client's UI, not the workspace's)\". The toolkit schema has no 'partial' status, so this is recorded as conformant with needs_human_review to keep the residual visible."
+        },
+        {
+          "source": "human",
+          "detail": "Bears on exception EX-CLOUD-LLM (conformant for EX-H1–H6 and EX-H8; EX-H7 (consent-to-human) surfaced best-effort via MCP `instructions`); declared and handled in docs/Architecture.md § Exception attestation, folded here per the toolkit schema rule that EX-*/CST-* live as references inside the AC findings they bear on."
+        }
+      ]
+    },
+    {
+      "ac_id": "AC-PRM-D",
+      "ac_source": "universal",
+      "status": "conformant",
+      "citations": [
+        {
+          "path": "tests/e2e/test_directory_data_update_flow.py"
+        },
+        {
+          "path": "tests/e2e/test_versioned_fellows_db.py",
+          "note": "cited test: test_install_only_does_not_refetch_on_sha_mismatch"
+        }
+      ],
+      "evidence": [
+        {
+          "source": "deterministic",
+          "tool": "conformance-attestation-gate",
+          "detail": "Attestation gate (scripts/conformance_lib.py) resolved 2 cited test ref(s), all non-deferred: tests/e2e/test_directory_data_update_flow.py -> live; test_versioned_fellows_db.py::test_install_only_does_not_refetch_on_sha_mismatch -> live. Static existence + marker-state only — pass/fail is enforced by the suite (`just test`)."
+        }
+      ]
+    },
+    {
+      "ac_id": "AC-MCP-A",
+      "ac_source": "universal",
+      "status": "conformant",
+      "citations": [
+        {
+          "path": "tests/e2e/test_pna_exception_mode.py"
+        },
+        {
+          "path": "tests/test_private_data_ops.py"
+        }
+      ],
+      "needs_human_review": true,
+      "evidence": [
+        {
+          "source": "deterministic",
+          "tool": "conformance-attestation-gate",
+          "detail": "Attestation gate (scripts/conformance_lib.py) resolved 2 cited test ref(s), all non-deferred: tests/e2e/test_pna_exception_mode.py -> live; tests/test_private_data_ops.py -> live. Static existence + marker-state only — pass/fail is enforced by the suite (`just test`)."
+        },
+        {
+          "source": "human",
+          "detail": "docs/Architecture.md self-attests partial-conformance: \"partial-conformance (per-session/per-install opt-in via `EX-CLOUD-LLM`; not per-call server-side gating)\". The toolkit schema has no 'partial' status, so this is recorded as conformant with needs_human_review to keep the residual visible."
+        },
+        {
+          "source": "human",
+          "detail": "Bears on exception EX-CLOUD-LLM (conformant for EX-H1–H6 and EX-H8; EX-H7 (consent-to-human) surfaced best-effort via MCP `instructions`); declared and handled in docs/Architecture.md § Exception attestation, folded here per the toolkit schema rule that EX-*/CST-* live as references inside the AC findings they bear on."
+        },
+        {
+          "source": "human",
+          "detail": "Bears on constraint CST-PWA-SANDBOX-SEALED (conformant); declared and handled in docs/Architecture.md § Constraint attestation, folded here per the toolkit schema rule that EX-*/CST-* live as references inside the AC findings they bear on."
+        }
+      ]
+    },
+    {
+      "ac_id": "AC-MCP-B",
+      "ac_source": "universal",
+      "status": "conformant",
+      "citations": [
+        {
+          "path": "tests/test_comms.py",
+          "note": "cited test: test_stage_email_basic_to"
+        }
+      ],
+      "evidence": [
+        {
+          "source": "deterministic",
+          "tool": "conformance-attestation-gate",
+          "detail": "Attestation gate (scripts/conformance_lib.py) resolved 1 cited test ref(s), all non-deferred: tests/test_comms.py::test_stage_email_basic_to -> live. Static existence + marker-state only — pass/fail is enforced by the suite (`just test`)."
+        }
+      ]
+    },
+    {
+      "ac_id": "AC-2",
+      "ac_source": "flavor-derived",
+      "status": "conformant",
+      "citations": [
+        {
+          "path": "tests/test_deploy_auth_round_trip.py",
+          "note": "cited test: test_directory_api_is_403_without_session"
+        },
+        {
+          "path": "tests/test_deploy_sqlite_api.py"
+        },
+        {
+          "path": "tests/test_deploy_mcpb_routes.py"
+        }
+      ],
+      "evidence": [
+        {
+          "source": "deterministic",
+          "tool": "conformance-attestation-gate",
+          "detail": "Attestation gate (scripts/conformance_lib.py) resolved 3 cited test ref(s), all non-deferred: tests/test_deploy_auth_round_trip.py::test_directory_api_is_403_without_session -> live; test_deploy_sqlite_api.py -> live; test_deploy_mcpb_routes.py -> live. Static existence + marker-state only — pass/fail is enforced by the suite (`just test`)."
+        },
+        {
+          "source": "human",
+          "detail": "Bears on constraint CST-PWA-SERVER-FLOOR (conformant by bounding); declared and handled in docs/Architecture.md § Constraint attestation, folded here per the toolkit schema rule that EX-*/CST-* live as references inside the AC findings they bear on."
+        }
+      ]
+    },
+    {
+      "ac_id": "AC-3",
+      "ac_source": "flavor-derived",
+      "status": "conformant",
+      "citations": [
+        {
+          "path": "tests/e2e/test_worker_rpc.py"
+        },
+        {
+          "path": "tests/e2e/test_worker_cold_start.py"
+        },
+        {
+          "path": "tests/e2e/test_local_first_boot.py"
+        }
+      ],
+      "evidence": [
+        {
+          "source": "deterministic",
+          "tool": "conformance-attestation-gate",
+          "detail": "Attestation gate (scripts/conformance_lib.py) resolved 3 cited test ref(s), all non-deferred: tests/e2e/test_worker_rpc.py -> live; test_worker_cold_start.py -> live; test_local_first_boot.py -> live. Static existence + marker-state only — pass/fail is enforced by the suite (`just test`)."
+        }
+      ]
+    },
+    {
+      "ac_id": "AC-5",
+      "ac_source": "flavor-derived",
+      "status": "conformant",
+      "citations": [
+        {
+          "path": "tests/e2e/test_offline_only_mode.py",
+          "note": "cited test: test_401_with_cached_data_shows_directory_from_cache"
+        },
+        {
+          "path": "tests/e2e/test_search_offline_fallback.py"
+        },
+        {
+          "path": "tests/e2e/test_local_first_boot.py"
+        }
+      ],
+      "evidence": [
+        {
+          "source": "deterministic",
+          "tool": "conformance-attestation-gate",
+          "detail": "Attestation gate (scripts/conformance_lib.py) resolved 3 cited test ref(s), all non-deferred: tests/e2e/test_offline_only_mode.py::test_401_with_cached_data_shows_directory_from_cache -> live; test_search_offline_fallback.py -> live; test_local_first_boot.py -> live. Static existence + marker-state only — pass/fail is enforced by the suite (`just test`)."
+        }
+      ]
+    },
+    {
+      "ac_id": "AC-8",
+      "ac_source": "flavor-derived",
+      "status": "conformant",
+      "citations": [
+        {
+          "path": "tests/test_magic_link_auth.py"
+        },
+        {
+          "path": "tests/test_deploy_auth_round_trip.py"
+        },
+        {
+          "path": "tests/test_deploy_client_errors.py"
+        },
+        {
+          "path": "tests/test_client_error_sanitizer.py"
+        }
+      ],
+      "evidence": [
+        {
+          "source": "deterministic",
+          "tool": "conformance-attestation-gate",
+          "detail": "Attestation gate (scripts/conformance_lib.py) resolved 4 cited test ref(s), all non-deferred: tests/test_magic_link_auth.py -> live; test_deploy_auth_round_trip.py -> live; test_deploy_client_errors.py -> live; test_client_error_sanitizer.py -> live. Static existence + marker-state only — pass/fail is enforced by the suite (`just test`)."
+        }
+      ]
+    },
+    {
+      "ac_id": "AC-12",
+      "ac_source": "flavor-derived",
+      "status": "conformant",
+      "citations": [
+        {
+          "path": "tests/e2e/test_unsupported_browser.py",
+          "note": "cited test: test_no_sah_falls_back_to_api_idb_provider"
+        },
+        {
+          "path": "tests/e2e/test_worker_cold_start.py"
+        }
+      ],
+      "evidence": [
+        {
+          "source": "deterministic",
+          "tool": "conformance-attestation-gate",
+          "detail": "Attestation gate (scripts/conformance_lib.py) resolved 2 cited test ref(s), all non-deferred: tests/e2e/test_unsupported_browser.py::test_no_sah_falls_back_to_api_idb_provider -> live; test_worker_cold_start.py -> live. Static existence + marker-state only — pass/fail is enforced by the suite (`just test`)."
+        }
+      ]
+    },
+    {
+      "ac_id": "AC-13",
+      "ac_source": "flavor-derived",
+      "status": "conformant",
+      "citations": [
+        {
+          "path": "tests/test_api.py",
+          "note": "cited test: TestSecurityHeaders"
+        }
+      ],
+      "evidence": [
+        {
+          "source": "deterministic",
+          "tool": "conformance-attestation-gate",
+          "detail": "Attestation gate (scripts/conformance_lib.py) resolved 1 cited test ref(s), all non-deferred: tests/test_api.py::TestSecurityHeaders -> live. Static existence + marker-state only — pass/fail is enforced by the suite (`just test`)."
+        }
+      ]
+    },
+    {
+      "ac_id": "AC-14",
+      "ac_source": "flavor-derived",
+      "status": "conformant",
+      "citations": [
+        {
+          "path": "tests/e2e/test_sw_post_caching.py"
+        },
+        {
+          "path": "tests/e2e/test_image_cache_no_bust.py"
+        }
+      ],
+      "evidence": [
+        {
+          "source": "deterministic",
+          "tool": "conformance-attestation-gate",
+          "detail": "Attestation gate (scripts/conformance_lib.py) resolved 2 cited test ref(s), all non-deferred: tests/e2e/test_sw_post_caching.py -> live; test_image_cache_no_bust.py -> live. Static existence + marker-state only — pass/fail is enforced by the suite (`just test`)."
+        }
+      ]
+    },
+    {
+      "ac_id": "AC-PRM-B",
+      "ac_source": "flavor-derived",
+      "status": "not-applicable",
+      "rationale": "Applies to `ingestion:multi-source-merge-with-dedup`; fellows is single-source (`single-source-static-mirror`)."
+    },
+    {
+      "ac_id": "AC-PRM-C",
+      "ac_source": "flavor-derived",
+      "status": "not-applicable",
+      "rationale": "Applies to `storage:native-sqlite-via-filesystem`; fellows uses `opfs-sqlite-wasm`."
+    }
+  ]
+}

--- a/docs/conformance/evaluate-report.json
+++ b/docs/conformance/evaluate-report.json
@@ -4,7 +4,7 @@
   "candidate": {
     "name": "fellows_local_db",
     "repo_url": "https://github.com/richbodo/fellows_local_db",
-    "commit": "658b28d5bef688cbd3bb21f92a16d64f3fc553e4",
+    "commit": "bbaf66e874ed3b97d0ce5f01f468f9e8fc4193e5",
     "pna_spec_version": "0.1",
     "picks_source": "declared",
     "axis_picks": {

--- a/docs/conformance/report.json
+++ b/docs/conformance/report.json
@@ -1,7 +1,7 @@
 {
   "meta": {
-    "generated_at": "2026-06-08T05:16:44Z",
-    "git_sha": "b30d1ea",
+    "generated_at": "2026-06-09T07:46:26Z",
+    "git_sha": "bbaf66e",
     "source": "docs/Architecture.md",
     "generator": "scripts/conformance_report.py",
     "toolkit_version": "0.1 (draft)",

--- a/docs/conformance/report.md
+++ b/docs/conformance/report.md
@@ -16,7 +16,7 @@ Every conformance claim this app makes is backed by live, executable evidence, a
 
 → To complete the determination (🟡 → 🟢), run the spec's audit flow: **[PNT User's Guide → Audit a candidate PNA](https://github.com/richbodo/personal_network_toolkit/blob/main/docs/users-guide.md#goal-2--audit-a-candidate-pna-before-installing-it)**.
 
-_Generated 2026-06-08T05:16:44Z for `b30d1ea`. Source of truth: [`docs/Architecture.md`](../Architecture.md)._
+_Generated 2026-06-09T07:46:26Z for `bbaf66e`. Source of truth: [`docs/Architecture.md`](../Architecture.md)._
 
 **What the IDs mean** — [**AC**](https://github.com/richbodo/personal_network_toolkit/blob/main/spec/PNA_Spec.md) Architectural Commitment (a rule every safe PNA honors) · [**CST**](https://github.com/richbodo/personal_network_toolkit/blob/main/spec/constraints.md) Constraint (a platform limit handled honestly, not hidden) · [**EX**](https://github.com/richbodo/personal_network_toolkit/blob/main/spec/exceptions.md) Exception (a declared departure from PNA rules).
 

--- a/docs/justfile.md
+++ b/docs/justfile.md
@@ -102,6 +102,29 @@ Export them or inline: `FELLOWS_BASE_URL=https://staging.example.com just smoke`
   it's passed to pytest as `-k FILTER`: `just test-e2e email_gate`.
 - **`test-fast`** — DB + API only. Skips Playwright; ~10× faster than `test`.
 
+### conformance
+
+See [`conformance_report_and_gate.md`](../plans/conformance_report_and_gate.md)
+and [`conformance/README.md`](conformance/README.md). Source of truth for every
+claim is the attestation table in [`Architecture.md`](Architecture.md).
+
+- **`conformance [ARGS]`** — generate the fellows-format report
+  (`docs/conformance/report.{json,md}`) and **hard-fail on findings**. The ship
+  gate: wired into `deploy-preflight` so no deploy route can bypass it. A
+  best-effort `gh` probe flags abandoned deferrals; pass `--no-gh` to skip it
+  offline. The same deterministic checker also runs as pytest under `just test`.
+- **`conformance-refresh`** — refresh the committed snapshot only when it's
+  gone stale (HEAD ≥ 10 commits past the last logged run). Non-fatal, offline.
+  Depended on by `just test`. Also re-emits the evaluate-report.
+- **`evaluate-report`** — emit the **toolkit-schema** artifact
+  (`docs/conformance/evaluate-report.json`) and validate it against PNT's render
+  contract. This is the deterministic emitter (derived from `Architecture.md`,
+  **not** an LLM audit) and the command the PNT keystone wires as its
+  `[verify].entrypoint`. Runs the real PNT lint when the toolkit checkout is
+  present (override its location with `PNT_REPO`); otherwise self-validates with
+  the emitter's built-in render-contract check. Prints
+  `satisfies the render contract` on success.
+
 ### build
 
 - **`build`** — assemble `deploy/dist/` (runs `build/build_pwa.py`). The

--- a/justfile
+++ b/justfile
@@ -328,10 +328,31 @@ conformance *args="":
 # >= 10 commits past the last logged run). Non-fatal and offline (`--no-gh`):
 # the snapshot rides along with work as it lands, the pytest gates enforce
 # findings, and deploy-preflight is the authoritative ship gate. Depended on by
-# `just test`.
+# `just test`. Regenerating the snapshot also refreshes the toolkit-schema
+# evaluate-report (see `evaluate-report`).
 [group('conformance')]
 conformance-refresh:
     {{python}} scripts/conformance_report.py --if-stale --no-gh
+
+# Emit the toolkit-schema evaluate-report (docs/conformance/evaluate-report.json)
+# and validate it against PNT's render contract. This is the DETERMINISTIC
+# emitter — derived from docs/Architecture.md's attestation, NOT an LLM audit —
+# and it is the command the PNT keystone wires as its `[verify].entrypoint`.
+# Runs the real PNT lint when the toolkit checkout is present (override its
+# location with PNT_REPO); falls back to the emitter's built-in render-contract
+# check otherwise. See docs/conformance/README.md.
+[group('conformance')]
+evaluate-report:
+    #!/usr/bin/env bash
+    set -euo pipefail
+    {{python}} scripts/evaluate_report.py
+    lint="${PNT_REPO:-$HOME/src/personal_network_toolkit}/tools/report-fixtures-lint.py"
+    if [ -f "$lint" ]; then
+        python3 "$lint" docs/conformance/evaluate-report.json
+    else
+        echo "Note: PNT lint not found at $lint — emitted + self-validated only."
+        echo "      Set PNT_REPO to your toolkit checkout to run the authoritative lint."
+    fi
 
 
 # ---- MCP servers ---------------------------------------------------------
@@ -472,6 +493,17 @@ deploy-preflight:
         echo "Deploy aborted: conformance findings above. A user-facing release"
         echo "must ship a finding-free attestation — fix the code or honestly"
         echo "downgrade the row before shipping (plans/conformance_report_and_gate.md)."
+        exit 1
+    fi
+    # The toolkit-schema evaluate-report (the keystone's [verify].entrypoint
+    # output) must still satisfy PNT's render contract. Hermetic (no toolkit
+    # checkout needed): --check builds in-memory and self-validates. This also
+    # fails loudly if a newly-declared EX/CST row has no AC home in the emitter.
+    echo "Deploy preflight: evaluate-report render contract…"
+    if ! {{python}} scripts/evaluate_report.py --check; then
+        echo
+        echo "Deploy aborted: docs/conformance/evaluate-report.json fails the toolkit"
+        echo "render contract. Run 'just evaluate-report' and fix scripts/evaluate_report.py."
         exit 1
     fi
     branch=$(git rev-parse --abbrev-ref HEAD 2>/dev/null || echo '?')

--- a/plans/conformance_report_and_gate.md
+++ b/plans/conformance_report_and_gate.md
@@ -157,3 +157,34 @@ Two contributions, once the fellows side is proven:
 Different reference designs will wire the *running* differently per their build
 (this repo: `just` + pytest). Keep the upstream contribution to the *form*
 (checker template + skill + discipline doc), not the wiring.
+
+## Follow-up — self-stable report commit (PR #267 hardening, 2026-06-09)
+
+The deterministic evaluate-report emitter (#267) initially set
+`candidate.commit` (and report.json's `meta.git_sha`) from raw `git rev-parse
+HEAD`. That made both reports record the *parent* of the commit that generated
+them (HEAD at generation time), so the archived keystone artifact
+self-referenced a stale commit — and any fresh checkout or ≥10-commit staleness
+refresh regenerated a *different* file (the commit bumped to the new HEAD),
+dirtying the tree. Not a loop today (staleness is 10-commit-gated, the log is
+gitignored, the refresh is non-fatal, no clean-tree CI), but a landmine for any
+future clean-tree gate and a keystone artifact that mis-reports the evaluated
+commit.
+
+Fix: a shared `scripts/conformance_lib.input_commit()` derives the commit that
+last touched the report's **inputs** — `git rev-list -1 HEAD -- docs/Architecture.md`,
+the attestation source both reports derive from — falling back to `rev-parse
+HEAD` when git can't resolve it. Inputs are Architecture.md **only**, *not* the
+emitter scripts: a commit that edits the emitter (this one included) must not
+move the recorded commit of the candidate it evaluates, or the fix would
+reintroduce its own self-reference. Both `evaluate_report.py` (`candidate.commit`)
+and `conformance_report.py` (report.json `meta.git_sha`) use the one helper, so
+they name the same evaluated commit and the committed reports stay byte-identical
+on regen. The staleness *log* keeps recording HEAD (the run point) — distinct
+from the report's displayed commit — so `_commits_since` still measures distance
+from the last run, not from the last attestation change. Regression coverage:
+`tests/test_evaluate_report.py::test_candidate_commit_is_the_input_commit`,
+`::test_build_is_invariant_to_committed_report_changing`,
+`::test_report_files_are_not_their_own_input`. (report.json still carries a
+wall-clock `generated_at`, so it churns on regen regardless — only the
+no-timestamp keystone evaluate-report.json is truly byte-identical.)

--- a/scripts/conformance_lib.py
+++ b/scripts/conformance_lib.py
@@ -56,6 +56,16 @@ TRACKING_ANCHOR = re.compile(r"tracking:\s*#(\d+)", re.IGNORECASE)
 # the smell. Keeps the attestation glanceable, not a debt ledger.
 DEFERRAL_CAP = 3
 
+# Flavor-derived ACs live in PNT's axes.md (triggered by an axis pick); every
+# other AC lives in PNA_Spec.md (universal). Single source of truth for the
+# split, consumed by scripts/conformance_report.py (PNT deep-linking) and
+# scripts/evaluate_report.py (the toolkit-schema `ac_source` field). Kept here
+# because neither can read the PNT repo at runtime.
+FLAVOR_DERIVED_ACS = frozenset({
+    "AC-2", "AC-3", "AC-5", "AC-8", "AC-12", "AC-13", "AC-14",
+    "AC-PRM-B", "AC-PRM-C",
+})
+
 
 # --- Markdown attestation parsing -------------------------------------------
 

--- a/scripts/conformance_lib.py
+++ b/scripts/conformance_lib.py
@@ -19,6 +19,7 @@ Pure stdlib, 3.8-safe (no `ast.unparse`).
 import ast
 import os
 import re
+import subprocess
 
 REPO_ROOT = os.path.dirname(os.path.dirname(os.path.abspath(__file__)))
 ARCH_MD = os.path.join(REPO_ROOT, "docs", "Architecture.md")
@@ -65,6 +66,59 @@ FLAVOR_DERIVED_ACS = frozenset({
     "AC-2", "AC-3", "AC-5", "AC-8", "AC-12", "AC-13", "AC-14",
     "AC-PRM-B", "AC-PRM-C",
 })
+
+
+# --- Git provenance (self-stable report commit) -----------------------------
+
+# Repo-relative path(s) the committed conformance reports are *derived from*.
+# The recorded commit is the one that last touched these inputs — NOT raw HEAD
+# — which makes the reports self-stable: committing a regenerated report does
+# not dirty the tree on the next regen, because an unrelated commit (and the
+# report-emitter tooling itself) never bumps the recorded commit; only an
+# attestation change moves it.
+#
+# Why this matters (the landmine this closes): with raw HEAD, the archived
+# evaluate-report.json recorded `candidate.commit` = the *parent* of the commit
+# that generated it (HEAD at generation time), so it self-referenced a stale
+# commit, and any fresh checkout / >=10-commit staleness refresh regenerated a
+# DIFFERENT file (candidate.commit bumped to the new HEAD) — dirtying the tree
+# for any future clean-tree CI. Gating on the attestation source instead means
+# the keystone artifact names the commit it actually describes and stays
+# byte-identical on regen. Inputs are docs/Architecture.md ONLY (the attestation
+# both reports derive from) — deliberately NOT the emitter scripts, since a
+# commit that edits the emitter must not move the recorded commit of the
+# candidate it evaluates. See plans/conformance_report_and_gate.md.
+REPORT_INPUT_PATHS = ("docs/Architecture.md",)
+
+
+def _run_git(args):
+    """Run `git <args>` at the repo root; return stripped stdout on success,
+    else None. Never raises — missing git / timeout / non-repo all yield None."""
+    try:
+        out = subprocess.run(
+            ["git", *args], cwd=REPO_ROOT,
+            capture_output=True, text=True, timeout=10,
+        )
+        return out.stdout.strip() if out.returncode == 0 else None
+    except Exception:
+        return None
+
+
+def input_commit(paths=REPORT_INPUT_PATHS):
+    """Full 40-char SHA of the most recent commit that touched the report's
+    INPUTS (default: docs/Architecture.md), with `git rev-parse HEAD` as a
+    fallback when git can't resolve a path-scoped commit (shallow clone, a path
+    never committed), or None when git is unavailable entirely.
+
+    Single source of truth for `candidate.commit` in
+    docs/conformance/evaluate-report.json and the display sha in
+    docs/conformance/report.json, so both reports name the same evaluated
+    commit and stay byte-identical on regen. See the section comment above for
+    the self-stability rationale."""
+    sha = _run_git(["rev-list", "-1", "HEAD", "--", *paths])
+    if sha:
+        return sha
+    return _run_git(["rev-parse", "HEAD"])
 
 
 # --- Markdown attestation parsing -------------------------------------------

--- a/scripts/conformance_report.py
+++ b/scripts/conformance_report.py
@@ -45,6 +45,7 @@ if _REPO_ROOT not in sys.path:
 from scripts.conformance_lib import (  # noqa: E402
     ARCH_MD,
     DEFERRAL_CAP,
+    FLAVOR_DERIVED_ACS,
     collect_strict_xfails,
     evaluate_attestation,
 )
@@ -74,9 +75,9 @@ PNT_AUDIT_GUIDE = (PNT_REPO + "/blob/main/docs/users-guide.md"
 
 # Flavor-derived ACs live in axes.md; every other AC lives in PNA_Spec.md.
 # (Mirrors PNT's split — see the "gaps you'll see in the table" note in
-# PNA_Spec.md.) Kept here because the report can't read the PNT repo at runtime.
-_AXES_ACS = {"AC-2", "AC-3", "AC-5", "AC-8", "AC-12", "AC-13", "AC-14",
-             "AC-PRM-B", "AC-PRM-C"}
+# PNA_Spec.md.) Single source of truth is conformance_lib.FLAVOR_DERIVED_ACS,
+# shared with scripts/evaluate_report.py so the two never drift.
+_AXES_ACS = FLAVOR_DERIVED_ACS
 
 _TOOLKIT_VERSION_RE = re.compile(r"Toolkit-Version:\*\*\s*\[([^\]]+)\]")
 
@@ -400,6 +401,14 @@ def write_artifacts(report):
     }
     with open(LOG_JSONL, "a", encoding="utf-8") as f:
         f.write(json.dumps(log_line) + "\n")
+    # Keep the toolkit-schema evaluate-report (docs/conformance/evaluate-report.json,
+    # the PNT keystone's [verify].entrypoint output) current alongside report.json.
+    # Local import avoids any load-order coupling; both modules share
+    # conformance_lib as their single source of truth. Intentionally NOT wrapped
+    # in try/except: an unmapped EX/CST row must fail this write loudly, the same
+    # as it fails `just evaluate-report` and the pytest gate.
+    from scripts import evaluate_report as _er
+    _er.write_report()
 
 
 def main(argv):

--- a/scripts/conformance_report.py
+++ b/scripts/conformance_report.py
@@ -48,6 +48,7 @@ from scripts.conformance_lib import (  # noqa: E402
     FLAVOR_DERIVED_ACS,
     collect_strict_xfails,
     evaluate_attestation,
+    input_commit,
 )
 
 OUT_DIR = os.path.join(_REPO_ROOT, "docs", "conformance")
@@ -119,7 +120,11 @@ def _short_status(status_text):
     return status_text.split("(")[0].strip() or status_text
 
 
-def _git_sha():
+def _head_short_sha():
+    """Short HEAD sha — the staleness-log marker only ("where did we last
+    regenerate?"), consumed by `_last_logged_sha` / `_commits_since`. Distinct
+    from the report's *displayed* commit (`_report_short_sha`), which names the
+    attested state, not the run point."""
     try:
         out = subprocess.run(
             ["git", "rev-parse", "--short", "HEAD"], cwd=_REPO_ROOT,
@@ -128,6 +133,17 @@ def _git_sha():
         return out.stdout.strip() if out.returncode == 0 else None
     except Exception:
         return None
+
+
+def _report_short_sha():
+    """Short form of the self-stable input-commit (the commit that last touched
+    docs/Architecture.md) for `meta.git_sha` — so report.json names the SAME
+    evaluated commit as the keystone evaluate-report.json's `candidate.commit`,
+    and committing the snapshot doesn't churn the sha on an unrelated commit.
+    Sliced (not `git --short`) so the length is deterministic as the repo grows.
+    See scripts/conformance_lib.input_commit."""
+    full = input_commit()
+    return full[:7] if full else None
 
 
 def _commits_since(sha):
@@ -223,7 +239,7 @@ def build_report(probe_gh=True):
     report = {
         "meta": {
             "generated_at": datetime.now(timezone.utc).strftime("%Y-%m-%dT%H:%M:%SZ"),
-            "git_sha": _git_sha(),
+            "git_sha": _report_short_sha(),
             "source": "docs/Architecture.md",
             "generator": "scripts/conformance_report.py",
             "toolkit_version": toolkit_version,
@@ -393,7 +409,11 @@ def write_artifacts(report):
         f.write(render_md(report))
     log_line = {
         "generated_at": report["meta"]["generated_at"],
-        "git_sha": report["meta"]["git_sha"],
+        # The log marks the RUN POINT (HEAD), which the staleness short-circuit
+        # measures distance from — deliberately NOT report.meta.git_sha (the
+        # attested input-commit), or `_commits_since` would grow unbounded since
+        # the last attestation change and force a regen every run.
+        "git_sha": _head_short_sha(),
         "deferral_count": report["headline"]["deferral_count"],
         "conformant_rows": report["headline"]["conformant_rows"],
         "findings_count": report["headline"]["findings_count"],

--- a/scripts/evaluate_report.py
+++ b/scripts/evaluate_report.py
@@ -1,0 +1,473 @@
+#!/usr/bin/env python3
+"""Deterministic emitter for docs/conformance/evaluate-report.json — the
+toolkit-schema artifact the Personal Network Toolkit (PNT) consumes as the
+keystone's `[verify].entrypoint` output.
+
+This is the DETERMINISTIC layer, NOT an LLM audit. It derives the whole report
+from `docs/Architecture.md`'s attestation table (via `scripts/conformance_lib.py`)
+plus the current git HEAD. Same commit + same attestation → byte-identical output
+(no wall-clock timestamp is stamped), so the artifact is reproducible and
+CI-able. Stdlib only.
+
+Render contract (the success criterion):
+    python3 ~/src/personal_network_toolkit/tools/report-fixtures-lint.py \
+        docs/conformance/evaluate-report.json
+must report "satisfies the render contract". `render_contract_violations()`
+below mirrors that lint so the fellows suite can validate hermetically (without
+the toolkit checked out); `just evaluate-report` runs the real toolkit lint when
+it is present.
+
+## Why AC-keyed (and where EX/CST go)
+
+The toolkit schema (`tools/evaluate-report.schema.json`) is **AC-keyed**:
+`findings[].ac_id` must match `^AC-[A-Z0-9-]+$`, and the schema's own `$comment`
+states that EX-*/CST-* are "the only place EX-*/CST-* live — as references
+inside the AC findings they bear on." So this emitter:
+
+  * emits **one finding per AC-* attestation row** — the Universal-ACs and
+    Flavor-derived-ACs tables, plus the not-applicable table;
+  * **folds each EX-*/CST-* row into the `evidence` of the AC finding(s) it
+    bears on**, via `EXTENSION_AC_HOME`. If `docs/Architecture.md` grows an
+    EX/CST row this map doesn't cover, `build_evaluate_report()` RAISES rather
+    than silently dropping a declared exception/constraint — the same
+    fails-loudly discipline the rest of the conformance gate enforces;
+  * leaves the fellows-local `UM-*` user-mediation rows and the
+    mediated-boundary registry out of scope here (they sit *beneath* the AC
+    families and are surfaced in the fellows-format `docs/conformance/report.json`
+    instead — they are not part of the toolkit's AC-keyed evaluate model).
+
+Status mapping: a row's `conformant` → `conformant`; `not-applicable` →
+`not-applicable` (with the row's Reason as `rationale`); `partial-conformance`
+→ `conformant` + `needs_human_review: true` (the toolkit schema has no
+`partial` status, so the residual is recorded honestly as a human-review flag,
+with the original Status text preserved in the evidence prose).
+
+Usage:
+  python scripts/evaluate_report.py            # build + validate + write the file
+  python scripts/evaluate_report.py --check     # build + validate only (no write); exit 1 on violation
+  python scripts/evaluate_report.py --no-write   # alias for --check
+"""
+import json
+import os
+import re
+import subprocess
+import sys
+
+# Importable whether run as a script (sibling of conformance_lib) or via the
+# package path (`from scripts.evaluate_report import ...`).
+_HERE = os.path.dirname(os.path.abspath(__file__))
+_REPO_ROOT = os.path.dirname(_HERE)
+if _REPO_ROOT not in sys.path:
+    sys.path.insert(0, _REPO_ROOT)
+
+from scripts.conformance_lib import (  # noqa: E402
+    ARCH_MD,
+    FLAVOR_DERIVED_ACS,
+    REPO_ROOT,
+    evaluate_attestation,
+    is_separator,
+    py_index,
+    split_row,
+)
+
+OUT_PATH = os.path.join(_REPO_ROOT, "docs", "conformance", "evaluate-report.json")
+
+REPORT_SCHEMA_VERSION = "0.1"
+CANDIDATE_NAME = "fellows_local_db"
+CANDIDATE_REPO_URL = "https://github.com/richbodo/fellows_local_db"
+GENERATED_BY = "scripts/evaluate_report.py (deterministic; derived from docs/Architecture.md attestation)"
+
+# EX-*/CST-* row -> the AC finding(s) whose evidence it belongs in. The schema
+# keeps EX/CST as references inside AC findings; this is that linkage, drawn from
+# the attestation's own semantics (each constraint/exception's Realization names
+# the capability it bears on). Coverage of every EX/CST row in
+# docs/Architecture.md is ENFORCED in build_evaluate_report(): an unmapped row
+# raises, so a newly-declared constraint cannot vanish from the evaluate report.
+EXTENSION_AC_HOME = {
+    # The cloud-LLM exception relaxes AC-MCP-A and is realized through AC-PRM-A.
+    "EX-CLOUD-LLM": ["AC-MCP-A", "AC-PRM-A"],
+    # Private-data durability ceilings bear on AC-9 (auto-backup of private data).
+    "CST-PWA-PRIVATE-SNAPSHOT": ["AC-9"],
+    "CST-PWA-STORAGE-EVICTABLE": ["AC-9"],
+    "CST-PWA-NO-SYNC": ["AC-9"],
+    "CST-PWA-NO-BACKGROUND": ["AC-9"],
+    # External-tool readability of the private store goes through the MCP path.
+    "CST-PWA-SANDBOX-SEALED": ["AC-MCP-A"],
+    # Multi-tab contention is detected via AC-11 (concurrent-access + Web Locks).
+    "CST-PWA-SINGLE-OWNER": ["AC-11"],
+    # The server floor is bounded to distribution — the AC-2 no-SaaS surface.
+    "CST-PWA-SERVER-FLOOR": ["AC-2"],
+}
+
+
+# --- Markdown helpers --------------------------------------------------------
+
+def _iter_tables(md_text):
+    """Yield (header_cells, [row_cells, ...]) for every GFM table in md_text."""
+    lines = md_text.splitlines()
+    i = 0
+    while i < len(lines):
+        line = lines[i]
+        if line.lstrip().startswith("|") and i + 1 < len(lines) and is_separator(lines[i + 1]):
+            header = split_row(line)
+            rows = []
+            j = i + 2
+            while j < len(lines) and lines[j].lstrip().startswith("|") and not is_separator(lines[j]):
+                rows.append(split_row(lines[j]))
+                j += 1
+            yield header, rows
+            i = j
+            continue
+        i += 1
+
+
+def _id_token(row_id):
+    """Leading id token of a row label ('AC-1 (two-store …)' -> 'AC-1')."""
+    return row_id.split()[0].strip() if row_id else ""
+
+
+def parse_axis_picks(md_text):
+    """{axis-anchor: pick} from the 'fellows's six axis picks' table.
+    The axis key is the canonical PNT axis anchor (#distribution, …) pulled from
+    the cell's link target; the pick is the backticked identifier."""
+    for header, rows in _iter_tables(md_text):
+        lower = [h.lower() for h in header]
+        if lower[:2] == ["axis", "pick"]:
+            picks = {}
+            for cells in rows:
+                if len(cells) < 2:
+                    continue
+                m = re.search(r"#([a-z0-9-]+)\)", cells[0])
+                axis = m.group(1) if m else re.sub(r"[^a-z0-9]+", "-", cells[0].lower()).strip("-")
+                pick = cells[1].strip().strip("`").strip()
+                if axis and pick:
+                    picks[axis] = pick
+            return picks
+    return {}
+
+
+def parse_not_applicable(md_text):
+    """[(ac_id, reason)] from the 'ACs that are not applicable' table."""
+    for header, rows in _iter_tables(md_text):
+        if [h.lower() for h in header] == ["ac", "reason"]:
+            return [(cells[0].strip(), cells[1].strip())
+                    for cells in rows if len(cells) >= 2 and cells[0].strip()]
+    return []
+
+
+def parse_pna_spec_version(md_text):
+    """'0.1' from the '**Toolkit-Version:** [0.1 (draft)]' line, or None."""
+    m = re.search(r"Toolkit-Version:\*\*\s*\[([^\]]+)\]", md_text)
+    if not m:
+        return None
+    return m.group(1).split()[0].strip() or None
+
+
+# --- Citation / evidence construction ---------------------------------------
+
+def _ref_to_citation(ref):
+    """A `path.py[::name]` attestation ref -> a schema code_location with a
+    repo-relative path (bare-filename shorthand resolved via the code index)."""
+    path_part, _, name = ref.partition("::")
+    if "/" in path_part:
+        rel = path_part
+    else:
+        cands = py_index().get(os.path.basename(path_part), [])
+        rel = os.path.relpath(cands[0], REPO_ROOT) if cands else path_part
+    cit = {"path": rel.replace("\\", "/")}
+    if name:
+        cit["note"] = "cited test: {}".format(name)
+    return cit
+
+
+def _status_is_partial(status_text):
+    return "partial" in status_text.lower()
+
+
+def _map_status(status_text):
+    s = status_text.lower()
+    if "not-applicable" in s or "not applicable" in s:
+        return "not-applicable"
+    if "partial" in s:
+        return "conformant"          # + needs_human_review, set by caller
+    if "conformant" in s:
+        return "conformant"
+    return "unable-to-determine"
+
+
+def _ac_finding(row, ext_evidence):
+    """Build one schema `finding` from an AC attestation row + any EX/CST
+    evidence folded in (ext_evidence: list of schema evidence dicts)."""
+    ac_id = _id_token(row["id"])
+    status_text = row["status_text"]
+    status = _map_status(status_text)
+    finding = {
+        "ac_id": ac_id,
+        "ac_source": "flavor-derived" if ac_id in FLAVOR_DERIVED_ACS else "universal",
+        "status": status,
+    }
+
+    citations = [_ref_to_citation(rs["ref"]) for rs in row["refs"]]
+    if citations:
+        finding["citations"] = citations
+
+    evidence = []
+    if row["refs"]:
+        joined = "; ".join("{} -> {}".format(rs["ref"], rs["status"]) for rs in row["refs"])
+        evidence.append({
+            "source": "deterministic",
+            "tool": "conformance-attestation-gate",
+            "detail": (
+                "Attestation gate (scripts/conformance_lib.py) resolved {} cited test "
+                "ref(s), all non-deferred: {}. Static existence + marker-state only — "
+                "pass/fail is enforced by the suite (`just test`)."
+            ).format(len(row["refs"]), joined),
+        })
+    if row["review_kind"]:
+        evidence.append({
+            "source": "human",
+            "detail": (
+                "docs/Architecture.md also declares a non-test verification kind for this "
+                "row (human-review / code inspection / by construction / by bounding)."
+            ),
+        })
+    if _status_is_partial(status_text):
+        finding["needs_human_review"] = True
+        evidence.append({
+            "source": "human",
+            "detail": (
+                "docs/Architecture.md self-attests partial-conformance: \"{}\". The toolkit "
+                "schema has no 'partial' status, so this is recorded as conformant with "
+                "needs_human_review to keep the residual visible."
+            ).format(status_text),
+        })
+    evidence.extend(ext_evidence)
+    if evidence:
+        finding["evidence"] = evidence
+    return finding
+
+
+# --- Report assembly ---------------------------------------------------------
+
+def _git_head_sha():
+    try:
+        out = subprocess.run(
+            ["git", "rev-parse", "HEAD"], cwd=_REPO_ROOT,
+            capture_output=True, text=True, timeout=10,
+        )
+        return out.stdout.strip() if out.returncode == 0 else None
+    except Exception:
+        return None
+
+
+def build_evaluate_report(commit="__HEAD__"):
+    """Build the toolkit-schema evaluate-report dict from docs/Architecture.md.
+
+    commit: pass an explicit sha, None to omit, or the sentinel '__HEAD__'
+    (default) to read git HEAD. Tests pass a fixed value for determinism.
+    """
+    with open(ARCH_MD, encoding="utf-8") as f:
+        arch_md = f.read()
+
+    rows = evaluate_attestation(arch_md)
+
+    # Partition parsed attestation rows by id prefix.
+    ac_rows = [r for r in rows if _id_token(r["id"]).startswith("AC-")]
+    ext_rows = {_id_token(r["id"]): r for r in rows
+                if _id_token(r["id"]).startswith(("EX-", "CST-"))}
+
+    ac_ids = {_id_token(r["id"]) for r in ac_rows}
+    ac_ids |= {ac for ac, _ in parse_not_applicable(arch_md)}
+
+    # Fail loudly if a declared EX/CST row has no AC home (would otherwise be
+    # silently dropped from the report).
+    for tok in sorted(ext_rows):
+        if tok not in EXTENSION_AC_HOME:
+            raise ValueError(
+                "evaluate_report: attestation row {!r} has no EXTENSION_AC_HOME mapping. "
+                "Add it (which AC finding does this exception/constraint bear on?) so the "
+                "declared {} is not silently dropped from the evaluate report.".format(
+                    tok, "exception" if tok.startswith("EX-") else "constraint"))
+
+    # Fold each EX/CST row into the evidence of its home AC(s).
+    ext_evidence_by_ac = {}
+    for tok, row in ext_rows.items():
+        kind = "exception" if tok.startswith("EX-") else "constraint"
+        section = "Exception" if kind == "exception" else "Constraint"
+        detail = (
+            "Bears on {kind} {tok} ({status}); declared and handled in docs/Architecture.md "
+            "§ {section} attestation, folded here per the toolkit schema rule that EX-*/CST-* "
+            "live as references inside the AC findings they bear on."
+        ).format(kind=kind, tok=tok, status=row["status_text"], section=section)
+        for ac in EXTENSION_AC_HOME[tok]:
+            if ac not in ac_ids:
+                raise ValueError(
+                    "evaluate_report: EXTENSION_AC_HOME maps {!r} to {!r}, which is not an "
+                    "emitted AC finding. Fix the mapping.".format(tok, ac))
+            ext_evidence_by_ac.setdefault(ac, []).append({"source": "human", "detail": detail})
+
+    findings = [_ac_finding(r, ext_evidence_by_ac.get(_id_token(r["id"]), [])) for r in ac_rows]
+
+    for ac_id, reason in parse_not_applicable(arch_md):
+        findings.append({
+            "ac_id": ac_id,
+            "ac_source": "flavor-derived" if ac_id in FLAVOR_DERIVED_ACS else "universal",
+            "status": "not-applicable",
+            "rationale": reason,
+        })
+
+    statuses = [f["status"] for f in findings]
+    if any(st == "non-conformant" for st in statuses):
+        posture = "non-conformant"
+    elif any(st == "unable-to-determine" for st in statuses):
+        posture = "indeterminate"
+    else:
+        posture = "conformant"
+
+    leading = [f["ac_id"] for f in findings if f.get("needs_human_review")]
+    n_conf = sum(1 for st in statuses if st == "conformant")
+    n_na = sum(1 for st in statuses if st == "not-applicable")
+    spec_version = parse_pna_spec_version(arch_md) or "0.1"
+
+    headline = (
+        "fellows_local_db is deterministically attested conformant to PNA Spec {ver} for its "
+        "declared flavor: {conf} conformant, {na} not-applicable, 0 non-conformant across {tot} "
+        "evaluated ACs."
+    ).format(ver=spec_version, conf=n_conf, na=n_na, tot=len(findings))
+    if leading:
+        headline += (
+            " {k} AC(s) carry self-attested partial-conformance flagged for human review ({ids}); "
+            "the EX-CLOUD-LLM exception and the CST-PWA-* platform constraints are handled honestly "
+            "and folded into the AC findings they bear on."
+        ).format(k=len(leading), ids=", ".join(leading))
+    headline += " Derived from docs/Architecture.md by scripts/evaluate_report.py — not an LLM audit."
+
+    summary = {"posture": posture, "headline": headline}
+    if leading:
+        summary["leading_concerns"] = leading
+
+    candidate = {
+        "name": CANDIDATE_NAME,
+        "repo_url": CANDIDATE_REPO_URL,
+    }
+    sha = _git_head_sha() if commit == "__HEAD__" else commit
+    if sha:
+        candidate["commit"] = sha
+    candidate["pna_spec_version"] = spec_version
+    candidate["picks_source"] = "declared"
+    axis_picks = parse_axis_picks(arch_md)
+    if axis_picks:
+        candidate["axis_picks"] = axis_picks
+
+    return {
+        "report_schema_version": REPORT_SCHEMA_VERSION,
+        "generated_by": GENERATED_BY,
+        "candidate": candidate,
+        "summary": summary,
+        "findings": findings,
+    }
+
+
+# --- Render-contract validation (mirrors PNT tools/report-fixtures-lint.py) --
+
+_AC_ID_RE = re.compile(r"^AC-[A-Z0-9-]+$")
+_POSTURES = {"conformant", "non-conformant", "mixed", "indeterminate"}
+_STATUSES = {"conformant", "non-conformant", "not-applicable", "unable-to-determine"}
+_TOP_REQUIRED = ("report_schema_version", "candidate", "summary", "findings")
+
+
+def render_contract_violations(obj):
+    """Return render-contract violations for a parsed report (empty == ok).
+
+    A faithful stdlib mirror of PNT's tools/report-fixtures-lint.py so the
+    fellows suite can validate hermetically. The toolkit lint remains the
+    authoritative check (run by `just evaluate-report`); this exists so CI
+    without the toolkit checked out still catches a malformed report.
+    """
+    errs = []
+    if not isinstance(obj, dict):
+        return ["top level is not a JSON object"]
+    for k in _TOP_REQUIRED:
+        if k not in obj:
+            errs.append("missing required top-level key {!r}".format(k))
+    if obj.get("report_schema_version") not in (None, "0.1"):
+        errs.append('report_schema_version must be "0.1", got {!r}'.format(
+            obj.get("report_schema_version")))
+    cand = obj.get("candidate")
+    if isinstance(cand, dict):
+        for k in ("pna_spec_version", "picks_source"):
+            if k not in cand:
+                errs.append("candidate is missing required key {!r}".format(k))
+    elif "candidate" in obj:
+        errs.append("candidate is not an object")
+    summ = obj.get("summary")
+    if isinstance(summ, dict):
+        if summ.get("posture") not in _POSTURES:
+            errs.append("summary.posture {!r} not one of {}".format(
+                summ.get("posture"), sorted(_POSTURES)))
+        if not isinstance(summ.get("headline"), str) or not summ.get("headline"):
+            errs.append("summary.headline must be a non-empty string")
+    elif "summary" in obj:
+        errs.append("summary is not an object")
+    findings = obj.get("findings")
+    if not isinstance(findings, list) or not findings:
+        errs.append("findings must be a non-empty array")
+        return errs
+    for i, f in enumerate(findings):
+        where = "findings[{}]".format(i)
+        if not isinstance(f, dict):
+            errs.append("{} is not an object".format(where))
+            continue
+        ac = f.get("ac_id")
+        if isinstance(ac, str) and _AC_ID_RE.match(ac):
+            where = "findings[{}]({})".format(i, ac)
+        else:
+            errs.append("{}.ac_id {!r} does not match ^AC-[A-Z0-9-]+$".format(where, ac))
+        st = f.get("status")
+        if st not in _STATUSES:
+            errs.append("{}.status {!r} not one of {}".format(where, st, sorted(_STATUSES)))
+            continue
+        has_cites = isinstance(f.get("citations"), list) and len(f["citations"]) > 0
+        if st in ("conformant", "non-conformant") and not has_cites:
+            errs.append("{}: status {} requires a non-empty 'citations' array".format(where, st))
+        if st == "non-conformant" and not f.get("requirement"):
+            errs.append("{}: status non-conformant requires 'requirement'".format(where))
+        if st in ("not-applicable", "unable-to-determine") and not f.get("rationale"):
+            errs.append("{}: status {} requires 'rationale'".format(where, st))
+    return errs
+
+
+def write_report(report=None):
+    """Write the evaluate-report to OUT_PATH (pretty JSON + trailing newline)."""
+    if report is None:
+        report = build_evaluate_report()
+    os.makedirs(os.path.dirname(OUT_PATH), exist_ok=True)
+    with open(OUT_PATH, "w", encoding="utf-8") as f:
+        json.dump(report, f, indent=2, ensure_ascii=False)
+        f.write("\n")
+    return OUT_PATH
+
+
+def main(argv):
+    check_only = "--check" in argv or "--no-write" in argv
+    report = build_evaluate_report()
+    violations = render_contract_violations(report)
+    if violations:
+        print("evaluate-report FAILS the render contract:", file=sys.stderr)
+        for v in violations:
+            print("  - {}".format(v), file=sys.stderr)
+        return 1
+    summ = report["summary"]
+    n = len(report["findings"])
+    if check_only:
+        print("evaluate-report: render contract OK — posture={}, {} AC findings (not written)."
+              .format(summ["posture"], n))
+        return 0
+    write_report(report)
+    print("Wrote {} — posture={}, {} AC findings; render contract OK.".format(
+        os.path.relpath(OUT_PATH, _REPO_ROOT), summ["posture"], n))
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main(sys.argv[1:]))

--- a/scripts/evaluate_report.py
+++ b/scripts/evaluate_report.py
@@ -50,7 +50,6 @@ Usage:
 import json
 import os
 import re
-import subprocess
 import sys
 
 # Importable whether run as a script (sibling of conformance_lib) or via the
@@ -65,6 +64,7 @@ from scripts.conformance_lib import (  # noqa: E402
     FLAVOR_DERIVED_ACS,
     REPO_ROOT,
     evaluate_attestation,
+    input_commit,
     is_separator,
     py_index,
     split_row,
@@ -249,22 +249,14 @@ def _ac_finding(row, ext_evidence):
 
 # --- Report assembly ---------------------------------------------------------
 
-def _git_head_sha():
-    try:
-        out = subprocess.run(
-            ["git", "rev-parse", "HEAD"], cwd=_REPO_ROOT,
-            capture_output=True, text=True, timeout=10,
-        )
-        return out.stdout.strip() if out.returncode == 0 else None
-    except Exception:
-        return None
-
-
-def build_evaluate_report(commit="__HEAD__"):
+def build_evaluate_report(commit="__AUTO__"):
     """Build the toolkit-schema evaluate-report dict from docs/Architecture.md.
 
-    commit: pass an explicit sha, None to omit, or the sentinel '__HEAD__'
-    (default) to read git HEAD. Tests pass a fixed value for determinism.
+    commit: pass an explicit sha, None to omit, or the sentinel '__AUTO__'
+    (default) to derive the self-stable input-commit — the commit that last
+    touched the attestation source docs/Architecture.md, NOT raw HEAD (see
+    scripts/conformance_lib.input_commit for why). Tests pass a fixed value for
+    determinism.
     """
     with open(ARCH_MD, encoding="utf-8") as f:
         arch_md = f.read()
@@ -350,7 +342,10 @@ def build_evaluate_report(commit="__HEAD__"):
         "name": CANDIDATE_NAME,
         "repo_url": CANDIDATE_REPO_URL,
     }
-    sha = _git_head_sha() if commit == "__HEAD__" else commit
+    # Self-stable commit (NOT raw HEAD): the commit that last touched the
+    # attestation source. Keeps the archived keystone artifact byte-identical
+    # on regen so committing it never dirties the tree. See input_commit().
+    sha = input_commit() if commit == "__AUTO__" else commit
     if sha:
         candidate["commit"] = sha
     candidate["pna_spec_version"] = spec_version

--- a/tests/test_evaluate_report.py
+++ b/tests/test_evaluate_report.py
@@ -1,0 +1,129 @@
+"""The deterministic evaluate-report emitter must itself be correct — its output
+is the toolkit keystone's `[verify].entrypoint` artifact, the thing a PNT
+maintainer (or CI) treats as ground truth for "does this candidate conform?".
+
+These run hermetically: `render_contract_violations()` mirrors PNT's
+`tools/report-fixtures-lint.py` so the fellows suite validates the render
+contract without the toolkit checked out. When the toolkit *is* present locally,
+`test_real_toolkit_lint_passes_when_available` runs the real lint as a
+belt-and-suspenders cross-check.
+
+See scripts/evaluate_report.py and plans/conformance_report_and_gate.md.
+"""
+import json
+import os
+import subprocess
+import sys
+
+import pytest
+
+from scripts import evaluate_report as er
+
+_FIXED_COMMIT = "0" * 40  # deterministic; avoids depending on git state
+
+
+def _report():
+    return er.build_evaluate_report(commit=_FIXED_COMMIT)
+
+
+def test_satisfies_render_contract():
+    """The whole point: the emitted report passes the toolkit render contract."""
+    report = _report()
+    violations = er.render_contract_violations(report)
+    assert violations == [], violations
+
+
+def test_is_reproducible():
+    """Same commit + same attestation -> byte-identical output (no timestamp).
+    This is what makes the artifact CI-able instead of churning every run."""
+    a = json.dumps(_report(), sort_keys=True)
+    b = json.dumps(_report(), sort_keys=True)
+    assert a == b
+
+
+def test_posture_is_conformant_on_current_attestation():
+    """Current attestation has no non-conformances and nothing undetermined."""
+    assert _report()["summary"]["posture"] == "conformant"
+
+
+def test_top_level_shape():
+    report = _report()
+    assert report["report_schema_version"] == "0.1"
+    cand = report["candidate"]
+    assert cand["pna_spec_version"] == "0.1"
+    assert cand["picks_source"] == "declared"
+    assert cand["commit"] == _FIXED_COMMIT
+    assert cand["axis_picks"]["distribution"] == "web-bundle-with-magic-link"
+
+
+def test_every_finding_keys_by_ac_and_meets_status_rules():
+    """ac_id matches the schema pattern; (non-)conformant carry citations;
+    not-applicable / unable-to-determine carry a rationale."""
+    for f in _report()["findings"]:
+        assert er._AC_ID_RE.match(f["ac_id"]), f["ac_id"]
+        if f["status"] in ("conformant", "non-conformant"):
+            assert f.get("citations"), f["ac_id"]
+        if f["status"] in ("not-applicable", "unable-to-determine"):
+            assert f.get("rationale"), f["ac_id"]
+
+
+def test_partial_rows_become_conformant_with_human_review():
+    """The three self-attested partials map to conformant + needs_human_review,
+    and lead the summary's concerns — the residual stays visible, not buried."""
+    report = _report()
+    flagged = {f["ac_id"] for f in report["findings"] if f.get("needs_human_review")}
+    assert flagged == {"AC-16", "AC-PRM-A", "AC-MCP-A"}
+    assert report["summary"]["leading_concerns"] == ["AC-16", "AC-PRM-A", "AC-MCP-A"]
+
+
+def test_extensions_are_folded_not_dropped():
+    """EX-* / CST-* are surfaced inside the AC findings they bear on (per the
+    schema's $comment), never silently dropped — the honesty guarantee."""
+    report = _report()
+    blob = json.dumps(report)
+    assert "EX-CLOUD-LLM" in blob
+    # Every mapped extension id appears somewhere in the report's evidence.
+    for ext_id in er.EXTENSION_AC_HOME:
+        assert ext_id in blob, "{} dropped from evaluate-report".format(ext_id)
+
+
+def test_unmapped_extension_fails_loudly(monkeypatch):
+    """If the attestation grows an EX/CST row the home-map doesn't cover, the
+    build RAISES rather than dropping a declared constraint. Drop EX-CLOUD-LLM's
+    mapping and confirm the build refuses."""
+    home = dict(er.EXTENSION_AC_HOME)
+    home.pop("EX-CLOUD-LLM")
+    monkeypatch.setattr(er, "EXTENSION_AC_HOME", home)
+    with pytest.raises(ValueError, match="EXTENSION_AC_HOME"):
+        er.build_evaluate_report(commit=_FIXED_COMMIT)
+
+
+def test_committed_artifact_is_render_contract_valid():
+    """The committed docs/conformance/evaluate-report.json — the file the toolkit
+    actually reads — is itself valid (catches a stale/hand-edited commit)."""
+    with open(er.OUT_PATH, encoding="utf-8") as f:
+        committed = json.load(f)
+    assert er.render_contract_violations(committed) == []
+
+
+def test_real_toolkit_lint_passes_when_available(tmp_path):
+    """Belt-and-suspenders: when the PNT checkout is present, the *real* lint
+    (the authoritative render contract) accepts a freshly-built report. Skipped
+    in environments without the toolkit (hermetic CI)."""
+    lint = os.path.expanduser(
+        os.environ.get("PNT_REPO", "~/src/personal_network_toolkit")
+        + "/tools/report-fixtures-lint.py"
+    )
+    if not os.path.isfile(lint):
+        pytest.skip("PNT toolkit lint not present at {}".format(lint))
+    out_file = tmp_path / "evaluate-report.json"
+    out_file.write_text(json.dumps(_report(), ensure_ascii=False))
+    result = subprocess.run(
+        [sys.executable, lint, str(out_file)],
+        capture_output=True, text=True, timeout=30,
+    )
+    assert result.returncode == 0, result.stdout + result.stderr
+    # The lint's per-file "ok" line + the "N/N reports satisfy the render
+    # contract" summary (phrasing differs by version; returncode is the signal).
+    assert "satisfy the render contract" in result.stdout
+    assert "FAIL" not in result.stdout

--- a/tests/test_evaluate_report.py
+++ b/tests/test_evaluate_report.py
@@ -106,6 +106,50 @@ def test_committed_artifact_is_render_contract_valid():
     assert er.render_contract_violations(committed) == []
 
 
+def test_candidate_commit_is_the_input_commit():
+    """candidate.commit tracks the commit that last touched the attestation
+    source (docs/Architecture.md) — self-stable, NOT raw HEAD — so committing
+    the regenerated keystone artifact never dirties the tree on the next regen.
+    With no git, the field is simply omitted. See input_commit() rationale and
+    plans/conformance_report_and_gate.md."""
+    from scripts.conformance_lib import input_commit
+    expected = input_commit()
+    cand = er.build_evaluate_report()["candidate"]  # default sentinel -> input_commit()
+    if expected is None:
+        assert "commit" not in cand
+    else:
+        assert cand["commit"] == expected
+
+
+def test_build_is_invariant_to_committed_report_changing(tmp_path, monkeypatch):
+    """The build derives purely from docs/Architecture.md + the input-commit,
+    never from its own output file: a no-op (or garbage) edit to the committed
+    report cannot change the next regen. The report files are NOT in their own
+    input set, so a >=10-commit staleness refresh / fresh checkout can't churn
+    them. See plans/conformance_report_and_gate.md."""
+    fixed = "0" * 40
+    out = tmp_path / "evaluate-report.json"
+    monkeypatch.setattr(er, "OUT_PATH", str(out))
+
+    er.write_report(er.build_evaluate_report(commit=fixed))
+    canonical = out.read_bytes()
+
+    # Perturb the committed artifact, then regenerate — must come back identical.
+    out.write_bytes(b'{"candidate": {"commit": "deadbeef"}, "junk": true}\n')
+    er.write_report(er.build_evaluate_report(commit=fixed))
+    assert out.read_bytes() == canonical
+
+
+def test_report_files_are_not_their_own_input():
+    """Structural complement to the byte-identity test: the git gate must never
+    include the generated report files, or committing a regenerated report would
+    bump the recorded input-commit and re-dirty the tree — the loop this closes."""
+    from scripts import conformance_lib as cl
+    assert cl.REPORT_INPUT_PATHS  # non-empty
+    for p in cl.REPORT_INPUT_PATHS:
+        assert not p.startswith("docs/conformance/"), p
+
+
 def test_real_toolkit_lint_passes_when_available(tmp_path):
     """Belt-and-suspenders: when the PNT checkout is present, the *real* lint
     (the authoritative render contract) accepts a freshly-built report. Skipped


### PR DESCRIPTION
## What & why

Adds a **deterministic, stdlib-only emitter** for `docs/conformance/evaluate-report.json`, conforming to PNT's `tools/evaluate-report.schema.json`. The toolkit consumes this as the keystone's `[verify].entrypoint` output — a schema-valid report is what lets the toolkit's `design.toml` flip `archival` to `archived`.

It derives the whole report from `docs/Architecture.md`'s attestation table (via the shared `scripts/conformance_lib.py`) plus git HEAD — **not** an LLM audit. Reproducible: same `candidate.commit` + same attestation → byte-identical output (no wall-clock timestamp), so it is CI-able.

**Result:** posture `conformant`, 25 AC findings (23 conformant, 2 not-applicable, 0 non-conformant) — same shape/count as the one-time LLM exemplar.

The verify command (the toolkit's `[verify].entrypoint`):

    just evaluate-report

## Design decisions

The toolkit schema is **AC-keyed** (`findings[].ac_id` must match `^AC-[A-Z0-9-]+$`), and the schema's own `$comment` places `EX-*`/`CST-*` "as references inside the AC findings they bear on." So the emitter:

- emits **one finding per AC row** (Universal + Flavor-derived + the not-applicable table);
- **folds each `EX-*`/`CST-*` row into the `evidence`** of the AC(s) it bears on, via `EXTENSION_AC_HOME`. A declared exception/constraint with no AC home makes the emitter **raise** — it can't be silently dropped (same fails-loudly discipline as the rest of the gate; covered by a test);
- maps status: `conformant` → `conformant`; `not-applicable` → `not-applicable` (+ the row's Reason as `rationale`); `partial-conformance` → `conformant` + `needs_human_review: true` (the schema has no `partial` status; the residual is kept visible and leads `summary.leading_concerns`).

`UM-*` / mediated-boundary rows are fellows-local, sit beneath the AC families, and stay in the fellows-format `report.{json,md}`.

## Stays current (gate wiring)

- `scripts/conformance_report.py`'s write path re-emits `evaluate-report.json` alongside `report.json` (so `just conformance` / `conformance-refresh` / the `just test` staleness refresh keep it in sync);
- `deploy-preflight` runs `scripts/evaluate_report.py --check` — hermetic (no toolkit checkout needed) — so every deploy route gates on render-contract validity, and an unmapped EX/CST row fails the deploy loudly;
- `tests/test_evaluate_report.py` validates the render contract under `just test` and cross-checks the **real** PNT lint when the toolkit checkout is present.

`FLAVOR_DERIVED_ACS` moved into `conformance_lib` as the single source of truth, shared by both `conformance_report.py` and `evaluate_report.py` so they can't drift.

## Tests

- `tests/test_evaluate_report.py` (10) — render-contract validity, reproducibility, status mapping, EX/CST fold-not-drop, unmapped-extension-raises, real-toolkit-lint cross-check.
- Re-ran the conformance suite (`test_conformance_report` / `test_attestation_has_evidence` / `test_xfail_discipline`) + `test-fast` (DB + API) — all green. No app/e2e code touched.

## Maintainer QA (manual)

1. **Generate + validate** (the headline check):

       just evaluate-report

   Expected tail: `1/1 reports satisfy the render contract`.

2. **Raw lint** (the toolkit's documented success criterion — point it at the **file**, not the dir):

       python3 ~/src/personal_network_toolkit/tools/report-fixtures-lint.py docs/conformance/evaluate-report.json

   ⚠️ Do **not** lint `docs/conformance/` as a directory — it would also try to lint `report.json` (fellows-format, not toolkit-schema) and fail. Always target `evaluate-report.json`.

3. **Ship-gate paths** (both must exit 0):

       python3 scripts/conformance_report.py --no-write
       python3 scripts/evaluate_report.py --check

4. **Wire-up for the toolkit:** set the keystone's `[verify].entrypoint` to `just evaluate-report` (or `python3 scripts/evaluate_report.py` where `just` isn't available). Once it emits a schema-valid report, archival can flip to `archived`.

This PR does **not** touch the `personal_network_toolkit` repo.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
