### PR TITLE
fix(reset): clear the persisted folder handle on Reset Everything

### DIFF
--- a/app/static/app.js
+++ b/app/static/app.js
@@ -2371,6 +2371,15 @@
         try {
           window.indexedDB.deleteDatabase('fellows-local-db');
         } catch (err) {}
+        // Reset Everything = brand-new install: also drop the worker-owned
+        // folder-handle store (a separate IndexedDB, mirrors FOLDER_IDB_NAME
+        // in vendor/sqlite-worker.js). The worker's wipeAll RPC already
+        // clears this when the worker is alive; this is the belt-and-
+        // suspenders for the worker-unavailable path. (Clear App Cache must
+        // NOT do this — it preserves the folder.)
+        try {
+          window.indexedDB.deleteDatabase('fellows-fs-handles');
+        } catch (err) {}
       }
 
       if ('caches' in window) {

--- a/app/static/vendor/sqlite-worker.js
+++ b/app/static/vendor/sqlite-worker.js
@@ -1818,6 +1818,14 @@ handlers.wipeAll = async function () {
     trace('wipeAll: root iteration failed: ' + (e3 && e3.message || e3));
   }
   poolUtil = null;
+  // Reset Everything is a "brand-new install" — also drop the persisted
+  // user-folder handle. It lives in its own IndexedDB (FOLDER_IDB_NAME),
+  // separate from OPFS and from the page's fellows-local-db, so the OPFS
+  // sweep above never touches it. Without this, a reinstall after reset
+  // re-hydrated a stale "folder set but unreachable" pointer at the old path.
+  folderRecord = _emptyFolderRecord();
+  try { await _folderIdbDelete(); }
+  catch (e) { trace('wipeAll: folder IDB delete failed: ' + (e && e.message || e)); }
   trace('wipeAll: removedVfs=' + removedVfs + ' rootRemoved=' + rootEntriesRemoved.length +
         ' rootFailed=' + rootEntriesFailed.length);
   return {

--- a/docs/persistence_and_upgrades.md
+++ b/docs/persistence_and_upgrades.md
@@ -53,7 +53,7 @@ there is no private store at all — see
 | Cache API `fellows-app-shell-vN` | service worker | HTML, JS, CSS, SW, manifest, icons, sqlite3.wasm, `vendor/sqlite-worker.js` | Yes — every CACHE_VERSION bump | Yes |
 | Cache API `fellows-images-v1` | service worker | Profile photos | No (separate cache name) — re-fetched as needed | Yes |
 | IndexedDB `fellows-local-db` | main (retired in Phase 6) | Offline-fallback full fellow rows | Regenerated on every successful boot | Yes |
-| IndexedDB `fellows-fs-handles` | worker | The `FileSystemDirectoryHandle` the user picked (key `relationships-folder`) — what makes folder mode "remember" the folder across browser restarts | Untouched | **No** (survives Clear App Cache); cleared by browser-level "Clear site data" |
+| IndexedDB `fellows-fs-handles` | worker | The `FileSystemDirectoryHandle` the user picked (key `relationships-folder`) — what makes folder mode "remember" the folder across browser restarts | Untouched | **No** (survives Clear App Cache); cleared by **Reset Everything** and by browser-level "Clear site data" |
 | OPFS `fellows.db` | worker | Imported Knack contact data | **Re-imported on user request** via the About-page *Update directory data* button when `fellows.db.meta.json:sha` differs from `build-meta.json:fellows_db_sha`. Boot path is install-only and never auto-refreshes a returning visitor (`plans/opt_in_directory_data_updates.md`). | **No** (gap; see "Open questions") |
 | OPFS `fellows.db.meta.json` | worker | `{sha, fetched_at, last_failure_at, last_failure_reason}` — the freshness sidecar that records what's locally installed. Sibling of `fellows.db` at the OPFS root, outside the SAH-pool dir, so a `relationships.db` restore can't desync it. | Updated after each successful user-driven re-import; otherwise untouched | **No** |
 | OPFS `relationships.db` *(folder mode — buffer; browse-only — dormant)* | worker | Groups, group members, fellow_tags, fellow_notes, settings. In folder mode this is a transient working buffer hydrated from folder bytes on boot and serialized back on every commit. In **browse-only mode it is dormant** — not opened for durable data (one read-only legacy peek for the migration prompt is the only access). | **Never** — that's the whole point of this file | **No** |
@@ -334,7 +334,11 @@ lost.
 
 - localStorage clears (including `fellows_authenticated_once`, unlike
   Clear App Cache).
-- IndexedDB clears.
+- IndexedDB clears — both `fellows-local-db` (the offline cache) **and**
+  `fellows-fs-handles` (the persisted folder handle), so a reinstall after
+  reset does **not** resurrect the old "folder set but unreachable" pointer.
+  The worker's `wipeAll` drops the handle; `clearEverything` also deletes the
+  database directly as a backstop for the worker-unavailable path.
 - All Cache API entries clear (shell + images).
 - The HttpOnly session cookie clears via `POST /api/logout`.
 - Service worker registrations are unregistered.

--- a/tests/e2e/test_user_folder_storage.py
+++ b/tests/e2e/test_user_folder_storage.py
@@ -1203,3 +1203,47 @@ class TestPhase2WriteLock:
             except Exception:
                 pass
             second_page.close()
+
+
+def test_reset_everything_wipeall_clears_persisted_folder_handle(
+    folder_attached_page, base_url_fixture
+):
+    """Reset Everything must clear the persisted user-folder handle so a fresh
+    boot after a reset (e.g. a reinstall) does NOT resurrect the old folder.
+
+    Regression: wipeAll — Reset Everything's storage wipe — cleared OPFS and
+    the page's `fellows-local-db` IndexedDB, but never the worker's *separate*
+    `fellows-fs-handles` IndexedDB that persists the FileSystemDirectoryHandle.
+    So after Reset Everything + reinstall the worker re-hydrated a stale
+    "Folder set but unreachable" pointer at the old path. The fix has wipeAll
+    drop the handle (folderRecord reset + _folderIdbDelete), with a page-side
+    deleteDatabase('fellows-fs-handles') backstop in clearEverything.
+    """
+    page = folder_attached_page
+    # Precondition: a folder handle is attached and persisted in IDB.
+    assert page.evaluate(
+        "async () => { const s = await window.__folderController.getState();"
+        " return !!s.hasHandle; }"
+    ) is True, "fixture should have attached a folder"
+
+    # Reset Everything's storage wipe is the worker wipeAll RPC.
+    page.evaluate("async () => { await window.__dataProvider.wipeAll(); }")
+
+    # Reload — the post-reset reinstall boot. The worker re-inits and would
+    # re-hydrate the handle from fellows-fs-handles if wipeAll hadn't cleared it.
+    page.reload(wait_until="domcontentloaded")
+    page.wait_for_function(
+        "() => window.__dataProvider"
+        " && typeof window.__dataProvider.listGroups === 'function'",
+        timeout=15000,
+    )
+
+    # The persisted handle must be gone — a fresh boot must not resurrect it.
+    has_handle = page.evaluate(
+        "async () => { const s = await window.__folderController.getState();"
+        " return !!s.hasHandle; }"
+    )
+    assert has_handle is False, (
+        "wipeAll must clear the persisted folder handle (fellows-fs-handles); "
+        "a reinstall re-hydrated the old folder pointer"
+    )


### PR DESCRIPTION
## Symptom

After **Reset Everything** + a fresh reinstall (new magic link, new install
codename), the app still showed *"Folder set but unreachable — Change folder to
re-pick"* pointing at the **old** folder (`shiptest/Fellows`), with Change
folder / Reconnect / Lock / Download surfaced — as if private data existed.
Diagnostics from the brand-new install:

```
worker: init OK ... hasFellowsDb=false hasRelDb=true
folder: hydrated handle parent=shiptest subfolder=Fellows lastSavedAt=2026-06-10T03:54:50 ...
storageMode=opfs (handle=yes permission=prompt)
Data folder: handle persisted=true ... badge: inaccessible
```

The groups didn't actually come back (the `relationships.db` was freshly
created this boot) — only a **stale folder pointer** did.

## Root cause

The user-folder handle is worker-owned and persisted in its **own** IndexedDB
database, **`fellows-fs-handles`** (key `relationships-folder`) — separate from
OPFS and from the page's `fellows-local-db`. But Reset Everything
(`clearEverything`) never cleared it:

- `clearEverything` deletes only `indexedDB.deleteDatabase('fellows-local-db')`.
- The worker's `wipeAll` RPC closes the DBs and sweeps **OPFS** root entries —
  it never touches `fellows-fs-handles`.

So the handle survived a "treat me like a brand-new install" reset and got
re-hydrated on the next worker init. (This is also why a fresh *incognito*
visitor never saw it — no persisted handle there.)

## Fix

- **Worker `wipeAll`** now also drops the handle —
  `folderRecord = _emptyFolderRecord(); await _folderIdbDelete();` — exactly what
  `clearFolderHandle` already does. This is the primary fix (the handle is
  worker-owned).
- **`clearEverything`** also `deleteDatabase('fellows-fs-handles')` directly, as
  a backstop for the worker-unavailable reset path. **Clear App Cache is
  unchanged** — it must *preserve* the folder.

Clearing the *pointer* does not delete the user's on-disk folder data — that
file stays on disk and can be re-attached deliberately; we just stop
auto-resurrecting a stale pointer.

## Test (negative invariant, proven)

`tests/e2e/test_user_folder_storage.py::test_reset_everything_wipeall_clears_persisted_folder_handle`:
attach a folder → `wipeAll` → reload → assert the handle is **not** re-hydrated
(`getState().hasHandle === false`).

Verified both ways:
- **Without the worker fix** (stashed): **FAILS** — the handle survives `wipeAll`
  and re-hydrates on reload (reproduces the bug).
- **With the fix**: passes.

Regression sweep green: `test_reset_everything.py`, `test_folder_probe.py`, and
the new test (13 passed).

## Docs

`persistence_and_upgrades.md` updated to match: the state-survival matrix row
for `fellows-fs-handles` now notes Reset Everything clears it, and the
"A user clicks Reset Everything" section spells out that both
`fellows-local-db` **and** `fellows-fs-handles` clear (so a reinstall doesn't
resurrect the old folder pointer).

## Note for merge

`app/static/app.js` may have in-flight uncommitted edits in another working
copy; this branch is cut from clean `origin/main`. The `app.js` change is a
small addition next to the existing `deleteDatabase('fellows-local-db')` line —
low conflict risk.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
