### PR TITLE
copy(about): rewrite About-page intro blurb

### DIFF
--- a/app/static/app.js
+++ b/app/static/app.js
@@ -6920,8 +6920,9 @@
     var aboutHtml = '<div class="stats-page">';
     aboutHtml += '<h2 class="stats-title">About This App</h2>';
     aboutHtml += '<div class="about-body">';
-    aboutHtml += '<p>V0.1 \u2014 This app is a much faster version of the fellows database. ';
-    aboutHtml += 'This app is shared with EHF fellows on request on the condition that they keep the information in it private to the EHF fellows. ';
+    aboutHtml += '<p>V0.1 \u2014 This app is a much faster version of the fellows database, permanently your own. ';
+    aboutHtml += 'It\u2019s a home-cooked software meal for my fellow fellows, made over a month of my time, with love.</p>';
+    aboutHtml += '<p>This app is shared with EHF fellows on request on the condition that they keep the information in it private to the EHF fellows. ';
     aboutHtml += 'Never post this anywhere\u2014 it contains the relevant bits of data from the old fellows directory. ';
     aboutHtml += 'There is no API, login, or web app, so this can only be shared intentionally. ';
     aboutHtml += 'For support, request to join the github repository or just ask on one of the fellows channels.</p>';


### PR DESCRIPTION
## What

Rewrites the intro blurb on the About page (under **About This App**),
replacing the single paragraph with two:

> **V0.1 — This app is a much faster version of the fellows database, permanently your own. It's a home-cooked software meal for my fellow fellows, made over a month of my time, with love.**
>
> **This app is shared with EHF fellows on request on the condition that they keep the information in it private to the EHF fellows. Never post this anywhere— it contains the relevant bits of data from the old fellows directory. There is no API, login, or web app, so this can only be shared intentionally. For support, request to join the github repository or just ask on one of the fellows channels.**

The existing "Having trouble with the app? Contact the EHF Communications Working Group." support line is unchanged.

## Why

Adds the home-cooked-software framing ("permanently your own… made over a month of my time, with love") to the directory's self-description.

## Scope

- Copy-only change in `renderAboutPage()` (`app/static/app.js`).
- Em dash / curly apostrophe use the file's house-style `—` / `’` escapes.
- No test asserts on this blurb (the About e2e test only checks the stats layout), and `docs/users_manual.md` does not mirror it — so no doc update is required.

## Manual QA for the maintainer

1. `just serve`, open `http://localhost:8765/#/about`.
2. Confirm the intro shows two paragraphs with the new copy, the em dash and apostrophe render correctly, and the "Having trouble…" line still follows.

Verified locally: `node --check app/static/app.js` passes, and the About page was driven in a browser showing both paragraphs rendering correctly.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
