### PR TITLE
fix(folder-banner): don't paint the data-folder nag over the email gate

### DIFF
--- a/app/static/app.js
+++ b/app/static/app.js
@@ -5043,6 +5043,13 @@
     setShellVisible(false);
     showLoading(false);
     showApp(false);
+    // Defense-in-depth: a stale-session boot can reach this gate with
+    // window.__dataProvider still assigned (bootDirectoryAsApp → 401/403 →
+    // startBrowserUx → initEmailGate). Hide the folder-push "set up a data
+    // folder" nag immediately so it can't sit on top of the gate; its own
+    // refresh also now guards on app-wrap visibility (see refreshFolderPushBanner).
+    var folderPushOnGate = document.getElementById('folder-push-banner');
+    if (folderPushOnGate) folderPushOnGate.classList.add('hidden');
 
     setGateReasonBanner(reason);
 
@@ -9251,7 +9258,18 @@
     // this fix: the 1500ms boot-time safety-net timer, the Settings-render
     // cascade, and — for the write-failed variant — afterFolderMutation.)
     var inApp = !!(window.__dataProvider && window.__dataProvider.kind);
-    if (!inApp) {
+    // ...but inApp alone is not enough. A stale-session boot leaves
+    // window.__dataProvider assigned and then routes to the email gate
+    // (bootDirectoryAsApp → pickDataProvider assigns the provider → 401/403 →
+    // the catch handler hands off to startBrowserUx → initEmailGate, which
+    // hides the app via showApp(false) but never clears the provider). So an
+    // already-installed user with an expired session saw this banner painted
+    // on top of the gate, while a fresh incognito visitor never did (they
+    // never call bootDirectoryAsApp, so the provider stays unset). Require the
+    // directory itself to be on screen — #app-wrap is hidden on the gate, the
+    // install landing, and the loading screens.
+    var appVisible = !!(appWrapEl && !appWrapEl.classList.contains('hidden'));
+    if (!inApp || !appVisible) {
       bannerEl.classList.add('hidden');
       return;
     }

--- a/tests/e2e/test_offline_only_mode.py
+++ b/tests/e2e/test_offline_only_mode.py
@@ -251,3 +251,74 @@ class TestOfflineOnlyMode:
             context.unroute(API_FELLOWS)
             context.unroute("**/api/auth/status")
             page.close()
+
+    def test_folder_push_banner_stays_hidden_on_gate_after_stale_session(self, context, base_url_fixture):
+        """Regression: the folder-push "set up a data folder" banner must NOT
+        paint on top of the email gate.
+
+        Repro (the only state that triggers it): an already-installed user
+        (fellows_authenticated_once) whose session expired boots via
+        bootDirectoryAsApp → pickDataProvider assigns window.__dataProvider →
+        401/403 → the catch handler hands off to startBrowserUx → initEmailGate.
+        The provider stays assigned, so the banner's old inApp-only guard let
+        the nag render over the gate. The fix also requires #app-wrap to be
+        visible (the gate hides it via showApp(false)). A fresh incognito
+        visitor never reproduces this — they never call bootDirectoryAsApp, so
+        the provider is never set; that asymmetry was the field symptom.
+        """
+        page = context.new_page()
+        # Installed browser-tab user → boots via bootDirectoryAsApp; no cache.
+        page.add_init_script(
+            "window.localStorage.setItem('fellows_authenticated_once', '1');"
+        )
+        context.route(
+            FELLOWS_DB,
+            lambda r: r.fulfill(status=401, body="session expired"),
+        )
+        context.route(
+            API_FELLOWS,
+            lambda r: r.fulfill(status=401, body="session expired"),
+        )
+        context.route(
+            "**/api/auth/status",
+            lambda r: r.fulfill(
+                status=200,
+                content_type="application/json",
+                body=json.dumps({
+                    "authEnabled": True,
+                    "authenticated": False,
+                    "hasSessionCookie": False,
+                    "installRecentlyAllowed": False,
+                }),
+            ),
+        )
+        try:
+            page.goto(base_url_fixture + "/", wait_until="domcontentloaded")
+            page.locator("#install-gate-private").wait_for(state="visible", timeout=10000)
+            # Bug precondition: the provider lingers (set during the failed
+            # bootDirectoryAsApp, never cleared by the gate handoff) and the
+            # app shell is hidden.
+            assert page.evaluate(
+                "() => !!(window.__dataProvider && window.__dataProvider.kind)"
+            ), "expected window.__dataProvider to remain set after the gate handoff"
+            expect(page.locator("#app-wrap")).to_be_hidden()
+            # Drive the banner re-evaluation exactly as the production 1.5s
+            # safety-net timer (setTimeout(refreshFolderPushBanner, 1500)) does,
+            # but deterministically via the test seam. Without the app-wrap
+            # guard this paints the nag over the gate; with it, it stays hidden.
+            page.wait_for_function(
+                "() => typeof window.__refreshFolderPushBanner === 'function'",
+                timeout=5000,
+            )
+            page.evaluate("() => window.__refreshFolderPushBanner()")
+            # Let the async getState()/countRelationships chain settle — a
+            # regression would flip the banner visible within this window.
+            page.wait_for_timeout(1000)
+            expect(page.locator("#folder-push-banner")).to_be_hidden()
+            # The gate is still the thing on screen.
+            expect(page.locator("#install-gate-private")).to_be_visible()
+        finally:
+            context.unroute(FELLOWS_DB)
+            context.unroute(API_FELLOWS)
+            context.unroute("**/api/auth/status")
+            page.close()


### PR DESCRIPTION
## Symptom

The folder-push **"Save your fellows data to disk." / "Set up data folder"**
banner (`#folder-push-banner`) renders **on top of the email gate** for some
users. Reported in person for an already-installed user (an expired session)
who opened `fellows.globaldonut.com` at the gate; **not** reproducible in a
fresh incognito Chrome window.

## Root cause (a live bug, not just a stale cached version)

1. An installed user has `fellows_authenticated_once` (or is standalone) → the
   boot dispatcher calls **`bootDirectoryAsApp()`**, not the fresh-visitor
   `startBrowserUx()` path.
2. `pickDataProvider()` assigns **`window.__dataProvider`** immediately
   (`app.js:12228`), *before* the auth check.
3. The 7-day session cookie has expired → `/fellows.db` returns **401/403** →
   `bootDirectoryAsApp`'s catch handler (the #125 fix) hands off to
   **`startBrowserUx()` → `initEmailGate()`**, which shows the gate via
   `showApp(false)`.
4. `initEmailGate` **never clears `window.__dataProvider` nor hides the
   banner.**
5. The banner's safety-net **`setTimeout(refreshFolderPushBanner, 1500)`**
   fires. Its only "are we inside the app?" guard was
   `inApp = !!(window.__dataProvider && .kind)` — now **true while the gate is
   on screen** → the nag paints over the gate.

The earlier #218 fix added that `inApp` guard assuming *"provider set ⟺ inside
the directory."* True for a **fresh** visitor, **false** for the
installed-but-stale-session handoff. That's exactly the field asymmetry: a
fresh incognito visitor never calls `bootDirectoryAsApp`, so the provider is
never set and the banner never shows — but an installed user with an expired
session hits it.

## Fix

- **`refreshFolderPushBanner`** — also require the directory to actually be on
  screen (`#app-wrap` visible), not just the provider to exist. `#app-wrap` is
  hidden on the gate / install landing / loading screens (the gate sets it via
  `showApp(false)`), so the banner can no longer leak onto them. The
  legitimate **browse-only cached-directory** case still shows the banner
  (`#app-wrap` is visible there).
- **`initEmailGate`** — defense-in-depth: hide `#folder-push-banner` when the
  gate renders, so it's cleared immediately regardless of refresh timing.

## Test (negative invariant, proven)

`tests/e2e/test_offline_only_mode.py::test_folder_push_banner_stays_hidden_on_gate_after_stale_session`
drives the exact repro (installed + expired session → gate with
`window.__dataProvider` set), then triggers the banner refresh via the
existing `window.__refreshFolderPushBanner` seam and asserts the banner stays
hidden.

Verified both directions:
- **Without the fix** (stashed `app.js`, kept the test): **FAILS** —
  `#folder-push-banner` is `visible` on the gate (reproduces the bug; logs
  show `boot_failed_auth`).
- **With the fix**: passes.

Regression sweep (all pass): the 3 existing `test_offline_only_mode` 401/gate
tests, the `folder_push` banner **appear / dismiss / CTA** tests in
`test_user_folder_storage.py` (the guard still shows the banner in-app), and
`test_install_landing` use-in-tab.

## Maintainer QA (prod)

Hard to hit on demand (needs an installed app with an expired 7-day session),
but to reproduce the pre-fix behavior on the current prod build: in an
installed copy / a tab with `localStorage.fellows_authenticated_once = '1'`,
let the session expire (or `POST /api/logout`) and reload — pre-fix, the
folder banner appears above the email gate; post-deploy it should not. The
e2e test pins it deterministically.

## Note for merge

`app/static/app.js` has in-flight uncommitted edits in another working copy
(parallel work). This branch is cut from clean `origin/main` and changes only
`refreshFolderPushBanner` (~9253) and `initEmailGate` (~5045); a small rebase
may be needed if those regions overlap.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
