### PR TITLE
docs(pre-ship): update test plan for the capability gate + mobile redesign

### DIFF
--- a/docs/pre_ship_test_plan.md
+++ b/docs/pre_ship_test_plan.md
@@ -8,12 +8,23 @@ The maintainer's **manual** QA checklist to run before every deploy to prod.
 manual tests live in this file. When an item here becomes automated, delete it from
 this plan in the same change that lands the test.
 
+> **This revision covers the private-data capability gate + the mobile redesign
+> (PR6).** Both land in the same ship that takes prod off the pre-gate build. The
+> gate makes private data (groups, members, tags, notes, group-settings, MCP)
+> **live only when a verified folder is attached**; off-folder the app is
+> **browse-only**. On phones, private data is **hidden** entirely. The two
+> highest-risk manual paths this introduces — the **real OS folder gestures** and
+> the **existing-user OPFS→folder migration** — have no automated equivalent and
+> are the focus of §§2–4 (Phase 1) and §2 (Phase 2). UI labels below match the
+> shipped Settings → **Private data** section; if a label drifted, trust the app.
+
 Two phases:
 
 - **Phase 1** runs locally against `just serve-prod` (see
   [`local_staging.md`](local_staging.md)). The irreducible local pass is the part
   that exercises the **real `just serve-prod` launcher** end-to-end and the **real
-  OS gestures** (folder picker, file downloads) that the Playwright stubs can't reach.
+  OS gestures** (folder picker, permission round-trip, file downloads) that the
+  Playwright stubs can't reach.
 - **Phase 2** runs against `https://fellows.globaldonut.com/` **after** the deploy
   lands — real devices, real Postmark, real Caddy, real Claude Desktop.
 
@@ -38,10 +49,13 @@ just test                              # full pytest + Playwright — MUST be gr
 ```
 
 `just test` is the gate. It already covers the auth decision-tree, MCPB Settings UI
-and auth-gated routes, folder-mode write/badge logic, mobile layout + interactions,
-the update-banner logic, and the app-basics regression set. If `just test` is red,
-fix it (or explicitly accept a known flake) before touching the manual steps below —
-a red suite means the thing you'd otherwise hand-test is already broken.
+and auth-gated routes, the **capability gate's data-layer enforcement** (browse-only
+refuses durable writes, even via the raw worker RPC; permission-lapse → reduce →
+reconnect), folder-mode write/lock/backup logic, **mobile layout + interactions +
+snapshots**, the update-banner logic, and the app-basics regression set. If
+`just test` is red, fix it (or explicitly accept a known flake) before touching the
+manual steps below — a red suite means the thing you'd otherwise hand-test is
+already broken.
 
 `just build-mcpb` only needs re-running when MCPB code changes (most ships don't touch
 it; safe to re-run anyway).
@@ -78,30 +92,84 @@ visitor sees — gate appears because `authEnabled: true`, which is the prod pos
 - [ ] **1.3** `just serve-prod-link` (second terminal) returns the unlock URL.
 - [ ] **1.4** Paste the URL → install landing appears → **Use the directory in this
       tab** → directory loads.
-- [ ] **1.5** `#/about` build badge shows the current local `git HEAD` short SHA
+- [ ] **1.5** You land in **browse-only** mode (no folder attached yet): directory +
+      search + a fellow's detail + Email/Call all work; this is expected and correct.
+- [ ] **1.6** `#/about` build badge shows the current local `git HEAD` short SHA
       (confirms the launcher's build-label substitution path; the literal
       `__FELLOWS_UI_DIAG__` here is a bug).
-- [ ] **1.6** Submit a non-allowlisted email (e.g. `wrong@example.com`) → UI still
+- [ ] **1.7** Submit a non-allowlisted email (e.g. `wrong@example.com`) → UI still
       says "Check your email…" and `just serve-prod-link` shows **no** new entry
       (anti-enumeration).
 
-### 2. Folder mode — real OS picker
+### 2. Capability gate — browse-only default → unlock with the real OS picker
 
-> Per-mutation badge/write logic runs under `just test` against a stubbed picker
-> (`test_user_folder_storage.py`). This manual pass covers what the stub deliberately
-> skips: the **real OS directory-picker gesture**, the **OS permission round-trip**,
-> and **Finder visibility** of the on-disk file.
+> The gate's enforcement (off-folder refuses durable writes; folder attach enables
+> them; a permission lapse reduces capability and reconnect restores it) is covered
+> by `just test` (`test_private_data_enforcement.py`, `test_browse_only_durability.py`,
+> `test_user_folder_storage.py`) against a **stubbed** picker. This pass covers what
+> the stub can't: the **real OS directory-picker gesture**, the **OS permission
+> round-trip + persistence**, and **Finder visibility** of the on-disk file and marker.
 
-Settings → **Choose data folder…** → pick `~/Documents/local-staging/` (or any fresh folder).
+Start in the browse-only state from §1.
 
-- [ ] **2.1** Badge flips to **Saved to local-staging / Fellows · just now**.
-- [ ] **2.2** In Finder, `Fellows/relationships.db` exists.
-- [ ] **2.3** Create / edit / delete a group → the on-disk file's size/timestamp
-      advances each time.
-- [ ] **2.4** Settings → **⬇ Download my private data** → a real `.db` blob lands in
-      `~/Downloads`.
+- [ ] **2.1** Browse-only is real, not cosmetic: group / private-data surfaces are
+      gated. Settings shows the **Private data** section with the nag *"Private data
+      (groups, notes) isn't connected — pick a folder to enable it."* The directory,
+      search, fellow detail, and Email/Call still work.
+- [ ] **2.2** Settings → **Private data** → **Choose folder…** → pick
+      `~/Documents/local-staging/` (or any fresh folder). The real OS picker opens; grant
+      permission.
+- [ ] **2.3** Probe passes → the gate flips **live**: the badge shows *Where your data
+      lives: …/Fellows*, group surfaces light up, and you can now create groups.
+- [ ] **2.4** In Finder, `Fellows/relationships.db` exists **and** a human-readable
+      `HOW-TO-MOVE-THIS-DATA.txt` marker sits beside it.
 
-### 3. Claude Desktop end-to-end *(only with Claude Desktop on macOS)*
+### 3. Folder mode — per-mutation durability, lock, reconnect
+
+> Per-mutation badge/write logic, the Web Lock, and the backup ring run under
+> `just test` against the stubbed picker (`test_user_folder_storage.py`). This pass
+> covers the **real on-disk write** and the **real permission-revoke round-trip**.
+
+- [ ] **3.1** Create / edit / delete a group → the on-disk `relationships.db`
+      size/timestamp advances each time; a `relationships.db.bak.<ISO>` backup appears
+      in the folder.
+- [ ] **3.2** Settings → **⬇ Download my private data** → a real, self-describing
+      `.db` blob (dated filename) lands in `~/Downloads`.
+- [ ] **3.3** Settings → **🔒 Lock my private data** → the app drops back to
+      browse-only, group surfaces gray out, and the badge reports the folder is
+      disconnected. Confirm no durable writes happen while locked.
+- [ ] **3.4** Permission-lapse → reconnect: revoke the folder permission (Chrome →
+      site settings → reset permissions, or just relaunch and let the permission lapse)
+      → the app reduces to browse-only with *"Locked — data folder disconnected. Pick a
+      folder to unlock again."* → **🔄 Reconnect your folder** → probe passes → group
+      surfaces restore with your data intact.
+
+### 4. Existing-user migration — OPFS groups → folder (highest-risk path)
+
+> The OPFS→folder copy + identity stamp + the content-previewed chooser are covered by
+> `just test` (`test_user_folder_storage.py`, `test_folder_probe.py`) against seeded
+> data. The **authoritative** check is Phase 2 §2 against a **real pre-gate install**;
+> this local pass is a best-effort rehearsal of the prompt + non-destructive copy.
+
+The migration prompt fires when a Chromium-desktop browser has **pre-gate OPFS groups
+but no folder**. To rehearse locally you must get groups into OPFS without a folder
+(e.g. create them in folder mode, then relocate/clear the folder so boot resolves
+browse-only while OPFS still holds rows). If you can't easily seed that state, **defer
+the real check to Phase 2 §2** — do not skip it silently.
+
+- [ ] **4.1** Boot with OPFS groups present but no folder → the prompt appears:
+      *"…`relationships.db` on this device. Pick a folder to keep …"* (browse-only
+      otherwise — your groups are not silently active).
+- [ ] **4.2** Pick a folder → probe passes → the OPFS groups are **copied into**
+      `<folder>/Fellows/relationships.db` and the gate unlocks; group counts match.
+- [ ] **4.3** Non-destructive: the OPFS copy is left intact until the folder write
+      verifies, so a cancelled/failed pick never loses data.
+- [ ] **4.4** Content-previewed chooser: re-pick a parent that already holds a
+      `Fellows*` folder → the dialog *"This folder already contains fellows data"* /
+      *"Use existing data here?"* previews groups/members/last-changed and defaults to
+      **Open existing data** (adopt, don't proliferate).
+
+### 5. Claude Desktop end-to-end *(only with Claude Desktop on macOS)*
 
 > The MCPB **Settings UI** flow (preamble, three-bundle list, warning banner, cancel,
 > continue-dispatches-three-downloads, button relabel, localStorage persistence) and
@@ -111,37 +179,46 @@ Settings → **Choose data folder…** → pick `~/Documents/local-staging/` (or
 > `test_comms.py`, `test_mcpb_parity.py`. What stays manual: the native Claude Desktop
 > install handshake and a live AI query — neither tool reaches Claude Desktop.
 
-- [ ] **3.1** Settings → **Set up Claude Desktop integration** → **Continue** → three
+Private-data MCP needs **folder mode** — off-folder there is no private store for
+`private_data_ops` to read (the setup surfaces a folder warning). Attach a folder
+(§2) before this section.
+
+- [ ] **5.1** Settings → **Set up Claude Desktop integration** → **Continue** → three
       real `.mcpb` files (~3–4 MB each; needs `just build-mcpb`) land in `~/Downloads`.
-- [ ] **3.2** Drag each `.mcpb` into Claude Desktop → install dialog → **Install**
+- [ ] **5.2** Drag each `.mcpb` into Claude Desktop → install dialog → **Install**
       (approve the red banner).
-- [ ] **3.3** `private_data_ops.mcpb` asks for a file → navigate to
+- [ ] **5.3** `private_data_ops.mcpb` asks for a file → navigate to
       `<your-data-folder>/Fellows/relationships.db` (the folder picked in §2).
-- [ ] **3.4** **Quit Claude Desktop (⌘Q) and reopen.**
-- [ ] **3.5** Ask *"How many fellows are in the directory?"* → expect a number.
-- [ ] **3.6** Ask *"List my saved groups"* → expect the groups (or "none yet").
-- [ ] **3.7** Ask *"Draft an invite email to my [group] group, don't send"* → a
+- [ ] **5.4** **Quit Claude Desktop (⌘Q) and reopen.**
+- [ ] **5.5** Ask *"How many fellows are in the directory?"* → expect a number.
+- [ ] **5.6** Ask *"List my saved groups"* → expect the groups (or "none yet").
+- [ ] **5.7** Ask *"Draft an invite email to my [group] group, don't send"* → a
       mail-compose window opens with To/Subject/Body pre-filled.
 
 (The AI-query path is local-only — Claude Desktop ↔ local MCP subprocesses ↔ local
 SQLite. No server contact.)
 
-### 4. Cross-browser data silos
+### 6. Cross-browser data silos (post-gate)
 
 > _(Automation candidate: the silo concept + export/import migration are modelable
-> with two Playwright contexts. The **real Safari** install path below is the residue.)_
+> with two Playwright contexts. The **real Safari** browse-only path below is the residue.)_
 
-- [ ] **4.1** Open `http://127.0.0.1:8766/` in **Chrome** AND **Safari**; sign in to both.
-- [ ] **4.2** About page in each → different install codenames.
-- [ ] **4.3** Create a group in Chrome → open Safari → no groups (silo confirmed;
-      Safari uses OPFS-only fallback, no `showDirectoryPicker`).
-- [ ] **4.4** Migrate: Chrome → ⬇ Download my private data; Safari → ⬆ Restore from a
-      file → the Chrome group appears in Safari.
+- [ ] **6.1** Open `http://127.0.0.1:8766/` in **Chrome** (folder attached, has groups)
+      AND **Safari**; sign in to both.
+- [ ] **6.2** About page in each → different install codenames.
+- [ ] **6.3** Silo + browse-only: groups exist in Chrome; **Safari is browse-only —
+      no groups and no private store at all** (Safari has no `showDirectoryPicker`). The
+      Private-data section in Safari points to the *back up → install Chrome → restore*
+      path, not a Safari-side store.
+- [ ] **6.4** Migration is **Chrome-side**: Chrome → **⬇ Download my private data**;
+      then in Chrome (a fresh/second folder) → **Restore from backup** → the group
+      appears. Restore lands in **folder mode** — you cannot restore into Safari
+      (no durable store there).
 
-*Note: Safari "Add to Dock" on localhost may refuse — the silo behavior still tests
-fine in a regular Safari window. Real Safari install is Phase 2.*
+*Note: Safari "Add to Dock" on localhost may refuse — the browse-only behavior still
+tests fine in a regular Safari window. Real Safari install is Phase 2.*
 
-### 5. Shutdown
+### 7. Shutdown
 
 ```bash
 # Ctrl-C in the serve-prod terminal, or:
@@ -176,46 +253,78 @@ just smoke                             # HTTPS health + manifest + diagnostics +
       has the unlock URL, the "expires in 30 minutes" notice, and the signing-key
       fingerprint section.
 - [ ] **1.4** Click the link **from the inbox** (not copy/paste) → install landing.
-- [ ] **1.5** Install the PWA → it opens standalone → directory loads.
+- [ ] **1.5** Install the PWA → it opens standalone → directory loads in **browse-only**.
 - [ ] **1.6** About page build label matches `just drift`.
 
-### 2. Real iOS Safari install (irreducible)
+### 2. Existing-user upgrade — the migration path (do this first; highest risk)
 
-- [ ] **2.1** Open `https://fellows.globaldonut.com/` on a real iPhone.
-- [ ] **2.2** Magic-link round-trip works (real email, real Postmark).
-- [ ] **2.3** **Add to Home Screen** from the share sheet → app installs.
-- [ ] **2.4** Open the installed PWA → directory loads.
-- [ ] **2.5** Tap a fellow → detail loads; back returns.
-- [ ] **2.6** Select a fellow → composer FAB appears → tap → sheet opens → create a group.
-- [ ] **2.7** Watch for the "bottom bar takes half the screen" symptom that Chromium
-      emulation can't reproduce.
+> This is the path with **no automated equivalent** and the most exposure: real users
+> on the pre-gate build who already created groups. There is no server-side state, so
+> nothing migrates for them automatically across the deploy — the in-browser
+> migration prompt (Chromium) or the manual export/import bridge (Safari/iOS) is the
+> whole story. Test with a **real pre-gate install that has groups** — ideally your own.
 
-### 3. Real Android Chrome install *(if you have an Android device)*
+- [ ] **2.1 (Chromium desktop):** open your existing pre-gate install that has groups
+      → on boot you get the *"…pick a folder to keep…"* prompt → pick a folder →
+      groups migrate into `<folder>/Fellows/relationships.db` → counts match, nothing lost.
+- [ ] **2.2 (Safari / iOS with groups):** open an existing install that has groups in
+      Safari or on a phone → it becomes **browse-only**; the groups are not active
+      in-app. Confirm the in-app guidance points to the export/import bridge. **This is
+      the population the test-group email is for** — the manual *back up → install
+      Chrome → restore* recovery (the 15-minute call) is the supported path; verify you
+      can walk it end-to-end for one such user before relying on it.
+
+### 3. Real iOS Safari install — browse-only + mobile redesign (irreducible)
+
+> Mobile layout/interactions/route-redirects are covered by `just test`
+> (`tests/e2e/mobile/`, snapshot baselines) under **Chromium emulation**. Real iOS
+> Safari is the residue — emulation can't reproduce the bottom-bar / safe-area
+> behavior (§3.6).
+
+- [ ] **3.1** Open `https://fellows.globaldonut.com/` on a real iPhone; magic-link
+      round-trip works (real email, real Postmark).
+- [ ] **3.2** **Add to Home Screen** → app installs → opens standalone → directory loads.
+- [ ] **3.3** **Browse-only is correct on phone:** no group/selection chrome, no
+      "choose folder" affordance (private-data controls are **hidden**, not grayed).
+      Search + a fellow's detail work.
+- [ ] **3.4** Mobile redesign: the **hamburger drawer** navigates (the desktop tab
+      strip is gone on phones); the fellow detail shows the **Email / Call** call-to-actions.
+- [ ] **3.5** Group routes redirect: manually visiting `#/groups` (or a group link)
+      **redirects to the directory** rather than showing a broken/blank group screen.
+- [ ] **3.6** Watch for the "bottom bar takes half the screen" safe-area symptom that
+      Chromium emulation can't reproduce.
+
+### 4. Real Android Chrome install *(if you have an Android device)*
 
 > _(Optional assist: tether the device and drive it via chrome-devtools-mcp over
 > `adb forward` + `--browser-url` — see [`debugging.md`](debugging.md) § Recipe D.)_
 
-- [ ] **3.1** Same flow as iOS, but Chrome shows an "Add to Home Screen" prompt instead
-      of Safari's share sheet.
+- [ ] **4.1** Same flow as iOS §3 (Chrome shows an "Add to Home Screen" prompt instead
+      of Safari's share sheet): install → directory → **browse-only** (private data
+      hidden — Android Chrome has the picker but routes through the Storage Access
+      Framework, which can't keep the durable promise) → hamburger nav → Email/Call
+      CTAs → group routes redirect.
 
-### 4. Real MCPB install *(if you tested it in Phase 1)*
+### 5. Real MCPB install *(if you tested it in Phase 1)*
 
-- [ ] **4.1** On prod, download a `.mcpb` from Settings → Claude Desktop integration.
-- [ ] **4.2** Confirm it installs into Claude Desktop as in Phase 1 §3.
-- [ ] **4.3** Quick query: "How many fellows are in the directory?" — count matches the
+- [ ] **5.1** On prod, download a `.mcpb` from Settings → Claude Desktop integration.
+- [ ] **5.2** Confirm it installs into Claude Desktop as in Phase 1 §5.
+- [ ] **5.3** Quick query: "How many fellows are in the directory?" — count matches the
       build's `fellows.db`.
 
-### 5. Update flow on a real install
+### 6. Update flow on a real install
 
 > The drift→banner *logic* is covered by `just test` (`test_update_check.py`). What
 > stays manual: the **real SW update** on a **really-installed** PWA — drivable on
 > real Chrome via chrome-devtools-mcp ([`debugging.md`](debugging.md) § Recipe B).
 
-- [ ] **5.1** Open your existing installed PWA (phone or laptop).
-- [ ] **5.2** Within ~30 s the "New version available — Reload" banner appears.
-- [ ] **5.3** Click Reload → fresh shell loads → About shows the new build label.
+- [ ] **6.1** Open your existing installed PWA (phone or laptop).
+- [ ] **6.2** Within ~30 s the "New version available — Reload" banner appears.
+- [ ] **6.3** Click Reload → fresh shell loads → About shows the new build label.
+- [ ] **6.4** A folder-attached install keeps its groups across the update (the folder
+      is the canonical store; the SW update only swaps the app shell).
 
-### 6. Worst-case rollback (don't run unless needed)
+### 7. Worst-case rollback (don't run unless needed)
 
 ```bash
 git revert <bad-merge-commit>          # or git revert --no-commit <range>
@@ -231,6 +340,7 @@ Even with `just test` green and both phases passed, these operate on trust:
 
 | Gap | Why | Mitigation |
 |---|---|---|
+| **Existing Safari/iOS users with groups** | The gate makes them browse-only; their OPFS groups can't migrate in-app (no folder on those platforms). | Manual *back up → install Chrome → restore* bridge + the test-group email + a 15-min call (Phase 2 §2.2). ~1–2 users. |
 | **External-process folder concurrency** | Web Locks are per-origin per-browser-profile. Dropbox / iCloud / Syncthing replicating the folder, or a second browser on the same synced folder, can corrupt the file. | Out of scope in `plans/user_folder_storage.md` § Risks. Tell users not to sync `relationships.db`. |
 | **Cross-device sync** | Intentionally unsupported; `relationships.db` is per-device. | Export / Import recipe in `docs/users_manual.md` § Migrating from another browser. |
 | **Real Postmark deliverability across providers** | Gmail / Proton / Outlook each spam-score differently. | Ship-and-watch: `just prod-stats` send/verify counts; investigate Postmark if verify rate drops. |
@@ -243,8 +353,10 @@ Even with `just test` green and both phases passed, these operate on trust:
 ## Related
 
 - [`local_staging.md`](local_staging.md) — how to run `just serve-prod`.
+- [`feature_platform_matrix.md`](feature_platform_matrix.md) — the authoritative per-platform feature map (private data = verified folder only; phones browse-only).
+- [`folder_troubleshooting.md`](folder_troubleshooting.md) — folder-pick/probe failure paths and the migration bridge.
 - [`debugging.md`](debugging.md) — attaching Claude Code to your real Chrome via chrome-devtools-mcp (assist for the Phase-2 manual steps).
 - [`DevOps.md`](DevOps.md) — what `just ship` / `just deploy` / `just smoke` do.
 - [`email_gate.md`](email_gate.md) — the magic-link decision tree.
-- [`persistence_and_upgrades.md`](persistence_and_upgrades.md) — the storage-layer matrix.
+- [`persistence_and_upgrades.md`](persistence_and_upgrades.md) — the storage-layer matrix (browse-only = localStorage-only).
 - `plans/maintainer_test_plan_through_pr_200.md` — superseded per-batch snapshot example.


### PR DESCRIPTION
## What

Updates `docs/pre_ship_test_plan.md` to match what's actually shipping in this
release — the **private-data capability gate** and the **mobile redesign (PR6)**.
The plan hadn't been touched since before either feature and described the
pre-gate world.

## Why now

We ship imminently and the maintainer runs this checklist by hand. As written it
would have had the tester **verify removed behavior**. Three steps directly
contradicted shipped behavior:

- **Phase 2 iOS** — "create a group" on a phone (phones are now **browse-only**;
  no group creation on mobile).
- **Phase 1 silos** — framed Safari as an "OPFS-only fallback" with siloed groups
  (Safari is now **browse-only with no private store**).
- **Phase 1 restore** — "restore into Safari" (no durable store there; restore is
  **Chrome-side**).

It was also missing coverage for the new, no-automation, highest-risk manual paths.

## What changed

- **Phase 1 §§2–4 rewritten around the gate:** browse-only default → real-OS-picker
  unlock (§2); per-mutation durability + 🔒 Lock + 🔄 Reconnect (§3); the
  **OPFS→folder migration prompt** + content-previewed chooser (§4).
- **Phase 2 reframed for real devices:** browse-only verification + the mobile
  redesign (hamburger nav, Email/Call CTAs, group-route redirect) on real
  iOS/Android; a dedicated **§2 "Existing-user upgrade"** (the Chromium migration
  prompt + the Safari/iOS manual export/import bridge — the population the
  test-group email targets).
- **Labels match the shipped UI** (`Choose folder…`, `🔄 Reconnect your folder`,
  `🔒 Lock my private data`, `⬇ Download my private data`, `Restore from backup`,
  the `HOW-TO-MOVE-THIS-DATA` marker), grounded in `app/static/app.js`.
- **Discipline preserved:** each new section's callout cites the automated coverage
  (`test_private_data_enforcement.py`, `test_browse_only_durability.py`,
  `test_user_folder_storage.py`, `tests/e2e/mobile/`) so only the irreducible-manual
  residue stays in the file.
- Gaps table gains the **existing-Safari/iOS-users-with-groups** row; Related links
  the platform matrix + folder troubleshooting.

## Maintainer QA note

Docs-only (the checklist itself). Its first exercise is the actual pre-ship pass
for this release — flag any step whose label/flow doesn't match the shipped app
and I'll correct it. No app/test code touched.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
