### PR TITLE
fix(test): tolerate orphan_scan_done in worker-rpc settings allowlist

### DIFF
--- a/tests/e2e/test_worker_rpc.py
+++ b/tests/e2e/test_worker_rpc.py
@@ -121,11 +121,15 @@ class TestGroupsRpc:
 
 
 # Boot- and folder-managed keys that legitimately populate `settings` in
-# folder mode (workspace identity stamp + the migrated has-email pref). The
-# RPC round-trip tests assert on their own keys via subset, ignoring these.
+# folder mode (workspace identity stamp + the migrated has-email pref + the
+# AC-10 orphan soft-scan's one-shot `orphan_scan_done` flag). These are
+# system-written, not user-authored; the RPC round-trip tests assert on their
+# own keys via subset, ignoring these. `orphan_scan_done` can leak in from a
+# prior test that triggered the boot scan through the shared folder fixture, so
+# it must be tolerated here regardless of suite ordering.
 _BOOT_MANAGED_KEYS = {
     "workspace_uuid", "device_label", "created_at", "write_generation",
-    "last_written_at", "has_email_only",
+    "last_written_at", "has_email_only", "orphan_scan_done",
 }
 
 


### PR DESCRIPTION
## What

Add `orphan_scan_done` to `_BOOT_MANAGED_KEYS` in `tests/e2e/test_worker_rpc.py`
so `TestSettingsRpc::test_no_user_keys_initially` tolerates the AC-10 orphan
soft-scan's one-shot flag.

## Why

The test asserts the folder-mode `settings` bag contains nothing beyond
boot-/folder-managed keys. `_BOOT_MANAGED_KEYS` listed the workspace identity
stamp + the has-email pref, but not `orphan_scan_done` — a system flag the
orphan soft-scan writes once after boot. Under full-suite ordering an earlier
test triggers the scan and leaves the key in the shared `worker_data_folder`
fixture, so the assertion trips. **The test passes in isolation**, which is why
it only surfaced in a full `just test` run (`1 failed, 724 passed, 6 skipped`).

`orphan_scan_done` is system-written boot state, not user-authored data, so the
accurate fix is to add it to the allowlist (the alternative — resetting folder
settings between tests — is a heavier fixture change for the same effect).

## Triage

Pre-existing test-isolation flake, **independent of #267** (which touched only
conformance scripts/docs, nothing in the worker/boot/test path). The key is
written by the opt-in directory-data-update feature; this test predates #267.

## Verification

    tests/e2e/test_worker_rpc.py::TestSettingsRpc::test_no_user_keys_initially[chromium] PASSED

Test-only change (no app/UI code), so no users-manual update needed.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
