### PR TITLE
fix(prod-stats): stream journalctl instead of buffering full history (fixes prod-stats-long OOM/exit 255)

### DIFF
--- a/scripts/prod_stats.py
+++ b/scripts/prod_stats.py
@@ -21,6 +21,7 @@ import sqlite3
 import subprocess
 import sys
 from collections import Counter
+from collections.abc import Iterator
 from datetime import datetime, timezone
 
 
@@ -37,35 +38,54 @@ ACCESS_RE = re.compile(
 FELLOWS_DB_PATH = "/opt/fellows/deploy/dist/fellows.db"
 
 
-def journal_entries(unit: str, since: str) -> list:
-    """Return journalctl -o json entries (dicts) for (unit, since).
+def journal_entries(unit: str, since: str) -> Iterator[dict]:
+    """Yield journalctl -o json entries (dicts) for (unit, since), one at a time.
 
-    Emits a stderr warning when the call succeeds but returns zero lines —
+    Streams the subprocess output line-by-line rather than buffering the whole
+    journal into memory. The full-history scan (`--since @0`, what
+    --include-emails forces) is >100 MB of JSON across >100k lines on a
+    long-lived host; the old `capture_output=True` + `.splitlines()` +
+    list-of-dicts approach peaked at ~700 MB of resident Python objects and
+    was OOM-killed on the 1 GB / no-swap prod droplet — surfacing as a
+    messageless `ssh` exit 255. Streaming keeps peak memory flat regardless
+    of journal size; ``tally`` consumes this generator in a single pass.
+
+    Emits a stderr warning when the call succeeds but yields zero entries —
     almost always the SSH user isn't in systemd-journal/adm and journalctl
     is silently withholding the unit's logs. Previously this failure mode
     was indistinguishable from a real zero-activity window.
     """
     try:
-        proc = subprocess.run(
+        proc = subprocess.Popen(
             ["journalctl", "-u", unit, "--since", since, "-o", "json", "--no-pager"],
-            capture_output=True,
+            stdout=subprocess.PIPE,
+            stderr=subprocess.PIPE,
             text=True,
         )
     except FileNotFoundError:
         print("journalctl not found (not a systemd host?)", file=sys.stderr)
-        return []
-    if proc.returncode != 0:
-        print(f"journalctl failed (exit {proc.returncode}): {proc.stderr.strip()}",
-              file=sys.stderr)
-        return []
-    entries = []
-    for line in proc.stdout.splitlines():
+        return
+    count = 0
+    # proc.stdout is a line-iterable text stream; each line is one JSON entry.
+    for line in proc.stdout:
         try:
             entry = json.loads(line)
         except json.JSONDecodeError:
             continue
-        entries.append(entry)
-    if not entries:
+        count += 1
+        yield entry
+    proc.stdout.close()
+    # journalctl writes little to stderr (warnings only), so reading it after
+    # stdout is drained won't deadlock in practice.
+    stderr = proc.stderr.read() if proc.stderr else ""
+    if proc.stderr:
+        proc.stderr.close()
+    returncode = proc.wait()
+    if returncode != 0:
+        print(f"journalctl failed (exit {returncode}): {stderr.strip()}",
+              file=sys.stderr)
+        return
+    if count == 0:
         print(
             f"WARNING: journalctl returned 0 entries for {unit}.\n"
             "  Almost always this means the SSH user isn't in the\n"
@@ -74,7 +94,6 @@ def journal_entries(unit: str, since: str) -> list:
             "  the operator workstation to re-apply the common role.",
             file=sys.stderr,
         )
-    return entries
 
 
 def _entry_message(entry: dict) -> str | None:

--- a/tests/test_prod_stats.py
+++ b/tests/test_prod_stats.py
@@ -12,6 +12,7 @@ emits: each entry is a dict with at least ``MESSAGE`` and
 """
 import hashlib
 import importlib.util
+import io
 import json
 import os
 import sqlite3
@@ -730,6 +731,72 @@ def test_print_human_errors_only_with_no_errors_says_so(capsys):
     assert "4xx errors:              0" in out
     assert "5xx errors:              0" in out
     assert "(none in window)" in out
+
+
+# ---- journal_entries(): streaming behavior -------------------------------
+
+class _FakePopen:
+    """Minimal subprocess.Popen stand-in for journal_entries tests.
+
+    stdout/stderr are StringIO streams (line-iterable, closeable, readable)
+    so we exercise the streaming parse + warning paths without shelling out
+    to a real journalctl.
+    """
+
+    def __init__(self, stdout_text="", stderr_text="", returncode=0):
+        self.stdout = io.StringIO(stdout_text)
+        self.stderr = io.StringIO(stderr_text)
+        self._returncode = returncode
+
+    def wait(self):
+        return self._returncode
+
+
+def test_journal_entries_streams_lines_and_skips_bad_json(monkeypatch):
+    """The OOM fix: journal_entries is a lazy generator that parses one line
+    at a time (no full-journal buffering), skipping non-JSON lines."""
+    lines = "\n".join([
+        json.dumps({"MESSAGE": "first"}),
+        "not-json-garbage",
+        json.dumps({"MESSAGE": "second"}),
+    ]) + "\n"
+    monkeypatch.setattr(prod_stats.subprocess, "Popen",
+                        lambda *a, **k: _FakePopen(lines))
+    gen = prod_stats.journal_entries("fellows-pwa", "@0")
+    # Regression guard: it must stay a lazy iterator, not a buffered list —
+    # buffering the full @0 journal is exactly what OOM-killed prod (255).
+    assert iter(gen) is gen
+    entries = list(gen)
+    assert [e["MESSAGE"] for e in entries] == ["first", "second"]
+
+
+def test_journal_entries_warns_on_zero_entries(monkeypatch, capsys):
+    monkeypatch.setattr(prod_stats.subprocess, "Popen",
+                        lambda *a, **k: _FakePopen(""))
+    assert list(prod_stats.journal_entries("fellows-pwa", "@0")) == []
+    assert "returned 0 entries" in capsys.readouterr().err
+
+
+def test_journal_entries_reports_journalctl_failure_without_zero_warning(
+    monkeypatch, capsys
+):
+    """A non-zero journalctl exit prints the failure (with stderr) and does
+    NOT also emit the misleading 'returned 0 entries' group-membership hint."""
+    monkeypatch.setattr(prod_stats.subprocess, "Popen",
+                        lambda *a, **k: _FakePopen("", stderr_text="boom", returncode=1))
+    assert list(prod_stats.journal_entries("fellows-pwa", "@0")) == []
+    err = capsys.readouterr().err
+    assert "journalctl failed (exit 1)" in err
+    assert "boom" in err
+    assert "returned 0 entries" not in err
+
+
+def test_journal_entries_handles_missing_journalctl(monkeypatch, capsys):
+    def _raise(*a, **k):
+        raise FileNotFoundError
+    monkeypatch.setattr(prod_stats.subprocess, "Popen", _raise)
+    assert list(prod_stats.journal_entries("fellows-pwa", "@0")) == []
+    assert "journalctl not found" in capsys.readouterr().err
 
 
 # ---- main() + --json -----------------------------------------------------


### PR DESCRIPTION
## What

`just prod-stats-long` (`/opt/fellows/bin/prod_stats --include-emails`) has been
failing on every run with a messageless `ssh` **exit 255**. It looked like the
intermittent network problem we've been chasing, but it's deterministic and
separate: it's an **out-of-memory kill**.

## Root cause

`--include-emails` forces a full-history journal scan (`--since '@0'`). The old
`journal_entries()` buffered the entire result into RAM:

- `subprocess.run(..., "-o", "json", capture_output=True, text=True)` — the whole
  journal as one Python `str`
- `.splitlines()` — a second copy as a list of strings
- `json.loads()` per line — a list of 100k+ journald dicts

On the prod droplet (1 vCPU / 961 MB / **0 swap**) the full-history JSON is
~110 MB across 102k lines, and the resident Python objects peak at
**~720-750 MB**. The kernel OOM-killer kills `python3` every run; `ssh` reports a
signal-killed remote command as exit 255 (usually with no message). The short
`prod-stats` (24h window) stays small and is unaffected.

Kernel evidence on the box (Jun 9-10): repeated `Out of memory: Killed process
... (python3)` at ~720 MB anon-rss — and `caddy`/`sshd` *themselves* invoking the
OOM-killer under the pressure, which is also the likely driver of the
intermittent connectivity blips.

## The fix

Rewrite `journal_entries()` as a **generator** that streams `journalctl` output
line-by-line via `subprocess.Popen`, parsing one entry at a time. `tally()`
already consumes it in a single pass, so peak memory stays flat regardless of
journal size.

Verified against the **real prod journal** (uploaded to a temp path, run,
removed — no deploy):

| | before | after |
|---|---|---|
| peak RSS | ~720 MB (OOM-killed) | **~73 MB** |
| exit code | 255 | **0** |
| wall clock | — (died) | ~15 s |

## Tests

`tests/test_prod_stats.py`: **43 passed** (39 existing + 4 new). New coverage for
the previously-untested streaming path: line-streaming + bad-JSON skip,
zero-entry warning, journalctl-failure reporting, missing-journalctl — **plus a
guard that `journal_entries` stays a lazy generator** (a revert to buffering
would re-introduce the OOM).

## Maintainer QA (after this merges + deploys)

`/opt/fellows/bin/prod_stats` is installed by the `fellows_app` ansible role (a
copy of `scripts/prod_stats.py`), so the fix reaches prod on the next deploy.

1. Deploy: `git checkout main && git pull && just ship` (or scp the script for a
   hotfix). Hold the deploy until the workstation-to-droplet link is stable.
2. On the droplet, confirm flat memory on the full scan — non-confidential, no
   `--include-emails`:

   ```
   /usr/bin/time -v /opt/fellows/bin/prod_stats --since @0 >/dev/null
   ```

   Expect `Maximum resident set size` ~70-80 MB and exit 0 (was ~720 MB / killed).
3. Run it end-to-end: `just prod-stats-long` — returns the recipient list, no
   exit 255.

## Related (not in this PR)

- A **2 GB swapfile was added to the droplet ad-hoc (2026-06-10)** as
  defense-in-depth; it alone already unblocks the existing command (the 737 MB
  balloon now spills ~90 MB to swap, exit 0). This PR makes `prod-stats-long`
  independent of swap.
- The intermittent "all ports down then partially back" connectivity traced to
  resource starvation from these OOM storms (not fail2ban / UFW / NIC / any
  intrusion). Mitigated by the swap above.
- The droplet is undersized (961 MB) for its 1.3 GB journal + caddy + python; a
  resize is worth considering separately. Capping `journald` `SystemMaxUse` would
  lose the magic-link send history that `prod-stats-long` reports, so prefer a
  resize.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
