### PR TITLE
test(e2e): de-flake version-handshake boot waits (15s → 30s)

### DIFF
--- a/tests/e2e/test_version_handshake.py
+++ b/tests/e2e/test_version_handshake.py
@@ -99,10 +99,15 @@ def test_version_skew_refuses_mutations_but_allows_reads(
     # folder handle persists in IndexedDB across the reboot.
     page.add_init_script(_FOLDER_PICKER_STUB_MIN)
     page.goto(base_url_fixture + "/", wait_until="domcontentloaded")
-    page.locator("#loading").wait_for(state="hidden", timeout=15000)
+    # Boot/worker-init waits use a 30s budget. Under full-suite load the
+    # worker cold-start (sqlite3.wasm compile + OPFS-SAH-Pool VFS install)
+    # contends for CPU and occasionally blows the old 15s budget, flaking
+    # this test even though boot is ~2s in isolation. 30s only bites on a
+    # genuine hang. Same class of fix as 45df9a3's folder-attach de-flake.
+    page.locator("#loading").wait_for(state="hidden", timeout=30000)
     page.wait_for_function(
         "() => window.__dataProvider && window.__dataProvider.kind === 'worker'",
-        timeout=15000,
+        timeout=30000,
     )
     attach_verified_folder(page, base_url_fixture)
 
@@ -113,7 +118,7 @@ def test_version_skew_refuses_mutations_but_allows_reads(
         lambda r: _rewrite_worker_version(r, base_url_fixture),
     )
     page.goto(base_url_fixture + "/", wait_until="domcontentloaded")
-    page.locator("#loading").wait_for(state="hidden", timeout=15000)
+    page.locator("#loading").wait_for(state="hidden", timeout=30000)
 
     # Provider is still the worker (only version constant skewed; init succeeded).
     kind = page.evaluate(


### PR DESCRIPTION
## What

De-flake `tests/e2e/test_version_handshake.py::test_version_skew_refuses_mutations_but_allows_reads` by bumping its three boot/worker-init waits from `timeout=15000` to `timeout=30000`.

## Why

The test failed once during a full `just test` run (742 passed, 6 skipped, **1 failed**) with:

```
playwright TimeoutError: Page.wait_for_function: Timeout 15000ms exceeded
```

It is **not a regression** — it re-runs green 4/4 in isolation (~2s each). Under the full ~10 min / 746-test suite, the worker cold-start (`sqlite3.wasm` compile + OPFS-SAH-Pool VFS install) contends for CPU and occasionally exceeds the old 15s budget. 30s only bites on a genuine hang.

Same class of fix as `45df9a3` (`test(e2e): de-flake folder-attach wait (8000ms → 15000ms)`).

## Scope

- Test-only. No app/worker/conformance code touched.
- AC-4 (versioned cross-boundary handshake) attestation evidence is unchanged — the test still asserts reads pass + mutations throw `VersionMismatchError` on skew; only the wait budget changed.

## Verification

- `pytest tests/e2e/test_version_handshake.py -v` → PASSED (2.67s), and 4/4 green across isolated re-runs.

## Maintainer QA

None required — test-only de-flake. Will confirm under the next full `just test` run.
