### PR TITLE
ci(secret-scan): run gitleaks CLI directly instead of gitleaks-action

### DIFF
--- a/.github/workflows/secret-scan.yml
+++ b/.github/workflows/secret-scan.yml
@@ -4,6 +4,12 @@ name: secret-scan
 #   - gitleaks scans for secrets/keys/tokens
 #   - scripts/check_pii.py scans added lines for PII + force-added data files
 # See SECURITY.md and .gitleaks.toml.
+#
+# gitleaks runs as the plain CLI, not gitleaks/gitleaks-action: the binary is
+# MIT-licensed and free everywhere, while the action requires a license key
+# once the repo is owned by a GitHub Organization (which broke this gate when
+# the repo moved to social-network-health). To bump the version, update
+# GITLEAKS_VERSION and the matching sha256 from the release's checksums.txt.
 
 on:
   pull_request:
@@ -12,27 +18,20 @@ on:
 
 permissions:
   contents: read
-  pull-requests: read  # gitleaks-action reads PR commits via the API
 
 jobs:
   scan:
     runs-on: ubuntu-latest
+    env:
+      GITLEAKS_VERSION: "8.30.1"
+      GITLEAKS_SHA256: "551f6fc83ea457d62a0d98237cbad105af8d557003051f41f3e7ca7b3f2470eb"
     steps:
       - uses: actions/checkout@v4
         with:
           fetch-depth: 0  # gitleaks history scan + check_pii range diff need full history
 
-      - name: gitleaks (secret scan)
-        uses: gitleaks/gitleaks-action@v2
-        env:
-          # Required for PR scanning (auto-provided; no setup needed).
-          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
-          GITLEAKS_CONFIG: ${{ github.workspace }}/.gitleaks.toml
-          # gitleaks-action is free for personal accounts and public repos. A
-          # GitHub *Organization* needs a free key in a GITLEAKS_LICENSE secret;
-          # if this repo ever moves to an org, add that secret and pass it here.
-
-      - name: PII / data-file guard (added lines)
+      - name: Resolve commit range
+        id: range
         run: |
           set -euo pipefail
           if [ "${{ github.event_name }}" = "pull_request" ]; then
@@ -47,5 +46,31 @@ jobs:
             git fetch --no-tags --depth=1 origin main >/dev/null 2>&1 || true
             BASE="$(git rev-parse -q --verify origin/main || echo HEAD~1)"
           fi
+          echo "Commit range: ${BASE}..${HEAD}"
+          echo "base=${BASE}" >> "$GITHUB_OUTPUT"
+          echo "head=${HEAD}" >> "$GITHUB_OUTPUT"
+
+      - name: Install gitleaks
+        run: |
+          set -euo pipefail
+          curl -sSfL -o gitleaks.tar.gz \
+            "https://github.com/gitleaks/gitleaks/releases/download/v${GITLEAKS_VERSION}/gitleaks_${GITLEAKS_VERSION}_linux_x64.tar.gz"
+          echo "${GITLEAKS_SHA256}  gitleaks.tar.gz" | sha256sum -c -
+          tar -xzf gitleaks.tar.gz gitleaks
+          sudo install -m 0755 gitleaks /usr/local/bin/gitleaks
+          rm -f gitleaks gitleaks.tar.gz
+          gitleaks version
+
+      - name: gitleaks (secret scan)
+        run: |
+          gitleaks detect --redact --no-banner \
+            -c .gitleaks.toml \
+            --log-opts="${{ steps.range.outputs.base }}..${{ steps.range.outputs.head }}"
+
+      - name: PII / data-file guard (added lines)
+        run: |
+          set -euo pipefail
+          BASE="${{ steps.range.outputs.base }}"
+          HEAD="${{ steps.range.outputs.head }}"
           echo "Scanning ${BASE}..${HEAD} for PII / data files"
           python3 scripts/check_pii.py --range "${BASE}..${HEAD}"


### PR DESCRIPTION
## Summary

Fixes the secret-scan check, red on every run since the repo moved to the `social-network-health` org on 2026-07-08: `gitleaks-action@v2` requires a license key for Organization-owned repos and was failing at the license gate before scanning anything (last green run: 2026-07-05, pre-transfer).

The gitleaks **binary** is MIT-licensed and free for everyone — only the wrapper action enforces org licensing — so this swaps the action for a direct CLI invocation:

- **Install step**: downloads the pinned release (`v8.30.1`), verifies its sha256 against the release's `checksums.txt`, installs to `/usr/local/bin`. Bump procedure (update `GITLEAKS_VERSION` + `GITLEAKS_SHA256`) is documented in the workflow header.
- **Scan step**: `gitleaks detect --redact --no-banner -c .gitleaks.toml --log-opts="BASE..HEAD"` — the same idiom as `just secret-scan`, scanning the same commit range the action scanned (PR commits on `pull_request`, push range on `push`).
- **Shared range resolution**: the BASE/HEAD logic (with the all-zeros/new-branch fallback) previously embedded in the PII step moves to its own step whose outputs feed both gitleaks and `scripts/check_pii.py`, so the two guards always scan the same range.
- Drops the `pull-requests: read` permission and `GITHUB_TOKEN` — those existed only for gitleaks-action's API access; the CLI reads the local clone.

No scanning behavior changes: same `.gitleaks.toml` allowlist, same diff-scoped PII guard. No license key, no new secret, no signup.

## Verification

- The `scan` check on **this PR** is the end-to-end test — it exercises the new install + range-resolve + scan steps on a real `pull_request` event. Green as of the run linked in the checks tab.
- Nothing outside `.github/workflows/` changed; the pytest suite is unaffected.

## Manual QA for the maintainer

- After merge, confirm the `push`-event path also goes green on the merge commit to `main` (the PR run only exercises the `pull_request` branch of the range logic).
- The `claude-review` check remains red for an unrelated reason: the Claude Code GitHub App isn't installed on the org — install it at https://github.com/apps/claude and grant it this repo.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
