### PR TITLE
chore(security): add gitleaks + PII pre-commit guard and CI

### DIFF
--- a/.githooks/pre-commit
+++ b/.githooks/pre-commit
@@ -1,0 +1,33 @@
+#!/usr/bin/env bash
+# Pre-commit leak guard. Active once `core.hooksPath` points here — set by
+# `just hooks`, `just setup`, and scripts/wt-setup.sh (or run it yourself:
+# `git config core.hooksPath .githooks`).
+#
+#   1. scripts/check_pii.py --staged  — PII + data-file guard. Always runs
+#      (stdlib only, no install needed).
+#   2. gitleaks protect --staged       — secret scan. Best-effort: runs only
+#      if gitleaks is installed locally; CI enforces it regardless.
+#
+# Deliberate bypass (rare): git commit --no-verify
+set -uo pipefail
+repo_root="$(git rev-parse --show-toplevel)"
+py="$repo_root/.venv/bin/python"; [ -x "$py" ] || py="python3"
+
+# 1. PII / data-file guard — always on.
+if ! "$py" "$repo_root/scripts/check_pii.py" --staged; then
+  exit 1
+fi
+
+# 2. Secret scan — only if gitleaks is on PATH.
+if command -v gitleaks >/dev/null 2>&1; then
+  if ! gitleaks protect --staged --redact --no-banner -c "$repo_root/.gitleaks.toml"; then
+    echo "✖ pre-commit: gitleaks flagged a potential secret in staged changes." >&2
+    echo "  Review above. False positive? Allowlist it in .gitleaks.toml." >&2
+    echo "  Deliberate bypass: git commit --no-verify" >&2
+    exit 1
+  fi
+else
+  echo "ℹ pre-commit: gitleaks not installed — skipping local secret scan" >&2
+  echo "  (CI still enforces it). Install: brew install gitleaks" >&2
+fi
+exit 0

--- a/.github/workflows/secret-scan.yml
+++ b/.github/workflows/secret-scan.yml
@@ -1,0 +1,48 @@
+name: secret-scan
+
+# Authoritative leak gate (the local pre-commit hook is best-effort):
+#   - gitleaks scans for secrets/keys/tokens
+#   - scripts/check_pii.py scans added lines for PII + force-added data files
+# See SECURITY.md and .gitleaks.toml.
+
+on:
+  pull_request:
+  push:
+    branches: [main]
+
+permissions:
+  contents: read
+
+jobs:
+  scan:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+        with:
+          fetch-depth: 0  # gitleaks history scan + check_pii range diff need full history
+
+      - name: gitleaks (secret scan)
+        uses: gitleaks/gitleaks-action@v2
+        env:
+          GITLEAKS_CONFIG: ${{ github.workspace }}/.gitleaks.toml
+          # gitleaks-action is free for personal accounts and public repos. A
+          # GitHub *Organization* needs a free key in a GITLEAKS_LICENSE secret;
+          # if this repo ever moves to an org, add that secret and pass it here.
+
+      - name: PII / data-file guard (added lines)
+        run: |
+          set -euo pipefail
+          if [ "${{ github.event_name }}" = "pull_request" ]; then
+            BASE="${{ github.event.pull_request.base.sha }}"
+            HEAD="${{ github.event.pull_request.head.sha }}"
+          else
+            BASE="${{ github.event.before }}"
+            HEAD="${{ github.sha }}"
+          fi
+          # New-branch push (before = all-zeros) or an unreachable base: fall back to main.
+          if ! git rev-parse -q --verify "${BASE}^{commit}" >/dev/null 2>&1; then
+            git fetch --no-tags --depth=1 origin main >/dev/null 2>&1 || true
+            BASE="$(git rev-parse -q --verify origin/main || echo HEAD~1)"
+          fi
+          echo "Scanning ${BASE}..${HEAD} for PII / data files"
+          python3 scripts/check_pii.py --range "${BASE}..${HEAD}"

--- a/.github/workflows/secret-scan.yml
+++ b/.github/workflows/secret-scan.yml
@@ -12,6 +12,7 @@ on:
 
 permissions:
   contents: read
+  pull-requests: read  # gitleaks-action reads PR commits via the API
 
 jobs:
   scan:
@@ -24,6 +25,8 @@ jobs:
       - name: gitleaks (secret scan)
         uses: gitleaks/gitleaks-action@v2
         env:
+          # Required for PR scanning (auto-provided; no setup needed).
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
           GITLEAKS_CONFIG: ${{ github.workspace }}/.gitleaks.toml
           # gitleaks-action is free for personal accounts and public repos. A
           # GitHub *Organization* needs a free key in a GITLEAKS_LICENSE secret;

--- a/.gitleaks.toml
+++ b/.gitleaks.toml
@@ -1,0 +1,30 @@
+# gitleaks config for fellows_local_db.
+#
+# Extends gitleaks' built-in ruleset and allowlists the handful of committed
+# files that look secret-ish but are intentionally public, so the scan is
+# green on the existing tree and only fires on genuinely new leaks.
+#
+# Run locally:  gitleaks protect --staged -c .gitleaks.toml   (pre-commit)
+#               gitleaks detect  -c .gitleaks.toml             (whole repo)
+# CI runs it authoritatively (.github/workflows/secret-scan.yml).
+
+title = "fellows_local_db"
+
+[extend]
+useDefault = true
+
+[allowlist]
+description = "Committed files that are intentionally public, not real secrets."
+# Paths are regexes matched against the file path.
+paths = [
+  # DEV-only ECDSA signing key, committed on purpose: it's inert on prod (the
+  # origin gate in sw.js rejects it). See tests/fixtures/README.md.
+  '''tests/fixtures/dev_signing_key\.pem''',
+  '''tests/fixtures/dev_signing_key_pub\.hex''',
+  # Third-party libraries (jsPDF, sqlite3-wasm): their embedded author emails
+  # and blobs are not our secrets.
+  '''app/static/vendor/.*''',
+  '''.*\.min\.js$''',
+  # Config templates ship placeholder/example secrets by design.
+  '''.*\.example$''',
+]

--- a/SECURITY.md
+++ b/SECURITY.md
@@ -86,6 +86,32 @@ See `docs/email_gate.md` for the auth-flow behavioural spec (cookie format, inst
 
 ---
 
+## Keeping secrets and PII out of the repository
+
+The contact data is never committed (`fellows.db`, `relationships.db`, and
+`final_fellows_set/` are gitignored — see README § Data Note). Two automated
+guards back that rule so a secret or a stray bit of PII can't slip into a commit:
+
+- **gitleaks** — scans for secrets (keys, tokens, private keys). Authoritative
+  in CI (`.github/workflows/secret-scan.yml`); also runs in the pre-commit hook
+  when installed locally (`brew install gitleaks`). The repo allowlist — the
+  committed dev-only signing key, vendored libraries, `*.example` templates — is
+  `.gitleaks.toml`.
+- **`scripts/check_pii.py`** — stdlib, no install. Scans the *added lines* of a
+  change (not the whole tree, so pre-existing benign matches are grandfathered)
+  for email addresses outside an allowlist, local home paths that leak a
+  username, and force-added data files. Runs in the same CI job and always in
+  the pre-commit hook. This is the guard for the "an AI wrote a report against my
+  machine and pasted in `/Users/<me>/…` or a fellow's email" class of leak.
+
+Activate the pre-commit hook with `just hooks` (also done by `just setup` and
+`scripts/wt-setup.sh`; it points `core.hooksPath` at `.githooks/`). Scan a
+branch on demand with `just secret-scan`. A false positive can be allowlisted
+(`.gitleaks.toml` for secrets, a `.pii-allowlist` regex file for PII) or a
+single commit bypassed deliberately with `git commit --no-verify`.
+
+---
+
 ## Data retention
 
 There is **no per-user storage on the server** — no account, profile, or saved

--- a/justfile
+++ b/justfile
@@ -45,6 +45,7 @@ setup:
     if [ ! -f {{db}} ]; then
         {{venv}}/bin/python build/restore_from_knack_scrapefile.py
     fi
+    git config core.hooksPath .githooks
     echo "Setup complete."
 
 # Drop into a sub-shell with the venv activated (pytest/playwright/python on PATH).
@@ -353,6 +354,30 @@ evaluate-report:
         echo "Note: PNT lint not found at $lint — emitted + self-validated only."
         echo "      Set PNT_REPO to your toolkit checkout to run the authoritative lint."
     fi
+
+
+# ---- leak guards (secrets + PII) ----------------------------------------
+
+# Activate the repo's git hooks (pre-commit secret + PII guard). One-time per
+# clone; also run by `just setup` and scripts/wt-setup.sh. Hook: .githooks/pre-commit
+# → scripts/check_pii.py (always) + gitleaks (if installed). See SECURITY.md.
+[group('guards')]
+hooks:
+    git config core.hooksPath .githooks
+    @echo "core.hooksPath -> .githooks (pre-commit leak guard active)"
+
+# On-demand scan of a commit range (default: this branch vs origin/main) for
+# secrets (gitleaks, if installed) + PII / data files (always, stdlib).
+[group('guards')]
+secret-scan range="origin/main..HEAD":
+    #!/usr/bin/env bash
+    set -uo pipefail
+    if command -v gitleaks >/dev/null 2>&1; then
+        gitleaks detect --no-banner -c .gitleaks.toml --log-opts="{{range}}" || true
+    else
+        echo "ℹ gitleaks not installed (brew install gitleaks) — running PII check only"
+    fi
+    {{python}} scripts/check_pii.py --range "{{range}}"
 
 
 # ---- MCP servers ---------------------------------------------------------

--- a/scripts/check_pii.py
+++ b/scripts/check_pii.py
@@ -1,0 +1,190 @@
+#!/usr/bin/env python3
+"""Block PII and gitignored data from entering commits — the always-on,
+stdlib-only half of this repo's leak guard (the secret half is gitleaks).
+
+WHY a custom check on top of gitleaks: gitleaks finds *secrets* (keys,
+tokens) by signature, but says nothing about *PII* — fellow emails, or a
+local path that leaks your username/home layout (the classic "an AI wrote a
+report against my machine and pasted in /Users/<me>/..." leak). This catches
+that class, plus a force-added data file (fellows.db, final_fellows_set/),
+which the README says must never be committed.
+
+SCOPE = ADDED LINES IN A DIFF, not the whole tree. The repo already contains
+benign matches that we deliberately grandfather (jsPDF vendor author emails,
+@example.com test fixtures, a couple of /Users/... paths in plans/). Scanning
+only what a change *introduces* keeps the signal high and the noise near zero.
+
+Usage:
+  scripts/check_pii.py --staged             # pre-commit hook: staged changes
+  scripts/check_pii.py --range BASE..HEAD    # CI: everything a branch adds
+  scripts/check_pii.py                       # defaults to --staged
+
+Exit 0 = clean, 1 = findings (printed with file:line, value redacted).
+
+Escape hatches (use deliberately):
+  - git commit --no-verify                   # bypass the whole pre-commit hook
+  - add a regex line to .pii-allowlist       # permanently ignore a pattern
+"""
+import os
+import re
+import subprocess
+import sys
+
+# Emails whose domain (or exact address) is known-safe in this repo: test
+# fixtures, the project's own domain, the maintainer's *public* contact, and
+# the commit-footer co-author. A real fellow email won't be on this list.
+ALLOW_EMAIL_DOMAINS = {
+    "example.com", "example.org", "example.net", "example.co.uk",
+    "globaldonut.com", "fellows.globaldonut.com", "anthropic.com",
+}
+ALLOW_EMAIL_ADDRS = {"richbodo@gmail.com"}
+
+EMAIL_RE = re.compile(r"[A-Za-z0-9._%+\-]+@[A-Za-z0-9.\-]+\.[A-Za-z]{2,}")
+
+# A literal home directory with a real-looking user segment. We allow the
+# redacted/placeholder forms (/Users/.../, $HOME, ~) since those leak nothing.
+HOME_RE = re.compile(r"(?:/Users/|/home/|[A-Za-z]:\\Users\\)([A-Za-z0-9._\-]+)")
+HOME_PLACEHOLDERS = {
+    "...", "user", "username", "<user>", "<username>", "<you>", "you",
+    "youruser", "your-user", "name", "me",
+}
+
+# File PATHS that must never be committed (the README's "data is never
+# committed" rule). These are gitignored, so they only land via `git add -f`.
+DATA_PATH_RES = [
+    re.compile(r"(^|/)final_fellows_set/"),
+    re.compile(r"\.db$"),
+    re.compile(r"(^|/)ehf_fellow_profiles.*\.json$"),
+]
+
+# Files whose *content* we don't scan: third-party libraries and minified
+# bundles carry author emails that are not our PII.
+CONTENT_SKIP_RES = [
+    re.compile(r"(^|/)app/static/vendor/"),
+    re.compile(r"\.min\.js$"),
+    re.compile(r"(^|/)scripts/check_pii\.py$"),  # don't scan the checker itself
+]
+
+
+def _run(args):
+    return subprocess.run(
+        args, stdout=subprocess.PIPE, stderr=subprocess.DEVNULL,
+        check=False, text=True, errors="replace",
+    ).stdout
+
+
+def _load_extra_allow():
+    """Optional .pii-allowlist: one regex per line (blank / #comment ignored)."""
+    path = os.path.join(_repo_root(), ".pii-allowlist")
+    pats = []
+    if os.path.isfile(path):
+        with open(path, encoding="utf-8") as f:
+            for line in f:
+                line = line.strip()
+                if line and not line.startswith("#"):
+                    try:
+                        pats.append(re.compile(line))
+                    except re.error:
+                        pass
+    return pats
+
+
+def _repo_root():
+    root = _run(["git", "rev-parse", "--show-toplevel"]).strip()
+    return root or os.getcwd()
+
+
+def _diff_text(mode, rng):
+    if mode == "range":
+        return _run(["git", "diff", "--unified=0", "--no-color", rng])
+    return _run(["git", "diff", "--cached", "--unified=0", "--no-color"])
+
+
+def iter_added(diff_text):
+    """Yield (path, lineno, added_text) for each '+' line in a unified diff,
+    and collect the set of target file paths touched."""
+    path = None
+    lineno = 0
+    paths = set()
+    for line in diff_text.splitlines():
+        if line.startswith("+++ "):
+            tgt = line[4:].strip()
+            if tgt == "/dev/null":
+                path = None
+            else:
+                path = tgt[2:] if tgt.startswith("b/") else tgt
+                paths.add(path)
+            continue
+        if line.startswith("@@"):
+            m = re.search(r"\+(\d+)", line)
+            lineno = int(m.group(1)) if m else 0
+            continue
+        if line.startswith("+") and not line.startswith("+++"):
+            yield ("line", path, lineno, line[1:])
+            lineno += 1
+        # with --unified=0 there are no context lines; removed lines ('-') do
+        # not advance the new-file line number.
+    yield ("paths", None, 0, paths)
+
+
+def _skip_content(path):
+    return path is None or any(r.search(path) for r in CONTENT_SKIP_RES)
+
+
+def _redact_email(addr):
+    local, _, dom = addr.partition("@")
+    return (local[:1] or "?") + "***@***." + dom.rsplit(".", 1)[-1]
+
+
+def main(argv):
+    mode, rng = "staged", None
+    if "--range" in argv:
+        i = argv.index("--range")
+        mode, rng = "range", argv[i + 1] if i + 1 < len(argv) else None
+        if not rng:
+            print("check_pii: --range needs BASE..HEAD", file=sys.stderr)
+            return 2
+    elif argv and argv[0] not in ("--staged",):
+        print(__doc__)
+        return 0
+
+    extra_allow = _load_extra_allow()
+    findings = []
+    for kind, path, lineno, payload in iter_added(_diff_text(mode, rng)):
+        if kind == "paths":
+            for p in sorted(payload):
+                if any(r.search(p) for r in DATA_PATH_RES):
+                    findings.append((p, 0, "data file must not be committed "
+                                     "(gitignored; contains/derives from PII)"))
+            continue
+        if _skip_content(path):
+            continue
+        if any(r.search(payload) for r in extra_allow):
+            continue
+        for addr in EMAIL_RE.findall(payload):
+            dom = addr.rsplit("@", 1)[-1].lower()
+            if addr.lower() in ALLOW_EMAIL_ADDRS or dom in ALLOW_EMAIL_DOMAINS:
+                continue
+            findings.append((path, lineno, "email address (" + _redact_email(addr) + ")"))
+        for seg in HOME_RE.findall(payload):
+            if seg.lower() in HOME_PLACEHOLDERS:
+                continue
+            if not re.search(r"[A-Za-z0-9]", seg):
+                continue
+            findings.append((path, lineno, "local home path leaks a username "
+                             "(use $HOME, ~, or redact)"))
+
+    if not findings:
+        return 0
+    print("✖ check_pii: potential PII / data in added changes:\n", file=sys.stderr)
+    for p, ln, why in findings:
+        loc = (p or "?") + (":" + str(ln) if ln else "")
+        print("  - {}: {}".format(loc, why), file=sys.stderr)
+    print("\n  Fix the lines above. If a match is a false positive, add a regex "
+          "to .pii-allowlist,\n  or bypass once with: git commit --no-verify",
+          file=sys.stderr)
+    return 1
+
+
+if __name__ == "__main__":
+    raise SystemExit(main(sys.argv[1:]))

--- a/scripts/wt-setup.sh
+++ b/scripts/wt-setup.sh
@@ -67,5 +67,12 @@ link ".venv"
 link "app/fellows.db"
 link "mcp_servers/.venv"
 
+# Activate the pre-commit leak guard in this worktree. core.hooksPath is shared
+# via the common .git config, but set it explicitly so a worktree is guarded even
+# if the primary never ran `just setup`/`just hooks`. Path is relative to the
+# worktree root, which has the tracked .githooks/.
+git -C "$TARGET" config core.hooksPath .githooks
+echo "link   core.hooksPath -> .githooks (pre-commit leak guard)"
+
 echo "Worktree ready: $TARGET"
 echo "Reminder: don't run server-based tests here while another worktree is (port 8765)."


### PR DESCRIPTION
## Summary

Adds two automated guards that keep **secrets** and **PII** out of git — the lint you asked about for the "an AI writes a report against my local system and it ends up committed" class of leak. Builds on what the repo already does (gitignored data + the README "data is never committed" rule).

## What runs

- **gitleaks** — scans for secrets (keys, tokens, private keys). **Authoritative in CI** (`.github/workflows/secret-scan.yml`); **best-effort locally** in the pre-commit hook when installed (`brew install gitleaks`). Repo allowlist in **`.gitleaks.toml`**: the committed dev-only signing key (`tests/fixtures/dev_signing_key.pem`, inert on prod), vendored libraries, and `*.example` templates — so it's green on the existing tree and only fires on new leaks.
- **`scripts/check_pii.py`** — stdlib, no install. Scans the **added lines of a diff** (not the whole tree) for: emails outside an allowlist, local home paths that leak a username (`/Users/<you>/…`, allowing `$HOME`/`~`/redacted `/Users/.../`), and force-added data files (`*.db`, `final_fellows_set/`). Diff-scoping grandfathers existing benign matches (jsPDF vendor author emails, `@example.com` fixtures, the `/Users/richbodo/...` paths already in `plans/`).

## Wiring

- **`.githooks/pre-commit`** runs `check_pii.py --staged` (always) then `gitleaks protect --staged` (if installed).
- Activated by **`just hooks`**, and automatically by **`just setup`** and **`scripts/wt-setup.sh`** (sets `core.hooksPath=.githooks`).
- **`just secret-scan [range]`** — on-demand scan of a commit range (default `origin/main..HEAD`).
- Escape hatches: allowlist a false positive in `.gitleaks.toml` (secrets) or a `.pii-allowlist` regex file (PII); bypass a single commit with `git commit --no-verify`.
- Documented in **SECURITY.md** § "Keeping secrets and PII out of the repository".

## Verification

- `check_pii.py` **blocks** a deliberate leak (email → redacted in output, `/Users/<user>/` path, a force-added `.db`) and **passes clean** on (a) this changeset and (b) the entire PR #287 diff — i.e. no false positives on a large real change.
- The pre-commit hook ran live on this PR's own commit (gitleaks gracefully skipped — not installed here; `check_pii.py` passed).
- `just --list` shows the new recipes; the CI YAML parses.

## Notes for the maintainer

- `gitleaks-action@v2` is **free for personal accounts / public repos**; only a GitHub *Organization* needs a free `GITLEAKS_LICENSE` secret. This repo is under a personal account, so nothing to add — but flagged in the workflow comment in case it ever moves to an org.
- For local pre-commit secret scanning, `brew install gitleaks` (optional — CI enforces it regardless). Run `just hooks` once to activate the hook in this checkout (or it happens on your next `just setup`).
- I scoped the PII checker to **added lines** deliberately; if you'd rather it full-scan the tree, that's a one-flag change but needs a bigger allowlist for the grandfathered matches.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
