### PR TITLE
test(e2e): de-flake folder-attach wait (8000ms → 15000ms)

### DIFF
--- a/tests/e2e/conftest.py
+++ b/tests/e2e/conftest.py
@@ -372,9 +372,14 @@ def worker_data_folder(standalone_page, base_url_fixture):
     # gate to flip open.
     page.goto(base_url_fixture + "/", wait_until="domcontentloaded")
     helper.wait()
+    # The heaviest wait in the folder-attach path: a full folder-mode worker
+    # re-init on (re)load before privateDataEnabled() flips and the
+    # `no-private-data` body class is removed. At 8000ms this was the only step
+    # to time out at the tail of a loaded full-suite run (it completes in ~2s in
+    # isolation); the sibling waits here already use 10000ms. Bump for headroom.
     page.wait_for_function(
         "() => document.body && !document.body.classList.contains('no-private-data')",
-        timeout=8000,
+        timeout=15000,
     )
     try:
         yield helper
@@ -410,9 +415,14 @@ def attach_verified_folder(page, base_url):
         "() => window.__dataProvider && typeof window.__dataProvider.listGroups === 'function'",
         timeout=10000,
     )
+    # The heaviest wait in the folder-attach path: a full folder-mode worker
+    # re-init on (re)load before privateDataEnabled() flips and the
+    # `no-private-data` body class is removed. At 8000ms this was the only step
+    # to time out at the tail of a loaded full-suite run (it completes in ~2s in
+    # isolation); the sibling waits here already use 10000ms. Bump for headroom.
     page.wait_for_function(
         "() => document.body && !document.body.classList.contains('no-private-data')",
-        timeout=8000,
+        timeout=15000,
     )
 
 


### PR DESCRIPTION
## What

De-flake `test_version_skew_refuses_mutations_but_allows_reads`, which timed
out in a full-suite run (`just test`), and harden the shared folder-attach
helpers it relies on.

## Triage (flake, not a regression)

The failure was a **`Timeout 8000ms exceeded`** inside
`attach_verified_folder` (`tests/e2e/conftest.py`) — specifically the wait for
the post-reload `no-private-data` body class to clear. That step is a **full
folder-mode worker re-init on reload** before `privateDataEnabled()` flips —
the heaviest operation in the folder-attach path.

The helper's three waits are `10000 / 10000 / `**`8000`**ms; the failing one is
the **odd-one-out short timeout on the slowest step**. It tripped only at the
**tail of a ~9m45s / 732-passed run** (machine under load). Run **in isolation
against current `main` it passes 3/3 in ~2s**. So: load-induced flake, not a
logic failure, and unrelated to recent app changes (this path is
`updatePrivateDataGate`, not touched by the folder-banner / prod-stats / docs
work).

## Fix

Bump that wait from `8000ms` → `15000ms` in both places it appears
(`attach_verified_folder` and the `folder_attached_page` fixture), giving the
heaviest step headroom under load. Sibling waits in the same helpers already
use 10000ms. **Test-only; no product code changes.**

## Verification

- Failing test: **3/3 pass in isolation** before the change (~2s each) —
  confirming the flake classification.
- After the change: passes; conftest parses and both folder-attach helpers
  still drive their tests.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
