### PR TITLE
fix(ship): build .mcpb bundles into the deploy so the Claude Desktop install works

### DIFF
--- a/ansible/roles/fellows_app/tasks/main.yml
+++ b/ansible/roles/fellows_app/tasks/main.yml
@@ -179,6 +179,40 @@
   become: false
   notify: Restart fellows app
 
+# Verify the three Claude Desktop .mcpb bundles actually landed in the
+# deployed dist. The /mcpb/<name>.mcpb routes are auth-gated — the 403
+# for an unauthenticated request is returned *before* the file-existence
+# check — so an HTTPS smoke can't distinguish "present" from "absent".
+# The honest check is on-disk, here, right after rsync. This is the
+# tripwire for the ship bug where the build never produced the bundles
+# and rsync --delete then removed them from prod, surfacing to fellows as
+# the "File wasn't available on site" download failure. Pass
+# --extra-vars fellows_skip_mcpb_check=true for a deliberate PWA-only deploy.
+- name: Verify Claude Desktop .mcpb bundles are present in deployed dist
+  ansible.builtin.stat:
+    path: "{{ app_root }}/deploy/dist/mcpb/{{ item }}.mcpb"
+  register: fellows_mcpb_stat
+  loop:
+    - comms
+    - shared_data_ops
+    - private_data_ops
+  when: not (fellows_skip_mcpb_check | default(false) | bool)
+
+- name: Fail if any .mcpb bundle is missing from deployed dist
+  ansible.builtin.fail:
+    msg: >-
+      {{ item.item }}.mcpb is missing from {{ app_root }}/deploy/dist/mcpb/.
+      The Claude Desktop install routes (/mcpb/{{ item.item }}.mcpb) will 404
+      ("File wasn't available on site"). Run `just build` (it now runs
+      build/build_mcpb.py) before deploy, or pass
+      --extra-vars fellows_skip_mcpb_check=true for a deliberate PWA-only deploy.
+  loop: "{{ fellows_mcpb_stat.results | default([]) }}"
+  loop_control:
+    label: "{{ item.item }}"
+  when:
+    - not (fellows_skip_mcpb_check | default(false) | bool)
+    - not (item.stat.exists | default(false))
+
 # If the Phase 4 env file is present, make sure it is readable by the new
 # service group. (The configure_email_auth_env.sh script originally created
 # it as root:deploy; this task rewrites the group so the new service user

--- a/docs/justfile.md
+++ b/docs/justfile.md
@@ -127,11 +127,19 @@ claim is the attestation table in [`Architecture.md`](Architecture.md).
 
 ### build
 
-- **`build`** — assemble `deploy/dist/` (runs `build/build_pwa.py`). The
-  build stamps the current `git rev-parse --short HEAD` into the
-  `__FELLOWS_UI_DIAG__` and `__CACHE_VERSION__` placeholders in
-  `app.js` and `sw.js` as it copies them. Format: `<YYYY-MM-DD>-<short-sha>`.
-  No manual bump step; every build label matches HEAD.
+- **`build`** — assemble `deploy/dist/` (runs `build/build_pwa.py`) **and** the
+  Claude Desktop `.mcpb` bundles into `deploy/dist/mcpb/` (runs
+  `build/build_mcpb.py`, which needs Node 20+). `build_mcpb` runs *after*
+  `build_pwa` because `build_pwa` `rmtree`'s `deploy/dist/` — running it after
+  is what keeps the bundles from being wiped before the deploy rsync ships
+  them. Set `FELLOWS_SKIP_MCPB=1` for a fast PWA-only build that skips the
+  Node toolchain (deploys leave it unset; `deploy` verifies the bundles are
+  present on the host post-rsync and fails loudly if not — bypass that with
+  `--extra-vars fellows_skip_mcpb_check=true`). The build also stamps the
+  current `git rev-parse --short HEAD` into the `__FELLOWS_UI_DIAG__` and
+  `__CACHE_VERSION__` placeholders in `app.js` and `sw.js` as it copies them.
+  Format: `<YYYY-MM-DD>-<short-sha>`. No manual bump step; every build label
+  matches HEAD.
 - **`build-meta`** — print `deploy/dist/build-meta.json` (build_label,
   git_sha, built_at). Useful to pair with `drift`.
 

--- a/justfile
+++ b/justfile
@@ -440,10 +440,28 @@ test-mcpb-parity:
 
 # ---- build / deploy ------------------------------------------------------
 
-# Assemble deploy/dist/ (runs build/build_pwa.py).
+# Assemble deploy/dist/ (build/build_pwa.py) AND the Claude Desktop
+# .mcpb bundles (build/build_mcpb.py) into deploy/dist/mcpb/.
+#
+# Ordering is load-bearing: build_pwa.py rmtree's deploy/dist/ and
+# recreates it from app/static/, so build-mcpb MUST run *after* it —
+# otherwise the bundles get wiped before they ship, the rsync --delete
+# removes them from prod, and the in-app "Set up Claude Desktop
+# integration" download 404s ("File wasn't available on site"). Wiring
+# build-mcpb in here is the fix: every `just build` / `deploy` / `ship`
+# now produces the bundles the deploy rsync ships. Set FELLOWS_SKIP_MCPB=1
+# for a fast PWA-only build that skips the Node toolchain (deploys leave
+# it unset so the bundles always ship; deploy verifies their presence).
 [group('build')]
 build:
+    #!/usr/bin/env bash
+    set -euo pipefail
     {{python}} build/build_pwa.py
+    if [ "${FELLOWS_SKIP_MCPB:-0}" = "1" ]; then
+        echo "build: FELLOWS_SKIP_MCPB=1 — skipping .mcpb bundles (PWA-only build)."
+    else
+        python3 build/build_mcpb.py
+    fi
 
 # Generate the prod ECDSA P-256 signing keypair (one-time, per maintainer).
 # Prompts for a passphrase, writes ~/.fellows/signing-key.enc.pem, prints

--- a/scripts/serve_prod_local.py
+++ b/scripts/serve_prod_local.py
@@ -30,6 +30,7 @@ import base64
 import os
 import shutil
 import sqlite3
+import subprocess
 import sys
 from datetime import datetime
 from functools import partial
@@ -122,20 +123,34 @@ def _build_dist(force: bool) -> None:
         encoding="utf-8",
     )
 
-    # Wire the .mcpb bundles if a previous `just build-mcpb` produced them.
-    # Without this, § 6/§ 7 of the maintainer test plan can't run locally.
-    if MCPB_SOURCE_DIR.is_dir():
-        bundles = sorted(MCPB_SOURCE_DIR.glob("*.mcpb"))
-        if bundles:
-            target = DIST_DIR / "mcpb"
-            target.mkdir(exist_ok=True)
-            for b in bundles:
-                shutil.copy2(b, target / b.name)
-            print(f"  Wired {len(bundles)} .mcpb bundle(s) from deploy/dist/mcpb/")
-    else:
+    # Wire the .mcpb bundles so /mcpb/<name>.mcpb routes serve real bytes —
+    # otherwise § 6/§ 7 of the maintainer test plan silently runs against
+    # absent bundles (the staging analog of the prod ship bug where `build`
+    # never produced them). Build them on demand if a prior
+    # `just build-mcpb` / `just build` hasn't, unless FELLOWS_SKIP_MCPB=1.
+    # Failing to build (e.g. no Node) surfaces loudly rather than leaving
+    # the routes silently 404ing under a green-looking staging server.
+    skip_mcpb = os.environ.get("FELLOWS_SKIP_MCPB", "0") == "1"
+    have_bundles = MCPB_SOURCE_DIR.is_dir() and any(MCPB_SOURCE_DIR.glob("*.mcpb"))
+    if not have_bundles and not skip_mcpb:
         print(
-            "  No .mcpb bundles found at deploy/dist/mcpb/ — run "
-            "`just build-mcpb` first if you want § 6/§ 7 tests."
+            "  No .mcpb bundles at deploy/dist/mcpb/ — building them "
+            "(build/build_mcpb.py; needs Node 20+)…"
+        )
+        subprocess.run(
+            [sys.executable, str(REPO_ROOT / "build" / "build_mcpb.py")], check=True
+        )
+    bundles = sorted(MCPB_SOURCE_DIR.glob("*.mcpb")) if MCPB_SOURCE_DIR.is_dir() else []
+    if bundles:
+        target = DIST_DIR / "mcpb"
+        target.mkdir(exist_ok=True)
+        for b in bundles:
+            shutil.copy2(b, target / b.name)
+        print(f"  Wired {len(bundles)} .mcpb bundle(s) from deploy/dist/mcpb/")
+    elif skip_mcpb:
+        print(
+            "  FELLOWS_SKIP_MCPB=1 — no .mcpb bundles wired "
+            "(§ 6/§ 7 staging tests will be skipped)."
         )
 
     print(f"  Built dist at {DIST_DIR.relative_to(REPO_ROOT)} (label: {label})")

--- a/tests/test_build_ships_mcpb.py
+++ b/tests/test_build_ships_mcpb.py
@@ -1,0 +1,121 @@
+"""Regression guard: the deploy/ship build path must produce the Claude
+Desktop ``.mcpb`` bundles and ship them where the server serves them.
+
+This locks the fix for the ship bug where ``just build`` ran only
+``build/build_pwa.py`` (which ``rmtree``'s ``deploy/dist/``), the ``.mcpb``
+bundles were never built into ``deploy/dist/mcpb/``, and the rsync
+``--delete`` then removed any stale copies from prod — surfacing to fellows
+as three "File wasn't available on site" download failures under
+*Set up Claude Desktop integration*.
+
+These are cheap, deterministic, Node-free checks (justfile / ansible /
+source-text parsing) at the altitude that would have caught the bug — not a
+full Node build of the bundles.
+"""
+from __future__ import annotations
+
+import re
+from pathlib import Path
+
+REPO_ROOT = Path(__file__).resolve().parent.parent
+JUSTFILE = REPO_ROOT / "justfile"
+DEPLOY_SERVER = REPO_ROOT / "deploy" / "server.py"
+FELLOWS_APP_TASKS = (
+    REPO_ROOT / "ansible" / "roles" / "fellows_app" / "tasks" / "main.yml"
+)
+
+
+def _recipe_body(name: str) -> str:
+    """Return the indented body of a justfile recipe ``name:`` (no args)."""
+    lines = JUSTFILE.read_text(encoding="utf-8").splitlines()
+    i, n = 0, len(lines)
+    while i < n and lines[i].rstrip() != f"{name}:":
+        i += 1
+    assert i < n, f"no `{name}:` recipe found in justfile"
+    i += 1
+    body: list[str] = []
+    while i < n:
+        line = lines[i]
+        if line.strip() == "" or line[:1] in (" ", "\t"):
+            body.append(line)
+        else:
+            break  # first column-0 non-blank line ends the recipe
+        i += 1
+    return "\n".join(body)
+
+
+def _recipe_header_deps(name: str) -> str:
+    """Return the dependency list after ``name:`` on the recipe header line."""
+    pat = re.compile(rf"^{re.escape(name)}:\s*(.*)$", re.MULTILINE)
+    m = pat.search(JUSTFILE.read_text(encoding="utf-8"))
+    assert m, f"no `{name}:` recipe header found in justfile"
+    return m.group(1).strip()
+
+
+class TestBuildRecipeProducesBundles:
+    def test_build_recipe_runs_build_mcpb(self):
+        body = _recipe_body("build")
+        assert "build/build_mcpb.py" in body, (
+            "the `build` recipe must run build/build_mcpb.py so deploy/ship "
+            "produce the .mcpb bundles (else the /mcpb/ routes 404)"
+        )
+
+    def test_build_recipe_runs_pwa_before_mcpb(self):
+        # build_pwa.py rmtree's deploy/dist/; build-mcpb MUST run after it or
+        # the bundles it produces are wiped before they ship.
+        body = _recipe_body("build")
+        assert "build/build_pwa.py" in body, "the `build` recipe must run build_pwa.py"
+        assert body.index("build/build_pwa.py") < body.index("build/build_mcpb.py"), (
+            "build_pwa.py (which wipes deploy/dist/) must run BEFORE build_mcpb.py"
+        )
+
+
+class TestDeployPathInvokesBuild:
+    def test_deploy_depends_on_build(self):
+        deps = _recipe_header_deps("deploy")
+        assert re.search(r"\bbuild\b", deps), f"`deploy` must depend on `build`: {deps!r}"
+
+    def test_ship_reaches_deploy(self):
+        deps = _recipe_header_deps("ship")
+        assert "deploy" in deps.split(), f"`ship` must run `deploy`: {deps!r}"
+
+
+class TestProducerServerParity:
+    def test_build_mcpb_outputs_where_server_serves(self):
+        from build.build_mcpb import OUTPUT_DIR
+
+        rel = OUTPUT_DIR.resolve().relative_to(REPO_ROOT.resolve())
+        assert rel == Path("deploy/dist/mcpb"), (
+            f"build_mcpb writes to {rel}, but deploy/server.py serves from "
+            "deploy/dist/mcpb/ — producer and server must agree"
+        )
+
+    def test_server_whitelist_matches_available_bundles(self):
+        from build.build_mcpb import available_bundles
+
+        text = DEPLOY_SERVER.read_text(encoding="utf-8")
+        m = re.search(r"MCPB_NAMES\s*=\s*frozenset\(\{([^}]*)\}\)", text)
+        assert m, "could not find MCPB_NAMES in deploy/server.py"
+        names = set(re.findall(r'"([^"]+)"', m.group(1)))
+        assert names == set(available_bundles()), (
+            "deploy/server.py MCPB_NAMES must match the bundles build_mcpb "
+            f"produces; server={sorted(names)} producer={available_bundles()}"
+        )
+
+
+class TestDeployVerifiesBundles:
+    """The deploy must fail loudly if the bundles didn't land — the /mcpb/
+    routes are auth-gated (403 before the file-existence check), so an
+    HTTPS smoke can't catch a missing bundle. The on-disk post-rsync check
+    in the fellows_app role is the tripwire."""
+
+    def test_ansible_verifies_mcpb_bundles_present(self):
+        text = FELLOWS_APP_TASKS.read_text(encoding="utf-8")
+        assert "deploy/dist/mcpb/{{ item }}.mcpb" in text, (
+            "the fellows_app role must stat the deployed .mcpb bundles post-rsync"
+        )
+        for name in ("comms", "shared_data_ops", "private_data_ops"):
+            assert name in text, f"bundle {name} not verified in the deploy role"
+        assert "ansible.builtin.fail" in text, (
+            "a missing .mcpb bundle must fail the deploy loudly"
+        )


### PR DESCRIPTION
## Problem

In the deployed app, *Set up Claude Desktop integration* (and About → *Re-install Claude Desktop bundles*) failed: all three downloads showed **"File wasn't available on site."** The `/mcpb/<name>.mcpb` routes 404 because the bundles were never on prod.

Root cause was a three-way compounding gap:

1. `just ship` → `just deploy` → the `build` recipe ran **only** `build/build_pwa.py`, which has zero MCPB references. The `.mcpb` bundles are built by a separate, manual-only recipe (`just build-mcpb`) that nothing in the deploy/ship chain ever called.
2. `build_pwa.py` `rmtree`s the entire `deploy/dist/` on every build (`build/build_pwa.py:357-359`), so even a prior manual `just build-mcpb` got wiped by the next build.
3. The ansible rsync uses `delete: true`, so with no local `dist/mcpb/` it actively **removed** any stale bundles from prod.

`deploy/server.py:_serve_mcpb_download` then 404s on the missing file → the user-visible error.

## Fix

- **`justfile`** — the `build` recipe now runs `build/build_mcpb.py` **after** `build_pwa.py`. The ordering is load-bearing: `build_pwa` wipes `deploy/dist/`, so building the bundles after is what keeps them from being wiped before the rsync ships them. `FELLOWS_SKIP_MCPB=1` skips it for fast PWA-only builds. Covers `just build` / `deploy` / `ship`; the rsync already ships whatever is in `dist/`, so no rsync change is needed.
- **`ansible/roles/fellows_app/tasks/main.yml`** — post-rsync task stats the three bundles on the host and **fails the deploy loudly** if any is missing. The `/mcpb/` routes are auth-gated (403 returned *before* the file-existence check), so an unauthenticated HTTPS smoke can't distinguish present from absent — the honest check is on-disk, post-rsync. Bypass with `--extra-vars fellows_skip_mcpb_check=true`.
- **`scripts/serve_prod_local.py`** — local staging now builds the bundles on demand instead of silently running the §6/§7 maintainer tests against absent bundles.
- **`tests/test_build_ships_mcpb.py`** (new) — Node-free regression guards: build wires `build_mcpb` after `build_pwa`; `deploy`→`build`; producer output dir == server serve dir; `MCPB_NAMES` ↔ manifests parity; the ansible verification task is present.
- **`docs/justfile.md`** — documents the new `build` behavior + `FELLOWS_SKIP_MCPB`.

## Behavior change

`just build` / `deploy` / `ship` now require **Node 20+** by default (set `FELLOWS_SKIP_MCPB=1` to skip). Since the bundles have ever been built, Node is already on the deploy machine — a no-op in practice.

## Verification done

- `just build` end-to-end now produces all three bundles in `deploy/dist/mcpb/` (comms 3.3 MB, private_data_ops 3.9 MB, shared_data_ops 3.9 MB).
- New guard test (8) + `test_build_pwa` (19) + `test_deploy_mcpb_routes` (12) + `just test-fast` (102) all pass; justfile parses; ansible YAML valid.

## Maintainer QA steps

1. `just build` → confirm `deploy/dist/mcpb/` holds `comms.mcpb`, `shared_data_ops.mcpb`, `private_data_ops.mcpb` (needs Node 20+).
2. `just ship` → the **"Verify Claude Desktop .mcpb bundles are present"** ansible task passes. Sanity-check the tripwire: `rm deploy/dist/mcpb/comms.mcpb` before a deploy and confirm it fails loudly (then rebuild).
3. On prod after deploy: installed PWA → enable the cloud-AI exception → **Settings → Set up Claude Desktop integration** → all three downloads succeed (no "File wasn't available on site"). Also verify **About → Re-install Claude Desktop bundles**.
4. (Optional) `just serve-prod` → confirm it builds/wires the bundles and the `/mcpb/` routes serve bytes for the §6/§7 staging tests.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
