### PR TITLE
docs(retention): server-side data-retention accounting (closes #147)

### DIFF
--- a/SECURITY.md
+++ b/SECURITY.md
@@ -86,6 +86,27 @@ See `docs/email_gate.md` for the auth-flow behavioural spec (cookie format, inst
 
 ---
 
+## Data retention
+
+There is **no per-user storage on the server** — no account, profile, or saved
+state; all user-authored private data lives in `relationships.db` in the
+browser on the user's own device and never reaches prod. What the server does
+keep is operational only: **journald events** (auth/diagnostic logs, carrying
+hash prefixes and UAs — never a raw email in the log line), **files on disk**
+(`fellows.db` contact mirror, `/etc/fellows/fellows-pwa.env` secrets, the static
+`dist/` bundle), and **in-memory state** lost on every restart (token,
+rate-limit, and session registries). journald runs Ubuntu's default
+**size-capped** rotation (no fixed time window; oldest-vacuumed-when-full), as
+no retention override is set in Ansible.
+
+Full accounting — every event and its fields, the on-disk and in-memory
+inventories, the retention window, and the Postmark third-party note — is in
+[`docs/data_retention.md`](docs/data_retention.md). The user-side removal paths
+(Clear App Cache / Reset Everything / browser-level deletion) are in
+[`docs/users_manual.md` § Clearing app data](docs/users_manual.md#clearing-app-data).
+
+---
+
 ## What's in the security backlog
 
 Currently in flight or queued:

--- a/app/static/app.js
+++ b/app/static/app.js
@@ -6927,6 +6927,7 @@
     aboutHtml += 'For support, request to join the github repository or just ask on one of the fellows channels.</p>';
     aboutHtml += '<p class="about-support">Having trouble with the app? Contact the EHF Communications Working Group.</p>';
     aboutHtml += '<p class="about-users-manual"><a href="https://github.com/richbodo/fellows_local_db/blob/main/docs/users_manual.md" target="_blank" rel="noopener">Help from the user manual</a> \u2014 how to install, use the app, fix common issues, and uninstall.</p>';
+    aboutHtml += '<p class="about-data-retention"><a href="https://github.com/richbodo/fellows_local_db/blob/main/docs/data_retention.md" target="_blank" rel="noopener">What data is kept</a> \u2014 what stays on your device, and what (and how long) the server keeps.</p>';
     // GitHub link sits above the update block: it's a destination (the
     // repo), not part of the identity-and-updates story below. Keeping
     // it adjacent to the user-manual link groups "where to go for more"

--- a/docs/Architecture.md
+++ b/docs/Architecture.md
@@ -494,6 +494,7 @@ Production-side, fellows-specific operator concerns (out of spec scope):
 - **Deployment, systemd hardening, droplet topology** — [`./DevOps.md`](./DevOps.md).
 - **Magic-link operator runbook (Postmark, env file, journald schema)** — [`./email_system_management.md`](./email_system_management.md).
 - **Data pipeline + recovery paths** — [`./data_provenance.md`](./data_provenance.md).
+- **Server-side data retention (what prod keeps: journald events, on-disk, in-memory)** — [`./data_retention.md`](./data_retention.md).
 - **Ansible specifics (tags, galaxy install, troubleshooting)** — [`../ansible/README.md`](../ansible/README.md).
 
 ---
@@ -508,6 +509,7 @@ Architecture-adjacent docs that specialize one part of the spec or operator surf
 | [`./persistence_and_upgrades.md`](./persistence_and_upgrades.md) | Storage slot — state-survival matrix across Clear App Cache / Reset Everything / app update; auto-backup; restore. |
 | [`./browser_support.md`](./browser_support.md) | Storage slot — capability detection inside the worker, required versions, unsupported-browser surfacing (AC-12). |
 | [`./data_provenance.md`](./data_provenance.md) | Ingestion slot — column-by-column source mapping; backup/restore workflow; recovery paths. |
+| [`./data_retention.md`](./data_retention.md) | Distribution / operator surface — server-side retention accounting (journald events, on-disk files, in-memory state) backing the AC-8 attestation; complements the user-side removal docs. |
 | [`./architectural_findings.md`](./architectural_findings.md) | Findings that feed back into the spec — the cloud-LLM "exception" / non-PNA-mode concept (`EX-CLOUD-LLM`) and the platform-ceiling **constraints** (`CST-*`) realized by the private-data capability gate (see *Constraint attestation* above). |
 
 ---

--- a/docs/data_retention.md
+++ b/docs/data_retention.md
@@ -1,0 +1,126 @@
+# Data Retention
+
+A transparency accounting of **what the production server keeps, where, and
+for how long** — and a pointer to how a user removes the app and all its data
+from their own device. This is a transparency doc, **not** a legal artifact
+(no GDPR posture or formal privacy policy is claimed here).
+
+It complements the user-facing side, which lives in the user guide:
+[*Where your data is stored*](./users_manual.md#where-your-data-is-stored),
+[*Clearing app data*](./users_manual.md#clearing-app-data), and
+[*Your device is now the directory*](./users_manual.md#your-device-is-now-the-directory).
+Server-side, this doc is the accounting; the auth-flow event *schema* and
+operator runbook live in [`./email_system_management.md`](./email_system_management.md),
+and the privacy boundary of the client-error sink in
+[`./email_gate.md` § Client error reporting](./email_gate.md#client-error-reporting).
+
+## The bright line: no per-user storage on the server
+
+Production (`deploy/server.py`) is a **delivery channel, not a service**: it
+authenticates a magic-link request, hands over the bundle + `fellows.db`, and
+steps back. There is **no per-user resource on the server** — no account, no
+profile, no saved state. All user-authored private data (groups, notes, tags,
+settings) lives in `relationships.db` in the browser's OPFS on the user's own
+device and **never reaches the server**. There is nothing per-user on prod to
+retain, breach, or hand over.
+
+What the server *does* keep falls into three buckets: **journald events**
+(operational logs), **files on disk**, and **in-memory state** (lost on
+restart). Each is enumerated below.
+
+## journald events
+
+The app service (`fellows-pwa`) and Caddy write to **stderr**, which systemd
+routes to **journald**. These structured log lines are the only durable record
+of server activity. Each event is a single-line JSON object; the table lists
+every event the server emits and whether it carries anything user-identifying.
+
+| Event | Emitted by | Fields | User-identifying? |
+|---|---|---|---|
+| `send_unlock_email` | `deploy/server.py` (`_handle_send_unlock`) | `result`, `email_hash_prefix` (first 12 hex of the HMAC), `token_prefix` (first 12), `postmark` subset (`status`, `message_id`, `error_code`, `message`, `submitted_at`) | **No raw email.** The raw recipient is in the outbound Postmark response (`meta["to"]`) but is **deliberately not logged** — only a PII-free subset is. The recipient is recoverable *out-of-band* by joining `email_hash_prefix` against `fellows.db` (`just prod-stats --include-emails`) or via the Postmark API. |
+| `verify_token` | `deploy/magic_link_auth.py` (`verify_token_event`) | `result` (enum `ok`/`expired`/`invalid`), `token_prefix` (join key back to `send_unlock_email`), `user_agent`, `build_label` | UA only. Email is **not** stored; it is recovered at query time via the `token_prefix` join. |
+| `auth_status` | `deploy/server.py` | operational status fields | No. |
+| `mcpb_download` | `deploy/server.py` | `name`, `size_bytes`, `user_agent` (truncated to 240 chars) | UA only. |
+| `client_error` | `deploy/server.py` (`_handle_client_errors`) | `client_ip_prefix` (truncated) plus the **sanitized** client payload (kind allow-list, build, route with slugs/tokens redacted, `lastSubmitHashPrefix`, UA) | Truncated IP prefix + UA only; the sanitizer (`deploy/client_error_sanitizer.py`) strips emails, slugs, and magic-link tokens before the line is written. |
+| `build_meta` | `deploy/server.py` | the build blob (label, git SHA) | No. |
+
+**Caddy** logs only errors; access logging is **off** (no `log` directive in
+`ansible/roles/caddy/templates/Caddyfile.j2`), so there is no per-request IP/URL
+access log.
+
+## On disk
+
+| Path | Contents | Per-user? |
+|---|---|---|
+| `…/deploy/dist/fellows.db` | Imported **contact data** (the shared mirror) — no user-authored rows. | No. |
+| `…/deploy/dist/` (rest of bundle) | Static app shell, profile images, `manifest.json` + `.sig`, `build-meta.json`. Public. | No. |
+| `/etc/fellows/fellows-pwa.env` | **Secrets** — `FELLOWS_ALLOWLIST_HMAC_KEY`, `FELLOWS_SESSION_SECRET`, Postmark token. Root/`fellows`-readable only. | No. |
+| sqlite WAL/journal under `dist/` | Transient SQLite sidecar files for the read path. | No. |
+
+There is **no** `relationships.db` on the server, and (since the allowlist is
+built in memory by HMAC-ing `fellows.db` at startup) **no** `allowed_emails.json`
+artifact ships in `dist/`.
+
+## In-memory state (lost on restart)
+
+Held only in the running process; **not persisted** and gone on every service
+restart or reboot. Defined on `AuthState` in `deploy/magic_link_auth.py`:
+
+- `AuthState.tokens` — issued magic-link tokens (`token → expiry`); a token is
+  redeemable for the remainder of its `TOKEN_TTL` (30 min) and cleaned up once
+  it ages past that.
+- `AuthState.rate_buckets` — per-`email_hash` timestamp lists backing the
+  send-unlock rate limit.
+- `AuthState.sessions` — the session registry (`session_id → {expires_at, …}`);
+  `SESSION_MAX_AGE` is 7 days. A leaked session secret alone can't mint a
+  working cookie without a matching entry here.
+
+## Retention window (journald)
+
+The Ansible config sets **no journald retention override** — the only
+journald-related task adds the operator to the `systemd-journal`/`adm` read
+groups (`ansible/roles/common/tasks/main.yml`). So the droplet runs Ubuntu's
+**default** journald policy:
+
+- **Size-bounded, not time-bounded.** `SystemMaxUse` defaults to ~10% of the
+  filesystem (capped at 4 GB); `MaxRetentionSec` is unset, so there is **no
+  fixed time window**. Entries persist until the size cap is reached, then the
+  **oldest are vacuumed first**. On the small (1 vCPU / ~961 MB) droplet the
+  practical window is whatever that size cap holds at the current event volume.
+- **Persistence** follows the default `Storage=auto`: persistent across reboots
+  if `/var/log/journal` exists, otherwise volatile in `/run` (lost on reboot).
+- A journal reset (or, if volatile, a reboot) clears everything.
+
+To pin the exact current figures, an operator can run (prod, out of band):
+
+```bash
+journalctl --disk-usage      # current journal size on disk
+ls -la /var/log/journal      # exists → persistent; absent → volatile (/run)
+```
+
+If a bounded retention window is ever desired, set `SystemMaxUse=` /
+`MaxRetentionSec=` in `/etc/systemd/journald.conf` via the `common` role.
+
+## Third-party transport (Postmark)
+
+Magic-link emails are sent through **Postmark**. The outbound message and the
+Postmark dashboard/API retain the **raw recipient address** and message
+metadata per **Postmark's own retention policy** — this is off-droplet, in a
+third-party transport, and outside the server's control. It is the one place a
+plaintext recipient list is reconstructable without joining against
+`fellows.db`. See [`./email_system_management.md`](./email_system_management.md).
+
+## Removing the app and its data (user side)
+
+Server-side there is nothing per-user to delete. On the **device**, the full
+removal paths (Clear App Cache vs. Reset Everything vs. browser-level site-data
+deletion vs. deleting an installed PWA) are documented for users in
+[*Clearing app data*](./users_manual.md#clearing-app-data) and
+[*Your device is now the directory*](./users_manual.md#your-device-is-now-the-directory).
+
+## See also
+
+- [`./email_gate.md`](./email_gate.md) — auth-flow behavioural spec and the client-error sink's privacy boundary.
+- [`./email_system_management.md`](./email_system_management.md) — magic-link operator runbook and journald event schema.
+- [`./Architecture.md`](./Architecture.md) — the AC-8 (anti-enumeration + abuse-bounded analytics) attestation this accounting backs.
+- [`../SECURITY.md`](../SECURITY.md) — threat model and the "no per-user server storage" bright line in context.

--- a/docs/users_manual.md
+++ b/docs/users_manual.md
@@ -444,6 +444,13 @@ they're **hidden** entirely (there's no action you could take on the phone
 to turn them on). To get private data on those devices, migrate to Chrome
 — see *[Migrating from another browser](#migrating-from-another-browser)*.
 
+**What the server keeps.** Your private data never reaches the server — there's
+no account or per-user storage on it at all. The only things production keeps
+are operational logs (which carry hashed prefixes, never your email in the log
+line) and the public app bundle. The **About** page links a full accounting —
+*What data is kept* — or read it directly in
+[`docs/data_retention.md`](https://github.com/richbodo/fellows_local_db/blob/main/docs/data_retention.md).
+
 ### Turning on saved groups (private data)
 
 On a **Chromium desktop browser** (Chrome / Edge / Brave / Arc / Opera),


### PR DESCRIPTION
Closes #147.

## What

Adds the **server-side data-retention accounting** — the remaining half of #147 (the user-side removal docs landed in PR #225). New `docs/data_retention.md` documents exactly what production keeps, where, and for how long, plus cross-links from the places an evaluator or user would look.

## Why

#147 asked for a transparency accounting of server retention + cross-links from `SECURITY.md`. The issue body was partially stale; the [scope note](https://github.com/richbodo/fellows_local_db/issues/147#issuecomment-4701431495) narrowed it to this. The biggest open unknown (the journald retention window) is resolved from the Ansible config rather than prod access — see below.

## Changes

- **`docs/data_retention.md`** (new):
  - journald event inventory — `send_unlock_email`, `verify_token`, `auth_status`, `mcpb_download`, `client_error`, `build_meta` — each with PII notes. The raw recipient is **never** in a log line (only `email_hash_prefix`); Caddy access logging is off.
  - on-disk (`fellows.db` contact mirror, `/etc/fellows/fellows-pwa.env` secrets, public `dist/`) + the **no per-user server storage** bright line.
  - in-memory state lost on restart (`AuthState.tokens` / `rate_buckets` / `sessions`).
  - retention window: **Ansible sets no journald override**, so it's Ubuntu's default **size-capped** rotation (no fixed time window; oldest-vacuumed-when-full). Exact bytes/persistence confirmable via `journalctl --disk-usage` + `ls /var/log/journal`.
  - Postmark third-party retention note (the one place a plaintext recipient list reconstructs, off-droplet).
- **`SECURITY.md`** — new *Data retention* section cross-linking the doc.
- **`docs/Architecture.md`** — listed under *Operator concerns* + *Annexes*.
- **`app/static/app.js`** — About page links it ("What data is kept").
- **`docs/users_manual.md`** — matching note in *Where your data is stored* (per the UI-change convention, since About gained a link).

## Decisions made with the maintainer

- Retention window documented from Ansible facts (no prod access needed).
- Retention doc is linked from the in-app About page (not operator-only).

## Manual QA for the maintainer

1. `just serve`, open `http://localhost:8765/#/about` → confirm the **"What data is kept"** link appears under "Help from the user manual" and points to `docs/data_retention.md`. *(Verified in-browser; screenshot taken during development.)*
2. Skim `docs/data_retention.md` against the live journald events on prod to confirm the event list is complete for your deployment.
3. *(Optional, to pin exact figures in the doc later)* on the droplet: `journalctl --disk-usage` and `ls -la /var/log/journal`.

Docs-only + one additive About link; `node --check app/static/app.js` passes; all internal anchors verified to resolve.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
