### PR TITLE
fix(auth): magic-link token reusable for full TTL (link-scanner race) + prod resource guardrails

### DIFF
--- a/ansible/roles/fellows_app/templates/fellows-pwa.service.j2
+++ b/ansible/roles/fellows_app/templates/fellows-pwa.service.j2
@@ -13,6 +13,20 @@ ExecStart=/usr/bin/python3 {{ app_root }}/deploy/server.py
 Restart=on-failure
 RestartSec=3
 
+# Resource guardrails (added for the wider 2026-06 rollout). The droplet is
+# 1 vCPU / ~960 MB. A pathological thread/connection pile-up under load (or a
+# future bug) could otherwise exhaust RAM and OOM the whole box — taking Caddy
+# and sshd down with it (the "all-ports outage" failure mode). MemoryMax caps
+# THIS service's cgroup, so a runaway is OOM-killed as just fellows-pwa and
+# Restart=on-failure brings it back, while Caddy + sshd survive. OOMScoreAdjust
+# biases the global OOM killer toward this service if the box as a whole runs
+# short. Normal usage is ~16-150 MB, so these never fire under legitimate load
+# (file page cache is reclaimable and not held against the cap). Raise these if
+# the droplet is ever resized.
+MemoryHigh=550M
+MemoryMax=700M
+OOMScoreAdjust=500
+
 # Hardening. The service binds 127.0.0.1:8765 (Caddy reverse-proxies) and
 # reads server.py + helpers + fellows.db + static files. It never writes to
 # its own code tree. dist/ is listed in ReadWritePaths only as a safety net

--- a/deploy/magic_link_auth.py
+++ b/deploy/magic_link_auth.py
@@ -29,15 +29,19 @@ SESSION_COOKIE = "fellows_session"
 SESSION_MAX_AGE = 7 * 24 * 3600
 TOKEN_TTL = 30 * 60
 INSTALL_WINDOW = TOKEN_TTL  # window (from token issue) during which install landing may show
-# Re-consume window: after a token is first consumed, the same token re-presented
-# within GRACE_WINDOW seconds returns the same session payload instead of
-# "invalid". Defends against bfcache / back-button replays in iOS Safari and
-# against email-side link scanners that GET the URL before the user clicks.
-# Net threat-model effect is a safety win: the dominant real-world failure was
-# "passive scanner consumes the token, legit user sees invalid"; the grace
-# window flips that to "scanner consumes, legit user's click within 60s also
-# succeeds." See plans/auth_debug_improvements.md (M3) for the rationale.
-GRACE_WINDOW = 60
+# Re-consume policy: a token, once consumed, stays redeemable for the
+# REMAINDER of its original TOKEN_TTL (not a brief fixed grace window). This
+# defends against email-side link scanners (which GET/execute the link before
+# the human clicks), bfcache / iOS back-button replays, and a second device
+# opening the same link. The dominant real-world failure was "a passive
+# scanner consumes the token, then the legit user's click seconds-to-minutes
+# later sees 'invalid'." A fixed 60 s grace (the prior GRACE_WINDOW) did not
+# cover the multi-minute gaps seen in prod — a scanner consumed at +222 s and
+# the human clicked at +309 s, 87 s after the scanner, outside 60 s. Bounding
+# re-use by TOKEN_TTL adds no exposure window: a never-consumed link is
+# already valid for the full TTL, so this only removes the "first consumer
+# wins, everyone else gets invalid" race. See
+# plans/auth_debug_improvements.md (M3) for the original grace rationale.
 RATE_WINDOW = 3600
 RATE_MAX = 3
 SESSION_VERSION = "v3"
@@ -89,7 +93,8 @@ class AuthState:
     tokens: dict[str, float] = {}
     # tok -> {"issued_at": <epoch>, "consumed_at": <epoch>}. Populated by
     # consume_token on first success; used to honor a re-consume of the same
-    # token within GRACE_WINDOW seconds. Cleaned up by cleanup_stale_tokens.
+    # token for the remainder of its TOKEN_TTL. Cleaned up by
+    # cleanup_stale_tokens once the token has aged past TOKEN_TTL.
     consumed: dict[str, dict] = {}
     rate_buckets: dict[str, list[float]] = {}
     # session_id (32-char hex) -> {"issued_at": float, "expires_at": float}.
@@ -170,7 +175,11 @@ def cleanup_stale_tokens() -> None:
             if exp < now:
                 del AuthState.tokens[t]
         for t, rec in list(AuthState.consumed.items()):
-            if (now - rec["consumed_at"]) >= GRACE_WINDOW:
+            # Consumed records must outlive the token's full TTL so a
+            # legitimate re-consume within that window still resolves (a
+            # scanner-then-human gap can be many minutes). Drop only once the
+            # original token has aged past TOKEN_TTL.
+            if (now - rec["issued_at"]) >= TOKEN_TTL:
                 del AuthState.consumed[t]
         for sid, srec in list(AuthState.sessions.items()):
             if srec["expires_at"] < now:
@@ -224,29 +233,34 @@ def consume_token(tok: str) -> dict:
 
     Returns one of:
       {"status": "ok", "issued_at": <epoch>, "session_id": <hex>} —
-          token was valid and unexpired, OR was consumed within the
-          last GRACE_WINDOW seconds. On a fresh consume the issued_at
-          is derived from the live token's stored expiry; on a
-          re-consume within the grace window it's the issued_at that
-          was captured at first consume. The session_id is freshly
-          minted on each consume and registered in
-          ``AuthState.sessions`` so the cookie that signs over it
-          will pass ``verify_session_value`` until the session
-          expires or is revoked.
-      {"status": "expired"} — token existed but was past TTL. Shown to user as
-          "that link expired".
-      {"status": "invalid"} — token was never issued, or was consumed more
-          than GRACE_WINDOW seconds ago. Shown to user as
-          "that link isn't valid".
+          token is valid: either freshly consumed (live and within
+          TTL), or re-consumed while still inside its ORIGINAL
+          TOKEN_TTL. On a fresh consume the issued_at is derived from
+          the live token's stored expiry; on a re-consume it is the
+          issued_at captured at first consume, so every minted session
+          carries the same install-window anchor as the first. The
+          session_id is freshly minted on each consume and registered
+          in ``AuthState.sessions`` so the cookie that signs over it
+          will pass ``verify_session_value`` until the session expires
+          or is revoked.
+      {"status": "expired"} — token existed but is past its 30-min TTL
+          (whether never consumed, or consumed and now aged out). Shown
+          to user as "that link expired".
+      {"status": "invalid"} — token was never issued (or was cleaned up
+          after its TTL elapsed). Shown to user as "that link isn't valid".
+
+    A consumed token stays re-consumable for the remainder of its
+    original TOKEN_TTL — see the module-level re-consume policy comment
+    for why (link scanners / bfcache / a second device must not be able
+    to burn the human's click).
     """
     now = time.time()
     with AuthState.lock:
         exp = AuthState.tokens.pop(tok, None)
         if exp is not None:
             if exp < now:
-                # Past-TTL tokens are treated as expired and NOT recorded
-                # in `consumed` — re-presenting them after this point is
-                # an "invalid" outcome, consistent with the prior contract.
+                # Past-TTL on first sight → expired, and NOT recorded in
+                # `consumed` (re-presenting it lands in the invalid branch).
                 return {"status": "expired"}
             issued_at = exp - TOKEN_TTL
             AuthState.consumed[tok] = {
@@ -259,19 +273,25 @@ def consume_token(tok: str) -> dict:
                 "issued_at": issued_at,
                 "session_id": session_id,
             }
-        # Token not in the live set — check whether it was just consumed.
+        # Token already consumed once. It stays usable for the remainder of
+        # its original TOKEN_TTL (not a brief grace window) so a scanner /
+        # second device / bfcache replay that consumed it first does not
+        # invalidate the human's later click. See the re-consume policy
+        # comment near TOKEN_TTL above.
         rec = AuthState.consumed.get(tok)
-        if rec and (now - rec["consumed_at"]) < GRACE_WINDOW:
-            session_id = _register_session(now, rec["issued_at"])
-            return {
-                "status": "ok",
-                "issued_at": rec["issued_at"],
-                "session_id": session_id,
-            }
-        if rec:
-            # Past the grace window; drop opportunistically so memory doesn't
-            # accumulate even when cleanup_stale_tokens hasn't run recently.
+        if rec is not None:
+            if (now - rec["issued_at"]) < TOKEN_TTL:
+                session_id = _register_session(now, rec["issued_at"])
+                return {
+                    "status": "ok",
+                    "issued_at": rec["issued_at"],
+                    "session_id": session_id,
+                }
+            # Past the original 30-min TTL: the link genuinely aged out.
+            # Drop opportunistically and report `expired` (not `invalid`) so
+            # the gate shows "that link expired, request a new one".
             AuthState.consumed.pop(tok, None)
+            return {"status": "expired"}
         return {"status": "invalid"}
 
 

--- a/deploy/server.py
+++ b/deploy/server.py
@@ -765,6 +765,17 @@ class Handler(SimpleHTTPRequestHandler):
         super().end_headers()
 
 
+class _FellowsServer(ThreadingHTTPServer):
+    # The stdlib default listen backlog (request_queue_size) is 5 — shallow
+    # for a burst of simultaneous install connections (a single install opens
+    # several: shell assets + fellows.db + the SW's no-store precache
+    # re-fetch). Raise it so a short spike queues in the kernel instead of
+    # getting connection-reset. Threads are still one-per-connection
+    # (ThreadingMixIn); the systemd MemoryMax guardrail bounds a pathological
+    # pile-up so a backlog this deep can't translate into an OOM of the box.
+    request_queue_size = 128
+
+
 def main():
     global AUTH_ACTIVE, BUILD_META
     init_auth()
@@ -774,7 +785,7 @@ def main():
         print(json.dumps({"event": "build_meta", "build": BUILD_META}), file=sys.stderr)
     DIST_DIR.mkdir(parents=True, exist_ok=True)
     os.chdir(DIST_DIR)
-    server = ThreadingHTTPServer(("127.0.0.1", PORT), Handler)
+    server = _FellowsServer(("127.0.0.1", PORT), Handler)
     bits = []
     if AUTH_ACTIVE:
         bits.append("auth")

--- a/docs/Architecture.md
+++ b/docs/Architecture.md
@@ -455,7 +455,7 @@ Fellows pins:
 
 - `TOKEN_TTL = 30 min`, `INSTALL_WINDOW = 30 min`, `SESSION_MAX_AGE = 7 days`.
 - Session cookie: HttpOnly, HMAC-signed, **v2 format** (v1 rejected on sight post-deploy).
-- Token re-consume grace window: ~60 s — defends against bfcache, iOS back-button, email-side link scanners.
+- Token re-consume window: the full `TOKEN_TTL` (30 min from issue) — a consumed token stays redeemable until it expires, so a link-scanner, a second device, a bfcache restore, or an iOS back-button that consumes the link first cannot burn the human's click. (Superseded the prior fixed ~60 s grace, which didn't cover the multi-minute scanner-to-human gaps seen in prod.)
 - Allowlist built in memory at startup by HMAC-ing each `contact_email` row in `fellows.db` with `FELLOWS_ALLOWLIST_HMAC_KEY`. No `allowed_emails.json` artifact ships in `dist/`.
 - Six-step browser-mode decision tree (see [`./email_gate.md`](./email_gate.md) for the full table).
 - Persistence marker (per WS persistence-marker contract): `localStorage['fellows_authenticated_once']` is the one localStorage key preserved across the workspace's Clear App Cache affordance.

--- a/docs/DevOps.md
+++ b/docs/DevOps.md
@@ -99,9 +99,14 @@ LockPersonality=yes
 MemoryDenyWriteExecute=yes
 SystemCallArchitectures=native
 ReadWritePaths=/opt/fellows/deploy/dist
+MemoryHigh=550M
+MemoryMax=700M
+OOMScoreAdjust=500
 ```
 
 `ProtectSystem=strict` remounts the entire filesystem read-only for the service except `/dev`, `/proc`, `/sys` (handled separately), and anything in `ReadWritePaths`. `dist/` is explicitly writable only as a safety net for SQLite journal files — the server's SQL path is SELECT-only in practice. If you later switch the Python code to open the DB with `?mode=ro`, you can drop `ReadWritePaths` entirely.
+
+`MemoryMax` / `MemoryHigh` / `OOMScoreAdjust` are **availability guardrails**, not security hardening (added for the wider 2026-06 rollout). The droplet is 1 vCPU / ~960 MB; `deploy/server.py` is a `ThreadingHTTPServer` (one thread per connection, no pool — bounded only by `TasksMax`), so a connection/thread pile-up under a burst, or a future bug, could exhaust RAM and OOM the **whole box**, taking Caddy + sshd with it (the resource-starvation "all-ports outage" failure mode). `MemoryMax=700M` caps the service's own cgroup so a runaway is OOM-killed as just `fellows-pwa` (and `Restart=on-failure` revives it) while Caddy + sshd survive; `OOMScoreAdjust=500` biases the global OOM killer toward this service if the box as a whole runs short. Normal usage is ~16–150 MB (file page cache is reclaimable and not held against the cap), so these never fire under legitimate load. Pair with the kernel listen backlog raised to 128 in `deploy/server.py` (stdlib default is 5) so a short connection spike queues instead of resetting. **Raise all three if the droplet is ever resized.**
 
 ## Network and firewall
 

--- a/docs/email_gate.md
+++ b/docs/email_gate.md
@@ -15,7 +15,7 @@ Operator procedures (Postmark, env file, Postmark response interpretation) stay 
 ## Definitions
 
 - **Session cookie** — `fellows_session`, HttpOnly, HMAC-signed, carrying `token_issued_at` (epoch seconds) and a server-side `session_id`. v3 format; v1 and v2 cookies are rejected on sight so prior sessions re-login cleanly after each version bump.
-- **Magic-link token** — single-use, `TOKEN_TTL = 30 min` from issue. Random 32-byte hex.
+- **Magic-link token** — random 32-byte hex, valid for `TOKEN_TTL = 30 min` from issue. **Re-consumable within that TTL**, not strictly single-use: a consumed token stays redeemable until it expires so a link-scanner, a second device, or a bfcache/back-button replay that opens the link before the human can't invalidate the human's click. Each consume mints a fresh session carrying the original `token_issued_at`. Past the TTL it reports `expired`.
 - **Install window** — `INSTALL_WINDOW = 30 min` measured from token issue (not from click). Same duration as token TTL by design: a user has 30 min from the email being sent to finish clicking and installing.
 - **Display mode** — *browser* (`display-mode != standalone`) vs *PWA* (`display-mode: standalone`).
 
@@ -23,8 +23,8 @@ Operator procedures (Postmark, env file, Postmark response interpretation) stay 
 
 1. **Email gate is the default.** The only exits from it are: (a) a URL carrying an unexpired magic-link token, or (b) an authenticated session *within* the install window, or (c) PWA mode with a valid session (→ directory).
 2. **Install landing never repeats.** It shows only inside the install window. Once the window closes, or the user explicitly logs out, the only path back is a fresh magic link.
-3. **Expired links are explicit.** Clicking an expired token lands on the email gate with a visible "that link expired" banner.
-4. **Invalid links are explicit.** Clicking a tampered or already-consumed token lands on the email gate with "that link isn't valid".
+3. **Expired links are explicit.** Clicking a token past its TTL lands on the email gate with a visible "that link expired" banner — including a token that was consumed earlier and has now aged past its TTL.
+4. **Invalid links are explicit.** Clicking a tampered or never-issued token lands on the email gate with "that link isn't valid". A token that was already consumed but is still within its TTL is **not** invalid — it re-consumes successfully (see the re-consume policy in [`magic_link_auth.py`](../deploy/magic_link_auth.py)); only a never-issued/tampered token, or one cleaned up after its TTL elapsed, is invalid.
 5. **Magic-link emails state the TTL.** Body includes: "This link will expire in 30 minutes."
 6. **Session cookie TTL is long** (`SESSION_MAX_AGE = 7 days`) so installed PWAs persist; the install window is decoupled and short.
 7. **Dev escape hatch is always reachable.** Two layers:

--- a/tests/e2e/test_install_landing.py
+++ b/tests/e2e/test_install_landing.py
@@ -183,9 +183,11 @@ class TestInstallLandingEscape:
 class TestRedeemDoubleFireGuard:
     """M2: a second tryUnlockFromHash invocation with the same token in the
     same tab must skip the POST entirely. Covers iOS Safari bfcache restore
-    and back-button replay, where today the second POST returns 401 invalid
-    (the first already consumed the single-use token) and the user sees
-    'That link isn't valid' even though they did everything right.
+    and back-button replay. (The server now re-consumes a token for its full
+    TTL — see deploy/magic_link_auth.py — so a redundant second POST would
+    succeed rather than return 401; this per-tab guard still avoids the
+    needless re-POST and keeps the hash stripped so a navigation event can't
+    re-arm the loop.)
     """
 
     def test_second_invocation_skips_verify_token_post(self, context, deploy_server):

--- a/tests/test_deploy_auth_round_trip.py
+++ b/tests/test_deploy_auth_round_trip.py
@@ -183,13 +183,13 @@ def test_verify_token_with_empty_token_returns_401_invalid(deploy_server):
     assert body == {"ok": False, "error": "invalid"}
 
 
-def test_verify_token_reuse_within_grace_window_returns_ok(deploy_server):
-    """A re-consume of the same token within ``GRACE_WINDOW`` seconds (M3
-    follow-up to the Anne-Marie iOS report) returns ok again, so a bfcache
-    replay or scanner pre-fetch doesn't break the legitimate user. Both
-    responses end up with the same session contract: 200 ok + a fresh
-    Set-Cookie carrying the original ``token_issued_at``. After the grace
-    window the token reverts to ``invalid`` — see the test below."""
+def test_verify_token_reuse_within_ttl_returns_ok(deploy_server):
+    """A re-consume of the same token while still within its TOKEN_TTL
+    returns ok again, so a bfcache replay, a second device, or a link-scanner
+    pre-fetch doesn't break the legitimate user. Both responses end up with
+    the same session contract: 200 ok + a fresh Set-Cookie carrying the
+    original ``token_issued_at``. After the TTL the token reports ``expired``
+    — see the test below."""
     _post_json(
         deploy_server, "/api/send-unlock", {"email": deploy_server["test_email"]}
     )
@@ -200,10 +200,12 @@ def test_verify_token_reuse_within_grace_window_returns_ok(deploy_server):
     assert s2 == 200 and b2 == {"ok": True}
 
 
-def test_verify_token_reuse_after_grace_window_returns_invalid(deploy_server):
-    """Outside the grace window a re-consume reverts to ``invalid`` —
-    re-asserts the original single-use property holds in the long run.
-    We rewind the consumed record's ``consumed_at`` rather than sleeping."""
+def test_verify_token_reuse_after_ttl_returns_expired(deploy_server):
+    """Past the token's TTL a re-consume reports ``expired`` (distinct from
+    ``invalid``) so the gate can render the right banner. Within the TTL a
+    re-consume still succeeds (test above + the scanner-race unit test in
+    test_magic_link_auth.py). We rewind the consumed record's ``issued_at``
+    rather than waiting 30 minutes."""
     state = deploy_server["auth_state"]
     ml = deploy_server["ml"]
     _post_json(
@@ -217,10 +219,11 @@ def test_verify_token_reuse_after_grace_window_returns_invalid(deploy_server):
     with state.lock:
         rec = state.consumed.get(token)
         assert rec is not None
-        rec["consumed_at"] = _time.time() - (ml.GRACE_WINDOW + 1)
+        rec["issued_at"] = _time.time() - (ml.TOKEN_TTL + 1)
+        rec["consumed_at"] = _time.time() - (ml.TOKEN_TTL + 1)
     s2, _, b2 = _post_json(deploy_server, "/api/verify-token", {"token": token})
     assert s2 == 401
-    assert b2 == {"ok": False, "error": "invalid"}
+    assert b2 == {"ok": False, "error": "expired"}
 
 
 def test_verify_token_after_ttl_expiry_returns_401_expired(deploy_server):

--- a/tests/test_magic_link_auth.py
+++ b/tests/test_magic_link_auth.py
@@ -216,33 +216,60 @@ def test_consume_token_distinguishes_invalid_expired_ok(monkeypatch):
     r = ml.consume_token(tok)
     assert r["status"] == "ok"
     assert "issued_at" in r
-    # Second consume within the grace window is ok with the original
-    # issued_at (M3) — see test_consume_within_grace_window_returns_ok
-    # below for the dedicated coverage.
+    # Second consume (still within the token's TTL) is ok with the original
+    # issued_at — see test_consume_token_survives_scanner_pre_consume below
+    # for the multi-minute-gap (link-scanner) case.
     r2 = ml.consume_token(tok)
     assert r2["status"] == "ok"
     assert r2["issued_at"] == r["issued_at"]
 
 
-def test_consume_within_grace_window_returns_ok_with_original_issued_at():
-    """M3: a second consume within GRACE_WINDOW seconds returns ok with
-    the issued_at captured at first consume (so the resulting session
-    cookie carries the same install-window anchor as the first one)."""
+def test_consume_re_consume_returns_ok_with_original_issued_at():
+    """A second consume (still within TTL) returns ok with the issued_at
+    captured at first consume, so the resulting session cookie carries the
+    same install-window anchor as the first one."""
     with ml.AuthState.lock:
         ml.AuthState.tokens.clear()
         ml.AuthState.consumed.clear()
     tok = ml.issue_token()
     r1 = ml.consume_token(tok)
     assert r1["status"] == "ok"
-    # Re-consume inside the window: ok, same issued_at.
+    # Re-consume immediately: ok, same issued_at.
     r2 = ml.consume_token(tok)
     assert r2["status"] == "ok"
     assert r2["issued_at"] == r1["issued_at"]
 
 
-def test_consume_after_grace_window_returns_invalid():
-    """M3: outside the window the re-consume reverts to invalid. Rewind
-    the consumed record's consumed_at rather than sleeping."""
+def test_consume_token_survives_scanner_pre_consume():
+    """Regression for the link-scanner race: a passive scanner consumes the
+    token minutes before the human clicks, but as long as the human's click
+    is still within the original TOKEN_TTL it succeeds — no 60 s grace cliff.
+
+    Models the prod incident: the scanner consumed at +222 s and the human
+    clicked at +309 s (87 s later), which the old GRACE_WINDOW=60 turned into
+    `invalid`. Here we rewind the record so the human's re-consume is well
+    past any 60 s window yet comfortably inside the 30-min TTL."""
+    with ml.AuthState.lock:
+        ml.AuthState.tokens.clear()
+        ml.AuthState.consumed.clear()
+    tok = ml.issue_token()
+    r1 = ml.consume_token(tok)  # the scanner
+    assert r1["status"] == "ok"
+    with ml.AuthState.lock:
+        rec = ml.AuthState.consumed.get(tok)
+        assert rec is not None
+        # Issued + scanner-consumed ~5 min ago → ~25 min of TTL remains.
+        # The old 60 s grace would have turned this human click into invalid.
+        rec["issued_at"] = time.time() - 300
+        rec["consumed_at"] = time.time() - 300
+    r2 = ml.consume_token(tok)  # the human, ~5 min after the scanner
+    assert r2["status"] == "ok"
+    assert r2["issued_at"] == rec["issued_at"]
+
+
+def test_consume_after_ttl_returns_expired():
+    """Past the original 30-min TTL a re-consume reports `expired` (not
+    `invalid`) and drops the record. Rewind issued_at rather than sleeping."""
     with ml.AuthState.lock:
         ml.AuthState.tokens.clear()
         ml.AuthState.consumed.clear()
@@ -252,9 +279,10 @@ def test_consume_after_grace_window_returns_invalid():
     with ml.AuthState.lock:
         rec = ml.AuthState.consumed.get(tok)
         assert rec is not None
-        rec["consumed_at"] = time.time() - (ml.GRACE_WINDOW + 1)
+        rec["issued_at"] = time.time() - (ml.TOKEN_TTL + 1)
+        rec["consumed_at"] = time.time() - (ml.TOKEN_TTL + 1)
     r2 = ml.consume_token(tok)
-    assert r2 == {"status": "invalid"}
+    assert r2 == {"status": "expired"}
     # Opportunistic drop on miss: the consumed record should be gone now.
     with ml.AuthState.lock:
         assert tok not in ml.AuthState.consumed
@@ -262,27 +290,30 @@ def test_consume_after_grace_window_returns_invalid():
 
 def test_cleanup_stale_tokens_drops_expired_consumed_entries():
     """cleanup_stale_tokens drops both past-TTL live tokens AND consumed
-    records past the grace window. Bounded memory across long uptimes."""
+    records whose original token has aged past TOKEN_TTL — bounded memory
+    across long uptimes, while keeping a consumed record alive long enough
+    for a legitimate re-consume within the token's TTL."""
     with ml.AuthState.lock:
         ml.AuthState.tokens.clear()
         ml.AuthState.consumed.clear()
-    # One stale live token, one stale consumed record, one fresh consumed record.
+    # One stale live token, one consumed record aged past TTL (drop), one
+    # consumed record still within TTL (retain for legitimate re-consume).
     now = time.time()
     with ml.AuthState.lock:
         ml.AuthState.tokens["stale-live"] = now - 10
-        ml.AuthState.consumed["stale-consumed"] = {
-            "issued_at": now - 200,
-            "consumed_at": now - (ml.GRACE_WINDOW + 5),
+        ml.AuthState.consumed["aged-out"] = {
+            "issued_at": now - (ml.TOKEN_TTL + 5),
+            "consumed_at": now - (ml.TOKEN_TTL + 5),
         }
-        ml.AuthState.consumed["fresh-consumed"] = {
+        ml.AuthState.consumed["still-within-ttl"] = {
             "issued_at": now - 5,
             "consumed_at": now - 5,
         }
     ml.cleanup_stale_tokens()
     with ml.AuthState.lock:
         assert "stale-live" not in ml.AuthState.tokens
-        assert "stale-consumed" not in ml.AuthState.consumed
-        assert "fresh-consumed" in ml.AuthState.consumed
+        assert "aged-out" not in ml.AuthState.consumed
+        assert "still-within-ttl" in ml.AuthState.consumed
 
 
 def test_cleanup_stale_tokens_drops_expired_sessions():


### PR DESCRIPTION
## Problem

A clean install ended at the magic link with **"that link isn't valid."** The journald logs show the magic-link token for the maintainer's email was verified **twice on every send** — once by the real browser (`Mac/Chrome-149`) and once by a `Windows/Chrome-148` agent (a mail-provider **link-scanner** / second consumer). The token was effectively single-use with only a **60 s** re-consume grace, so when the scanner consumed it more than 60 s before the human clicked, the human got `invalid`.

Proven in prod (token `49f357881410`): scanner consumed at `06:22:10`, human clicked at `06:23:37` — **87 s later** → `invalid` (401). This will recur for any fellow whose mail provider scans links.

(The maintainer's separate "zero bytes / dead hang" was a stale pre-#280 Service Worker on that one machine — a clean browser loads prod fine — not a server bug. No code change needed for that; clear site data / incognito.)

## Fix — token reusable for its full TTL

`deploy/magic_link_auth.py`: a consumed token now stays redeemable for the **remainder of its original 30-min `TOKEN_TTL`** instead of a fixed 60 s window.

- `consume_token` re-consume branch bounds on `issued_at` vs `TOKEN_TTL`; past the TTL it returns `expired` (not `invalid`) so the gate shows the right banner.
- `cleanup_stale_tokens` retains consumed records for the full TTL (so a legitimate multi-minute scanner→human gap still resolves).
- Retired `GRACE_WINDOW`.
- **No new exposure:** a never-consumed link is already valid for the full TTL, and the first consume already mints a session — this only removes the "first consumer wins, everyone else gets `invalid`" race. The token stays single-recipient + allowlist-gated, 30-min TTL.
- Tests: `test_consume_token_survives_scanner_pre_consume` (the regression), grace tests reframed to TTL semantics, round-trip `after-TTL → expired`.

## Prod resource guardrails — for the wider rollout

Context: the rollout is organic word-of-mouth over 1–2 weeks, realistic peak **≤20 concurrent**. The live 1 vCPU / 960 MB droplet handles that comfortably (it's idle at load 0.08; static + `fellows.db` + `.mcpb` are all streamed in 64 KB chunks; TLS+gzip are in Caddy). These are **cheap insurance against the unpredictable tail**, not a fix for expected load:

- **systemd `MemoryHigh=550M` / `MemoryMax=700M` / `OOMScoreAdjust=500`** on `fellows-pwa` (`ThreadingHTTPServer` spawns one unbounded thread per connection). A pathological pile-up is now OOM-killed as just the app (auto-restarts via `Restart=on-failure`) instead of exhausting RAM and taking **Caddy + sshd** down with the whole box — the resource-starvation "all-ports outage" in past notes. Normal usage is ~16–150 MB, so these never fire under legitimate load.
- **Listen backlog `request_queue_size` 5 → 128** in `deploy/server.py` so a short burst of simultaneous install connections queues in the kernel instead of getting connection-reset.

Docs updated to match: `email_gate.md` (token def + invariants 3/4), `Architecture.md` (re-consume window), `DevOps.md` (systemd guardrails).

## Tests

`test_magic_link_auth.py` (29) + `test_deploy_auth_round_trip.py` + `test_deploy_{client_errors,sqlite_api,mcpb_routes}` + `test_attestation_has_evidence` + `test_xfail_discipline` + e2e `test_magic_link_standalone_unlock` & `test_install_landing` — all green. `GRACE_WINDOW` removed with no stray references.

## Maintainer QA steps

1. **Deploy:** `just ship`. The systemd unit is part of the `fellows_app` role, so a normal deploy applies it.
2. **Confirm the guardrails landed:** `just prod-ssh` then
   `systemctl show fellows-pwa -p MemoryMax -p MemoryHigh -p OOMScoreAdjust` → expect `700M` / `550M` / `500`. If the restart didn't pick them up, `sudo systemctl daemon-reload && sudo systemctl restart fellows-pwa`.
3. **Token reuse (the fix):** request a fresh link, **wait ~2 minutes** (well past the old 60 s), then click → should sign in (no "that link isn't valid"). Optionally confirm `verify_token` shows `result=ok` in `just prod-logs`.
4. **Expiry still distinct:** a link older than 30 min → gate shows **"that link expired"** (not "isn't valid").
5. **Backlog/limits are invisible under normal load** — nothing to see; just confirm installs work and `journalctl -u fellows-pwa` shows no OOM kills.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
